### PR TITLE
[auto] Translate JAVA API Reference to German

### DIFF
--- a/german/java/_index.md
+++ b/german/java/_index.md
@@ -1,0 +1,13 @@
+---
+title: Aspose.Diagram for Java
+type: docs
+weight: 11
+url: /de/java/
+description: Aspose.Diagram for Java API-Referenzen enthalten Beispiele, Code‑Snippets und API‑Dokumentation. Sie bieten Pakete, Klassen, Schnittstellen und weitere API‑Details.
+is_root: true
+---
+
+## Packages
+| Paket | Beschreibung |
+| --- | --- |
+| [com.aspose.diagram](./com.aspose.diagram) | Das com.aspose.diagram-Paket stellt Klassen zum Erzeugen, Konvertieren, Modifizieren, Rendern und Drucken von Microsoft‑Visio‑Dokumenten bereit, ohne Microsoft Visio zu verwenden. |

--- a/german/java/com.aspose.diagram/_index.md
+++ b/german/java/com.aspose.diagram/_index.md
@@ -1,0 +1,471 @@
+---
+title: com.aspose.diagram
+second_title: Aspose.Diagram for Java API-Referenz
+description: Das com.aspose.diagram-Paket stellt Klassen zum Erzeugen, Konvertieren, Modifizieren, Rendern und Drucken von Microsoft‑Visio‑Dokumenten bereit, ohne Microsoft Visio zu verwenden.
+type: docs
+weight: 10
+url: /de/java/com.aspose.diagram/
+---
+
+
+Das com.aspose.diagram-Paket stellt Klassen zum Erzeugen, Konvertieren, Modifizieren, Rendern und Drucken von Microsoft‑Visio‑Dokumenten bereit, ohne Microsoft Visio zu verwenden.
+
+
+## Klassen
+
+| Klasse | Beschreibung |
+| --- | --- |
+| [AbstractInterruptMonitor](../com.aspose.diagram/abstractinterruptmonitor) | Überwacht Unterbrechungsanfragen bei allen zeitintensiven Vorgängen. |
+| [Act](../com.aspose.diagram/act) | Definiert benutzerdefinierte Befehlsnamen, die im Kontextmenü eines Objekts erscheinen, und legt die Aktionen fest, die die Befehle ausführen. |
+| [ActCollection](../com.aspose.diagram/actcollection) | Act-Sammlung. |
+| [ActiveXControl](../com.aspose.diagram/activexcontrol) | Stellt das ActiveX-Steuerelement dar. |
+| [ActiveXControlBase](../com.aspose.diagram/activexcontrolbase) | Stellt das ActiveX-Steuerelement dar. |
+| [ActiveXPersistenceType](../com.aspose.diagram/activexpersistencetype) | Stellt die Persistenzmethode zum Speichern eines ActiveX-Steuerelements dar. |
+| [Align](../com.aspose.diagram/align) | Gibt die Ausrichtung einer Form relativ zur Führungslinie oder zum Führungspunkt an, an dem die Form befestigt ist. |
+| [AlignNameValue](../com.aspose.diagram/alignnamevalue) | Optionaler int. |
+| [Alignment](../com.aspose.diagram/alignment) | Gibt die Tab‑Ausrichtung an. |
+| [AlignmentValue](../com.aspose.diagram/alignmentvalue) | Gibt die Tab‑Ausrichtung an. |
+| [Annotation](../com.aspose.diagram/annotation) | Enthält Elemente, die Informationen über in einer Dokumentseite eingefügte Kommentare enthalten. |
+| [AnnotationCollection](../com.aspose.diagram/annotationcollection) | Annotation-Sammlung. |
+| [ArcTo](../com.aspose.diagram/arcto) | Enthält die x- und y-Koordinaten sowie die Krümmung eines Kreisbogens, die jeweils durch die Elemente X, Y und A dargestellt werden. |
+| [ArcToCollection](../com.aspose.diagram/arctocollection) | ArcTo-Sammlung. |
+| [ArrowSize](../com.aspose.diagram/arrowsize) | Gibt die Größe der Pfeilspitze der Linie an. |
+| [ArrowSizeValue](../com.aspose.diagram/arrowsizevalue) | Gibt die Größe der Pfeilspitze der Linie an. |
+| [AsposeDiagramPrintDocument](../com.aspose.diagram/asposediagramprintdocument) | Es ist die eigene Version der .NET PrintDocument‑Klasse, die an ein PrintPreviewDialog‑Formular übergeben werden kann, um ein Diagramm zu drucken und eine Vorschau anzuzeigen. |
+| [AutoLinkComparison](../com.aspose.diagram/autolinkcomparison) | Definiert eine Regel, die eine Spalte im übergeordneten DataRecordset‑Element mit einem Formulardaten‑Element aus der letzten erfolgreichen automatischen Verknüpfungsaktion vergleicht, die in der Benutzeroberfläche durchgeführt wurde. |
+| [AutoSpaceOptions](../com.aspose.diagram/autospaceoptions) | Stellt Autospace-Optionen dar. |
+| [BOOL](../com.aspose.diagram/bool) | Boolesch. |
+| [Bevel](../com.aspose.diagram/bevel) | Stellt eine Abschrägung einer Form dar |
+| [BevelLightingType](../com.aspose.diagram/bevellightingtype) | Gibt den Typ des Schattens für eine Form an. |
+| [BevelLightingTypeValue](../com.aspose.diagram/bevellightingtypevalue) | Stellt ein voreingestelltes Licht rechts dar, das auf eine Form angewendet werden kann |
+| [BevelMaterialType](../com.aspose.diagram/bevelmaterialtype) | Gibt den Typ des Schattens für eine Form an. |
+| [BevelMaterialTypeValue](../com.aspose.diagram/bevelmaterialtypevalue) | Beschreibt das Oberflächenbild einer Form. |
+| [BevelPresetType](../com.aspose.diagram/bevelpresettype) | Stellt eine Voreinstellung für einen Abschrägungstyp dar, die auf eine Form in 3D angewendet werden kann. |
+| [BevelType](../com.aspose.diagram/beveltype) | Gibt den Typ des Schattens für eine Form an. |
+| [BevelTypeValue](../com.aspose.diagram/beveltypevalue) | Stellt eine Voreinstellung für einen Abschrägungstyp dar, die auf eine Form in 3D angewendet werden kann. |
+| [BoolValue](../com.aspose.diagram/boolvalue) | Boolescher Wert. |
+| [Bullet](../com.aspose.diagram/bullet) | Bestimmt den Aufzählungszeichenstil. |
+| [BulletValue](../com.aspose.diagram/bulletvalue) | Bestimmt den Aufzählungszeichenstil. |
+| [Calendar](../com.aspose.diagram/calendar) | Bestimmt den Kalender, der für benutzerdefinierte Eigenschaften, Textfelder und Formeln von Elementen verwendet wird. |
+| [CalendarValue](../com.aspose.diagram/calendarvalue) | Bestimmt den Kalender, der für benutzerdefinierte Eigenschaften, Textfelder und Formeln von Elementen verwendet wird. |
+| [Case](../com.aspose.diagram/case) | Bestimmt die Groß-/Kleinschreibung des Textes einer Form. |
+| [CaseValue](../com.aspose.diagram/casevalue) | Bestimmt die Groß-/Kleinschreibung des Textes einer Form. |
+| [Char](../com.aspose.diagram/char) | Enthält die Formatierungsattribute für den Text einer Form, wie Schriftart, Farbe, Textstil, Groß-/Kleinschreibung, Position relativ zur Grundlinie und Punktgröße. |
+| [CharCollection](../com.aspose.diagram/charcollection) | Zeichensammlung. |
+| [CheckBoxActiveXControl](../com.aspose.diagram/checkboxactivexcontrol) | Stellt ein CheckBox-ActiveX-Steuerelement dar. |
+| [CheckValueType](../com.aspose.diagram/checkvaluetype) | Stellt den Typ des Prüfwerts der CheckBox dar. |
+| [Collection](../com.aspose.diagram/collection) | Es ist die Basisklasse für Sammlungen. |
+| [CollectionBase](../com.aspose.diagram/collectionbase) | Stellt die abstrakte Basisklasse für eine stark typisierte Sammlung bereit. |
+| [Color](../com.aspose.diagram/color) | Stellt eine ARGB‑Farbe (Alpha, Rot, Grün, Blau) dar. |
+| [ColorEntry](../com.aspose.diagram/colorentry) | Enthält einen Eintrag in der Farbpalette. |
+| [ColorEntryCollection](../com.aspose.diagram/colorentrycollection) | Enthält die Farbpalette des Dokuments. |
+| [ColorValue](../com.aspose.diagram/colorvalue) | Stellt einen Farbwert dar |
+| [ComboBoxActiveXControl](../com.aspose.diagram/comboboxactivexcontrol) | Stellt ein ComboBox-ActiveX-Steuerelement dar. |
+| [CommandButtonActiveXControl](../com.aspose.diagram/commandbuttonactivexcontrol) | Stellt eine Befehlsschaltfläche dar. |
+| [CompositingQuality](../com.aspose.diagram/compositingquality) | Gibt die Qualitätsstufe an, die beim Compositing verwendet werden soll. |
+| [CompoundType](../com.aspose.diagram/compoundtype) | Gibt die Größe der Pfeilspitze der Linie an. |
+| [CompoundTypeValue](../com.aspose.diagram/compoundtypevalue) | Stellt den Stil zum Zeichnen von Linien dar. |
+| [CompressionType](../com.aspose.diagram/compressiontype) | Dieses Attribut ist nur sinnvoll, wenn die Fremddaten ein rasterbasiertes Fremdobjekt sind, wie z. B. eine DIB-, JPG-, PNG-, TIFF- oder GIF-Datei. |
+| [ConFixedCode](../com.aspose.diagram/confixedcode) | Bestimmt, wann ein Connector umgeleitet wird. |
+| [ConFixedCodeValue](../com.aspose.diagram/confixedcodevalue) | Bestimmt, wann ein Connector umgeleitet wird. |
+| [ConLineJumpCode](../com.aspose.diagram/conlinejumpcode) | Bestimmt, ob ein Connector springt, wenn zwei Connectoren sich kreuzen. |
+| [ConLineJumpCodeValue](../com.aspose.diagram/conlinejumpcodevalue) | Bestimmt, ob ein Connector springt, wenn zwei Connectoren sich kreuzen. |
+| [ConLineJumpDirX](../com.aspose.diagram/conlinejumpdirx) | Bestimmt die Sprungrichtung für Linien, die auf einem horizontalen Segment eines dynamischen Connectors auftreten. |
+| [ConLineJumpDirXValue](../com.aspose.diagram/conlinejumpdirxvalue) | Bestimmt die Sprungrichtung für Linien, die auf einem horizontalen Segment eines dynamischen Connectors auftreten. |
+| [ConLineJumpDirY](../com.aspose.diagram/conlinejumpdiry) | Bestimmt die Sprungrichtung für Linien, die auf einem vertikalen Segment eines dynamischen Connectors auftreten. |
+| [ConLineJumpDirYValue](../com.aspose.diagram/conlinejumpdiryvalue) | Bestimmt die Sprungrichtung für Linien, die auf einem vertikalen Segment eines dynamischen Connectors auftreten. |
+| [ConLineJumpStyle](../com.aspose.diagram/conlinejumpstyle) | Bestimmt den Sprungstil für Linien auf einem dynamischen Connector. |
+| [ConLineJumpStyleValue](../com.aspose.diagram/conlinejumpstylevalue) | Bestimmt den Sprungstil für Linien auf einem dynamischen Connector. |
+| [ConLineRouteExt](../com.aspose.diagram/conlinerouteext) | Bestimmt das Erscheinungsbild eines Connectors. |
+| [ConLineRouteExtValue](../com.aspose.diagram/conlinerouteextvalue) | Bestimmt das Erscheinungsbild eines Connectors. |
+| [ConType](../com.aspose.diagram/contype) | Gibt den Verhaltenstyp der x- oder y-Koordinate des Steuergriffs an, der nach dem Verschieben des Griffs auftritt. |
+| [ConValue](../com.aspose.diagram/convalue) | Gibt den Verhaltenstyp der x- oder y-Koordinate des Steuergriffs an, der nach dem Verschieben des Griffs auftritt. |
+| [Connect](../com.aspose.diagram/connect) | Stellt eine Verbindung zwischen zwei Formen in einer Zeichnung dar, z. B. eine Linie und ein Feld in einem Organigramm. |
+| [ConnectCollection](../com.aspose.diagram/connectcollection) | Connect‑Sammlung. |
+| [ConnectedShapesFlags](../com.aspose.diagram/connectedshapesflags) | Filtert das Array der zurückgegebenen Shape-IDs nach der Richtung der Connectoren. |
+| [Connection](../com.aspose.diagram/connection) | Enthält Elemente für einen für die Form definierten Verbindungspunkt. |
+| [ConnectionABCD](../com.aspose.diagram/connectionabcd) | Das Element ConnectionABCD ist eine veraltete Version des Elements Connection und existiert nur aus Gründen der Rückwärtskompatibilität. |
+| [ConnectionABCDCollection](../com.aspose.diagram/connectionabcdcollection) | ConnectionABCD‑Sammlung. |
+| [ConnectionCollection](../com.aspose.diagram/connectioncollection) | Connection‑Sammlung. |
+| [ConnectionPointPlace](../com.aspose.diagram/connectionpointplace) | Gibt den Ort auf der Form an, an dem der Connector verbunden wird. |
+| [ConnectorRule](../com.aspose.diagram/connectorrule) | Stellt die Connector‑Regel zwischen zwei Formen mit einem Connector dar, einschließlich des Verbindungspunkts, von dem aus die Verbindung startet, der Ziel‑Form und deren Verbindungspunkt. |
+| [ConnectorsTypeValue](../com.aspose.diagram/connectorstypevalue) | Kann einen der folgenden Werte haben: RightAngle, StraightLines oder CurvedLines. |
+| [ContainerTypeValue](../com.aspose.diagram/containertypevalue) | Kann einen der folgenden Werte haben: Document, Page oder Master. |
+| [ContextTypeValue](../com.aspose.diagram/contexttypevalue) | Gibt die Eigenschaften der Gruppe oder Form an, die für den Vergleich verwendet werden sollen. |
+| [Control](../com.aspose.diagram/control) | Enthält Elemente für die x‑ und y‑Koordinaten jedes für eine Form definierten Steuergriffs sowie Elemente, die angeben, wie sich der Steuergriff verhalten soll. |
+| [ControlBorderType](../com.aspose.diagram/controlbordertype) | Stellt den Rahmentyp des ActiveX‑Steuerelements dar. |
+| [ControlCaptionAlignmentType](../com.aspose.diagram/controlcaptionalignmenttype) | Stellt die Position der Beschriftung relativ zum Steuerelement dar. |
+| [ControlCollection](../com.aspose.diagram/controlcollection) | Control‑Sammlung. |
+| [ControlListStyle](../com.aspose.diagram/controlliststyle) | Stellt das visuelle Erscheinungsbild der Liste in einer ListBox oder ComboBox dar. |
+| [ControlMatchEntryType](../com.aspose.diagram/controlmatchentrytype) | Stellt dar, wie ein ListBox oder ComboBox seine Liste durchsucht, während der Benutzer tippt. |
+| [ControlMousePointerType](../com.aspose.diagram/controlmousepointertype) | Stellt den Typ des Symbols dar, das als Mauszeiger für das Steuerelement angezeigt wird. |
+| [ControlPictureAlignmentType](../com.aspose.diagram/controlpicturealignmenttype) | Stellt die Ausrichtung des Bildes innerhalb des Formulars oder Bildes dar. |
+| [ControlPicturePositionType](../com.aspose.diagram/controlpicturepositiontype) | Stellt den Ort des Bildes des Steuerelements relativ zu seiner Beschriftung dar. |
+| [ControlPictureSizeMode](../com.aspose.diagram/controlpicturesizemode) | Stellt dar, wie das Bild angezeigt wird. |
+| [ControlScrollBarType](../com.aspose.diagram/controlscrollbartype) | Stellt den Typ der Bildlaufleiste dar. |
+| [ControlScrollOrientation](../com.aspose.diagram/controlscrollorientation) | Stellt den Typ der Bildlauforientierung dar |
+| [ControlSpecialEffectType](../com.aspose.diagram/controlspecialeffecttype) | Stellt den Typ des Spezialeffekts dar. |
+| [ControlType](../com.aspose.diagram/controltype) | Stellt alle Typen von ActiveX-Steuerelementen dar. |
+| [Coordinate](../com.aspose.diagram/coordinate) | Abstrakte Klasse für die x- und y-Koordinaten. |
+| [CoordinateCollection](../com.aspose.diagram/coordinatecollection) | Koordinatensammlung. |
+| [CountryCode](../com.aspose.diagram/countrycode) | Stellt Diagramm-Länderkürzel dar. |
+| [Cp](../com.aspose.diagram/cp) | Markiert den Beginn eines Zeichen-Eigenschaftslaufs, der gemäß dem entsprechenden Char-Element formatiert ist. |
+| [CustomProp](../com.aspose.diagram/customprop) | CustomProp-Struktur. |
+| [CustomPropCollection](../com.aspose.diagram/custompropcollection) | CustomProps-Sammlung. |
+| [CustomValue](../com.aspose.diagram/customvalue) | Wert der Eigenschaft. |
+| [DataColumn](../com.aspose.diagram/datacolumn) | Definiert, wie eine Datenspalte im Fenster Externe Daten in der Visio-Benutzeroberfläche angezeigt wird und qualifiziert die Daten in der Spalte, indem ihr Datentyp und Formatierung festgelegt werden. |
+| [DataColumnCollection](../com.aspose.diagram/datacolumncollection) | DataColumn-Sammlung. |
+| [DataConnection](../com.aspose.diagram/dataconnection) | Abstrahiert die Kommunikation zwischen einem oder mehreren DataRecordset-Elementen und einer Nicht-XML-Datenquelle. |
+| [DataConnectionCollection](../com.aspose.diagram/dataconnectioncollection) | DataConnection-Sammlung. |
+| [DataConnectionType](../com.aspose.diagram/dataconnectiontype) | Ermöglicht das Konfigurieren von Optionen für die Verbindungen zur Datenbank. |
+| [DataRecordSet](../com.aspose.diagram/datarecordset) | Speichert, formatiert, aktualisiert und stellt Daten bereit, die aus einer Datenbank in Microsoft Visio abgefragt wurden. |
+| [DataRecordSetCollection](../com.aspose.diagram/datarecordsetcollection) | DataRecordSet-Sammlung. |
+| [DateTime](../com.aspose.diagram/datetime) | Stellt einen Zeitpunkt dar, typischerweise ausgedrückt als Datum und Uhrzeit. |
+| [DateValue](../com.aspose.diagram/datevalue) | Datum- und Uhrzeitwert. |
+| [Diagram](../com.aspose.diagram/diagram) | Stammelement der Visio-Objekthierarchie. |
+| [DiagramException](../com.aspose.diagram/diagramexception) | Basisklasse für alle Aspose.Diagram-Ausnahmen |
+| [DiagramSaveOptions](../com.aspose.diagram/diagramsaveoptions) | Kann verwendet werden, um zusätzliche Optionen beim Speichern eines Diagramms im Visio-Format (VDX\VSX) anzugeben. |
+| [DisplayMode](../com.aspose.diagram/displaymode) | Wenn es in einem Group-Element enthalten ist, gibt das DisplayMode-Element an, wie eine Gruppierung und ihre Mitglieder angezeigt werden. |
+| [DisplayModeSmartTagDef](../com.aspose.diagram/displaymodesmarttagdef) | Das DisplayMode-Element bestimmt, ob das Smart-Tag erscheint, wenn der Benutzer die Maus über das Tag hält, wenn die Form ausgewählt ist oder die ganze Zeit. |
+| [DisplayModeSmartTagDefValue](../com.aspose.diagram/displaymodesmarttagdefvalue) | Das DisplayMode-Element bestimmt, ob das Smart-Tag erscheint, wenn der Benutzer die Maus über das Tag hält, wenn die Form ausgewählt ist oder die ganze Zeit. |
+| [DisplayModeValue](../com.aspose.diagram/displaymodevalue) | Wenn es in einem Group-Element enthalten ist, gibt das DisplayMode-Element an, wie eine Gruppierung und ihre Mitglieder angezeigt werden. |
+| [DocProps](../com.aspose.diagram/docprops) | Enthält Elemente, die die Vorschauqualität, den Umfang und das Ausgabeformat des Dokuments steuern. |
+| [DocumentProperties](../com.aspose.diagram/documentproperties) | Enthält Dokumenteigenschaftselemente wie den Titel, den Autor usw. des Dokuments. |
+| [DocumentSettings](../com.aspose.diagram/documentsettings) | Enthält Elemente, die Dokumenteinstellungen festlegen. |
+| [DocumentSheet](../com.aspose.diagram/documentsheet) | Gibt die ShapeSheet-Struktur eines Dokuments an. |
+| [DoubleValue](../com.aspose.diagram/doublevalue) | Double-Wert |
+| [DrawingResizeType](../com.aspose.diagram/drawingresizetype) | Bestimmt, ob die Zeichenfläche automatisch an das Diagramm angepasst wird. |
+| [DrawingResizeTypeValue](../com.aspose.diagram/drawingresizetypevalue) | Bestimmt, ob die Zeichenfläche automatisch an das Diagramm angepasst wird. |
+| [DrawingScaleType](../com.aspose.diagram/drawingscaletype) | Gibt den Typ der Zeichenmaßstabes an, der für eine Seite verwendet werden soll. |
+| [DrawingScaleTypeValue](../com.aspose.diagram/drawingscaletypevalue) | Gibt den Typ der Zeichenmaßstabes an, der für eine Seite verwendet werden soll. |
+| [DrawingSizeType](../com.aspose.diagram/drawingsizetype) | Gibt die Zeichenflächegröße einer Seite an. |
+| [DrawingSizeTypeValue](../com.aspose.diagram/drawingsizetypevalue) | Gibt die Zeichenflächegröße einer Seite an. |
+| [DropButtonStyle](../com.aspose.diagram/dropbuttonstyle) | Stellt das Symbol dar, das auf der Dropdown-Schaltfläche angezeigt wird. |
+| [DynFeedback](../com.aspose.diagram/dynfeedback) | Gibt den Typ des visuellen Feedbacks an, das Benutzern beim Ziehen eines Connectors bereitgestellt wird. |
+| [DynFeedbackValue](../com.aspose.diagram/dynfeedbackvalue) | Gibt den Typ des visuellen Feedbacks an, das Benutzern beim Ziehen eines Connectors bereitgestellt wird. |
+| [Ellipse](../com.aspose.diagram/ellipse) | Enthält Elemente, die die x- und y-Koordinaten des Mittelpunktes der Ellipse sowie zwei Punkte auf der Ellipse angeben. |
+| [EllipseCollection](../com.aspose.diagram/ellipsecollection) | Ellipsensammlung. |
+| [EllipticalArcTo](../com.aspose.diagram/ellipticalarcto) | Enthält Elemente, die Informationen über einen elliptischen Bogen angeben. |
+| [EllipticalArcToCollection](../com.aspose.diagram/ellipticalarctocollection) | EllipticalArcTo-Sammlung. |
+| [EmfRenderSetting](../com.aspose.diagram/emfrendersetting) | Einstellung zum Rendern von Emf-Metadateien. |
+| [Encoding](../com.aspose.diagram/encoding) | Stellt eine Zeichenkodierung dar. |
+| [Event](../com.aspose.diagram/event) | Enthält Elemente, die Formeln angeben, die Formereignisse steuern. |
+| [EventItem](../com.aspose.diagram/eventitem) | Kapselt einen Ereigniscode. |
+| [EventItemCollection](../com.aspose.diagram/eventitemcollection) | EventItem-Sammlung. |
+| [Field](../com.aspose.diagram/field) | Enthält Elemente, die Funktionen und Formeln angeben, die in den Text der Form eingefügt werden. |
+| [FieldCollection](../com.aspose.diagram/fieldcollection) | Feldsammlung. |
+| [FileFontSource](../com.aspose.diagram/filefontsource) | Stellt die einzelne TrueType-Schriftdatei dar, die im Dateisystem gespeichert ist. |
+| [FileFormatInfo](../com.aspose.diagram/fileformatinfo) | Enthält Daten, die von den Dateiformat-Erkennungsmethoden von [FileFormatUtil](../com.aspose.diagram/fileformatutil) zurückgegeben werden. |
+| [FileFormatType](../com.aspose.diagram/fileformattype) | Enumeriert Tabellenkalkulationsdateiformattypen |
+| [FileFormatUtil](../com.aspose.diagram/fileformatutil) | Stellt Dienstprogrammmethoden zum Konvertieren von Dateiformat-Enums in Zeichenketten oder Dateierweiterungen und zurück bereit. |
+| [Fill](../com.aspose.diagram/fill) | Enthält die aktuellen Füllformatierungswerte für die Form und den Formschatten, einschließlich Muster, Vordergrundfarbe und Hintergrundfarbe. |
+| [FillType](../com.aspose.diagram/filltype) | Füllformattyp. |
+| [Fld](../com.aspose.diagram/fld) | Gibt einen Einfügepunkt für ein Textfeld für das entsprechende Feld-Element an. |
+| [FloatPointNumCollection](../com.aspose.diagram/floatpointnumcollection) | Enthält eine Sammlung von Verdopplungs-Punktzahlen |
+| [FolderFontSource](../com.aspose.diagram/folderfontsource) | Stellt den Ordner dar, der TrueType-Schriftdateien enthält. |
+| [Font](../com.aspose.diagram/font) | Enthält Informationen über eine Schrift. |
+| [FontCollection](../com.aspose.diagram/fontcollection) | Enthält eine Sammlung von Schrift-Elementen. |
+| [FontConfigs](../com.aspose.diagram/fontconfigs) | Gibt Schrift-Einstellungen an |
+| [FontSourceBase](../com.aspose.diagram/fontsourcebase) | Dies ist eine abstrakte Basisklasse für die Klassen, die dem Benutzer ermöglichen, verschiedene Schriftquellen anzugeben |
+| [FontSourceType](../com.aspose.diagram/fontsourcetype) | Gibt den Typ einer Schriftquelle an. |
+| [Foreign](../com.aspose.diagram/foreign) | Enthält Elemente, die die Breite und Höhe eines Objekts aus einem anderen Programm angeben, das in einem Microsoft Visio-Dokument verwendet wird. |
+| [ForeignData](../com.aspose.diagram/foreigndata) | Enthält einen MIME (Multipurpose Internet Mail Extensions) codierten BLOB von Bilddaten, wie Windows-Metadatei, Bitmap oder OLE-Daten. |
+| [ForeignType](../com.aspose.diagram/foreigntype) | Datentyp. |
+| [FormatTxt](../com.aspose.diagram/formattxt) | Abstrakte Klasse für die Textformatierung |
+| [FormatTxtCollection](../com.aspose.diagram/formattxtcollection) | FormatTxt-Sammlung, die den Text einer Form enthält. |
+| [FromPartValue](../com.aspose.diagram/frompartvalue) | Der Teil einer Form, von dem eine Verbindung ausgeht. |
+| [Geom](../com.aspose.diagram/geom) | Enthält Elemente, die die Koordinaten der Scheitelpunkte für die Linien und Bögen angeben, aus denen die Form besteht. |
+| [GeomCollection](../com.aspose.diagram/geomcollection) | Geom-Sammlung. |
+| [GlowEffect](../com.aspose.diagram/gloweffect) | Diese Klasse definiert einen Leuchteffekt, bei dem eine farbige, unscharfe Kontur außerhalb der Objektkanten hinzugefügt wird. |
+| [GlueSettings](../com.aspose.diagram/gluesettings) | Die Bitwerte zeigen an, dass eine bestimmte Klebe-Einstellung ein- oder ausgeschaltet ist. |
+| [GlueSettingsValue](../com.aspose.diagram/gluesettingsvalue) | Gibt die Objekte an, an die Formen geklebt werden, wenn Kleben im Dokument aktiviert ist. |
+| [GlueType](../com.aspose.diagram/gluetype) | Gibt an, ob dynamisches (Form-zu-Form) Kleben beim Verbinden mit einer Form erlaubt ist. |
+| [GlueTypeValue](../com.aspose.diagram/gluetypevalue) | Gibt an, ob dynamisches (Form-zu-Form) Kleben beim Verbinden mit einer Form erlaubt ist. |
+| [GluedShapesFlags](../com.aspose.diagram/gluedshapesflags) | Gibt Konstanten an, die bestimmen, welche Formen zurückgegeben werden, basierend auf der Dimensionalität und Richtungsabhängigkeit der Verbindungspunkte, die an einer bestimmten Form geklebt sind; wird an die Methode Shape.GluedShapes übergeben. |
+| [GradientDirectionType](../com.aspose.diagram/gradientdirectiontype) | Stellt alle Richtungsarten eines Farbverlaufs dar. |
+| [GradientFill](../com.aspose.diagram/gradientfill) | Stellt die Verlauffüllung dar. |
+| [GradientFillDir](../com.aspose.diagram/gradientfilldir) | Gibt den Typ des Farbverlaufs der Füllung einer Form an |
+| [GradientFillType](../com.aspose.diagram/gradientfilltype) | Stellt alle Typen der Verlauffüllung dar. |
+| [GradientStop](../com.aspose.diagram/gradientstop) | Stellt den Verlauf-Stopp dar. |
+| [GradientStopCollection](../com.aspose.diagram/gradientstopcollection) | Stellt die Sammlung von Verlauf-Stops dar. |
+| [GradientStyleType](../com.aspose.diagram/gradientstyletype) | Stellt den Schattierungsstil des Farbverlaufs dar. |
+| [GridDensity](../com.aspose.diagram/griddensity) | Gibt den Typ des horizontalen/vertikalen Rasters an, der für eine Seite verwendet werden soll. |
+| [GridDensityValue](../com.aspose.diagram/griddensityvalue) | Gibt den Typ des horizontalen/vertikalen Rasters an, der für eine Seite verwendet werden soll. |
+| [Group](../com.aspose.diagram/group) | Enthält Elemente, die steuern, wie Sie Formen zu einer Gruppe hinzufügen, Gruppenmitglieder verschieben und Gruppen auswählen. |
+| [HTMLSaveOptions](../com.aspose.diagram/htmlsaveoptions) | Ermöglicht das Angeben zusätzlicher Optionen beim Rendern von Diagrammseiten zu HTML. |
+| [HeaderFooter](../com.aspose.diagram/headerfooter) | Enthält Elemente für die Kopf- und Fußzeile eines Dokuments. |
+| [HeaderFooterFont](../com.aspose.diagram/headerfooterfont) | Gibt die für den Kopf- und Fußzeilentext verwendete Schriftart an. |
+| [Help](../com.aspose.diagram/help) | Enthält Elemente, die das Hilfedatei-Thema und die Copyright-Informationen des Shape-Elements angeben. |
+| [HorzAlign](../com.aspose.diagram/horzalign) | Gibt die horizontale Ausrichtung des Textes im Textblock der Form an. |
+| [HorzAlignValue](../com.aspose.diagram/horzalignvalue) | Gibt die horizontale Ausrichtung des Textes im Textblock der Form an. |
+| [Hyperlink](../com.aspose.diagram/hyperlink) | Enthält Elemente zum Erstellen mehrerer Sprünge zwischen einer Form oder Zeichenfläche und einer anderen Zeichenfläche, einer anderen Datei oder einer Website. |
+| [HyperlinkCollection](../com.aspose.diagram/hyperlinkcollection) | Hyperlink-Sammlung. |
+| [IconSizeValue](../com.aspose.diagram/iconsizevalue) | Optionaler int. |
+| [Image](../com.aspose.diagram/image) | Enthält die Gamma-, Helligkeits-, Kontrast-, Unschärfe-, Schärfungs-, Rauschunterdrückungs- und Transparenzwerte für ein Bitmap. |
+| [ImageActiveXControl](../com.aspose.diagram/imageactivexcontrol) | Stellt die Bildsteuerung dar. |
+| [ImageColorMode](../com.aspose.diagram/imagecolormode) | Gibt den Farbmodus für die erzeugten Bilder von Dokumentseiten an. |
+| [ImageFormat](../com.aspose.diagram/imageformat) | Gibt das Dateiformat des Bildes an. |
+| [ImageSaveOptions](../com.aspose.diagram/imagesaveoptions) | Ermöglicht das Angeben zusätzlicher Optionen beim Rendern von Diagrammseiten zu Bildern. |
+| [IndividualFontConfigs](../com.aspose.diagram/individualfontconfigs) | Schriftkonfigurationen für jedes [Diagram](../com.aspose.diagram/diagram)-Objekt. |
+| [InfiniteLine](../com.aspose.diagram/infiniteline) | Enthält Elemente, die die x- und y-Koordinaten von zwei Punkten auf einer unendlichen Linie angeben. |
+| [InfiniteLineCollection](../com.aspose.diagram/infinitelinecollection) | InfiniteLine‑Sammlung. |
+| [InputMethodEditorMode](../com.aspose.diagram/inputmethodeditormode) | Stellt den Standard‑Laufzeitmodus des Input Method Editors dar. |
+| [IntValue](../com.aspose.diagram/intvalue) | Ganzzahlwert |
+| [InterpolationMode](../com.aspose.diagram/interpolationmode) | Die Aufzählung InterpolationMode gibt den Algorithmus an, der verwendet wird, wenn Bilder skaliert oder rotiert werden. |
+| [InterruptMonitor](../com.aspose.diagram/interruptmonitor) | Stellt alle Operatoren bezüglich des Interrupts dar. |
+| [Issue](../com.aspose.diagram/issue) | Stellt ein einzelnes Validierungsproblem im Dokument dar. |
+| [IssueCollection](../com.aspose.diagram/issuecollection) | Issue‑Sammlung. |
+| [IssueTarget](../com.aspose.diagram/issuetarget) | Abhängig vom Ziel des übergeordneten Validierungsproblems gibt es entweder die Seite oder sowohl die Seite als auch die Form an, mit denen das übergeordnete Validierungsproblem verknüpft ist. |
+| [LabelActiveXControl](../com.aspose.diagram/labelactivexcontrol) | Stellt das Label‑ActiveX‑Steuerelement dar. |
+| [Layer](../com.aspose.diagram/layer) | Enthält Elemente, die eine einzelne Ebene und deren Eigenschaften für eine Seite definieren. |
+| [LayerCollection](../com.aspose.diagram/layercollection) | Ebenen‑Sammlung. |
+| [LayerMem](../com.aspose.diagram/layermem) | Enthält das Element LayerMember, das jede Ebene angibt, der die Form zugewiesen ist. |
+| [Layout](../com.aspose.diagram/layout) | Enthält Elemente, die die Platzierung von Formen und die Routing‑Einstellungen von Verbindern steuern. |
+| [LayoutDirection](../com.aspose.diagram/layoutdirection) | Wird verwendet, um die Richtung des Layouts festzulegen. |
+| [LayoutOptions](../com.aspose.diagram/layoutoptions) | Wird verwendet, um Stil und zusätzliche Optionen des Layouts von Formen anzugeben, um ein Neu‑Layout von Seite(n) durchzuführen. |
+| [LayoutStyle](../com.aspose.diagram/layoutstyle) | Wird verwendet, um den Stil des Layouts anzugeben. |
+| [License](../com.aspose.diagram/license) | Stellt Methoden zum Lizenzieren der Komponente bereit. |
+| [LightRigDirectionType](../com.aspose.diagram/lightrigdirectiontype) | Stellt den Lichtgestell‑Richtungstyp dar. |
+| [Line](../com.aspose.diagram/line) | Enthält Elemente, die allgemeine Positionsinformationen zu einer Form angeben. |
+| [LineAdjustFrom](../com.aspose.diagram/lineadjustfrom) | Gibt an, welche dynamischen Verbinder auseinandergezogen werden sollen, wenn sie übereinander geroutet werden. |
+| [LineAdjustFromValue](../com.aspose.diagram/lineadjustfromvalue) | Gibt an, welche dynamischen Verbinder auseinandergezogen werden sollen, wenn sie übereinander geroutet werden. |
+| [LineAdjustTo](../com.aspose.diagram/lineadjustto) | Gibt an, welche dynamischen Verbinder übereinander ausgerichtet werden sollen, wenn sie übereinander geroutet werden. |
+| [LineAdjustToValue](../com.aspose.diagram/lineadjusttovalue) | Gibt an, welche dynamischen Verbinder übereinander ausgerichtet werden sollen, wenn sie übereinander geroutet werden. |
+| [LineJumpCode](../com.aspose.diagram/linejumpcode) | Bestimmt die dynamischen Verbinder, zu denen Sprünge hinzugefügt werden sollen. |
+| [LineJumpCodeValue](../com.aspose.diagram/linejumpcodevalue) | Bestimmt die dynamischen Verbinder, zu denen Sprünge hinzugefügt werden sollen. |
+| [LineJumpStyle](../com.aspose.diagram/linejumpstyle) | Gibt den Linien‑Sprungstil für alle Verbinder auf der Zeichen‑Seite an, die keinen lokalen Linien‑Sprungstil haben. |
+| [LineJumpStyleValue](../com.aspose.diagram/linejumpstylevalue) | Gibt den Linien‑Sprungstil für alle Verbinder auf der Zeichen‑Seite an, die keinen lokalen Linien‑Sprungstil haben. |
+| [LineRouteExt](../com.aspose.diagram/linerouteext) | Gibt das Standard‑Aussehen für alle Verbinder auf einer Seite an. |
+| [LineRouteExtValue](../com.aspose.diagram/linerouteextvalue) | Gibt das Standard‑Aussehen für alle Verbinder auf einer Seite an. |
+| [LineTo](../com.aspose.diagram/lineto) | Enthält die x- und y-Koordinaten des Endknotens eines geraden Liniensegments. |
+| [LineToCollection](../com.aspose.diagram/linetocollection) | LineTo-Sammlung. |
+| [ListBoxActiveXControl](../com.aspose.diagram/listboxactivexcontrol) | Stellt ein ListBox ActiveX-Steuerelement dar. |
+| [LoadFileFormat](../com.aspose.diagram/loadfileformat) | Aufzählung für die Auswahl des Diagrammformat-Ladevorgangs. |
+| [LoadOptions](../com.aspose.diagram/loadoptions) | Ermöglicht das Angeben zusätzlicher Optionen beim Laden eines Diagramms in ein Diagramm-Objekt. |
+| [LocalizeFont](../com.aspose.diagram/localizefont) | Gibt an, ob der Formtext lokalisiert (in eine andere Sprache übersetzt) werden soll. |
+| [LocalizeFontValue](../com.aspose.diagram/localizefontvalue) | Gibt an, ob der Formtext lokalisiert (in eine andere Sprache übersetzt) werden soll. |
+| [Margin](../com.aspose.diagram/margin) | Gibt den Rand an. |
+| [Master](../com.aspose.diagram/master) | Enthält Elemente, die einen Master für das Dokument definieren. |
+| [MasterCollection](../com.aspose.diagram/mastercollection) | Master-Sammlung. |
+| [MasterShortcut](../com.aspose.diagram/mastershortcut) | Gibt eine im Dokument definierte Master-Verknüpfung an. |
+| [MasterShortcutCollection](../com.aspose.diagram/mastershortcutcollection) | MasterShortcut-Sammlung. |
+| [MeasureConst](../com.aspose.diagram/measureconst) | Einheiten von\\ Maß. |
+| [MemoryFontSource](../com.aspose.diagram/memoryfontsource) | Stellt die einzelne TrueType-Schriftdatei dar, die im Speicher abgelegt ist. |
+| [MilestoneHelper](../com.aspose.diagram/milestonehelper) | MilestoneHelper zum Festlegen der Eigenschaft einer Meilenstein-Form. |
+| [Misc](../com.aspose.diagram/misc) | Enthält verschiedene Elemente von Formen und Gruppen, wie solche, die die Auswahlhervorhebung und Sichtbarkeit steuern. |
+| [MoveTo](../com.aspose.diagram/moveto) | Enthält die x- und y-Koordinaten des ersten Scheitelpunkts einer Form oder die x- und y-Koordinaten des ersten Scheitelpunkts nach einem Pfadunterbruch. |
+| [MoveToCollection](../com.aspose.diagram/movetocollection) | MoveTo-Sammlung. |
+| [NURBSTo](../com.aspose.diagram/nurbsto) | Enthält die x- und y-Koordinaten, die Position des vorletzten Knoten, die Position des letzten Gewichts, die Position des ersten Knotens, die Position des ersten Gewichts sowie die Formel für einen nicht-uniformen rationalen B-Spline (NURBS). |
+| [NURBSToCollection](../com.aspose.diagram/nurbstocollection) | NURBSTo-Sammlung. |
+| [ObjType](../com.aspose.diagram/objtype) | Gibt an, ob Objekte in Diagrammen platzierbar oder routbar sind, wenn Sie Microsoft Visio zum Anordnen von Formen auf der Zeichenfläche verwenden. |
+| [ObjTypeValue](../com.aspose.diagram/objtypevalue) | Gibt an, ob Objekte in Diagrammen platzierbar oder routbar sind, wenn Sie Microsoft Visio zum Anordnen von Formen auf der Zeichenfläche verwenden. |
+| [ObjectKind](../com.aspose.diagram/objectkind) | Gibt den Typ des Textfelds an. |
+| [ObjectKindValue](../com.aspose.diagram/objectkindvalue) | Gibt den Typ des Textfelds an. |
+| [ObjectType](../com.aspose.diagram/objecttype) | Wenn das Attribut ForeignType "Object" ist, muss das Element ForeignData ebenfalls ein Attribut ObjectType besitzen. |
+| [OptionsValue](../com.aspose.diagram/optionsvalue) | Optionaler vorzeichenloser Ganzzahlwert. |
+| [OutputFormat](../com.aspose.diagram/outputformat) | Gibt das Ausgabeformat für eine Zeichnung an. |
+| [OutputFormatValue](../com.aspose.diagram/outputformatvalue) | Gibt das Ausgabeformat für eine Zeichnung an. |
+| [Page](../com.aspose.diagram/page) | Enthält Elemente, die eine Seite im Dokument definieren. |
+| [PageCollection](../com.aspose.diagram/pagecollection) | Seitensammlung. |
+| [PageEndSavingArgs](../com.aspose.diagram/pageendsavingargs) | Informationen für eine Seite beenden den Speicherungsprozess. |
+| [PageLayout](../com.aspose.diagram/pagelayout) | Enthält Zellen, die die Seitengestaltungseinstellungen für Formen und Verbinder steuern, wie z. B. den Abstand zwischen allen Formen auf der Seite, den Abstand zwischen allen Verbindern auf der Seite und den Routing‑Stil für alle Verbinder auf der Seite. |
+| [PageLineJumpDirX](../com.aspose.diagram/pagelinejumpdirx) | Gibt die Richtung von Liniensprüngen auf horizontalen Segmenten dynamischer Verbinder auf der Zeichenfläche an, für die keine lokale Sprungrichtung festgelegt wurde. |
+| [PageLineJumpDirXValue](../com.aspose.diagram/pagelinejumpdirxvalue) | Gibt die Richtung von Liniensprüngen auf horizontalen Segmenten dynamischer Verbinder auf der Zeichenfläche an, für die keine lokale Sprungrichtung festgelegt wurde. |
+| [PageLineJumpDirY](../com.aspose.diagram/pagelinejumpdiry) | Gibt die Richtung von Liniensprüngen auf vertikalen dynamischen Verbindern auf der Zeichenfläche an, für die keine lokale Sprungrichtung festgelegt wurde. |
+| [PageLineJumpDirYValue](../com.aspose.diagram/pagelinejumpdiryvalue) | Gibt die Richtung von Liniensprüngen auf vertikalen dynamischen Verbindern auf der Zeichenfläche an, für die keine lokale Sprungrichtung festgelegt wurde. |
+| [PageProps](../com.aspose.diagram/pageprops) | Enthält Zellen, die Seitenattribute steuern, wie Seitenbreite, -höhe und Maßstab. |
+| [PageSavingArgs](../com.aspose.diagram/pagesavingargs) | Informationen für einen Seiten‑Speicherungsprozess. |
+| [PageSheet](../com.aspose.diagram/pagesheet) | Enthält Elemente, die das Seitenblatt für ein Seiten‑ oder Master‑Element definieren. |
+| [PageSize](../com.aspose.diagram/pagesize) | Enthält Informationen zur Seitengröße der erzeugten Bilder. |
+| [PageStartSavingArgs](../com.aspose.diagram/pagestartsavingargs) | Informationen für eine Seite starten den Speicherungsprozess. |
+| [PaperSizeFormat](../com.aspose.diagram/papersizeformat) | Aufzählung für die Auswahl des Papiergrößen‑Formats beim Speichern. |
+| [Para](../com.aspose.diagram/para) | Enthält die Absatzformatierungselemente für den Text der Form, wie Einzüge, Zeilenabstand, Aufzählungszeichen und horizontale Ausrichtung der Absätze. |
+| [ParaCollection](../com.aspose.diagram/paracollection) | Absatzsammlung. |
+| [PdfCompliance](../com.aspose.diagram/pdfcompliance) | Gibt das PDF‑Konformitätsniveau für die Ausgabedatei an. |
+| [PdfDigitalSignatureHashAlgorithm](../com.aspose.diagram/pdfdigitalsignaturehashalgorithm) | Gibt den digitalen Hash‑Algorithmus an, der von der digitalen Signatur verwendet wird. |
+| [PdfEncryptionAlgorithm](../com.aspose.diagram/pdfencryptionalgorithm) | Gibt den zu verwendenden Verschlüsselungsalgorithmus zum Verschlüsseln eines PDF‑Dokuments an. |
+| [PdfEncryptionDetails](../com.aspose.diagram/pdfencryptiondetails) | Enthält Details zur PDF‑Verschlüsselung. |
+| [PdfPermissions](../com.aspose.diagram/pdfpermissions) | Gibt die Benutzerberechtigungen für das PDF‑Dokument an. |
+| [PdfSaveOptions](../com.aspose.diagram/pdfsaveoptions) | Ermöglicht das Angeben zusätzlicher Optionen beim Rendern von Diagrammseiten zu PDF. |
+| [PdfTextCompression](../com.aspose.diagram/pdftextcompression) | Gibt einen Kompressionstyp an, der auf alle Inhalte der PDF‑Datei außer Bildern angewendet wird. |
+| [PinPosValue](../com.aspose.diagram/pinposvalue) | Gibt die Pin‑Position für die Form an. |
+| [PixelOffsetMode](../com.aspose.diagram/pixeloffsetmode) | Gibt an, wie Pixel beim Rendern versetzt werden. |
+| [PlaceDepth](../com.aspose.diagram/placedepth) | Für eine automatisch angeordnete Zeichnung gibt die Methode an, mit der die Zeichnung vor der Erstellung des Layouts analysiert wird, und bestimmt den Layouttyp. |
+| [PlaceDepthValue](../com.aspose.diagram/placedepthvalue) | Für eine automatisch angeordnete Zeichnung gibt die Methode an, mit der die Zeichnung vor der Erstellung des Layouts analysiert wird, und bestimmt den Layouttyp. |
+| [PlaceFlip](../com.aspose.diagram/placeflip) | Gibt an, wie platzierbare Formen auf einer Seite gedreht und/oder gespiegelt werden, wenn Formen mit dem Befehl „Formen anordnen“ in Microsoft Visio angeordnet werden. |
+| [PlaceFlipValue](../com.aspose.diagram/placeflipvalue) | Gibt an, wie platzierbare Formen auf einer Seite gedreht und/oder gespiegelt werden, wenn Formen mit dem Befehl „Formen anordnen“ in Microsoft Visio angeordnet werden. |
+| [PlaceStyle](../com.aspose.diagram/placestyle) | Gibt an, wie Formen auf der Seite platziert werden, wenn Formen angeordnet werden, nachdem ein Benutzer „Formen anordnen“ (Form‑Menü) auswählt. |
+| [PlaceStyleValue](../com.aspose.diagram/placestylevalue) | Gibt an, wie Formen auf der Seite platziert werden, wenn Formen angeordnet werden, nachdem ein Benutzer „Formen anordnen“ (Form‑Menü) auswählt. |
+| [PolylineTo](../com.aspose.diagram/polylineto) | Enthält x- und y-Koordinaten des letzten Punktes einer Polylinie und einer Polylinienformel. |
+| [PolylineToCollection](../com.aspose.diagram/polylinetocollection) | PolylineTo Sammlung. |
+| [Pos](../com.aspose.diagram/pos) | Gibt die Position des Textes der Shape relativ zur Grundlinie an. |
+| [PosValue](../com.aspose.diagram/posvalue) | Gibt die Position des Textes der Shape relativ zur Grundlinie an. |
+| [Pp](../com.aspose.diagram/pp) | Gibt den Beginn eines Absatz-Eigenschaften-Laufs an. |
+| [PresetCameraType](../com.aspose.diagram/presetcameratype) | Stellt verschiedene algorithmische Methoden zum Einstellen aller Kameraeigenschaften, einschließlich Position, dar. |
+| [PresetColorMatricsValue](../com.aspose.diagram/presetcolormatricsvalue) | Wird verwendet, um die Farbeigenschaft von Shape theme style festzulegen. |
+| [PresetQuickStyleValue](../com.aspose.diagram/presetquickstylevalue) | Gibt den Schnellstilwert des Themas an. |
+| [PresetShadowType](../com.aspose.diagram/presetshadowtype) | Stellt den voreingestellten Schattentyp dar. |
+| [PresetStyleMatricsValue](../com.aspose.diagram/presetstylematricsvalue) | Wird verwendet, um die Eigenschaft von Shape theme style festzulegen. |
+| [PresetThemeValue](../com.aspose.diagram/presetthemevalue) | Gibt den Themenwert an. |
+| [PresetThemeVariantValue](../com.aspose.diagram/presetthemevariantvalue) | Gibt den Variantenwert des Themas an. |
+| [PreviewScope](../com.aspose.diagram/previewscope) | Gibt an, ob das Dokument eine Vorschau enthält und, falls ja, ob die Vorschau nur die erste Seite oder alle Seiten im Dokument zeigt. |
+| [PreviewScopeValue](../com.aspose.diagram/previewscopevalue) | Gibt an, ob das Dokument eine Vorschau enthält und, falls ja, ob die Vorschau nur die erste Seite oder alle Seiten im Dokument zeigt. |
+| [PrintPageOrientation](../com.aspose.diagram/printpageorientation) | Bestimmt, ob die Seite im Hoch- oder Querformat gedruckt wird. |
+| [PrintPageOrientationValue](../com.aspose.diagram/printpageorientationvalue) | Bestimmt, ob die Seite im Hoch- oder Querformat gedruckt wird. |
+| [PrintProps](../com.aspose.diagram/printprops) | Enthält Elemente, die steuern, wie die Zeichenfläche auf der Druckerseite formatiert (angezeigt) wird. |
+| [PrintSaveOptions](../com.aspose.diagram/printsaveoptions) | Ermöglicht das Angeben zusätzlicher Optionen beim Drucken des Diagramms. |
+| [Prop](../com.aspose.diagram/prop) | Enthält Elemente zur Definition benutzerdefinierter Eigenschaften und Elemente zur Zuordnung von Daten zu einer Form. |
+| [PropCollection](../com.aspose.diagram/propcollection) | Prop Sammlung. |
+| [PropType](../com.aspose.diagram/proptype) | Typ der Eigenschaft. |
+| [Protection](../com.aspose.diagram/protection) | Sperren hilft, unbeabsichtigte Änderungen an der Form zu verhindern, verhindert jedoch nicht, dass Microsoft Visio Werte unter anderen Umständen zurücksetzt. |
+| [RadioButtonActiveXControl](../com.aspose.diagram/radiobuttonactivexcontrol) | Stellt ein RadioButton ActiveX-Steuerelement dar. |
+| [RectangleAlignmentType](../com.aspose.diagram/rectanglealignmenttype) | Stellt dar, wie zwei Rechtecke relativ zueinander positioniert werden. |
+| [ReflectionEffectType](../com.aspose.diagram/reflectioneffecttype) |  |
+| [RelCubBezTo](../com.aspose.diagram/relcubbezto) | Enthält x- und y-Koordinaten für die Punkte eines RelCubBezTo. |
+| [RelCubBezToCollection](../com.aspose.diagram/relcubbeztocollection) | RelCubBezTo Sammlung. |
+| [RelEllipticalArcTo](../com.aspose.diagram/relellipticalarcto) | Enthält Elemente, die Informationen über einen elliptischen Bogen angeben. Koordinaten werden als relative Koordinaten angegeben. |
+| [RelEllipticalArcToCollection](../com.aspose.diagram/relellipticalarctocollection) | RelEllipticalArcTo Sammlung. |
+| [RelLineTo](../com.aspose.diagram/rellineto) | Enthält die x- und y-Koordinaten des Endknotens eines geraden Liniensegments. |
+| [RelLineToCollection](../com.aspose.diagram/rellinetocollection) | RelLineTo Sammlung. |
+| [RelMoveTo](../com.aspose.diagram/relmoveto) | Enthält die x- und y-Koordinaten des ersten Scheitelpunkts einer Form oder die x- und y-Koordinaten des ersten Scheitelpunkts nach einem Unterbrechung im Pfad. Koordinaten werden als relative Koordinaten angegeben. |
+| [RelMoveToCollection](../com.aspose.diagram/relmovetocollection) | RelMoveTo Sammlung. |
+| [RelQuadBezTo](../com.aspose.diagram/relquadbezto) | Enthält x- und y-Koordinaten für die Punkte eines RelQuadBezTo. |
+| [RelQuadBezToCollection](../com.aspose.diagram/relquadbeztocollection) | RelQuadBezTo Sammlung. |
+| [RemoveHiddenInfoItem](../com.aspose.diagram/removehiddeninfoitem) | Gibt an, dass versteckte Informationen aus dem Diagramm entfernt werden. |
+| [RenderingSaveOptions](../com.aspose.diagram/renderingsaveoptions) | Dies ist eine abstrakte Basisklasse für Klassen, die dem Benutzer ermöglichen, zusätzliche Optionen beim Speichern eines Diagramms in einem bestimmten Format anzugeben. |
+| [ResizeMode](../com.aspose.diagram/resizemode) | Gibt die aktuelle Einstellung für das Größenänderungsverhalten der Form an, wenn sie in einer Gruppe enthalten ist. |
+| [ResizeModeValue](../com.aspose.diagram/resizemodevalue) | Gibt die aktuelle Einstellung für das Größenänderungsverhalten der Form an, wenn sie in einer Gruppe enthalten ist. |
+| [Reviewer](../com.aspose.diagram/reviewer) | Enthält Elemente, die Identifizierungsinformationen über einen Dokumentprüfer enthalten. |
+| [ReviewerCollection](../com.aspose.diagram/reviewercollection) | Reviewer Sammlung. |
+| [RotationType](../com.aspose.diagram/rotationtype) | Gibt den Typ des Schattens für eine Form an. |
+| [RotationTypeValue](../com.aspose.diagram/rotationtypevalue) | Gibt den Projektionstyp der Effekt‑Eigenschaften einer Form an. |
+| [RouteStyle](../com.aspose.diagram/routestyle) | Gibt den Routing‑Stil und die Richtung für alle dynamischen Verbinder auf der Zeichenfläche an, die keinen lokalen Routing‑Stil haben. |
+| [RouteStyleValue](../com.aspose.diagram/routestylevalue) | Gibt den Routing‑Stil und die Richtung für alle dynamischen Verbinder auf der Zeichenfläche an, die keinen lokalen Routing‑Stil haben. |
+| [Row](../com.aspose.diagram/row) | Zeigt eine Zeile im Datenrecordset an. |
+| [RowCollection](../com.aspose.diagram/rowcollection) | Row Sammlung. |
+| [Rule](../com.aspose.diagram/rule) | Stellt eine einzelne Validierungsregel in einem Diagramm‑Validierungsregelset dar. |
+| [RuleCollection](../com.aspose.diagram/rulecollection) | Regel Sammlung. |
+| [RuleInfo](../com.aspose.diagram/ruleinfo) | Gibt Informationen über die Validierungsregel an, auf die sich das übergeordnete Validierungsproblem bezieht. |
+| [RuleSet](../com.aspose.diagram/ruleset) | Stellt ein Satz von Diagramm‑Validierungsregeln dar. |
+| [RuleSetCollection](../com.aspose.diagram/rulesetcollection) | RuleSet Sammlung. |
+| [RuleValue](../com.aspose.diagram/rulevalue) | Regelwert. |
+| [RulerDensity](../com.aspose.diagram/rulerdensity) | Gibt die horizontalen Unterteilungen auf dem Lineal für die Seite an. |
+| [RulerDensityValue](../com.aspose.diagram/rulerdensityvalue) | Gibt die horizontalen Unterteilungen auf dem Lineal für die Seite an. |
+| [RulerGrid](../com.aspose.diagram/rulergrid) | Enthält Elemente, die die Einstellungen der Lineale und des Rasters der Seite festlegen. |
+| [SVGSaveOptions](../com.aspose.diagram/svgsaveoptions) | Ermöglicht das Angeben zusätzlicher Optionen beim Rendern von Diagrammseiten zu SVG. |
+| [SaveFileFormat](../com.aspose.diagram/savefileformat) | Aufzählung für die Auswahl des Diagrammformat‑Speicherns. |
+| [SaveOptions](../com.aspose.diagram/saveoptions) | Dies ist eine abstrakte Basisklasse für Klassen, die dem Benutzer ermöglichen, zusätzliche Optionen beim Speichern eines Diagramms in einem bestimmten Format anzugeben. |
+| [Scratch](../com.aspose.diagram/scratch) | Enthält einen Arbeitsbereich zum Eingeben und Testen von Formeln, auf die von anderen Elementen verwiesen wird. |
+| [ScratchCollection](../com.aspose.diagram/scratchcollection) | Scratch-Sammlung. |
+| [ScrollBarActiveXControl](../com.aspose.diagram/scrollbaractivexcontrol) | Stellt das ScrollBar-Steuerelement dar. |
+| [SelectMode](../com.aspose.diagram/selectmode) | Gibt an, wie der Benutzer eine Gruppenform und deren Mitglieder auswählt. |
+| [SelectModeValue](../com.aspose.diagram/selectmodevalue) | Gibt an, wie der Benutzer eine Gruppenform und deren Mitglieder auswählt. |
+| [Shape](../com.aspose.diagram/shape) | Enthält Elemente, die eine Form in einem Master, einer Seite oder einem Gruppenform-Element definieren. |
+| [ShapeCollection](../com.aspose.diagram/shapecollection) | Sammlung von Formen. |
+| [ShapeFixedCode](../com.aspose.diagram/shapefixedcode) | Gibt das Platzierungsverhalten für eine platzierbare Form an. |
+| [ShapeFixedCodeValue](../com.aspose.diagram/shapefixedcodevalue) | Gibt das Platzierungsverhalten für eine platzierbare Form an. |
+| [ShapePlaceFlip](../com.aspose.diagram/shapeplaceflip) | Gibt an, wie eine platzierbare Form auf der Seite gedreht und/oder gespiegelt wird, wenn ein Benutzer Lay Out Shapes (Shapes‑Menü) auswählt. |
+| [ShapePlaceFlipValue](../com.aspose.diagram/shapeplaceflipvalue) | Gibt an, wie eine platzierbare Form auf der Seite gedreht und/oder gespiegelt wird, wenn ein Benutzer Lay Out Shapes (Shapes‑Menü) auswählt. |
+| [ShapePlaceStyle](../com.aspose.diagram/shapeplacestyle) | Bestimmt den Platzierungsstil für untergeordnete Elemente. |
+| [ShapePlaceStyleValue](../com.aspose.diagram/shapeplacestylevalue) | Bestimmt den Platzierungsstil für untergeordnete Elemente. |
+| [ShapePlowCode](../com.aspose.diagram/shapeplowcode) | Gibt an, ob sich eine platzierbare Form entfernt, wenn Sie eine andere platzierbare Form in die Nähe der Form auf der Zeichenfläche ziehen. |
+| [ShapePlowCodeValue](../com.aspose.diagram/shapeplowcodevalue) | Gibt an, ob sich eine platzierbare Form entfernt, wenn Sie eine andere platzierbare Form in die Nähe der Form auf der Zeichenfläche ziehen. |
+| [ShapeRouteStyle](../com.aspose.diagram/shaperoutestyle) | Gibt den Routing‑Stil und die Richtung für einen Verbinder auf der Zeichenfläche an. |
+| [ShapeRouteStyleValue](../com.aspose.diagram/shaperoutestylevalue) | Gibt den Routing‑Stil und die Richtung für einen Verbinder auf der Zeichenfläche an. |
+| [ShapeShdwShow](../com.aspose.diagram/shapeshdwshow) | Gibt den Typ des Schattens für eine Form an. |
+| [ShapeShdwShowValue](../com.aspose.diagram/shapeshdwshowvalue) | Gibt den Typ des Schattens für eine Form an. |
+| [ShapeShdwType](../com.aspose.diagram/shapeshdwtype) | Gibt den Typ des Schattens für eine Form an. |
+| [ShapeShdwTypeValue](../com.aspose.diagram/shapeshdwtypevalue) | Gibt den Typ des Schattens für eine Form an. |
+| [ShdwType](../com.aspose.diagram/shdwtype) | Zeigt den Standard‑Schattentyp für eine Seite an. |
+| [ShdwTypeValue](../com.aspose.diagram/shdwtypevalue) | Zeigt den Standard‑Schattentyp für eine Seite an. |
+| [ShowDropButtonType](../com.aspose.diagram/showdropbuttontype) | Gibt an, wann die Drop‑Schaltfläche angezeigt wird |
+| [SmartTagDef](../com.aspose.diagram/smarttagdef) | Enthält Elemente, die Informationen für jedes für eine Form oder Seite definierte SmartTag enthalten. |
+| [SmartTagDefCollection](../com.aspose.diagram/smarttagdefcollection) | SmartTagDef‑Sammlung. |
+| [SmoothingMode](../com.aspose.diagram/smoothingmode) | Gibt an, ob Glättung (Antialiasing) auf Linien und Kurven sowie die Kanten von gefüllten Bereichen angewendet wird. |
+| [SnapExtensions](../com.aspose.diagram/snapextensions) | Gibt an, ob eine bestimmte Snap‑Erweiterungseinstellung für das aktive Fenster aktiviert oder deaktiviert ist. |
+| [SnapExtensionsValue](../com.aspose.diagram/snapextensionsvalue) | Gibt an, ob eine bestimmte Snap‑Erweiterungseinstellung für das aktive Fenster aktiviert oder deaktiviert ist. |
+| [SnapSettings](../com.aspose.diagram/snapsettings) | Gibt die Objekte an, an die Formen einrasten, wenn das Einrasten im Fenster aktiv ist. |
+| [SnapSettingsValue](../com.aspose.diagram/snapsettingsvalue) | Gibt die Objekte an, an die Formen einrasten, wenn das Einrasten im Fenster aktiv ist |
+| [SolutionXML](../com.aspose.diagram/solutionxml) | Enthält lösungsspezifische, wohlgeformte XML‑Daten, die in einem expliziten Namensraum vorangestellt sind und zusammen mit einem Dokument gespeichert werden. |
+| [SolutionXMLCollection](../com.aspose.diagram/solutionxmlcollection) | SolutionXML‑Sammlung. |
+| [SpinButtonActiveXControl](../com.aspose.diagram/spinbuttonactivexcontrol) | Stellt das SpinButton-Steuerelement dar. |
+| [SplineKnot](../com.aspose.diagram/splineknot) | Enthält X‑ und Y‑Koordinaten für den Kontrollpunkt einer Spline und den Knoten einer Spline, dargestellt durch die Elemente X, Y bzw. A. |
+| [SplineKnotCollection](../com.aspose.diagram/splineknotcollection) | SplineKnot‑Sammlung. |
+| [SplineStart](../com.aspose.diagram/splinestart) | Enthält X‑ und Y‑Koordinaten für den zweiten Kontrollpunkt einer Spline, ihren zweiten Knoten, ihren ersten Knoten, den letzten Knoten und den Grad der Spline. |
+| [SplineStartCollection](../com.aspose.diagram/splinestartcollection) | SplineStart‑Sammlung. |
+| [Str2Value](../com.aspose.diagram/str2value) | String-Wert. |
+| [StrValue](../com.aspose.diagram/strvalue) | String-Wert |
+| [StreamProviderOptions](../com.aspose.diagram/streamprovideroptions) | Stellt die Stream-Optionen dar. |
+| [Style](../com.aspose.diagram/style) | Gibt die Zeichenformatierung an, die auf einen Textbereich im Textblock der Form angewendet wird. |
+| [StyleProp](../com.aspose.diagram/styleprop) | Enthält Elemente, die das Stilverhalten steuern, z. B. ob ein Stil Text-, Linien- und Füllattribute enthält. |
+| [StyleSheet](../com.aspose.diagram/stylesheet) | Stellt einen im Dokument definierten Stil dar. |
+| [StyleSheetCollection](../com.aspose.diagram/stylesheetcollection) | Sammlung von StyleSheets. |
+| [StyleValue](../com.aspose.diagram/stylevalue) | Gibt die Zeichenformatierung an, die auf einen Textbereich im Textblock der Form angewendet wird. |
+| [Tab](../com.aspose.diagram/tab) | Enthält eine Sammlung von Tab-Elementen. |
+| [TabCollection](../com.aspose.diagram/tabcollection) | Enthält eine Sammlung von Tab-Elementen |
+| [TabsCollection](../com.aspose.diagram/tabscollection) | Enthält eine Sammlung von TabCollection-Elementen |
+| [Text](../com.aspose.diagram/text) | Enthält den Text einer Form. |
+| [TextBlock](../com.aspose.diagram/textblock) | Enthält Elemente, die die Ausrichtung, Ränder und Standard-Tabstopp-Positionen des Textes im Textblock einer Form festlegen. |
+| [TextBoxActiveXControl](../com.aspose.diagram/textboxactivexcontrol) | Stellt ein Textfeld-ActiveX-Steuerelement dar. |
+| [TextCollection](../com.aspose.diagram/textcollection) | Enthält den Text einer Form. |
+| [TextDirection](../com.aspose.diagram/textdirection) | Gibt die Richtung der Zeichen in einem Textblock an. |
+| [TextDirectionValue](../com.aspose.diagram/textdirectionvalue) | Gibt die Richtung der Zeichen in einem Textblock an. |
+| [TextXForm](../com.aspose.diagram/textxform) | Enthält Elemente, die Positionsinformationen zum Textblock einer Form angeben. |
+| [ThreeDFormat](../com.aspose.diagram/threedformat) | Stellt die dreidimensionale Formatierung einer Form dar. |
+| [TiffCompression](../com.aspose.diagram/tiffcompression) | Gibt an, welche Art von Kompression beim Speichern von Seiten im TIFF-Format angewendet werden soll. |
+| [TimeLineHelper](../com.aspose.diagram/timelinehelper) | TimeLineHelper zum Festlegen der Eigenschaft einer Zeitlinienform. |
+| [ToPartValue](../com.aspose.diagram/topartvalue) | Der Teil einer Form, zu dem eine Verbindung hergestellt wird. |
+| [ToggleButtonActiveXControl](../com.aspose.diagram/togglebuttonactivexcontrol) | Stellt ein ToggleButton-ActiveX-Steuerelement dar. |
+| [Tp](../com.aspose.diagram/tp) | Gibt den Beginn eines Tab-Eigenschaftslaufs an. |
+| [Txt](../com.aspose.diagram/txt) | Text der Form |
+| [TypeConnection](../com.aspose.diagram/typeconnection) | Gibt verschiedene Typen an, basierend auf dem Element, in dem es enthalten ist. |
+| [TypeConnectionValue](../com.aspose.diagram/typeconnectionvalue) | Gibt verschiedene Typen an, basierend auf dem Element, in dem es enthalten ist. |
+| [TypeField](../com.aspose.diagram/typefield) | Typ gibt einen Datentyp für den Textfeldwert an. |
+| [TypeFieldValue](../com.aspose.diagram/typefieldvalue) | Typ gibt einen Datentyp für den Textfeldwert an. |
+| [TypeProp](../com.aspose.diagram/typeprop) | Typ gibt einen Datentyp für den benutzerdefinierten Eigenschaftswert an. |
+| [TypePropValue](../com.aspose.diagram/typepropvalue) | Typ gibt einen Datentyp für den benutzerdefinierten Eigenschaftswert an. |
+| [TypeValue](../com.aspose.diagram/typevalue) | Optionale Aufzählung. |
+| [UIVisibility](../com.aspose.diagram/uivisibility) | Gibt die Tab‑Ausrichtung an. |
+| [UIVisibilityValue](../com.aspose.diagram/uivisibilityvalue) | Gibt die Tab‑Ausrichtung an. |
+| [UnitFormulaErr](../com.aspose.diagram/unitformulaerr) | Gibt Attribute eines Elements an. |
+| [UnitFormulaErrV](../com.aspose.diagram/unitformulaerrv) | Angegebene Attribute eines Elements. |
+| [UnknownControl](../com.aspose.diagram/unknowncontrol) | Unbekannte Steuerung. |
+| [User](../com.aspose.diagram/user) | Enthält einen Arbeitsbereich zum Eingeben von Formeln in benutzerspezifischen Elementen, auf die von anderen Elementen und Add‑On‑Tools verwiesen wird. |
+| [UserCollection](../com.aspose.diagram/usercollection) | Benutzersammlung. |
+| [Validation](../com.aspose.diagram/validation) | Speichert Informationen zur Diagrammvalidierung für das Dokument. |
+| [ValidationProperties](../com.aspose.diagram/validationproperties) | Kapselt Eigenschaften, die sich auf die Validierung des Dokuments beziehen. |
+| [Value](../com.aspose.diagram/value) | Wert. |
+| [VbaModule](../com.aspose.diagram/vbamodule) | Stellt ein Modul dar, das im VBA‑Projekt enthalten ist. |
+| [VbaModuleCollection](../com.aspose.diagram/vbamodulecollection) | Stellt die Liste von [VbaModule](../com.aspose.diagram/vbamodule) dar |
+| [VbaModuleType](../com.aspose.diagram/vbamoduletype) | Stellt den Typ des VBA‑Moduls dar. |
+| [VbaProject](../com.aspose.diagram/vbaproject) | Stellt das VBA‑Projekt dar. |
+| [VbaProjectReference](../com.aspose.diagram/vbaprojectreference) | Stellt die Referenz des VBA‑Projekts dar. |
+| [VbaProjectReferenceCollection](../com.aspose.diagram/vbaprojectreferencecollection) | Stellt alle Referenzen des VBA‑Projekts dar. |
+| [VbaProjectReferenceType](../com.aspose.diagram/vbaprojectreferencetype) | Stellt den Typ der VBA‑Projekt‑Referenz dar. |
+| [VerticalAlign](../com.aspose.diagram/verticalalign) | Gibt die vertikale Ausrichtung des Textes innerhalb des Textblocks an. |
+| [VerticalAlignValue](../com.aspose.diagram/verticalalignvalue) | Gibt die vertikale Ausrichtung des Textes innerhalb des Textblocks an. |
+| [VisRuleTargetsValue](../com.aspose.diagram/visruletargetsvalue) | Gibt Inhalte an, die das Ziel der Validierungsregel definieren; wird an die Eigenschaft ValidationRule.TargetType übergeben und von ihr zurückgegeben. |
+| [WalkPreference](../com.aspose.diagram/walkpreference) | Gibt an, ob ein Endpunkt einer 1‑D‑Form zu einem horizontalen oder vertikalen Verbindungspunkt der Form, an die sie geklebt ist, mit dynamischem Kleben verschoben wird, wenn die Form in eine mehrdeutige Position bewegt wird. |
+| [WalkPreferenceValue](../com.aspose.diagram/walkpreferencevalue) | Gibt an, ob ein Endpunkt einer 1‑D‑Form zu einem horizontalen oder vertikalen Verbindungspunkt der Form, an die sie geklebt ist, mit dynamischem Kleben verschoben wird, wenn die Form in eine mehrdeutige Position bewegt wird. |
+| [WarningInfo](../com.aspose.diagram/warninginfo) | Warnungsinfo |
+| [WarningType](../com.aspose.diagram/warningtype) | Warnungstyp |
+| [Window](../com.aspose.diagram/window) | Stellt ein offenes Fenster in einer Microsoft‑Visio‑Instanz dar. |
+| [WindowCollection](../com.aspose.diagram/windowcollection) | Fenstersammlung. |
+| [WindowStateValue](../com.aspose.diagram/windowstatevalue) | Eine ganze Zahl, die Bit‑Flags angibt. |
+| [WindowTypeValue](../com.aspose.diagram/windowtypevalue) | Ein aufzählbarer Wert, der einer der folgenden sein kann: Drawing, Sheet, Stencil oder Icon. |
+| [XAMLSaveOptions](../com.aspose.diagram/xamlsaveoptions) | Ermöglicht das Angeben zusätzlicher Optionen beim Rendern von Diagrammseiten zu XAML. |
+| [XForm](../com.aspose.diagram/xform) | Enthält Elemente, die Linienattribute für eine Form steuern, wie Muster, Stärke und Farbe. |
+| [XForm1D](../com.aspose.diagram/xform1d) | Enthält x- und y-Koordinaten des Anfangs- und Endpunkts einer 1‑D‑Form. |
+| [XJustify](../com.aspose.diagram/xjustify) | Der x‑Versatz des Smart‑Tag‑Buttons relativ zu dem durch die X‑ und Y‑Elemente definierten Punkt. |
+| [XJustifyValue](../com.aspose.diagram/xjustifyvalue) | Der x‑Versatz des Smart‑Tag‑Buttons relativ zu dem durch die X‑ und Y‑Elemente definierten Punkt. |
+| [XPSSaveOptions](../com.aspose.diagram/xpssaveoptions) | Ermöglicht das Angeben zusätzlicher Optionen beim Rendern von Diagrammseiten zu XPS. |
+| [YJustify](../com.aspose.diagram/yjustify) | Gibt den y‑Versatz des Smart‑Tag‑Buttons relativ zu dem durch die X‑ und Y‑Elemente definierten Punkt an. |
+| [YJustifyValue](../com.aspose.diagram/yjustifyvalue) | Gibt den y‑Versatz des Smart‑Tag‑Buttons relativ zu dem durch die X‑ und Y‑Elemente definierten Punkt an. |
+
+## Schnittstellen
+
+| Schnittstelle | Beschreibung |
+| --- | --- |
+| [IPageSavingCallback](../com.aspose.diagram/ipagesavingcallback) | Steuert/zeigt den Fortschritt des Seiten‑Speichervorgangs an. |
+| [IStreamProvider](../com.aspose.diagram/istreamprovider) | Stellt den exportierten Stream‑Provider dar. |
+| [IWarningCallback](../com.aspose.diagram/iwarningcallback) | Rückruf‑Schnittstelle für Warnungen. |

--- a/german/java/com.aspose.diagram/abstractinterruptmonitor/_index.md
+++ b/german/java/com.aspose.diagram/abstractinterruptmonitor/_index.md
@@ -1,0 +1,147 @@
+---
+title: AbstractInterruptMonitor
+second_title: Aspose.Diagram for Java API-Referenz
+description: Überwacht Unterbrechungsanfragen bei allen zeitintensiven Vorgängen.
+type: docs
+weight: 10
+url: /de/java/com.aspose.diagram/abstractinterruptmonitor/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public abstract class AbstractInterruptMonitor
+```
+
+Überwacht Unterbrechungsanfragen bei allen zeitintensiven Vorgängen.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [AbstractInterruptMonitor()](#AbstractInterruptMonitor--) |  |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [isInterruptionRequested()](#isInterruptionRequested--) | Gibt an, ob für den aktuellen Vorgang eine Unterbrechung angefordert wird. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AbstractInterruptMonitor() {#AbstractInterruptMonitor--}
+```
+public AbstractInterruptMonitor()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isInterruptionRequested() {#isInterruptionRequested--}
+```
+public abstract boolean isInterruptionRequested()
+```
+
+
+Gibt an, ob für den aktuellen Vorgang eine Unterbrechung angefordert wird. Wenn true, wird der aktuelle Vorgang unterbrochen.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/act/_index.md
+++ b/german/java/com.aspose.diagram/act/_index.md
@@ -1,0 +1,395 @@
+---
+title: Act
+second_title: Aspose.Diagram for Java API-Referenz
+description: Definiert benutzerdefinierte Befehlsnamen, die im Kontextmenü eines Objekts erscheinen, und legt die Aktionen fest, die die Befehle ausführen.
+type: docs
+weight: 11
+url: /de/java/com.aspose.diagram/act/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Act
+```
+
+Definiert benutzerdefinierte Befehlsnamen, die im Kontextmenü eines Objekts erscheinen, und legt die Aktionen fest, die die Befehle ausführen.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [Act()](#Act--) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAction()](#getAction--) | Enthält die Formel, die ausgeführt wird, wenn ein Benutzer den in dem entsprechenden Menü‑Element definierten Befehlsnamen anklickt. |
+| [getBeginGroup()](#getBeginGroup--) | Gibt an, ob über dieser Aktion ein Trennzeichen im Menü eingefügt wird. |
+| [getButtonFace()](#getButtonFace--) | Identifiziert das Symbol, das neben einem Eintrag im Kontextmenü angezeigt wird. |
+| [getChecked()](#getChecked--) | Bestimmt, ob neben dem Befehlsnamen im Kontextmenü einer Form ein Häkchen angezeigt wird. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getDisabled()](#getDisabled--) | Das deaktivierte Element bestimmt, ob der Befehlsname im Kontextmenü angezeigt wird. |
+| [getFlyoutChild()](#getFlyoutChild--) | Bestimmt, ob die Aktionszeile ein untergeordnetes Flyout‑Menü der letzten darüber liegenden Zeile ist, die kein Flyout‑Kind ist. |
+| [getID()](#getID--) | Die eindeutige ID des Elements innerhalb seines übergeordneten Elements. |
+| [getIX()](#getIX--) | Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements. |
+| [getInvisible()](#getInvisible--) | Das unsichtbare Element gibt an, ob die Aktion im Smart‑Tag oder Kontextmenü sichtbar ist. |
+| [getMenu()](#getMenu--) | Gibt den Namen des Befehls an, der im Kontextmenü einer Form oder Seite erscheint. |
+| [getName()](#getName--) | Der Name des Elements. |
+| [getNameU()](#getNameU--) | Der universelle Name des Elements. |
+| [getReadOnly()](#getReadOnly--) | Bestimmt, ob die Aktion im Smart‑Tag oder Kontextmenü schreibgeschützt ist. |
+| [getSortKey()](#getSortKey--) | Gibt eine Zahl an, die die Reihenfolge der Aktionen bestimmt, die im Kontext‑ oder Smart‑Tag‑Menü angezeigt werden. |
+| [getTagName()](#getTagName--) | Sie enthält den Namen des Smart-Tags, dem die Aktion zugeordnet ist. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/act\#getDel--) |
+| [setID(int value)](#setID-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getID()](../../com.aspose.diagram/act\#getID--) |
+| [setIX(int value)](#setIX-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getIX()](../../com.aspose.diagram/act\#getIX--) |
+| [setName(String value)](#setName-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getName()](../../com.aspose.diagram/act\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getNameU()](../../com.aspose.diagram/act\#getNameU--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Act() {#Act--}
+```
+public Act()
+```
+
+
+Konstruktor.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAction() {#getAction--}
+```
+public DoubleValue getAction()
+```
+
+
+Enthält die Formel, die ausgeführt wird, wenn ein Benutzer den in dem entsprechenden Menü‑Element definierten Befehlsnamen anklickt.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBeginGroup() {#getBeginGroup--}
+```
+public BoolValue getBeginGroup()
+```
+
+
+Gibt an, ob über dieser Aktion ein Trennzeichen im Menü eingefügt wird.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getButtonFace() {#getButtonFace--}
+```
+public Str2Value getButtonFace()
+```
+
+
+Identifiziert das Symbol, das neben einem Eintrag im Kontextmenü angezeigt wird.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getChecked() {#getChecked--}
+```
+public BoolValue getChecked()
+```
+
+
+Bestimmt, ob neben dem Befehlsnamen im Kontextmenü einer Form ein Häkchen angezeigt wird.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getDisabled() {#getDisabled--}
+```
+public BoolValue getDisabled()
+```
+
+
+Das deaktivierte Element bestimmt, ob der Befehlsname im Kontextmenü angezeigt wird.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getFlyoutChild() {#getFlyoutChild--}
+```
+public BoolValue getFlyoutChild()
+```
+
+
+Bestimmt, ob die Aktionszeile ein untergeordnetes Flyout‑Menü der letzten darüber liegenden Zeile ist, die kein Flyout‑Kind ist.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+Die eindeutige ID des Elements innerhalb seines übergeordneten Elements.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements.
+
+**Returns:**
+int
+### getInvisible() {#getInvisible--}
+```
+public BoolValue getInvisible()
+```
+
+
+Das unsichtbare Element gibt an, ob die Aktion im Smart‑Tag oder Kontextmenü sichtbar ist.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getMenu() {#getMenu--}
+```
+public Str2Value getMenu()
+```
+
+
+Gibt den Namen des Befehls an, der im Kontextmenü einer Form oder Seite erscheint.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Der Name des Elements.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+Der universelle Name des Elements.
+
+**Returns:**
+java.lang.String
+### getReadOnly() {#getReadOnly--}
+```
+public BoolValue getReadOnly()
+```
+
+
+Bestimmt, ob die Aktion im Smart‑Tag oder Kontextmenü schreibgeschützt ist.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getSortKey() {#getSortKey--}
+```
+public Str2Value getSortKey()
+```
+
+
+Gibt eine Zahl an, die die Reihenfolge der Aktionen bestimmt, die im Kontext‑ oder Smart‑Tag‑Menü angezeigt werden.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getTagName() {#getTagName--}
+```
+public Str2Value getTagName()
+```
+
+
+Sie enthält den Namen des Smart-Tags, dem die Aktion zugeordnet ist.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/act\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getID()](../../com.aspose.diagram/act\#getID--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getIX()](../../com.aspose.diagram/act\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getName()](../../com.aspose.diagram/act\#getName--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getNameU()](../../com.aspose.diagram/act\#getNameU--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/actcollection/_index.md
+++ b/german/java/com.aspose.diagram/actcollection/_index.md
@@ -1,0 +1,234 @@
+---
+title: ActCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: Act-Sammlung.
+type: docs
+weight: 12
+url: /de/java/com.aspose.diagram/actcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ActCollection extends Collection
+```
+
+Act-Sammlung.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [add(Act item)](#add-com.aspose.diagram.Act-) | Füge das Act-Objekt zur Sammlung hinzu. |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [getAct(int ID)](#getAct-int-) | Liefert das Element mit der angegebenen ID. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Act item)](#remove-com.aspose.diagram.Act-) | Entferne das Act-Objekt aus der Sammlung. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Act item) {#add-com.aspose.diagram.Act-}
+```
+public int add(Act item)
+```
+
+
+Füge das Act-Objekt zur Sammlung hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [Act](../../com.aspose.diagram/act) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Act get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[Act](../../com.aspose.diagram/act) - 
+### getAct(int ID) {#getAct-int-}
+```
+public Act getAct(int ID)
+```
+
+
+Liefert das Element mit der angegebenen ID.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| ID | int |  |
+
+**Returns:**
+[Act](../../com.aspose.diagram/act) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Act item) {#remove-com.aspose.diagram.Act-}
+```
+public void remove(Act item)
+```
+
+
+Entferne das Act-Objekt aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [Act](../../com.aspose.diagram/act) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/activexcontrol/_index.md
+++ b/german/java/com.aspose.diagram/activexcontrol/_index.md
@@ -1,0 +1,422 @@
+---
+title: ActiveXControl
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt das ActiveX-Steuerelement dar.
+type: docs
+weight: 13
+url: /de/java/com.aspose.diagram/activexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase)
+```
+public abstract class ActiveXControl extends ActiveXControlBase
+```
+
+Stellt das ActiveX-Steuerelement dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBackOleColor()](#getBackOleColor--) | die OLE‑Farbe des Hintergrunds. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | die Binärdaten des Steuerelements. |
+| [getForeOleColor()](#getForeOleColor--) | die OLE‑Farbe des Vordergrunds. |
+| [getHeight()](#getHeight--) | die Höhe des Steuerelements in Punkt‑Einheiten. |
+| [getIMEMode()](#getIMEMode--) | der Standard‑Laufzeitmodus des Input Method Editors für das Steuerelement, wenn es den Fokus erhält. |
+| [getMouseIcon()](#getMouseIcon--) | ein benutzerdefiniertes Symbol, das als Mauszeiger für das Steuerelement angezeigt wird. |
+| [getMousePointer()](#getMousePointer--) | der Typ des als Mauszeiger für das Steuerelement angezeigten Symbols. |
+| [getType()](#getType--) | Ermittelt den Typ des ActiveX-Steuerelements. |
+| [getWidth()](#getWidth--) | die Breite des Steuerelements in Punkt-Einheiten. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | Gibt an, ob das Steuerelement automatisch die Größe ändert, um seinen gesamten Inhalt anzuzeigen. |
+| [isEnabled()](#isEnabled--) | Gibt an, ob das Steuerelement den Fokus erhalten und auf benutzergenerierte Ereignisse reagieren kann. |
+| [isLocked()](#isLocked--) | Gibt an, ob Daten im Steuerelement für die Bearbeitung gesperrt sind. |
+| [isTransparent()](#isTransparent--) | Gibt an, ob das Steuerelement transparent ist. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setHeight(double value)](#setHeight-double-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setIMEMode(int value)](#setIMEMode-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) |
+| [setLocked(boolean value)](#setLocked-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | Für die Beschreibung dieser Eigenschaft siehe bitte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) |
+| [setWidth(double value)](#setWidth-double-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+die OLE‑Farbe des Hintergrunds.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+die Binärdaten des Steuerelements.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+Die OLE-Farbe des Vordergrunds. Gilt nicht für das Image-Steuerelement.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+die Höhe des Steuerelements in Punkt‑Einheiten.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+der Standard‑Laufzeitmodus des Input Method Editors für das Steuerelement, wenn es den Fokus erhält.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+ein benutzerdefiniertes Symbol, das als Mauszeiger für das Steuerelement angezeigt wird.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+der Typ des als Mauszeiger für das Steuerelement angezeigten Symbols.
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public abstract int getType()
+```
+
+
+Ermittelt den Typ des ActiveX-Steuerelements.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+die Breite des Steuerelements in Punkt-Einheiten.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+Gibt an, ob das Steuerelement automatisch die Größe ändert, um seinen gesamten Inhalt anzuzeigen.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+Gibt an, ob das Steuerelement den Fokus erhalten und auf benutzergenerierte Ereignisse reagieren kann.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+Gibt an, ob Daten im Steuerelement für die Bearbeitung gesperrt sind.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+Gibt an, ob das Steuerelement transparent ist.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/activexcontrolbase/_index.md
+++ b/german/java/com.aspose.diagram/activexcontrolbase/_index.md
@@ -1,0 +1,297 @@
+---
+title: ActiveXControlBase
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt das ActiveX-Steuerelement dar.
+type: docs
+weight: 14
+url: /de/java/com.aspose.diagram/activexcontrolbase/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public abstract class ActiveXControlBase
+```
+
+Stellt das ActiveX-Steuerelement dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBackOleColor()](#getBackOleColor--) | die OLE‑Farbe des Hintergrunds. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | die Binärdaten des Steuerelements. |
+| [getForeOleColor()](#getForeOleColor--) | die OLE‑Farbe des Vordergrunds. |
+| [getHeight()](#getHeight--) | die Höhe des Steuerelements in Punkt‑Einheiten. |
+| [getMouseIcon()](#getMouseIcon--) | ein benutzerdefiniertes Symbol, das als Mauszeiger für das Steuerelement angezeigt wird. |
+| [getMousePointer()](#getMousePointer--) | der Typ des als Mauszeiger für das Steuerelement angezeigten Symbols. |
+| [getType()](#getType--) | Ermittelt den Typ des ActiveX-Steuerelements. |
+| [getWidth()](#getWidth--) | die Breite des Steuerelements in Punkt-Einheiten. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setHeight(double value)](#setHeight-double-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | Für die Beschreibung dieser Eigenschaft siehe bitte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setWidth(double value)](#setWidth-double-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+die OLE‑Farbe des Hintergrunds.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+die Binärdaten des Steuerelements.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+Die OLE-Farbe des Vordergrunds. Gilt nicht für das Image-Steuerelement.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+die Höhe des Steuerelements in Punkt‑Einheiten.
+
+**Returns:**
+double
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+ein benutzerdefiniertes Symbol, das als Mauszeiger für das Steuerelement angezeigt wird.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+der Typ des als Mauszeiger für das Steuerelement angezeigten Symbols.
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public abstract int getType()
+```
+
+
+Ermittelt den Typ des ActiveX-Steuerelements.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+die Breite des Steuerelements in Punkt-Einheiten.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/activexpersistencetype/_index.md
+++ b/german/java/com.aspose.diagram/activexpersistencetype/_index.md
@@ -1,0 +1,165 @@
+---
+title: ActiveXPersistenceType
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt die Persistenzmethode zum Speichern eines ActiveX-Steuerelements dar.
+type: docs
+weight: 15
+url: /de/java/com.aspose.diagram/activexpersistencetype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ActiveXPersistenceType
+```
+
+Stellt die Persistenzmethode zum Speichern eines ActiveX-Steuerelements dar.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [PROPERTY_BAG](#PROPERTY-BAG) | Die Daten werden als XML‑Daten gespeichert. |
+| [STORAGE](#STORAGE) | Die Daten werden als binäre Speicher‑Daten gespeichert. |
+| [STREAM](#STREAM) | Die Daten werden als binäre Stream‑Daten gespeichert. |
+| [STREAM_INIT](#STREAM-INIT) | Die Daten werden als binäre StreamInit‑Daten gespeichert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PROPERTY_BAG {#PROPERTY-BAG}
+```
+public static final int PROPERTY_BAG
+```
+
+
+Die Daten werden als XML‑Daten gespeichert.
+
+### STORAGE {#STORAGE}
+```
+public static final int STORAGE
+```
+
+
+Die Daten werden als binäre Speicher‑Daten gespeichert.
+
+### STREAM {#STREAM}
+```
+public static final int STREAM
+```
+
+
+Die Daten werden als binäre Stream‑Daten gespeichert.
+
+### STREAM_INIT {#STREAM-INIT}
+```
+public static final int STREAM_INIT
+```
+
+
+Die Daten werden als binäre StreamInit‑Daten gespeichert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/align/_index.md
+++ b/german/java/com.aspose.diagram/align/_index.md
@@ -1,0 +1,227 @@
+---
+title: Align
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt die Ausrichtung einer Form relativ zur Führungslinie oder zum Führungspunkt an, an dem die Form befestigt ist.
+type: docs
+weight: 16
+url: /de/java/com.aspose.diagram/align/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Align
+```
+
+Gibt die Ausrichtung einer Form in Bezug auf die Führung oder den Führungspunkt an, an dem die Form befestigt ist. Das Align-Element erscheint nur bei Formen, die an Führungen oder Führungspunkten befestigt sind.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAlignBottom()](#getAlignBottom--) | Bestimmt die vertikale Position, relativ zum Ursprung des übergeordneten Elements, einer horizontalen Führung oder eines Führungspunkts, an dem die untere Begrenzung der Form ausgerichtet ist. |
+| [getAlignCenter()](#getAlignCenter--) | Bestimmt die horizontale Position, relativ zum Ursprung des übergeordneten Elements, einer vertikalen Führung oder eines Führungspunkts, an dem die horizontale Mitte der Form ausgerichtet ist. |
+| [getAlignLeft()](#getAlignLeft--) | Bestimmt die horizontale Position, relativ zum Ursprung des übergeordneten Elements, einer vertikalen Führung oder eines Führungspunkts, an dem die linke Begrenzung der Form ausgerichtet ist. |
+| [getAlignMiddle()](#getAlignMiddle--) | Bestimmt die vertikale Position, relativ zum Ursprung seines übergeordneten Elements, eines horizontalen Führungs‑ oder Führungspunkts, an dem das vertikale Zentrum der Form ausgerichtet ist. |
+| [getAlignRight()](#getAlignRight--) | Bestimmt die horizontale Position, relativ zum Ursprung seines übergeordneten Elements, eines vertikalen Führungs‑ oder Führungspunkts, an dem die rechte Begrenzung der Form ausgerichtet ist. |
+| [getAlignTop()](#getAlignTop--) | Bestimmt die vertikale Position, relativ zum Ursprung seines übergeordneten Elements, eines horizontalen Führungs‑ oder Führungspunkts, an dem die obere Begrenzung der Form ausgerichtet ist. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/align\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAlignBottom() {#getAlignBottom--}
+```
+public DoubleValue getAlignBottom()
+```
+
+
+Bestimmt die vertikale Position, relativ zum Ursprung des übergeordneten Elements, einer horizontalen Führung oder eines Führungspunkts, an dem die untere Begrenzung der Form ausgerichtet ist.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getAlignCenter() {#getAlignCenter--}
+```
+public DoubleValue getAlignCenter()
+```
+
+
+Bestimmt die horizontale Position, relativ zum Ursprung des übergeordneten Elements, einer vertikalen Führung oder eines Führungspunkts, an dem die horizontale Mitte der Form ausgerichtet ist.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getAlignLeft() {#getAlignLeft--}
+```
+public DoubleValue getAlignLeft()
+```
+
+
+Bestimmt die horizontale Position, relativ zum Ursprung des übergeordneten Elements, einer vertikalen Führung oder eines Führungspunkts, an dem die linke Begrenzung der Form ausgerichtet ist.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getAlignMiddle() {#getAlignMiddle--}
+```
+public DoubleValue getAlignMiddle()
+```
+
+
+Bestimmt die vertikale Position, relativ zum Ursprung seines übergeordneten Elements, eines horizontalen Führungs‑ oder Führungspunkts, an dem das vertikale Zentrum der Form ausgerichtet ist.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getAlignRight() {#getAlignRight--}
+```
+public DoubleValue getAlignRight()
+```
+
+
+Bestimmt die horizontale Position, relativ zum Ursprung seines übergeordneten Elements, eines vertikalen Führungs‑ oder Führungspunkts, an dem die rechte Begrenzung der Form ausgerichtet ist.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getAlignTop() {#getAlignTop--}
+```
+public DoubleValue getAlignTop()
+```
+
+
+Bestimmt die vertikale Position, relativ zum Ursprung seines übergeordneten Elements, eines horizontalen Führungs‑ oder Führungspunkts, an dem die obere Begrenzung der Form ausgerichtet ist.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/align\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/alignment/_index.md
+++ b/german/java/com.aspose.diagram/alignment/_index.md
@@ -1,0 +1,179 @@
+---
+title: Ausrichtung
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt die Tab‑Ausrichtung an.
+type: docs
+weight: 18
+url: /de/java/com.aspose.diagram/alignment/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Alignment
+```
+
+Gibt die Tab‑Ausrichtung an.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [Alignment(int value)](#Alignment-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Gibt die Tab‑Ausrichtung an. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/alignment\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Alignment(int value) {#Alignment-int-}
+```
+public Alignment(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Gibt die Tab‑Ausrichtung an.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/alignment\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/alignmentvalue/_index.md
+++ b/german/java/com.aspose.diagram/alignmentvalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: AlignmentValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt die Tab‑Ausrichtung an.
+type: docs
+weight: 19
+url: /de/java/com.aspose.diagram/alignmentvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class AlignmentValue
+```
+
+Gibt die Tab‑Ausrichtung an.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [CENTER](#CENTER) | Mitte. |
+| [DECIMAL](#DECIMAL) | Dezimal. |
+| [LEFT](#LEFT) | Links. |
+| [RIGHT](#RIGHT) | Rechts. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CENTER {#CENTER}
+```
+public static final int CENTER
+```
+
+
+Mitte.
+
+### DECIMAL {#DECIMAL}
+```
+public static final int DECIMAL
+```
+
+
+Dezimal.
+
+### LEFT {#LEFT}
+```
+public static final int LEFT
+```
+
+
+Links.
+
+### RIGHT {#RIGHT}
+```
+public static final int RIGHT
+```
+
+
+Rechts.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/alignnamevalue/_index.md
+++ b/german/java/com.aspose.diagram/alignnamevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: AlignNameValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Optionaler int.
+type: docs
+weight: 17
+url: /de/java/com.aspose.diagram/alignnamevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class AlignNameValue
+```
+
+Optionaler int. Gibt an, ob der Text des Masters im Schablonenfenster links, rechts oder zentriert ausgerichtet ist.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [ALIGN_TEXT_CENTER](#ALIGN-TEXT-CENTER) | Text zentrieren. |
+| [ALIGN_TEXT_LEFT](#ALIGN-TEXT-LEFT) | Text links ausrichten. |
+| [ALIGN_TEXT_RIGHT](#ALIGN-TEXT-RIGHT) | Text rechts ausrichten. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALIGN_TEXT_CENTER {#ALIGN-TEXT-CENTER}
+```
+public static final int ALIGN_TEXT_CENTER
+```
+
+
+Text zentrieren.
+
+### ALIGN_TEXT_LEFT {#ALIGN-TEXT-LEFT}
+```
+public static final int ALIGN_TEXT_LEFT
+```
+
+
+Text links ausrichten.
+
+### ALIGN_TEXT_RIGHT {#ALIGN-TEXT-RIGHT}
+```
+public static final int ALIGN_TEXT_RIGHT
+```
+
+
+Text rechts ausrichten.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/annotation/_index.md
+++ b/german/java/com.aspose.diagram/annotation/_index.md
@@ -1,0 +1,288 @@
+---
+title: Annotation
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält Elemente, die Informationen über in einer Dokumentseite eingefügte Kommentare enthalten.
+type: docs
+weight: 20
+url: /de/java/com.aspose.diagram/annotation/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Annotation
+```
+
+Enthält Elemente, die Informationen über in einer Dokumentseite eingefügte Kommentare enthalten.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getComment()](#getComment--) | Enthält den Kommentartext im Zeichenkettenformat für eine Form. |
+| [getDate()](#getDate--) | gibt an, wann ein Kommentar erstellt wurde |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getEditDate()](#getEditDate--) | Gibt an, wann ein Kommentar zuletzt geändert wurde |
+| [getIX()](#getIX--) | Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements. |
+| [getLangID()](#getLangID--) | Gibt die Locale-ID (LCID) der Sprache an, in der die Zellformel, der Text, die benutzerdefinierte Eigenschaft oder der Kommentar eingegeben wurde. |
+| [getMarkerIndex()](#getMarkerIndex--) | Gibt die dem Kommentarmarker zugewiesene Indexnummer an. |
+| [getReviewerID()](#getReviewerID--) | Enthält die ID-Nummer des Prüfers, der Markups zum Dokument hinzufügt. |
+| [getShapeID()](#getShapeID--) | Die Shape-ID des Kommentars. |
+| [getX()](#getX--) | Die X-Koordinate des Kommentarmarkers in Seitenkoordinaten. |
+| [getY()](#getY--) | Die Y-Koordinate des Kommentarmarkers in Seitenkoordinaten. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/annotation\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getIX()](../../com.aspose.diagram/annotation\#getIX--) |
+| [setShapeID(int value)](#setShapeID-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getShapeID()](../../com.aspose.diagram/annotation\#getShapeID--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getComment() {#getComment--}
+```
+public Str2Value getComment()
+```
+
+
+Enthält den Kommentartext im Zeichenkettenformat für eine Form.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getDate() {#getDate--}
+```
+public DateValue getDate()
+```
+
+
+gibt an, wann ein Kommentar erstellt wurde
+
+**Returns:**
+[DateValue](../../com.aspose.diagram/datevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getEditDate() {#getEditDate--}
+```
+public DateValue getEditDate()
+```
+
+
+Gibt an, wann ein Kommentar zuletzt geändert wurde
+
+**Returns:**
+[DateValue](../../com.aspose.diagram/datevalue)
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements.
+
+**Returns:**
+int
+### getLangID() {#getLangID--}
+```
+public IntValue getLangID()
+```
+
+
+Gibt die Locale-ID (LCID) der Sprache an, in der die Zellformel, der Text, die benutzerdefinierte Eigenschaft oder der Kommentar eingegeben wurde.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getMarkerIndex() {#getMarkerIndex--}
+```
+public IntValue getMarkerIndex()
+```
+
+
+Gibt die dem Kommentarmarker zugewiesene Indexnummer an.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getReviewerID() {#getReviewerID--}
+```
+public IntValue getReviewerID()
+```
+
+
+Enthält die ID-Nummer des Prüfers, der Markups zum Dokument hinzufügt.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getShapeID() {#getShapeID--}
+```
+public int getShapeID()
+```
+
+
+Die Shape-ID des Kommentars.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+Die X-Koordinate des Kommentarmarkers in Seitenkoordinaten.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+Die Y-Koordinate des Kommentarmarkers in Seitenkoordinaten.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/annotation\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getIX()](../../com.aspose.diagram/annotation\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setShapeID(int value) {#setShapeID-int-}
+```
+public void setShapeID(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getShapeID()](../../com.aspose.diagram/annotation\#getShapeID--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/annotationcollection/_index.md
+++ b/german/java/com.aspose.diagram/annotationcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: AnnotationCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: Annotation-Sammlung.
+type: docs
+weight: 21
+url: /de/java/com.aspose.diagram/annotationcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class AnnotationCollection extends Collection
+```
+
+Annotation-Sammlung.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [add(Annotation item)](#add-com.aspose.diagram.Annotation-) | Füge das Annotation‑Objekt zur Sammlung hinzu. |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Annotation item)](#remove-com.aspose.diagram.Annotation-) | Entferne das Annotation‑Objekt aus der Sammlung. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Annotation item) {#add-com.aspose.diagram.Annotation-}
+```
+public int add(Annotation item)
+```
+
+
+Füge das Annotation‑Objekt zur Sammlung hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [Annotation](../../com.aspose.diagram/annotation) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Annotation get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[Annotation](../../com.aspose.diagram/annotation) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Annotation item) {#remove-com.aspose.diagram.Annotation-}
+```
+public void remove(Annotation item)
+```
+
+
+Entferne das Annotation‑Objekt aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [Annotation](../../com.aspose.diagram/annotation) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/arcto/_index.md
+++ b/german/java/com.aspose.diagram/arcto/_index.md
@@ -1,0 +1,274 @@
+---
+title: ArcTo
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält die x- und y-Koordinaten und die Krümmung eines kreisförmigen Bogens, die jeweils durch die Elemente X, Y und A dargestellt werden.
+type: docs
+weight: 22
+url: /de/java/com.aspose.diagram/arcto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class ArcTo extends Coordinate
+```
+
+Enthält die x- und y-Koordinaten sowie die Krümmung eines Kreisbogens, die jeweils durch die Elemente X, Y und A dargestellt werden.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [ArcTo()](#ArcTo--) | Erstellt eine Instanz der Klasse [ArcTo](../../com.aspose.diagram/arcto). |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | Der Abstand vom Mittelpunkt des Bogens zum Mittelpunkt seiner Sehne. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getIX()](#getIX--) | Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements. |
+| [getX()](#getX--) | Die x-Koordinate des Endknotens eines Bogens. |
+| [getY()](#getY--) | Die y-Koordinate des Endknotens eines Bogens. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getA()](../../com.aspose.diagram/arcto\#getA--) |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/arcto\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getIX()](../../com.aspose.diagram/arcto\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getX()](../../com.aspose.diagram/arcto\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getY()](../../com.aspose.diagram/arcto\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ArcTo() {#ArcTo--}
+```
+public ArcTo()
+```
+
+
+Erstellt eine Instanz der Klasse [ArcTo](../../com.aspose.diagram/arcto).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+Der Abstand vom Mittelpunkt des Bogens zum Mittelpunkt seiner Sehne.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+Die x-Koordinate des Endknotens eines Bogens.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+Die y-Koordinate des Endknotens eines Bogens.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getA()](../../com.aspose.diagram/arcto\#getA--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/arcto\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getIX()](../../com.aspose.diagram/arcto\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getX()](../../com.aspose.diagram/arcto\#getX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getY()](../../com.aspose.diagram/arcto\#getY--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/arctocollection/_index.md
+++ b/german/java/com.aspose.diagram/arctocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: ArcToCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: ArcTo-Sammlung.
+type: docs
+weight: 23
+url: /de/java/com.aspose.diagram/arctocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ArcToCollection extends Collection
+```
+
+ArcTo-Sammlung.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public ArcTo get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[ArcTo](../../com.aspose.diagram/arcto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/arrowsize/_index.md
+++ b/german/java/com.aspose.diagram/arrowsize/_index.md
@@ -1,0 +1,204 @@
+---
+title: ArrowSize
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt die Größe der Pfeilspitze der Linie an.
+type: docs
+weight: 24
+url: /de/java/com.aspose.diagram/arrowsize/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ArrowSize
+```
+
+Gibt die Größe der Pfeilspitze der Linie an.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [ArrowSize(int value)](#ArrowSize-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Gibt die Größe der Pfeilspitze der Linie an. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [isThemed()](#isThemed--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setThemed(boolean value)](#setThemed-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isThemed()](../../com.aspose.diagram/arrowsize\#isThemed--) |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/arrowsize\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ArrowSize(int value) {#ArrowSize-int-}
+```
+public ArrowSize(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Gibt die Größe der Pfeilspitze der Linie an.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### isThemed() {#isThemed--}
+```
+public boolean isThemed()
+```
+
+
+
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setThemed(boolean value) {#setThemed-boolean-}
+```
+public void setThemed(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isThemed()](../../com.aspose.diagram/arrowsize\#isThemed--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/arrowsize\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/arrowsizevalue/_index.md
+++ b/german/java/com.aspose.diagram/arrowsizevalue/_index.md
@@ -1,0 +1,201 @@
+---
+title: ArrowSizeValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt die Größe der Pfeilspitze der Linie an.
+type: docs
+weight: 25
+url: /de/java/com.aspose.diagram/arrowsizevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ArrowSizeValue
+```
+
+Gibt die Größe der Pfeilspitze der Linie an.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [COLOSSAL](#COLOSSAL) | Kolossal. |
+| [EXTRA_LARGE](#EXTRA-LARGE) | ExtraGroß. |
+| [JUMBO](#JUMBO) | Jumbo. |
+| [LARGE](#LARGE) | Groß. |
+| [MEDIUM](#MEDIUM) | Mittel. |
+| [SMALL](#SMALL) | Klein. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+| [VERY_SMALL](#VERY-SMALL) | SehrKlein. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### COLOSSAL {#COLOSSAL}
+```
+public static final int COLOSSAL
+```
+
+
+Kolossal.
+
+### EXTRA_LARGE {#EXTRA-LARGE}
+```
+public static final int EXTRA_LARGE
+```
+
+
+ExtraGroß.
+
+### JUMBO {#JUMBO}
+```
+public static final int JUMBO
+```
+
+
+Jumbo.
+
+### LARGE {#LARGE}
+```
+public static final int LARGE
+```
+
+
+Groß.
+
+### MEDIUM {#MEDIUM}
+```
+public static final int MEDIUM
+```
+
+
+Mittel.
+
+### SMALL {#SMALL}
+```
+public static final int SMALL
+```
+
+
+Klein.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### VERY_SMALL {#VERY-SMALL}
+```
+public static final int VERY_SMALL
+```
+
+
+SehrKlein.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/asposediagramprintdocument/_index.md
+++ b/german/java/com.aspose.diagram/asposediagramprintdocument/_index.md
@@ -1,0 +1,143 @@
+---
+title: AsposeDiagramPrintDocument
+second_title: Aspose.Diagram for Java API-Referenz
+description: Seine eigene Version der .NET PrintDocument-Klasse, die an ein PrintPreviewDialog-Formular übergeben werden kann, um ein Diagramm zu drucken und eine Vorschau anzuzeigen.
+type: docs
+weight: 26
+url: /de/java/com.aspose.diagram/asposediagramprintdocument/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class AsposeDiagramPrintDocument
+```
+
+Es ist die eigene Version der .NET PrintDocument‑Klasse, die an ein PrintPreviewDialog‑Formular übergeben werden kann, um ein Diagramm zu drucken und eine Vorschau anzuzeigen.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [AsposeDiagramPrintDocument(Diagram diagram)](#AsposeDiagramPrintDocument-com.aspose.diagram.Diagram-) | Initialisiert eine neue Instanz dieser Klasse, die an ein PrintPreviewDialog-Formular übergeben werden kann, um ein Diagramm zu drucken und eine Vorschau anzuzeigen. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AsposeDiagramPrintDocument(Diagram diagram) {#AsposeDiagramPrintDocument-com.aspose.diagram.Diagram-}
+```
+public AsposeDiagramPrintDocument(Diagram diagram)
+```
+
+
+Initialisiert eine neue Instanz dieser Klasse, die an ein PrintPreviewDialog-Formular übergeben werden kann, um ein Diagramm zu drucken und eine Vorschau anzuzeigen.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| diagram | [Diagram](../../com.aspose.diagram/diagram) |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/autolinkcomparison/_index.md
+++ b/german/java/com.aspose.diagram/autolinkcomparison/_index.md
@@ -1,0 +1,200 @@
+---
+title: AutoLinkComparison
+second_title: Aspose.Diagram for Java API-Referenz
+description: Definiert eine Regel, die eine Spalte im übergeordneten DataRecordset‑Element mit einem Formulardaten‑Element aus der letzten erfolgreichen automatischen Verknüpfungsaktion vergleicht, die in der Benutzeroberfläche durchgeführt wurde.
+type: docs
+weight: 27
+url: /de/java/com.aspose.diagram/autolinkcomparison/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class AutoLinkComparison
+```
+
+Definiert eine Regel, die eine Spalte im übergeordneten DataRecordset‑Element mit einem Formulardaten‑Element aus der letzten erfolgreichen automatischen Verknüpfungsaktion vergleicht, die in der Benutzeroberfläche durchgeführt wurde.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getColumnName()](#getColumnName--) | Entspricht einem Spaltennamen im ADO-Datensatz. |
+| [getContextType()](#getContextType--) | Gibt die Eigenschaften der Gruppe oder Form an, die für den Vergleich verwendet werden sollen. |
+| [getContextTypeLabel()](#getContextTypeLabel--) | Wenn der ContextType‑Wert 2 oder 3 ist, ist dieses Attribut erforderlich, um einen Vergleich zu definieren. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setColumnName(String value)](#setColumnName-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getColumnName()](../../com.aspose.diagram/autolinkcomparison\#getColumnName--) |
+| [setContextType(int value)](#setContextType-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getContextType()](../../com.aspose.diagram/autolinkcomparison\#getContextType--) |
+| [setContextTypeLabel(String value)](#setContextTypeLabel-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getContextTypeLabel()](../../com.aspose.diagram/autolinkcomparison\#getContextTypeLabel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColumnName() {#getColumnName--}
+```
+public String getColumnName()
+```
+
+
+Entspricht einem Spaltennamen im ADO-Datensatz.
+
+**Returns:**
+java.lang.String
+### getContextType() {#getContextType--}
+```
+public int getContextType()
+```
+
+
+Gibt die Eigenschaften der Gruppe oder Form an, die für den Vergleich verwendet werden sollen. Mögliche Werte sind in der folgenden Tabelle aufgeführt.
+
+**Returns:**
+int
+### getContextTypeLabel() {#getContextTypeLabel--}
+```
+public String getContextTypeLabel()
+```
+
+
+Wenn der ContextType‑Wert 2 oder 3 ist, ist dieses Attribut erforderlich, um einen Vergleich zu definieren. Für ContextType = 2 muss ContextTypeLabel die Shape‑Daten‑Element‑Bezeichnung sein, und für ContextType = 3 muss ContextTypeLabel der lokale Zeilenname sein.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setColumnName(String value) {#setColumnName-java.lang.String-}
+```
+public void setColumnName(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getColumnName()](../../com.aspose.diagram/autolinkcomparison\#getColumnName--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setContextType(int value) {#setContextType-int-}
+```
+public void setContextType(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getContextType()](../../com.aspose.diagram/autolinkcomparison\#getContextType--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setContextTypeLabel(String value) {#setContextTypeLabel-java.lang.String-}
+```
+public void setContextTypeLabel(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getContextTypeLabel()](../../com.aspose.diagram/autolinkcomparison\#getContextTypeLabel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/autospaceoptions/_index.md
+++ b/german/java/com.aspose.diagram/autospaceoptions/_index.md
@@ -1,0 +1,186 @@
+---
+title: AutoSpaceOptions
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt Autospace-Optionen dar.
+type: docs
+weight: 28
+url: /de/java/com.aspose.diagram/autospaceoptions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class AutoSpaceOptions
+```
+
+Stellt Autospace-Optionen dar.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [AutoSpaceOptions()](#AutoSpaceOptions--) |  |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDistanceInHorizontal()](#getDistanceInHorizontal--) | Definiert den Abstand zwischen den Formen in horizontaler Richtung in Zoll. |
+| [getDistanceInVertical()](#getDistanceInVertical--) | Definiert den Abstand zwischen den Formen in vertikaler Richtung in Zoll. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDistanceInHorizontal(double value)](#setDistanceInHorizontal-double-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDistanceInHorizontal()](../../com.aspose.diagram/autospaceoptions\#getDistanceInHorizontal--) |
+| [setDistanceInVertical(double value)](#setDistanceInVertical-double-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDistanceInVertical()](../../com.aspose.diagram/autospaceoptions\#getDistanceInVertical--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AutoSpaceOptions() {#AutoSpaceOptions--}
+```
+public AutoSpaceOptions()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDistanceInHorizontal() {#getDistanceInHorizontal--}
+```
+public double getDistanceInHorizontal()
+```
+
+
+Definiert den Abstand zwischen den Formen in horizontaler Richtung in Zoll. Standardwert 0,375 Zoll.
+
+**Returns:**
+double
+### getDistanceInVertical() {#getDistanceInVertical--}
+```
+public double getDistanceInVertical()
+```
+
+
+Definiert den Abstand zwischen den Formen in vertikaler Richtung in Zoll. Standardwert 0,375 Zoll.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDistanceInHorizontal(double value) {#setDistanceInHorizontal-double-}
+```
+public void setDistanceInHorizontal(double value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDistanceInHorizontal()](../../com.aspose.diagram/autospaceoptions\#getDistanceInHorizontal--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double |  |
+
+### setDistanceInVertical(double value) {#setDistanceInVertical-double-}
+```
+public void setDistanceInVertical(double value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDistanceInVertical()](../../com.aspose.diagram/autospaceoptions\#getDistanceInVertical--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/bevel/_index.md
+++ b/german/java/com.aspose.diagram/bevel/_index.md
@@ -1,0 +1,175 @@
+---
+title: Bevel
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt eine Abschrägung einer Form dar
+type: docs
+weight: 30
+url: /de/java/com.aspose.diagram/bevel/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Bevel
+```
+
+Stellt eine Abschrägung einer Form dar
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getHeight()](#getHeight--) | Die Höhe der Schräge bzw. wie weit über der Form sie angewendet wird. |
+| [getWidth()](#getWidth--) | Die Breite der Schräge bzw. wie weit in die Form sie angewendet wird. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setHeight(DoubleValue value)](#setHeight-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getHeight()](../../com.aspose.diagram/bevel\#getHeight--) |
+| [setWidth(DoubleValue value)](#setWidth-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getWidth()](../../com.aspose.diagram/bevel\#getWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getHeight() {#getHeight--}
+```
+public DoubleValue getHeight()
+```
+
+
+Die Höhe der Schräge, bzw. wie weit über der Form sie angewendet wird. In Punkten.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getWidth() {#getWidth--}
+```
+public DoubleValue getWidth()
+```
+
+
+Die Breite der Schräge bzw. wie weit in die Form sie angewendet wird.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setHeight(DoubleValue value) {#setHeight-com.aspose.diagram.DoubleValue-}
+```
+public void setHeight(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getHeight()](../../com.aspose.diagram/bevel\#getHeight--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setWidth(DoubleValue value) {#setWidth-com.aspose.diagram.DoubleValue-}
+```
+public void setWidth(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getWidth()](../../com.aspose.diagram/bevel\#getWidth--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/bevellightingtype/_index.md
+++ b/german/java/com.aspose.diagram/bevellightingtype/_index.md
@@ -1,0 +1,179 @@
+---
+title: BevelLightingType
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt den Typ des Schattens für eine Form an.
+type: docs
+weight: 31
+url: /de/java/com.aspose.diagram/bevellightingtype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class BevelLightingType
+```
+
+Gibt den Typ des Schattens für eine Form an.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [BevelLightingType(int value)](#BevelLightingType-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Gibt den Typ der Abschrägung an. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/bevellightingtype\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BevelLightingType(int value) {#BevelLightingType-int-}
+```
+public BevelLightingType(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Gibt den Typ der Abschrägung an.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/bevellightingtype\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/bevellightingtypevalue/_index.md
+++ b/german/java/com.aspose.diagram/bevellightingtypevalue/_index.md
@@ -1,0 +1,381 @@
+---
+title: BevelLightingTypeValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt ein voreingestelltes Licht rechts dar, das auf eine Form angewendet werden kann
+type: docs
+weight: 32
+url: /de/java/com.aspose.diagram/bevellightingtypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class BevelLightingTypeValue
+```
+
+Stellt ein voreingestelltes Licht rechts dar, das auf eine Form angewendet werden kann
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [BALANCED](#BALANCED) | Balanced |
+| [BRIGHT_ROOM](#BRIGHT-ROOM) | Bright room |
+| [CHILLY](#CHILLY) | Chilly |
+| [CONTRASTING](#CONTRASTING) | Contrasting |
+| [FLAT](#FLAT) | Flat |
+| [FLOOD](#FLOOD) | Flood |
+| [FREEZING](#FREEZING) | Freezing |
+| [GLOW](#GLOW) | Glow |
+| [HARSH](#HARSH) | Harsh |
+| [LEGACY_FLAT_1](#LEGACY-FLAT-1) | LegacyFlat1 |
+| [LEGACY_FLAT_2](#LEGACY-FLAT-2) | LegacyFlat2 |
+| [LEGACY_FLAT_3](#LEGACY-FLAT-3) | LegacyFlat3 |
+| [LEGACY_FLAT_4](#LEGACY-FLAT-4) | LegacyFlat4 |
+| [LEGACY_HARSH_1](#LEGACY-HARSH-1) | LegacyHarsh1 |
+| [LEGACY_HARSH_2](#LEGACY-HARSH-2) | LegacyHarsh2 |
+| [LEGACY_HARSH_3](#LEGACY-HARSH-3) | LegacyHarsh3 |
+| [LEGACY_HARSH_4](#LEGACY-HARSH-4) | LegacyHarsh4 |
+| [LEGACY_NORMAL_1](#LEGACY-NORMAL-1) | LegacyNormal1 |
+| [LEGACY_NORMAL_2](#LEGACY-NORMAL-2) | LegacyNormal2 |
+| [LEGACY_NORMAL_3](#LEGACY-NORMAL-3) | LegacyNormal3 |
+| [LEGACY_NORMAL_4](#LEGACY-NORMAL-4) | LegacyNormal4 |
+| [MORNING](#MORNING) | Morning |
+| [SOFT](#SOFT) | Weich |
+| [SUNRISE](#SUNRISE) | Sonnenaufgang |
+| [SUNSET](#SUNSET) | Sonnenuntergang |
+| [THREE_POINT](#THREE-POINT) | Drei-Punkt |
+| [TWO_POINT](#TWO-POINT) | Zwei-Punkt |
+| [UNDEFINED](#UNDEFINED) | Keine Lichtvorrichtung. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BALANCED {#BALANCED}
+```
+public static final int BALANCED
+```
+
+
+Balanced
+
+### BRIGHT_ROOM {#BRIGHT-ROOM}
+```
+public static final int BRIGHT_ROOM
+```
+
+
+Bright room
+
+### CHILLY {#CHILLY}
+```
+public static final int CHILLY
+```
+
+
+Chilly
+
+### CONTRASTING {#CONTRASTING}
+```
+public static final int CONTRASTING
+```
+
+
+Contrasting
+
+### FLAT {#FLAT}
+```
+public static final int FLAT
+```
+
+
+Flat
+
+### FLOOD {#FLOOD}
+```
+public static final int FLOOD
+```
+
+
+Flood
+
+### FREEZING {#FREEZING}
+```
+public static final int FREEZING
+```
+
+
+Freezing
+
+### GLOW {#GLOW}
+```
+public static final int GLOW
+```
+
+
+Glow
+
+### HARSH {#HARSH}
+```
+public static final int HARSH
+```
+
+
+Harsh
+
+### LEGACY_FLAT_1 {#LEGACY-FLAT-1}
+```
+public static final int LEGACY_FLAT_1
+```
+
+
+LegacyFlat1
+
+### LEGACY_FLAT_2 {#LEGACY-FLAT-2}
+```
+public static final int LEGACY_FLAT_2
+```
+
+
+LegacyFlat2
+
+### LEGACY_FLAT_3 {#LEGACY-FLAT-3}
+```
+public static final int LEGACY_FLAT_3
+```
+
+
+LegacyFlat3
+
+### LEGACY_FLAT_4 {#LEGACY-FLAT-4}
+```
+public static final int LEGACY_FLAT_4
+```
+
+
+LegacyFlat4
+
+### LEGACY_HARSH_1 {#LEGACY-HARSH-1}
+```
+public static final int LEGACY_HARSH_1
+```
+
+
+LegacyHarsh1
+
+### LEGACY_HARSH_2 {#LEGACY-HARSH-2}
+```
+public static final int LEGACY_HARSH_2
+```
+
+
+LegacyHarsh2
+
+### LEGACY_HARSH_3 {#LEGACY-HARSH-3}
+```
+public static final int LEGACY_HARSH_3
+```
+
+
+LegacyHarsh3
+
+### LEGACY_HARSH_4 {#LEGACY-HARSH-4}
+```
+public static final int LEGACY_HARSH_4
+```
+
+
+LegacyHarsh4
+
+### LEGACY_NORMAL_1 {#LEGACY-NORMAL-1}
+```
+public static final int LEGACY_NORMAL_1
+```
+
+
+LegacyNormal1
+
+### LEGACY_NORMAL_2 {#LEGACY-NORMAL-2}
+```
+public static final int LEGACY_NORMAL_2
+```
+
+
+LegacyNormal2
+
+### LEGACY_NORMAL_3 {#LEGACY-NORMAL-3}
+```
+public static final int LEGACY_NORMAL_3
+```
+
+
+LegacyNormal3
+
+### LEGACY_NORMAL_4 {#LEGACY-NORMAL-4}
+```
+public static final int LEGACY_NORMAL_4
+```
+
+
+LegacyNormal4
+
+### MORNING {#MORNING}
+```
+public static final int MORNING
+```
+
+
+Morning
+
+### SOFT {#SOFT}
+```
+public static final int SOFT
+```
+
+
+Weich
+
+### SUNRISE {#SUNRISE}
+```
+public static final int SUNRISE
+```
+
+
+Sonnenaufgang
+
+### SUNSET {#SUNSET}
+```
+public static final int SUNSET
+```
+
+
+Sonnenuntergang
+
+### THREE_POINT {#THREE-POINT}
+```
+public static final int THREE_POINT
+```
+
+
+Drei-Punkt
+
+### TWO_POINT {#TWO-POINT}
+```
+public static final int TWO_POINT
+```
+
+
+Zwei-Punkt
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Keine Lichtvorrichtung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/bevelmaterialtype/_index.md
+++ b/german/java/com.aspose.diagram/bevelmaterialtype/_index.md
@@ -1,0 +1,179 @@
+---
+title: BevelMaterialType
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt den Typ des Schattens für eine Form an.
+type: docs
+weight: 33
+url: /de/java/com.aspose.diagram/bevelmaterialtype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class BevelMaterialType
+```
+
+Gibt den Typ des Schattens für eine Form an.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [BevelMaterialType(int value)](#BevelMaterialType-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Gibt den Typ der Abschrägung an. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/bevelmaterialtype\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BevelMaterialType(int value) {#BevelMaterialType-int-}
+```
+public BevelMaterialType(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Gibt den Typ der Abschrägung an.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/bevelmaterialtype\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/bevelmaterialtypevalue/_index.md
+++ b/german/java/com.aspose.diagram/bevelmaterialtypevalue/_index.md
@@ -1,0 +1,271 @@
+---
+title: BevelMaterialTypeValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Beschreibt das Oberflächenbild einer Form.
+type: docs
+weight: 34
+url: /de/java/com.aspose.diagram/bevelmaterialtypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class BevelMaterialTypeValue
+```
+
+Beschreibt das Oberflächenbild einer Form.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [CLEAR](#CLEAR) | Löschen |
+| [DARK_EDGE](#DARK-EDGE) | Dunkle Kante |
+| [FLAT](#FLAT) | Flat |
+| [LEGACY_MATTE](#LEGACY-MATTE) | Legacy matt |
+| [LEGACY_METAL](#LEGACY-METAL) | Legacy Metall |
+| [LEGACY_PLASTIC](#LEGACY-PLASTIC) | Legacy Kunststoff |
+| [LEGACY_WIREFRAME](#LEGACY-WIREFRAME) | Legacy Drahtgitter |
+| [MATTE](#MATTE) | Matt |
+| [METAL](#METAL) | Metall |
+| [PLASTIC](#PLASTIC) | Kunststoff |
+| [POWDER](#POWDER) | Powder |
+| [SOFT_EDGE](#SOFT-EDGE) | Soft edge |
+| [SOFT_METAL](#SOFT-METAL) | Soft metal |
+| [TRANSLUCENT_POWDER](#TRANSLUCENT-POWDER) | Translucent powder |
+| [UNDEFINED](#UNDEFINED) |  |
+| [WARM_MATTE](#WARM-MATTE) | Warm matte |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CLEAR {#CLEAR}
+```
+public static final int CLEAR
+```
+
+
+Löschen
+
+### DARK_EDGE {#DARK-EDGE}
+```
+public static final int DARK_EDGE
+```
+
+
+Dunkle Kante
+
+### FLAT {#FLAT}
+```
+public static final int FLAT
+```
+
+
+Flat
+
+### LEGACY_MATTE {#LEGACY-MATTE}
+```
+public static final int LEGACY_MATTE
+```
+
+
+Legacy matt
+
+### LEGACY_METAL {#LEGACY-METAL}
+```
+public static final int LEGACY_METAL
+```
+
+
+Legacy Metall
+
+### LEGACY_PLASTIC {#LEGACY-PLASTIC}
+```
+public static final int LEGACY_PLASTIC
+```
+
+
+Legacy Kunststoff
+
+### LEGACY_WIREFRAME {#LEGACY-WIREFRAME}
+```
+public static final int LEGACY_WIREFRAME
+```
+
+
+Legacy Drahtgitter
+
+### MATTE {#MATTE}
+```
+public static final int MATTE
+```
+
+
+Matt
+
+### METAL {#METAL}
+```
+public static final int METAL
+```
+
+
+Metall
+
+### PLASTIC {#PLASTIC}
+```
+public static final int PLASTIC
+```
+
+
+Kunststoff
+
+### POWDER {#POWDER}
+```
+public static final int POWDER
+```
+
+
+Powder
+
+### SOFT_EDGE {#SOFT-EDGE}
+```
+public static final int SOFT_EDGE
+```
+
+
+Soft edge
+
+### SOFT_METAL {#SOFT-METAL}
+```
+public static final int SOFT_METAL
+```
+
+
+Soft metal
+
+### TRANSLUCENT_POWDER {#TRANSLUCENT-POWDER}
+```
+public static final int TRANSLUCENT_POWDER
+```
+
+
+Translucent powder
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+### WARM_MATTE {#WARM-MATTE}
+```
+public static final int WARM_MATTE
+```
+
+
+Warm matte
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/bevelpresettype/_index.md
+++ b/german/java/com.aspose.diagram/bevelpresettype/_index.md
@@ -1,0 +1,246 @@
+---
+title: BevelPresetType
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt eine Voreinstellung für einen Abschrägungstyp dar, die auf eine Form in 3D angewendet werden kann.
+type: docs
+weight: 35
+url: /de/java/com.aspose.diagram/bevelpresettype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class BevelPresetType
+```
+
+Stellt eine Voreinstellung für einen Abschrägungstyp dar, die auf eine Form in 3D angewendet werden kann.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [ANGLE](#ANGLE) | Winkel |
+| [ART_DECO](#ART-DECO) | Art déco |
+| [CIRCLE](#CIRCLE) | Kreis |
+| [CONVEX](#CONVEX) | Konvex |
+| [COOL_SLANT](#COOL-SLANT) | Coole Schräge |
+| [CROSS](#CROSS) | Kreuz |
+| [DIVOT](#DIVOT) | Mulde |
+| [HARD_EDGE](#HARD-EDGE) | Harte Kante |
+| [NONE](#NONE) | Keine Abschrägung |
+| [RELAXED_INSET](#RELAXED-INSET) | Entspannte Einrückung |
+| [RIBLET](#RIBLET) | Rippe |
+| [SLOPE](#SLOPE) | Steigung |
+| [SOFT_ROUND](#SOFT-ROUND) | Weiche Rundung |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ANGLE {#ANGLE}
+```
+public static final int ANGLE
+```
+
+
+Winkel
+
+### ART_DECO {#ART-DECO}
+```
+public static final int ART_DECO
+```
+
+
+Art déco
+
+### CIRCLE {#CIRCLE}
+```
+public static final int CIRCLE
+```
+
+
+Kreis
+
+### CONVEX {#CONVEX}
+```
+public static final int CONVEX
+```
+
+
+Konvex
+
+### COOL_SLANT {#COOL-SLANT}
+```
+public static final int COOL_SLANT
+```
+
+
+Coole Schräge
+
+### CROSS {#CROSS}
+```
+public static final int CROSS
+```
+
+
+Kreuz
+
+### DIVOT {#DIVOT}
+```
+public static final int DIVOT
+```
+
+
+Mulde
+
+### HARD_EDGE {#HARD-EDGE}
+```
+public static final int HARD_EDGE
+```
+
+
+Harte Kante
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Keine Abschrägung
+
+### RELAXED_INSET {#RELAXED-INSET}
+```
+public static final int RELAXED_INSET
+```
+
+
+Entspannte Einrückung
+
+### RIBLET {#RIBLET}
+```
+public static final int RIBLET
+```
+
+
+Rippe
+
+### SLOPE {#SLOPE}
+```
+public static final int SLOPE
+```
+
+
+Steigung
+
+### SOFT_ROUND {#SOFT-ROUND}
+```
+public static final int SOFT_ROUND
+```
+
+
+Weiche Rundung
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/beveltype/_index.md
+++ b/german/java/com.aspose.diagram/beveltype/_index.md
@@ -1,0 +1,179 @@
+---
+title: BevelType
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt den Typ des Schattens für eine Form an.
+type: docs
+weight: 36
+url: /de/java/com.aspose.diagram/beveltype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class BevelType
+```
+
+Gibt den Typ des Schattens für eine Form an.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [BevelType(int value)](#BevelType-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Gibt den Typ der Abschrägung an. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/beveltype\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BevelType(int value) {#BevelType-int-}
+```
+public BevelType(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Gibt den Typ der Abschrägung an.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/beveltype\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/beveltypevalue/_index.md
+++ b/german/java/com.aspose.diagram/beveltypevalue/_index.md
@@ -1,0 +1,255 @@
+---
+title: BevelTypeValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt eine Voreinstellung für einen Abschrägungstyp dar, die auf eine Form in 3D angewendet werden kann.
+type: docs
+weight: 37
+url: /de/java/com.aspose.diagram/beveltypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class BevelTypeValue
+```
+
+Stellt eine Voreinstellung für einen Abschrägungstyp dar, die auf eine Form in 3D angewendet werden kann.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [ANGLE](#ANGLE) | Winkel |
+| [ART_DECO](#ART-DECO) | Art déco |
+| [CIRCLE](#CIRCLE) | Kreis |
+| [CONVEX](#CONVEX) | Konvex |
+| [COOL_SLANT](#COOL-SLANT) | Coole Schräge |
+| [CROSS](#CROSS) | Kreuz |
+| [DIVOT](#DIVOT) | Mulde |
+| [HARD_EDGE](#HARD-EDGE) | Harte Kante |
+| [NONE](#NONE) | Keine Abschrägung |
+| [RELAXED_INSET](#RELAXED-INSET) | Entspannte Einrückung |
+| [RIBLET](#RIBLET) | Rippe |
+| [SLOPE](#SLOPE) | Steigung |
+| [SOFT_ROUND](#SOFT-ROUND) | Weiche Rundung |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ANGLE {#ANGLE}
+```
+public static final int ANGLE
+```
+
+
+Winkel
+
+### ART_DECO {#ART-DECO}
+```
+public static final int ART_DECO
+```
+
+
+Art déco
+
+### CIRCLE {#CIRCLE}
+```
+public static final int CIRCLE
+```
+
+
+Kreis
+
+### CONVEX {#CONVEX}
+```
+public static final int CONVEX
+```
+
+
+Konvex
+
+### COOL_SLANT {#COOL-SLANT}
+```
+public static final int COOL_SLANT
+```
+
+
+Coole Schräge
+
+### CROSS {#CROSS}
+```
+public static final int CROSS
+```
+
+
+Kreuz
+
+### DIVOT {#DIVOT}
+```
+public static final int DIVOT
+```
+
+
+Mulde
+
+### HARD_EDGE {#HARD-EDGE}
+```
+public static final int HARD_EDGE
+```
+
+
+Harte Kante
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Keine Abschrägung
+
+### RELAXED_INSET {#RELAXED-INSET}
+```
+public static final int RELAXED_INSET
+```
+
+
+Entspannte Einrückung
+
+### RIBLET {#RIBLET}
+```
+public static final int RIBLET
+```
+
+
+Rippe
+
+### SLOPE {#SLOPE}
+```
+public static final int SLOPE
+```
+
+
+Steigung
+
+### SOFT_ROUND {#SOFT-ROUND}
+```
+public static final int SOFT_ROUND
+```
+
+
+Weiche Rundung
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/bool/_index.md
+++ b/german/java/com.aspose.diagram/bool/_index.md
@@ -1,0 +1,156 @@
+---
+title: BOOL
+second_title: Aspose.Diagram for Java API-Referenz
+description: Boolesch.
+type: docs
+weight: 29
+url: /de/java/com.aspose.diagram/bool/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class BOOL
+```
+
+Boolesch.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [FALSE](#FALSE) | Falsch. |
+| [TRUE](#TRUE) | Wahr. |
+| [UNDEFINED](#UNDEFINED) | Undefinierter Zustand. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FALSE {#FALSE}
+```
+public static final int FALSE
+```
+
+
+Falsch.
+
+### TRUE {#TRUE}
+```
+public static final int TRUE
+```
+
+
+Wahr.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefinierter Zustand.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/boolvalue/_index.md
+++ b/german/java/com.aspose.diagram/boolvalue/_index.md
@@ -1,0 +1,230 @@
+---
+title: BoolValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Boolescher Wert.
+type: docs
+weight: 38
+url: /de/java/com.aspose.diagram/boolvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class BoolValue
+```
+
+Boolescher Wert.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [BoolValue(int value, int unit)](#BoolValue-int-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Attribute eines Elements. |
+| [getValue()](#getValue--) | Boolescher Wert |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [isThemed()](#isThemed--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setThemed(boolean value)](#setThemed-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isThemed()](../../com.aspose.diagram/boolvalue\#isThemed--) |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | Für die Beschreibung dieser Eigenschaft siehe [getUfe()](../../com.aspose.diagram/boolvalue\#getUfe--) |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe [getValue()](../../com.aspose.diagram/boolvalue\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BoolValue(int value, int unit) {#BoolValue-int-int-}
+```
+public BoolValue(int value, int unit)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+| Einheit | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Attribute eines Elements.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Boolescher Wert
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### isThemed() {#isThemed--}
+```
+public boolean isThemed()
+```
+
+
+
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setThemed(boolean value) {#setThemed-boolean-}
+```
+public void setThemed(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isThemed()](../../com.aspose.diagram/boolvalue\#isThemed--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getUfe()](../../com.aspose.diagram/boolvalue\#getUfe--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getValue()](../../com.aspose.diagram/boolvalue\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/bullet/_index.md
+++ b/german/java/com.aspose.diagram/bullet/_index.md
@@ -1,0 +1,179 @@
+---
+title: Bullet
+second_title: Aspose.Diagram for Java API-Referenz
+description: Bestimmt den Aufzählungszeichenstil.
+type: docs
+weight: 39
+url: /de/java/com.aspose.diagram/bullet/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Bullet
+```
+
+Bestimmt den Aufzählungszeichenstil.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [Bullet(int value)](#Bullet-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Bestimmt den Aufzählungszeichenstil. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/bullet\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Bullet(int value) {#Bullet-int-}
+```
+public Bullet(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Bestimmt den Aufzählungszeichenstil.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/bullet\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/bulletvalue/_index.md
+++ b/german/java/com.aspose.diagram/bulletvalue/_index.md
@@ -1,0 +1,210 @@
+---
+title: BulletValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Bestimmt den Aufzählungszeichenstil.
+type: docs
+weight: 40
+url: /de/java/com.aspose.diagram/bulletvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class BulletValue
+```
+
+Bestimmt den Aufzählungszeichenstil.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [NONE](#NONE) | Keine. |
+| [STYLE_1](#STYLE-1) | Punkt. |
+| [STYLE_2](#STYLE-2) | Rombus. |
+| [STYLE_3](#STYLE-3) | Quadrat. |
+| [STYLE_4](#STYLE-4) | Großes Quadrat. |
+| [STYLE_5](#STYLE-5) | Romben. |
+| [STYLE_6](#STYLE-6) | Pfeil. |
+| [STYLE_7](#STYLE-7) | Häkchen. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Keine.
+
+### STYLE_1 {#STYLE-1}
+```
+public static final int STYLE_1
+```
+
+
+Punkt.
+
+### STYLE_2 {#STYLE-2}
+```
+public static final int STYLE_2
+```
+
+
+Rombus.
+
+### STYLE_3 {#STYLE-3}
+```
+public static final int STYLE_3
+```
+
+
+Quadrat.
+
+### STYLE_4 {#STYLE-4}
+```
+public static final int STYLE_4
+```
+
+
+Großes Quadrat.
+
+### STYLE_5 {#STYLE-5}
+```
+public static final int STYLE_5
+```
+
+
+Romben.
+
+### STYLE_6 {#STYLE-6}
+```
+public static final int STYLE_6
+```
+
+
+Pfeil.
+
+### STYLE_7 {#STYLE-7}
+```
+public static final int STYLE_7
+```
+
+
+Häkchen.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/calendar/_index.md
+++ b/german/java/com.aspose.diagram/calendar/_index.md
@@ -1,0 +1,204 @@
+---
+title: Calendar
+second_title: Aspose.Diagram for Java API-Referenz
+description: Bestimmt den Kalender, der für Textfelder benutzerdefinierter Eigenschaften und Elementformeln verwendet wird.
+type: docs
+weight: 41
+url: /de/java/com.aspose.diagram/calendar/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Calendar
+```
+
+Bestimmt den Kalender, der für benutzerdefinierte Eigenschaften, Textfelder und Formeln von Elementen verwendet wird.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [Calendar(int value)](#Calendar-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Bestimmt den Kalender, der für benutzerdefinierte Eigenschaften, Textfelder und Formeln von Elementen verwendet wird. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getUfe()](../../com.aspose.diagram/calendar\#getUfe--) |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/calendar\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Calendar(int value) {#Calendar-int-}
+```
+public Calendar(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Bestimmt den Kalender, der für benutzerdefinierte Eigenschaften, Textfelder und Formeln von Elementen verwendet wird.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getUfe()](../../com.aspose.diagram/calendar\#getUfe--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/calendar\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/calendarvalue/_index.md
+++ b/german/java/com.aspose.diagram/calendarvalue/_index.md
@@ -1,0 +1,228 @@
+---
+title: CalendarValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Bestimmt den Kalender, der für Textfelder benutzerdefinierter Eigenschaften und Elementformeln verwendet wird.
+type: docs
+weight: 42
+url: /de/java/com.aspose.diagram/calendarvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class CalendarValue
+```
+
+Bestimmt den Kalender, der für benutzerdefinierte Eigenschaften, Textfelder und Formeln von Elementen verwendet wird.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [ARABIC_HIJIRI](#ARABIC-HIJIRI) | Arabischer Hijri. |
+| [ENGLISH_TRANSLITERATED](#ENGLISH-TRANSLITERATED) | Englisch transliteriert. |
+| [FRENCH_TRANSLITERATED](#FRENCH-TRANSLITERATED) | Französisch transliteriert. |
+| [HEBREW_LUNAR](#HEBREW-LUNAR) | Hebräisch lunär. |
+| [JAPANESE_EMPEROR_REIGN](#JAPANESE-EMPEROR-REIGN) | Japanische Kaiserherrschaft. |
+| [KOREAN_DANKI](#KOREAN-DANKI) | Koreanischer Danki. |
+| [SAKA_ERA](#SAKA-ERA) | Saka-Ära. |
+| [TAIWAN_CALENDAR](#TAIWAN-CALENDAR) | Taiwanischer Kalender. |
+| [THAI_BUDDHIST](#THAI-BUDDHIST) | Thai-buddhistisch. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+| [WESTERN](#WESTERN) | Westlich. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ARABIC_HIJIRI {#ARABIC-HIJIRI}
+```
+public static final int ARABIC_HIJIRI
+```
+
+
+Arabischer Hijri.
+
+### ENGLISH_TRANSLITERATED {#ENGLISH-TRANSLITERATED}
+```
+public static final int ENGLISH_TRANSLITERATED
+```
+
+
+Englisch transliteriert.
+
+### FRENCH_TRANSLITERATED {#FRENCH-TRANSLITERATED}
+```
+public static final int FRENCH_TRANSLITERATED
+```
+
+
+Französisch transliteriert.
+
+### HEBREW_LUNAR {#HEBREW-LUNAR}
+```
+public static final int HEBREW_LUNAR
+```
+
+
+Hebräisch lunär.
+
+### JAPANESE_EMPEROR_REIGN {#JAPANESE-EMPEROR-REIGN}
+```
+public static final int JAPANESE_EMPEROR_REIGN
+```
+
+
+Japanische Kaiserherrschaft.
+
+### KOREAN_DANKI {#KOREAN-DANKI}
+```
+public static final int KOREAN_DANKI
+```
+
+
+Koreanischer Danki.
+
+### SAKA_ERA {#SAKA-ERA}
+```
+public static final int SAKA_ERA
+```
+
+
+Saka-Ära.
+
+### TAIWAN_CALENDAR {#TAIWAN-CALENDAR}
+```
+public static final int TAIWAN_CALENDAR
+```
+
+
+Taiwanischer Kalender.
+
+### THAI_BUDDHIST {#THAI-BUDDHIST}
+```
+public static final int THAI_BUDDHIST
+```
+
+
+Thai-buddhistisch.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### WESTERN {#WESTERN}
+```
+public static final int WESTERN
+```
+
+
+Westlich.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/case/_index.md
+++ b/german/java/com.aspose.diagram/case/_index.md
@@ -1,0 +1,204 @@
+---
+title: Case
+second_title: Aspose.Diagram for Java API-Referenz
+description: Bestimmt die Groß-/Kleinschreibung des Textes einer Form.
+type: docs
+weight: 43
+url: /de/java/com.aspose.diagram/case/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Case
+```
+
+Bestimmt die Groß-/Kleinschreibung des Textes einer Form.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [Case(int value)](#Case-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Bestimmt die Groß-/Kleinschreibung des Textes einer Form. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getUfe()](../../com.aspose.diagram/case\#getUfe--) |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/case\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Case(int value) {#Case-int-}
+```
+public Case(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Bestimmt die Groß-/Kleinschreibung des Textes einer Form.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getUfe()](../../com.aspose.diagram/case\#getUfe--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/case\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/casevalue/_index.md
+++ b/german/java/com.aspose.diagram/casevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: CaseValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Bestimmt die Groß-/Kleinschreibung des Textes einer Form.
+type: docs
+weight: 44
+url: /de/java/com.aspose.diagram/casevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class CaseValue
+```
+
+Bestimmt die Groß-/Kleinschreibung des Textes einer Form. Alle Großbuchstaben (1) und Anfangsbuchstaben (2) ändern das Aussehen des Textes, der in Großbuchstaben eingegeben wurde, nicht. Der Text muss in Kleinbuchstaben eingegeben werden, damit diese Optionen wirksam werden.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [ALL_CAPITAL_LETTERS](#ALL-CAPITAL-LETTERS) | Alle Großbuchstaben (Uppercase). |
+| [INITIAL_CAPITAL_LETTERS_ONLY](#INITIAL-CAPITAL-LETTERS-ONLY) | Nur Anfangsgroßbuchstaben. |
+| [NORMAL_CASE](#NORMAL-CASE) | Normaler Fall. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALL_CAPITAL_LETTERS {#ALL-CAPITAL-LETTERS}
+```
+public static final int ALL_CAPITAL_LETTERS
+```
+
+
+Alle Großbuchstaben (Uppercase).
+
+### INITIAL_CAPITAL_LETTERS_ONLY {#INITIAL-CAPITAL-LETTERS-ONLY}
+```
+public static final int INITIAL_CAPITAL_LETTERS_ONLY
+```
+
+
+Nur Anfangsgroßbuchstaben.
+
+### NORMAL_CASE {#NORMAL-CASE}
+```
+public static final int NORMAL_CASE
+```
+
+
+Normaler Fall.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/char/_index.md
+++ b/german/java/com.aspose.diagram/char/_index.md
@@ -1,0 +1,937 @@
+---
+title: Char
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält die Formatierungsattribute für den Text von Formen, wie Schriftfarbe, Textstil, Groß-/Kleinschreibung, Position relativ zur Grundlinie und Punktgröße.
+type: docs
+weight: 45
+url: /de/java/com.aspose.diagram/char/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Char
+```
+
+Enthält die Formatierungsattribute für den Text einer Form, wie Schriftart, Farbe, Textstil, Groß-/Kleinschreibung, Position relativ zur Grundlinie und Punktgröße.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [Char()](#Char--) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAsianFont()](#getAsianFont--) | Gibt die ID-Nummer der Schriftart an, die zum Formatieren von Text mit asiatischen Zeichen verwendet wird. |
+| [getAsianFontName()](#getAsianFontName--) | Sie gibt den Namen der asiatischen Schriftart an, die zum Formatieren des Textes verwendet wird. Sie wird für Visio 2013 verwendet. |
+| [getCase()](#getCase--) | Bestimmt die Groß-/Kleinschreibung des Textes einer Form. |
+| [getClass()](#getClass--) |  |
+| [getColor()](#getColor--) | Wenn sie in einem Char-Element enthalten ist, das Color-Element. |
+| [getColorTrans()](#getColorTrans--) | Bestimmt den Transparenzgrad für die Textfarbe einer Ebene oder Form, von 0 (vollständig undurchsichtig) bis 1 (vollständig transparent). |
+| [getComplexScriptFont()](#getComplexScriptFont--) | Enthält die Nummer der Schriftart, die zum Formatieren von Text mit komplexen Skriptzeichen verwendet wird. |
+| [getComplexScriptFontName()](#getComplexScriptFontName--) | Sie gibt den Namen der ComplexScript-Schriftart an, die zum Formatieren des Textes verwendet wird. Sie wird für Visio 2013 verwendet. |
+| [getComplexScriptSize()](#getComplexScriptSize--) | Die Größe der Schriftart, die zum Formatieren von Text mit komplexen Skriptzeichen verwendet wird. |
+| [getDblUnderline()](#getDblUnderline--) | Gibt an, ob der Textbereich darunter einen doppelten Unterstrich hat. |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getDoubleStrikethrough()](#getDoubleStrikethrough--) | Bestimmt, ob der Text als doppelter Durchstrich formatiert ist. |
+| [getFont()](#getFont--) | Gibt die ID-Nummer der Schriftart an, die zum Formatieren des Textes verwendet wird. |
+| [getFontName()](#getFontName--) | Gibt den Namen der Schriftart an, die zum Formatieren des Textes verwendet wird. Sie wird für Visio 2013 verwendet. |
+| [getFontScale()](#getFontScale--) | Gibt die Schriftbreite an. |
+| [getHighlight()](#getHighlight--) | Gibt die Hervorhebung an. |
+| [getIX()](#getIX--) | Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements. |
+| [getLangID()](#getLangID--) | Gibt die Locale-ID (LCID) der Sprache an, in der die Zellformel, der Text, die benutzerdefinierte Eigenschaft oder der Kommentar eingegeben wurde. |
+| [getLetterspace()](#getLetterspace--) | Gibt den Abstand zwischen zwei oder mehreren Zeichen an. |
+| [getLocale()](#getLocale--) | Gibt das Gebietsschema des Textabschnitts für die Rechtschreibprüfung an. |
+| [getLocalizeFont()](#getLocalizeFont--) | Gibt an, ob der Formtext lokalisiert (in eine andere Sprache übersetzt) werden soll. |
+| [getOverline()](#getOverline--) | Gibt an, ob der Text eine Linie darüber hat. |
+| [getPerpendicular()](#getPerpendicular--) | Gibt an, ob ein Textfeld senkrecht zum übrigen Text in einem Textblock erscheint. |
+| [getPos()](#getPos--) | Gibt die Position des Textes der Shape relativ zur Grundlinie an. |
+| [getRTLText()](#getRTLText--) | Bestimmt, ob die Textausrichtung des aktuellen Zeichenabschnitts von links nach rechts oder von rechts nach links verläuft. |
+| [getSize()](#getSize--) | Gibt die Größe des Textes im Textblock der Form an. |
+| [getStrikethru()](#getStrikethru--) | Gibt an, ob der Text als Durchgestrichen formatiert ist. |
+| [getStyle()](#getStyle--) | Gibt die Zeichenformatierung an, die auf einen Textbereich im Textblock der Form angewendet wird. |
+| [getUseVertical()](#getUseVertical--) | Bestimmt, ob der Zeichenabschnitt vertikal oder horizontal ist. |
+| [hashCode()](#hashCode--) |  |
+| [isBold()](#isBold--) | Gibt an, ob die Schriftart fett ist. |
+| [isDoubleStrikethrough()](#isDoubleStrikethrough--) | Gibt an, ob die Schriftart doppelter Durchstrich ist. |
+| [isDoubleUnderline()](#isDoubleUnderline--) | Gibt an, ob die Schriftart doppelter Unterstrich ist. |
+| [isItalic()](#isItalic--) | Gibt an, ob die Schriftart kursiv ist. |
+| [isStrikethrough()](#isStrikethrough--) | Gibt an, ob die Schriftart durchgestrichen ist. |
+| [isSubscript()](#isSubscript--) | Gibt an, ob die Schriftart tiefgestellt ist. |
+| [isSuperscript()](#isSuperscript--) | Gibt an, ob die Schriftart hochgestellt ist. |
+| [isUnderline()](#isUnderline--) | Gibt an, ob die Schriftart unterstrichen ist. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAsianFont(IntValue value)](#setAsianFont-com.aspose.diagram.IntValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getAsianFont()](../../com.aspose.diagram/char\#getAsianFont--) |
+| [setAsianFontName(StrValue value)](#setAsianFontName-com.aspose.diagram.StrValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getAsianFontName()](../../com.aspose.diagram/char\#getAsianFontName--) |
+| [setCase(Case value)](#setCase-com.aspose.diagram.Case-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getCase()](../../com.aspose.diagram/char\#getCase--) |
+| [setColor(ColorValue value)](#setColor-com.aspose.diagram.ColorValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getColor()](../../com.aspose.diagram/char\#getColor--) |
+| [setColorTrans(DoubleValue value)](#setColorTrans-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getColorTrans()](../../com.aspose.diagram/char\#getColorTrans--) |
+| [setComplexScriptFont(IntValue value)](#setComplexScriptFont-com.aspose.diagram.IntValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getComplexScriptFont()](../../com.aspose.diagram/char\#getComplexScriptFont--) |
+| [setComplexScriptFontName(StrValue value)](#setComplexScriptFontName-com.aspose.diagram.StrValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getComplexScriptFontName()](../../com.aspose.diagram/char\#getComplexScriptFontName--) |
+| [setComplexScriptSize(DoubleValue value)](#setComplexScriptSize-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getComplexScriptSize()](../../com.aspose.diagram/char\#getComplexScriptSize--) |
+| [setDblUnderline(BoolValue value)](#setDblUnderline-com.aspose.diagram.BoolValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDblUnderline()](../../com.aspose.diagram/char\#getDblUnderline--) |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/char\#getDel--) |
+| [setDoubleStrikethrough(BoolValue value)](#setDoubleStrikethrough-com.aspose.diagram.BoolValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDoubleStrikethrough()](../../com.aspose.diagram/char\#getDoubleStrikethrough--) |
+| [setFont(IntValue value)](#setFont-com.aspose.diagram.IntValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getFont()](../../com.aspose.diagram/char\#getFont--) |
+| [setFontName(StrValue value)](#setFontName-com.aspose.diagram.StrValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getFontName()](../../com.aspose.diagram/char\#getFontName--) |
+| [setFontScale(DoubleValue value)](#setFontScale-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getFontScale()](../../com.aspose.diagram/char\#getFontScale--) |
+| [setHighlight(BoolValue value)](#setHighlight-com.aspose.diagram.BoolValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getHighlight()](../../com.aspose.diagram/char\#getHighlight--) |
+| [setIX(int value)](#setIX-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getIX()](../../com.aspose.diagram/char\#getIX--) |
+| [setLangID(IntValue value)](#setLangID-com.aspose.diagram.IntValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getLangID()](../../com.aspose.diagram/char\#getLangID--) |
+| [setLetterspace(DoubleValue value)](#setLetterspace-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getLetterspace()](../../com.aspose.diagram/char\#getLetterspace--) |
+| [setLocale(StrValue value)](#setLocale-com.aspose.diagram.StrValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getLocale()](../../com.aspose.diagram/char\#getLocale--) |
+| [setLocalizeFont(LocalizeFont value)](#setLocalizeFont-com.aspose.diagram.LocalizeFont-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getLocalizeFont()](../../com.aspose.diagram/char\#getLocalizeFont--) |
+| [setOverline(BoolValue value)](#setOverline-com.aspose.diagram.BoolValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getOverline()](../../com.aspose.diagram/char\#getOverline--) |
+| [setPerpendicular(StrValue value)](#setPerpendicular-com.aspose.diagram.StrValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getPerpendicular()](../../com.aspose.diagram/char\#getPerpendicular--) |
+| [setPos(Pos value)](#setPos-com.aspose.diagram.Pos-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getPos()](../../com.aspose.diagram/char\#getPos--) |
+| [setRTLText(BoolValue value)](#setRTLText-com.aspose.diagram.BoolValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getRTLText()](../../com.aspose.diagram/char\#getRTLText--) |
+| [setSize(DoubleValue value)](#setSize-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getSize()](../../com.aspose.diagram/char\#getSize--) |
+| [setStrikethru(BoolValue value)](#setStrikethru-com.aspose.diagram.BoolValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getStrikethru()](../../com.aspose.diagram/char\#getStrikethru--) |
+| [setStyle(Style value)](#setStyle-com.aspose.diagram.Style-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getStyle()](../../com.aspose.diagram/char\#getStyle--) |
+| [setUseVertical(BoolValue value)](#setUseVertical-com.aspose.diagram.BoolValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getUseVertical()](../../com.aspose.diagram/char\#getUseVertical--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Char() {#Char--}
+```
+public Char()
+```
+
+
+Konstruktor.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAsianFont() {#getAsianFont--}
+```
+public IntValue getAsianFont()
+```
+
+
+Gibt die ID-Nummer der Schriftart an, die zum Formatieren von Text mit asiatischen Zeichen verwendet wird.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getAsianFontName() {#getAsianFontName--}
+```
+public StrValue getAsianFontName()
+```
+
+
+Sie gibt den Namen der asiatischen Schriftart an, die zum Formatieren des Textes verwendet wird. Sie wird für Visio 2013 verwendet.
+
+**Returns:**
+[StrValue](../../com.aspose.diagram/strvalue)
+### getCase() {#getCase--}
+```
+public Case getCase()
+```
+
+
+Bestimmt die Groß-/Kleinschreibung des Textes einer Form.
+
+**Returns:**
+[Case](../../com.aspose.diagram/case)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColor() {#getColor--}
+```
+public ColorValue getColor()
+```
+
+
+Wenn sie in einem Char-Element enthalten ist, das Color-Element.
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getColorTrans() {#getColorTrans--}
+```
+public DoubleValue getColorTrans()
+```
+
+
+Bestimmt den Transparenzgrad für die Textfarbe einer Ebene oder Form, von 0 (vollständig undurchsichtig) bis 1 (vollständig transparent).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getComplexScriptFont() {#getComplexScriptFont--}
+```
+public IntValue getComplexScriptFont()
+```
+
+
+Enthält die Nummer der Schriftart, die zum Formatieren von Text verwendet wird, der aus Zeichen komplexer Schriftsysteme besteht. Komplexe Schriftsysteme sind Sprachen, deren Zeichen Ligaturen oder Formenbildung erfordern, wie z. B. rechts‑nach‑links‑Sprachen (Arabisch, Farsi, Hebräisch und Urdu) und mehrere südasiatische Sprachen.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getComplexScriptFontName() {#getComplexScriptFontName--}
+```
+public StrValue getComplexScriptFontName()
+```
+
+
+Sie gibt den Namen der ComplexScript-Schriftart an, die zum Formatieren des Textes verwendet wird. Sie wird für Visio 2013 verwendet.
+
+**Returns:**
+[StrValue](../../com.aspose.diagram/strvalue)
+### getComplexScriptSize() {#getComplexScriptSize--}
+```
+public DoubleValue getComplexScriptSize()
+```
+
+
+Die Größe der Schrift, die zum Formatieren von Text verwendet wird, der aus komplexen Skriptzeichen besteht. Komplexe Skripte sind Sprachen, deren Zeichen Ligaturen oder Formenbildung erfordern, wie z. B. die rechts‑nach‑links‑Sprachen (Arabisch, Farsi, Hebräisch und Urdu) und mehrere südasiatische Sprachen.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDblUnderline() {#getDblUnderline--}
+```
+public BoolValue getDblUnderline()
+```
+
+
+Gibt an, ob der Textbereich darunter einen doppelten Unterstrich hat.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getDoubleStrikethrough() {#getDoubleStrikethrough--}
+```
+public BoolValue getDoubleStrikethrough()
+```
+
+
+Bestimmt, ob der Text als doppelter Durchstrich formatiert ist.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getFont() {#getFont--}
+```
+public IntValue getFont()
+```
+
+
+Gibt die ID-Nummer der Schriftart an, die zum Formatieren des Textes verwendet wird.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getFontName() {#getFontName--}
+```
+public StrValue getFontName()
+```
+
+
+Gibt den Namen der Schriftart an, die zum Formatieren des Textes verwendet wird. Sie wird für Visio 2013 verwendet.
+
+**Returns:**
+[StrValue](../../com.aspose.diagram/strvalue)
+### getFontScale() {#getFontScale--}
+```
+public DoubleValue getFontScale()
+```
+
+
+Gibt die Schriftbreite an.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getHighlight() {#getHighlight--}
+```
+public BoolValue getHighlight()
+```
+
+
+Gibt die Hervorhebung an.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements.
+
+**Returns:**
+int
+### getLangID() {#getLangID--}
+```
+public IntValue getLangID()
+```
+
+
+Gibt die Locale-ID (LCID) der Sprache an, in der die Zellformel, der Text, die benutzerdefinierte Eigenschaft oder der Kommentar eingegeben wurde. Für eine Liste der von Microsoft‑Office‑Anwendungen unterstützten Sprachen und ihrer entsprechenden Sprach‑IDs siehe das Element DocLangID.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getLetterspace() {#getLetterspace--}
+```
+public DoubleValue getLetterspace()
+```
+
+
+Gibt den Abstand zwischen zwei oder mehr Zeichen an. Der Abstand kann in Schritten von 1/20 Punkt hinzugefügt oder entfernt werden.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLocale() {#getLocale--}
+```
+public StrValue getLocale()
+```
+
+
+Gibt das Gebietsschema des Textabschnitts für die Rechtschreibprüfung an.
+
+**Returns:**
+[StrValue](../../com.aspose.diagram/strvalue)
+### getLocalizeFont() {#getLocalizeFont--}
+```
+public LocalizeFont getLocalizeFont()
+```
+
+
+Gibt an, ob der Formtext lokalisiert (in eine andere Sprache übersetzt) werden soll.
+
+**Returns:**
+[LocalizeFont](../../com.aspose.diagram/localizefont)
+### getOverline() {#getOverline--}
+```
+public BoolValue getOverline()
+```
+
+
+Gibt an, ob der Text eine Linie darüber hat.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getPerpendicular() {#getPerpendicular--}
+```
+public StrValue getPerpendicular()
+```
+
+
+Gibt an, ob ein Textfeld senkrecht zum übrigen Text in einem Textblock erscheint.
+
+**Returns:**
+[StrValue](../../com.aspose.diagram/strvalue)
+### getPos() {#getPos--}
+```
+public Pos getPos()
+```
+
+
+Gibt die Position des Textes der Shape relativ zur Grundlinie an.
+
+**Returns:**
+[Pos](../../com.aspose.diagram/pos)
+### getRTLText() {#getRTLText--}
+```
+public BoolValue getRTLText()
+```
+
+
+Bestimmt, ob die Textausrichtung des aktuellen Zeichenabschnitts von links nach rechts oder von rechts nach links verläuft.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getSize() {#getSize--}
+```
+public DoubleValue getSize()
+```
+
+
+Gibt die Größe des Textes im Textblock der Form an.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getStrikethru() {#getStrikethru--}
+```
+public BoolValue getStrikethru()
+```
+
+
+Gibt an, ob der Text als Durchgestrichen formatiert ist.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getStyle() {#getStyle--}
+```
+public Style getStyle()
+```
+
+
+Gibt die Zeichenformatierung an, die auf einen Textbereich im Textblock der Form angewendet wird.
+
+**Returns:**
+[Style](../../com.aspose.diagram/style)
+### getUseVertical() {#getUseVertical--}
+```
+public BoolValue getUseVertical()
+```
+
+
+Bestimmt, ob der Zeichenabschnitt vertikal oder horizontal ist.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isBold() {#isBold--}
+```
+public boolean isBold()
+```
+
+
+Gibt an, ob die Schriftart fett ist.
+
+**Returns:**
+boolean
+### isDoubleStrikethrough() {#isDoubleStrikethrough--}
+```
+public boolean isDoubleStrikethrough()
+```
+
+
+Gibt an, ob die Schriftart doppelter Durchstrich ist.
+
+**Returns:**
+boolean
+### isDoubleUnderline() {#isDoubleUnderline--}
+```
+public boolean isDoubleUnderline()
+```
+
+
+Gibt an, ob die Schriftart doppelter Unterstrich ist.
+
+**Returns:**
+boolean
+### isItalic() {#isItalic--}
+```
+public boolean isItalic()
+```
+
+
+Gibt an, ob die Schriftart kursiv ist.
+
+**Returns:**
+boolean
+### isStrikethrough() {#isStrikethrough--}
+```
+public boolean isStrikethrough()
+```
+
+
+Gibt an, ob die Schriftart durchgestrichen ist.
+
+**Returns:**
+boolean
+### isSubscript() {#isSubscript--}
+```
+public boolean isSubscript()
+```
+
+
+Gibt an, ob die Schriftart tiefgestellt ist.
+
+**Returns:**
+boolean
+### isSuperscript() {#isSuperscript--}
+```
+public boolean isSuperscript()
+```
+
+
+Gibt an, ob die Schriftart hochgestellt ist.
+
+**Returns:**
+boolean
+### isUnderline() {#isUnderline--}
+```
+public boolean isUnderline()
+```
+
+
+Gibt an, ob die Schriftart unterstrichen ist.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAsianFont(IntValue value) {#setAsianFont-com.aspose.diagram.IntValue-}
+```
+public void setAsianFont(IntValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getAsianFont()](../../com.aspose.diagram/char\#getAsianFont--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setAsianFontName(StrValue value) {#setAsianFontName-com.aspose.diagram.StrValue-}
+```
+public void setAsianFontName(StrValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getAsianFontName()](../../com.aspose.diagram/char\#getAsianFontName--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [StrValue](../../com.aspose.diagram/strvalue) |  |
+
+### setCase(Case value) {#setCase-com.aspose.diagram.Case-}
+```
+public void setCase(Case value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getCase()](../../com.aspose.diagram/char\#getCase--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [Case](../../com.aspose.diagram/case) |  |
+
+### setColor(ColorValue value) {#setColor-com.aspose.diagram.ColorValue-}
+```
+public void setColor(ColorValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getColor()](../../com.aspose.diagram/char\#getColor--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setColorTrans(DoubleValue value) {#setColorTrans-com.aspose.diagram.DoubleValue-}
+```
+public void setColorTrans(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getColorTrans()](../../com.aspose.diagram/char\#getColorTrans--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setComplexScriptFont(IntValue value) {#setComplexScriptFont-com.aspose.diagram.IntValue-}
+```
+public void setComplexScriptFont(IntValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getComplexScriptFont()](../../com.aspose.diagram/char\#getComplexScriptFont--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setComplexScriptFontName(StrValue value) {#setComplexScriptFontName-com.aspose.diagram.StrValue-}
+```
+public void setComplexScriptFontName(StrValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getComplexScriptFontName()](../../com.aspose.diagram/char\#getComplexScriptFontName--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [StrValue](../../com.aspose.diagram/strvalue) |  |
+
+### setComplexScriptSize(DoubleValue value) {#setComplexScriptSize-com.aspose.diagram.DoubleValue-}
+```
+public void setComplexScriptSize(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getComplexScriptSize()](../../com.aspose.diagram/char\#getComplexScriptSize--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDblUnderline(BoolValue value) {#setDblUnderline-com.aspose.diagram.BoolValue-}
+```
+public void setDblUnderline(BoolValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDblUnderline()](../../com.aspose.diagram/char\#getDblUnderline--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/char\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setDoubleStrikethrough(BoolValue value) {#setDoubleStrikethrough-com.aspose.diagram.BoolValue-}
+```
+public void setDoubleStrikethrough(BoolValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDoubleStrikethrough()](../../com.aspose.diagram/char\#getDoubleStrikethrough--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setFont(IntValue value) {#setFont-com.aspose.diagram.IntValue-}
+```
+public void setFont(IntValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getFont()](../../com.aspose.diagram/char\#getFont--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setFontName(StrValue value) {#setFontName-com.aspose.diagram.StrValue-}
+```
+public void setFontName(StrValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getFontName()](../../com.aspose.diagram/char\#getFontName--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [StrValue](../../com.aspose.diagram/strvalue) |  |
+
+### setFontScale(DoubleValue value) {#setFontScale-com.aspose.diagram.DoubleValue-}
+```
+public void setFontScale(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getFontScale()](../../com.aspose.diagram/char\#getFontScale--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setHighlight(BoolValue value) {#setHighlight-com.aspose.diagram.BoolValue-}
+```
+public void setHighlight(BoolValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getHighlight()](../../com.aspose.diagram/char\#getHighlight--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getIX()](../../com.aspose.diagram/char\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setLangID(IntValue value) {#setLangID-com.aspose.diagram.IntValue-}
+```
+public void setLangID(IntValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getLangID()](../../com.aspose.diagram/char\#getLangID--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setLetterspace(DoubleValue value) {#setLetterspace-com.aspose.diagram.DoubleValue-}
+```
+public void setLetterspace(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getLetterspace()](../../com.aspose.diagram/char\#getLetterspace--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setLocale(StrValue value) {#setLocale-com.aspose.diagram.StrValue-}
+```
+public void setLocale(StrValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getLocale()](../../com.aspose.diagram/char\#getLocale--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [StrValue](../../com.aspose.diagram/strvalue) |  |
+
+### setLocalizeFont(LocalizeFont value) {#setLocalizeFont-com.aspose.diagram.LocalizeFont-}
+```
+public void setLocalizeFont(LocalizeFont value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getLocalizeFont()](../../com.aspose.diagram/char\#getLocalizeFont--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [LocalizeFont](../../com.aspose.diagram/localizefont) |  |
+
+### setOverline(BoolValue value) {#setOverline-com.aspose.diagram.BoolValue-}
+```
+public void setOverline(BoolValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getOverline()](../../com.aspose.diagram/char\#getOverline--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setPerpendicular(StrValue value) {#setPerpendicular-com.aspose.diagram.StrValue-}
+```
+public void setPerpendicular(StrValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getPerpendicular()](../../com.aspose.diagram/char\#getPerpendicular--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [StrValue](../../com.aspose.diagram/strvalue) |  |
+
+### setPos(Pos value) {#setPos-com.aspose.diagram.Pos-}
+```
+public void setPos(Pos value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getPos()](../../com.aspose.diagram/char\#getPos--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [Pos](../../com.aspose.diagram/pos) |  |
+
+### setRTLText(BoolValue value) {#setRTLText-com.aspose.diagram.BoolValue-}
+```
+public void setRTLText(BoolValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getRTLText()](../../com.aspose.diagram/char\#getRTLText--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setSize(DoubleValue value) {#setSize-com.aspose.diagram.DoubleValue-}
+```
+public void setSize(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getSize()](../../com.aspose.diagram/char\#getSize--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setStrikethru(BoolValue value) {#setStrikethru-com.aspose.diagram.BoolValue-}
+```
+public void setStrikethru(BoolValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getStrikethru()](../../com.aspose.diagram/char\#getStrikethru--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setStyle(Style value) {#setStyle-com.aspose.diagram.Style-}
+```
+public void setStyle(Style value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getStyle()](../../com.aspose.diagram/char\#getStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [Style](../../com.aspose.diagram/style) |  |
+
+### setUseVertical(BoolValue value) {#setUseVertical-com.aspose.diagram.BoolValue-}
+```
+public void setUseVertical(BoolValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getUseVertical()](../../com.aspose.diagram/char\#getUseVertical--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/charcollection/_index.md
+++ b/german/java/com.aspose.diagram/charcollection/_index.md
@@ -1,0 +1,234 @@
+---
+title: CharCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: Zeichensammlung.
+type: docs
+weight: 46
+url: /de/java/com.aspose.diagram/charcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class CharCollection extends Collection
+```
+
+Zeichensammlung.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [add(Char item)](#add-com.aspose.diagram.Char-) | Füge das Char‑Objekt zur Sammlung hinzu. |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [getChar(int IX)](#getChar-int-) | Gibt das Element am angegebenen IX zurück. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Char item)](#remove-com.aspose.diagram.Char-) | Entferne das Char‑Objekt aus der Sammlung. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Char item) {#add-com.aspose.diagram.Char-}
+```
+public int add(Char item)
+```
+
+
+Füge das Char‑Objekt zur Sammlung hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [Char](../../com.aspose.diagram/char) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Char get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[Char](../../com.aspose.diagram/char) - 
+### getChar(int IX) {#getChar-int-}
+```
+public Char getChar(int IX)
+```
+
+
+Gibt das Element am angegebenen IX zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| IX | int | intDer nullbasierte Index des Elements innerhalb seines übergeordneten Elements. |
+
+**Returns:**
+[Char](../../com.aspose.diagram/char) - [Char](../../com.aspose.diagram/char)Char.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Char item) {#remove-com.aspose.diagram.Char-}
+```
+public void remove(Char item)
+```
+
+
+Entferne das Char‑Objekt aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [Char](../../com.aspose.diagram/char) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/checkboxactivexcontrol/_index.md
+++ b/german/java/com.aspose.diagram/checkboxactivexcontrol/_index.md
@@ -1,0 +1,704 @@
+---
+title: CheckBoxActiveXControl
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt ein CheckBox-ActiveX-Steuerelement dar.
+type: docs
+weight: 47
+url: /de/java/com.aspose.diagram/checkboxactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class CheckBoxActiveXControl extends ActiveXControl
+```
+
+Stellt ein CheckBox-ActiveX-Steuerelement dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAccelerator()](#getAccelerator--) | Die Beschleunigungstaste für das Steuerelement. |
+| [getAlignment()](#getAlignment--) | Die Position der Beschriftung relativ zum Steuerelement. |
+| [getBackOleColor()](#getBackOleColor--) | die OLE‑Farbe des Hintergrunds. |
+| [getCaption()](#getCaption--) | Der beschreibende Text, der auf einem Steuerelement erscheint. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | die Binärdaten des Steuerelements. |
+| [getForeOleColor()](#getForeOleColor--) | die OLE‑Farbe des Vordergrunds. |
+| [getGroupName()](#getGroupName--) | Der Name der Gruppe. |
+| [getHeight()](#getHeight--) | die Höhe des Steuerelements in Punkt‑Einheiten. |
+| [getIMEMode()](#getIMEMode--) | der Standard‑Laufzeitmodus des Input Method Editors für das Steuerelement, wenn es den Fokus erhält. |
+| [getMouseIcon()](#getMouseIcon--) | ein benutzerdefiniertes Symbol, das als Mauszeiger für das Steuerelement angezeigt wird. |
+| [getMousePointer()](#getMousePointer--) | der Typ des als Mauszeiger für das Steuerelement angezeigten Symbols. |
+| [getPicture()](#getPicture--) | Die Daten des Bildes. |
+| [getPicturePosition()](#getPicturePosition--) | Der Ort des Bildes des Steuerelements relativ zu seiner Beschriftung. |
+| [getSpecialEffect()](#getSpecialEffect--) | der Spezialeffekt des Steuerelements. |
+| [getType()](#getType--) | Ermittelt den Typ des ActiveX-Steuerelements. |
+| [getValue()](#getValue--) | Gibt an, ob das Steuerelement aktiviert ist oder nicht. |
+| [getWidth()](#getWidth--) | die Breite des Steuerelements in Punkt-Einheiten. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | Gibt an, ob das Steuerelement automatisch die Größe ändert, um seinen gesamten Inhalt anzuzeigen. |
+| [isChecked()](#isChecked--) | Gibt an, ob das Kontrollkästchen aktiviert ist. |
+| [isEnabled()](#isEnabled--) | Gibt an, ob das Steuerelement den Fokus erhalten und auf benutzergenerierte Ereignisse reagieren kann. |
+| [isLocked()](#isLocked--) | Gibt an, ob Daten im Steuerelement für die Bearbeitung gesperrt sind. |
+| [isTransparent()](#isTransparent--) | Gibt an, ob das Steuerelement transparent ist. |
+| [isTripleState()](#isTripleState--) | Gibt an, wie das angegebene Steuerelement Nullwerte darstellt. |
+| [isWordWrapped()](#isWordWrapped--) | Gibt an, ob der Inhalt des Steuerelements am Zeilenende automatisch umbrochen wird. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAccelerator(char value)](#setAccelerator-char-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getAccelerator()](../../com.aspose.diagram/checkboxactivexcontrol\#getAccelerator--) |
+| [setAlignment(int value)](#setAlignment-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getAlignment()](../../com.aspose.diagram/checkboxactivexcontrol\#getAlignment--) |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setCaption(String value)](#setCaption-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getCaption()](../../com.aspose.diagram/checkboxactivexcontrol\#getCaption--) |
+| [setChecked(boolean value)](#setChecked-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isChecked()](../../com.aspose.diagram/checkboxactivexcontrol\#isChecked--) |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setGroupName(String value)](#setGroupName-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getGroupName()](../../com.aspose.diagram/checkboxactivexcontrol\#getGroupName--) |
+| [setHeight(double value)](#setHeight-double-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setIMEMode(int value)](#setIMEMode-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) |
+| [setLocked(boolean value)](#setLocked-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | Für die Beschreibung dieser Eigenschaft siehe bitte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setPicture(byte[] value)](#setPicture-byte---) | Für die Beschreibung dieser Eigenschaft siehe bitte [getPicture()](../../com.aspose.diagram/checkboxactivexcontrol\#getPicture--) |
+| [setPicturePosition(int value)](#setPicturePosition-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getPicturePosition()](../../com.aspose.diagram/checkboxactivexcontrol\#getPicturePosition--) |
+| [setSpecialEffect(int value)](#setSpecialEffect-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getSpecialEffect()](../../com.aspose.diagram/checkboxactivexcontrol\#getSpecialEffect--) |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) |
+| [setTripleState(boolean value)](#setTripleState-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isTripleState()](../../com.aspose.diagram/checkboxactivexcontrol\#isTripleState--) |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/checkboxactivexcontrol\#getValue--) |
+| [setWidth(double value)](#setWidth-double-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [setWordWrapped(boolean value)](#setWordWrapped-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isWordWrapped()](../../com.aspose.diagram/checkboxactivexcontrol\#isWordWrapped--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAccelerator() {#getAccelerator--}
+```
+public char getAccelerator()
+```
+
+
+Die Beschleunigungstaste für das Steuerelement.
+
+**Returns:**
+char
+### getAlignment() {#getAlignment--}
+```
+public int getAlignment()
+```
+
+
+Die Position der Beschriftung relativ zum Steuerelement.
+
+**Returns:**
+int
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+die OLE‑Farbe des Hintergrunds.
+
+**Returns:**
+int
+### getCaption() {#getCaption--}
+```
+public String getCaption()
+```
+
+
+Der beschreibende Text, der auf einem Steuerelement erscheint.
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+die Binärdaten des Steuerelements.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+Die OLE-Farbe des Vordergrunds. Gilt nicht für das Image-Steuerelement.
+
+**Returns:**
+int
+### getGroupName() {#getGroupName--}
+```
+public String getGroupName()
+```
+
+
+Der Name der Gruppe.
+
+**Returns:**
+java.lang.String
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+die Höhe des Steuerelements in Punkt‑Einheiten.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+der Standard‑Laufzeitmodus des Input Method Editors für das Steuerelement, wenn es den Fokus erhält.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+ein benutzerdefiniertes Symbol, das als Mauszeiger für das Steuerelement angezeigt wird.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+der Typ des als Mauszeiger für das Steuerelement angezeigten Symbols.
+
+**Returns:**
+int
+### getPicture() {#getPicture--}
+```
+public byte[] getPicture()
+```
+
+
+Die Daten des Bildes.
+
+**Returns:**
+byte[]
+### getPicturePosition() {#getPicturePosition--}
+```
+public int getPicturePosition()
+```
+
+
+Der Ort des Bildes des Steuerelements relativ zu seiner Beschriftung.
+
+**Returns:**
+int
+### getSpecialEffect() {#getSpecialEffect--}
+```
+public int getSpecialEffect()
+```
+
+
+der Spezialeffekt des Steuerelements.
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Ermittelt den Typ des ActiveX-Steuerelements.
+
+**Returns:**
+int
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Gibt an, ob das Steuerelement aktiviert ist oder nicht.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+die Breite des Steuerelements in Punkt-Einheiten.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+Gibt an, ob das Steuerelement automatisch die Größe ändert, um seinen gesamten Inhalt anzuzeigen.
+
+**Returns:**
+boolean
+### isChecked() {#isChecked--}
+```
+public boolean isChecked()
+```
+
+
+Gibt an, ob das Kontrollkästchen aktiviert ist.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+Gibt an, ob das Steuerelement den Fokus erhalten und auf benutzergenerierte Ereignisse reagieren kann.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+Gibt an, ob Daten im Steuerelement für die Bearbeitung gesperrt sind.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+Gibt an, ob das Steuerelement transparent ist.
+
+**Returns:**
+boolean
+### isTripleState() {#isTripleState--}
+```
+public boolean isTripleState()
+```
+
+
+Gibt an, wie das angegebene Steuerelement Nullwerte darstellt.
+
+| ------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| Einstellung | Beschreibung                                                                                                                                     |
+| True    | Das Steuerelement durchläuft die Zustände für Ja-, Nein- und Nullwerte. Das Steuerelement erscheint abgedunkelt (grau), wenn seine Value‑Eigenschaft auf Null gesetzt ist. |
+| False   | (Standard) Das Steuerelement durchläuft die Zustände für Ja‑ und Nein‑Werte. Nullwerte werden angezeigt, als wären sie Nein‑Werte.                           |
+
+|
+
+**Returns:**
+boolean
+### isWordWrapped() {#isWordWrapped--}
+```
+public boolean isWordWrapped()
+```
+
+
+Gibt an, ob der Inhalt des Steuerelements am Zeilenende automatisch umbrochen wird.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAccelerator(char value) {#setAccelerator-char-}
+```
+public void setAccelerator(char value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getAccelerator()](../../com.aspose.diagram/checkboxactivexcontrol\#getAccelerator--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | char |  |
+
+### setAlignment(int value) {#setAlignment-int-}
+```
+public void setAlignment(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getAlignment()](../../com.aspose.diagram/checkboxactivexcontrol\#getAlignment--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setCaption(String value) {#setCaption-java.lang.String-}
+```
+public void setCaption(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getCaption()](../../com.aspose.diagram/checkboxactivexcontrol\#getCaption--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setChecked(boolean value) {#setChecked-boolean-}
+```
+public void setChecked(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isChecked()](../../com.aspose.diagram/checkboxactivexcontrol\#isChecked--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setGroupName(String value) {#setGroupName-java.lang.String-}
+```
+public void setGroupName(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getGroupName()](../../com.aspose.diagram/checkboxactivexcontrol\#getGroupName--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setPicture(byte[] value) {#setPicture-byte---}
+```
+public void setPicture(byte[] value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getPicture()](../../com.aspose.diagram/checkboxactivexcontrol\#getPicture--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | byte[] |  |
+
+### setPicturePosition(int value) {#setPicturePosition-int-}
+```
+public void setPicturePosition(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getPicturePosition()](../../com.aspose.diagram/checkboxactivexcontrol\#getPicturePosition--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setSpecialEffect(int value) {#setSpecialEffect-int-}
+```
+public void setSpecialEffect(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getSpecialEffect()](../../com.aspose.diagram/checkboxactivexcontrol\#getSpecialEffect--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setTripleState(boolean value) {#setTripleState-boolean-}
+```
+public void setTripleState(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isTripleState()](../../com.aspose.diagram/checkboxactivexcontrol\#isTripleState--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/checkboxactivexcontrol\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double |  |
+
+### setWordWrapped(boolean value) {#setWordWrapped-boolean-}
+```
+public void setWordWrapped(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isWordWrapped()](../../com.aspose.diagram/checkboxactivexcontrol\#isWordWrapped--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/checkvaluetype/_index.md
+++ b/german/java/com.aspose.diagram/checkvaluetype/_index.md
@@ -1,0 +1,156 @@
+---
+title: CheckValueType
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt den Typ des Prüfwerts der CheckBox dar.
+type: docs
+weight: 48
+url: /de/java/com.aspose.diagram/checkvaluetype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class CheckValueType
+```
+
+Stellt den Typ des Prüfwerts der CheckBox dar.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [CHECKED](#CHECKED) | Ausgewählt |
+| [MIXED](#MIXED) | Gemischt |
+| [UN_CHECKED](#UN-CHECKED) | Nicht ausgewählt |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CHECKED {#CHECKED}
+```
+public static final int CHECKED
+```
+
+
+Ausgewählt
+
+### MIXED {#MIXED}
+```
+public static final int MIXED
+```
+
+
+Gemischt
+
+### UN_CHECKED {#UN-CHECKED}
+```
+public static final int UN_CHECKED
+```
+
+
+Nicht ausgewählt
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/collection/_index.md
+++ b/german/java/com.aspose.diagram/collection/_index.md
@@ -1,0 +1,188 @@
+---
+title: Sammlung
+second_title: Aspose.Diagram for Java API-Referenz
+description: Es ist die Basisklasse für Sammlungen.
+type: docs
+weight: 49
+url: /de/java/com.aspose.diagram/collection/
+---
+
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+java.lang.Iterable
+```
+public abstract class Collection implements Iterable
+```
+
+Es ist die Basisklasse für Sammlungen.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [Collection()](#Collection--) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Collection() {#Collection--}
+```
+public Collection()
+```
+
+
+Konstruktor.
+
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/collectionbase/_index.md
+++ b/german/java/com.aspose.diagram/collectionbase/_index.md
@@ -1,0 +1,264 @@
+---
+title: CollectionBase
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt die abstrakte Basisklasse für eine stark typisierte Sammlung bereit.
+type: docs
+weight: 50
+url: /de/java/com.aspose.diagram/collectionbase/
+---
+
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+java.lang.Iterable
+```
+public abstract class CollectionBase implements Iterable
+```
+
+Stellt die abstrakte Basisklasse für eine stark typisierte Sammlung bereit.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [CollectionBase()](#CollectionBase--) | Initialisiert eine neue Instanz der Klasse CollectionBase mit der standardmäßigen Anfangskapazität. |
+| [CollectionBase(int capacity)](#CollectionBase-int-) | Initialisiert eine neue Instanz der Klasse CollectionBase mit der angegebenen Kapazität. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [add(Object o)](#add-java.lang.Object-) | Fügt ein Element zur CollectionBase-Instanz hinzu. |
+| [clear()](#clear--) | Entfernt alle Objekte aus der CollectionBase-Instanz. |
+| [contains(Object o)](#contains-java.lang.Object-) | Gibt zurück, ob die Instanz dieses Objekt enthält |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ruft ein Element an der angegebenen Position ab. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ermittelt die Anzahl der in der CollectionBase-Instanz enthaltenen Elemente. |
+| [hashCode()](#hashCode--) |  |
+| [indexOf(Object o)](#indexOf-java.lang.Object-) | Bestimmt den Index eines bestimmten Elements in der CollectionBase-Instanz. |
+| [iterator()](#iterator--) | Gibt einen Enumerator zurück, der die CollectionBase-Instanz durchläuft. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [removeAt(int index)](#removeAt-int-) | Entfernt das Element am angegebenen Index. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CollectionBase() {#CollectionBase--}
+```
+public CollectionBase()
+```
+
+
+Initialisiert eine neue Instanz der Klasse CollectionBase mit der standardmäßigen Anfangskapazität.
+
+### CollectionBase(int capacity) {#CollectionBase-int-}
+```
+public CollectionBase(int capacity)
+```
+
+
+Initialisiert eine neue Instanz der Klasse CollectionBase mit der angegebenen Kapazität.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Kapazität | int | Die Anzahl der Elemente, die die neue Liste zunächst speichern kann. |
+
+### add(Object o) {#add-java.lang.Object-}
+```
+public int add(Object o)
+```
+
+
+Fügt ein Element zur CollectionBase-Instanz hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| o | java.lang.Object | Das Objekt, das zur CollectionBase-Instanz hinzugefügt werden soll. |
+
+**Returns:**
+int - Die Position, in die das neue Element eingefügt wurde.
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Objekte aus der CollectionBase-Instanz.
+
+### contains(Object o) {#contains-java.lang.Object-}
+```
+public boolean contains(Object o)
+```
+
+
+Gibt zurück, ob die Instanz dieses Objekt enthält
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| o | java.lang.Object | Testobjekt |
+
+**Returns:**
+boolean - Gibt an, ob die Instanz dieses Objekt enthält
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Object get(int index)
+```
+
+
+Ruft ein Element an der angegebenen Position ab.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Angegebener Positionsindex. |
+
+**Returns:**
+java.lang.Object - Das Element an der angegebenen Position.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ermittelt die Anzahl der in der CollectionBase-Instanz enthaltenen Elemente.
+
+**Returns:**
+int - Die Anzahl der im CollectionBase-Instanz enthaltenen Elemente.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### indexOf(Object o) {#indexOf-java.lang.Object-}
+```
+public int indexOf(Object o)
+```
+
+
+Bestimmt den Index eines bestimmten Elements in der CollectionBase-Instanz.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| o | java.lang.Object | Bestimmt den Index eines bestimmten Elements in der CollectionBase-Instanz. |
+
+**Returns:**
+int - Der Index des Werts, falls in der Liste gefunden; sonst -1.
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Gibt einen Enumerator zurück, der die CollectionBase-Instanz durchläuft.
+
+**Returns:**
+java.util.Iterator - Ein Iterator für die CollectionBase-Instanz.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### removeAt(int index) {#removeAt-int-}
+```
+public void removeAt(int index)
+```
+
+
+Entfernt das Element am angegebenen Index.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Der nullbasierte Index des zu entfernenden Elements. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/color/_index.md
+++ b/german/java/com.aspose.diagram/color/_index.md
@@ -1,0 +1,1819 @@
+---
+title: Color
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt eine ARGB‑Alpha‑Rot‑Grün‑Blau‑Farbe dar.
+type: docs
+weight: 51
+url: /de/java/com.aspose.diagram/color/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Color
+```
+
+Stellt eine ARGB‑Farbe (Alpha, Rot, Grün, Blau) dar.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [Color()](#Color--) | Konstruktorfunktion |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object obj)](#equals-java.lang.Object-) | Prüft, ob das angegebene Objekt ein Color‑Objekt ist und diesem Objekt entspricht. |
+| [fromArgb(int argb)](#fromArgb-int-) | Erstellt ein Color‑Objekt aus einem 32‑Bit‑ARGB‑Wert. |
+| [fromArgb(int red, int green, int blue)](#fromArgb-int-int-int-) | Erstellt ein Color‑Objekt aus den angegebenen 8‑Bit‑Farbwerten (Rot, Grün und Blau). |
+| [fromArgb(int alpha, int red, int green, int blue)](#fromArgb-int-int-int-int-) | Erstellt ein Color‑Objekt aus den vier ARGB‑Komponenten (Alpha, Rot, Grün und Blau). |
+| [getA()](#getA--) | Liefert den Alpha‑Komponentenwert dieses Color‑Objekts. |
+| [getAliceBlue()](#getAliceBlue--) | Ruft eine systemdefinierte Farbe ab. |
+| [getAntiqueWhite()](#getAntiqueWhite--) | Ruft eine systemdefinierte Farbe ab. |
+| [getAqua()](#getAqua--) | Ruft eine systemdefinierte Farbe ab. |
+| [getAquamarine()](#getAquamarine--) | Ruft eine systemdefinierte Farbe ab. |
+| [getAzure()](#getAzure--) | Ruft eine systemdefinierte Farbe ab. |
+| [getB()](#getB--) | Liefert den Blau‑Komponentenwert dieses Color‑Objekts. |
+| [getBeige()](#getBeige--) | Ruft eine systemdefinierte Farbe ab. |
+| [getBisque()](#getBisque--) | Ruft eine systemdefinierte Farbe ab. |
+| [getBlack()](#getBlack--) | Ruft eine systemdefinierte Farbe ab. |
+| [getBlanchedAlmond()](#getBlanchedAlmond--) | Ruft eine systemdefinierte Farbe ab. |
+| [getBlue()](#getBlue--) | Ruft eine systemdefinierte Farbe ab. |
+| [getBlueViolet()](#getBlueViolet--) | Ruft eine systemdefinierte Farbe ab. |
+| [getBrown()](#getBrown--) | Ruft eine systemdefinierte Farbe ab. |
+| [getBurlyWood()](#getBurlyWood--) | Ruft eine systemdefinierte Farbe ab. |
+| [getCadetBlue()](#getCadetBlue--) | Ruft eine systemdefinierte Farbe ab. |
+| [getChartreuse()](#getChartreuse--) | Ruft eine systemdefinierte Farbe ab. |
+| [getChocolate()](#getChocolate--) | Ruft eine systemdefinierte Farbe ab. |
+| [getClass()](#getClass--) |  |
+| [getCoral()](#getCoral--) | Ruft eine systemdefinierte Farbe ab. |
+| [getCornflowerBlue()](#getCornflowerBlue--) | Ruft eine systemdefinierte Farbe ab. |
+| [getCornsilk()](#getCornsilk--) | Ruft eine systemdefinierte Farbe ab. |
+| [getCrimson()](#getCrimson--) | Ruft eine systemdefinierte Farbe ab. |
+| [getCyan()](#getCyan--) | Ruft eine systemdefinierte Farbe ab. |
+| [getDarkBlue()](#getDarkBlue--) | Ruft eine systemdefinierte Farbe ab. |
+| [getDarkCyan()](#getDarkCyan--) | Ruft eine systemdefinierte Farbe ab. |
+| [getDarkGoldenrod()](#getDarkGoldenrod--) | Ruft eine systemdefinierte Farbe ab. |
+| [getDarkGray()](#getDarkGray--) | Ruft eine systemdefinierte Farbe ab. |
+| [getDarkGreen()](#getDarkGreen--) | Ruft eine systemdefinierte Farbe ab. |
+| [getDarkKhaki()](#getDarkKhaki--) | Ruft eine systemdefinierte Farbe ab. |
+| [getDarkMagenta()](#getDarkMagenta--) | Ruft eine systemdefinierte Farbe ab. |
+| [getDarkOliveGreen()](#getDarkOliveGreen--) | Ruft eine systemdefinierte Farbe ab. |
+| [getDarkOrange()](#getDarkOrange--) | Ruft eine systemdefinierte Farbe ab. |
+| [getDarkOrchid()](#getDarkOrchid--) | Ruft eine systemdefinierte Farbe ab. |
+| [getDarkRed()](#getDarkRed--) | Ruft eine systemdefinierte Farbe ab. |
+| [getDarkSalmon()](#getDarkSalmon--) | Ruft eine systemdefinierte Farbe ab. |
+| [getDarkSeaGreen()](#getDarkSeaGreen--) | Ruft eine systemdefinierte Farbe ab. |
+| [getDarkSlateBlue()](#getDarkSlateBlue--) | Ruft eine systemdefinierte Farbe ab. |
+| [getDarkSlateGray()](#getDarkSlateGray--) | Ruft eine systemdefinierte Farbe ab. |
+| [getDarkTurquoise()](#getDarkTurquoise--) | Ruft eine systemdefinierte Farbe ab. |
+| [getDarkViolet()](#getDarkViolet--) | Ruft eine systemdefinierte Farbe ab. |
+| [getDeepPink()](#getDeepPink--) | Ruft eine systemdefinierte Farbe ab. |
+| [getDeepSkyBlue()](#getDeepSkyBlue--) | Ruft eine systemdefinierte Farbe ab. |
+| [getDimGray()](#getDimGray--) | Ruft eine systemdefinierte Farbe ab. |
+| [getDodgerBlue()](#getDodgerBlue--) | Ruft eine systemdefinierte Farbe ab. |
+| [getEmpty()](#getEmpty--) | Ruft eine systemdefinierte leere Farbe ab. |
+| [getFirebrick()](#getFirebrick--) | Ruft eine systemdefinierte Farbe ab. |
+| [getFloralWhite()](#getFloralWhite--) | Ruft eine systemdefinierte Farbe ab. |
+| [getForestGreen()](#getForestGreen--) | Ruft eine systemdefinierte Farbe ab. |
+| [getFuchsia()](#getFuchsia--) | Ruft eine systemdefinierte Farbe ab. |
+| [getG()](#getG--) | Liefert den Grün‑Komponentenwert dieses Color‑Objekts. |
+| [getGainsboro()](#getGainsboro--) | Ruft eine systemdefinierte Farbe ab. |
+| [getGhostWhite()](#getGhostWhite--) | Ruft eine systemdefinierte Farbe ab. |
+| [getGold()](#getGold--) | Ruft eine systemdefinierte Farbe ab. |
+| [getGoldenrod()](#getGoldenrod--) | Ruft eine systemdefinierte Farbe ab. |
+| [getGray()](#getGray--) | Ruft eine systemdefinierte Farbe ab. |
+| [getGreen()](#getGreen--) | Ruft eine systemdefinierte Farbe ab. |
+| [getGreenYellow()](#getGreenYellow--) | Ruft eine systemdefinierte Farbe ab. |
+| [getHoneydew()](#getHoneydew--) | Ruft eine systemdefinierte Farbe ab. |
+| [getHotPink()](#getHotPink--) | Ruft eine systemdefinierte Farbe ab. |
+| [getIndianRed()](#getIndianRed--) | Ruft eine systemdefinierte Farbe ab. |
+| [getIndigo()](#getIndigo--) | Ruft eine systemdefinierte Farbe ab. |
+| [getIvory()](#getIvory--) | Ruft eine systemdefinierte Farbe ab. |
+| [getKhaki()](#getKhaki--) | Ruft eine systemdefinierte Farbe ab. |
+| [getLavender()](#getLavender--) | Ruft eine systemdefinierte Farbe ab. |
+| [getLavenderBlush()](#getLavenderBlush--) | Ruft eine systemdefinierte Farbe ab. |
+| [getLawnGreen()](#getLawnGreen--) | Ruft eine systemdefinierte Farbe ab. |
+| [getLemonChiffon()](#getLemonChiffon--) | Ruft eine systemdefinierte Farbe ab. |
+| [getLightBlue()](#getLightBlue--) | Ruft eine systemdefinierte Farbe ab. |
+| [getLightCoral()](#getLightCoral--) | Ruft eine systemdefinierte Farbe ab. |
+| [getLightCyan()](#getLightCyan--) | Ruft eine systemdefinierte Farbe ab. |
+| [getLightGoldenrodYellow()](#getLightGoldenrodYellow--) | Ruft eine systemdefinierte Farbe ab. |
+| [getLightGray()](#getLightGray--) | Ruft eine systemdefinierte Farbe ab. |
+| [getLightGreen()](#getLightGreen--) | Ruft eine systemdefinierte Farbe ab. |
+| [getLightPink()](#getLightPink--) | Ruft eine systemdefinierte Farbe ab. |
+| [getLightSalmon()](#getLightSalmon--) | Ruft eine systemdefinierte Farbe ab. |
+| [getLightSeaGreen()](#getLightSeaGreen--) | Ruft eine systemdefinierte Farbe ab. |
+| [getLightSkyBlue()](#getLightSkyBlue--) | Ruft eine systemdefinierte Farbe ab. |
+| [getLightSlateGray()](#getLightSlateGray--) | Ruft eine systemdefinierte Farbe ab. |
+| [getLightSteelBlue()](#getLightSteelBlue--) | Ruft eine systemdefinierte Farbe ab. |
+| [getLightYellow()](#getLightYellow--) | Ruft eine systemdefinierte Farbe ab. |
+| [getLime()](#getLime--) | Ruft eine systemdefinierte Farbe ab. |
+| [getLimeGreen()](#getLimeGreen--) | Ruft eine systemdefinierte Farbe ab. |
+| [getLinen()](#getLinen--) | Ruft eine systemdefinierte Farbe ab. |
+| [getMagenta()](#getMagenta--) | Ruft eine systemdefinierte Farbe ab. |
+| [getMaroon()](#getMaroon--) | Ruft eine systemdefinierte Farbe ab. |
+| [getMediumAquamarine()](#getMediumAquamarine--) | Ruft eine systemdefinierte Farbe ab. |
+| [getMediumBlue()](#getMediumBlue--) | Ruft eine systemdefinierte Farbe ab. |
+| [getMediumOrchid()](#getMediumOrchid--) | Ruft eine systemdefinierte Farbe ab. |
+| [getMediumPurple()](#getMediumPurple--) | Ruft eine systemdefinierte Farbe ab. |
+| [getMediumSeaGreen()](#getMediumSeaGreen--) | Ruft eine systemdefinierte Farbe ab. |
+| [getMediumSlateBlue()](#getMediumSlateBlue--) | Ruft eine systemdefinierte Farbe ab. |
+| [getMediumSpringGreen()](#getMediumSpringGreen--) | Ruft eine systemdefinierte Farbe ab. |
+| [getMediumTurquoise()](#getMediumTurquoise--) | Ruft eine systemdefinierte Farbe ab. |
+| [getMediumVioletRed()](#getMediumVioletRed--) | Ruft eine systemdefinierte Farbe ab. |
+| [getMidnightBlue()](#getMidnightBlue--) | Ruft eine systemdefinierte Farbe ab. |
+| [getMintCream()](#getMintCream--) | Ruft eine systemdefinierte Farbe ab. |
+| [getMistyRose()](#getMistyRose--) | Ruft eine systemdefinierte Farbe ab. |
+| [getMoccasin()](#getMoccasin--) | Ruft eine systemdefinierte Farbe ab. |
+| [getNavajoWhite()](#getNavajoWhite--) | Ruft eine systemdefinierte Farbe ab. |
+| [getNavy()](#getNavy--) | Ruft eine systemdefinierte Farbe ab. |
+| [getOldLace()](#getOldLace--) | Ruft eine systemdefinierte Farbe ab. |
+| [getOlive()](#getOlive--) | Ruft eine systemdefinierte Farbe ab. |
+| [getOliveDrab()](#getOliveDrab--) | Ruft eine systemdefinierte Farbe ab. |
+| [getOrange()](#getOrange--) | Ruft eine systemdefinierte Farbe ab. |
+| [getOrangeRed()](#getOrangeRed--) | Ruft eine systemdefinierte Farbe ab. |
+| [getOrchid()](#getOrchid--) | Ruft eine systemdefinierte Farbe ab. |
+| [getPaleGoldenrod()](#getPaleGoldenrod--) | Ruft eine systemdefinierte Farbe ab. |
+| [getPaleGreen()](#getPaleGreen--) | Ruft eine systemdefinierte Farbe ab. |
+| [getPaleTurquoise()](#getPaleTurquoise--) | Ruft eine systemdefinierte Farbe ab. |
+| [getPaleVioletRed()](#getPaleVioletRed--) | Ruft eine systemdefinierte Farbe ab. |
+| [getPapayaWhip()](#getPapayaWhip--) | Ruft eine systemdefinierte Farbe ab. |
+| [getPeachPuff()](#getPeachPuff--) | Ruft eine systemdefinierte Farbe ab. |
+| [getPeru()](#getPeru--) | Ruft eine systemdefinierte Farbe ab. |
+| [getPink()](#getPink--) | Ruft eine systemdefinierte Farbe ab. |
+| [getPlum()](#getPlum--) | Ruft eine systemdefinierte Farbe ab. |
+| [getPowderBlue()](#getPowderBlue--) | Ruft eine systemdefinierte Farbe ab. |
+| [getPurple()](#getPurple--) | Ruft eine systemdefinierte Farbe ab. |
+| [getR()](#getR--) | Liefert den Rot‑Komponentenwert dieses Color‑Objekts. |
+| [getRed()](#getRed--) | Ruft eine systemdefinierte Farbe ab. |
+| [getRosyBrown()](#getRosyBrown--) | Ruft eine systemdefinierte Farbe ab. |
+| [getRoyalBlue()](#getRoyalBlue--) | Ruft eine systemdefinierte Farbe ab. |
+| [getSaddleBrown()](#getSaddleBrown--) | Ruft eine systemdefinierte Farbe ab. |
+| [getSalmon()](#getSalmon--) | Ruft eine systemdefinierte Farbe ab. |
+| [getSandyBrown()](#getSandyBrown--) | Ruft eine systemdefinierte Farbe ab. |
+| [getSeaGreen()](#getSeaGreen--) | Ruft eine systemdefinierte Farbe ab. |
+| [getSeaShell()](#getSeaShell--) | Ruft eine systemdefinierte Farbe ab. |
+| [getSienna()](#getSienna--) | Ruft eine systemdefinierte Farbe ab. |
+| [getSilver()](#getSilver--) | Ruft eine systemdefinierte Farbe ab. |
+| [getSkyBlue()](#getSkyBlue--) | Ruft eine systemdefinierte Farbe ab. |
+| [getSlateBlue()](#getSlateBlue--) | Ruft eine systemdefinierte Farbe ab. |
+| [getSlateGray()](#getSlateGray--) | Ruft eine systemdefinierte Farbe ab. |
+| [getSnow()](#getSnow--) | Ruft eine systemdefinierte Farbe ab. |
+| [getSpringGreen()](#getSpringGreen--) | Ruft eine systemdefinierte Farbe ab. |
+| [getSteelBlue()](#getSteelBlue--) | Ruft eine systemdefinierte Farbe ab. |
+| [getTan()](#getTan--) | Ruft eine systemdefinierte Farbe ab. |
+| [getTeal()](#getTeal--) | Ruft eine systemdefinierte Farbe ab. |
+| [getThistle()](#getThistle--) | Ruft eine systemdefinierte Farbe ab. |
+| [getTomato()](#getTomato--) | Ruft eine systemdefinierte Farbe ab. |
+| [getTransparent()](#getTransparent--) | Ruft eine systemdefinierte Farbe ab. |
+| [getTurquoise()](#getTurquoise--) | Ruft eine systemdefinierte Farbe ab. |
+| [getViolet()](#getViolet--) | Ruft eine systemdefinierte Farbe ab. |
+| [getWheat()](#getWheat--) | Ruft eine systemdefinierte Farbe ab. |
+| [getWhite()](#getWhite--) | Ruft eine systemdefinierte Farbe ab. |
+| [getWhiteSmoke()](#getWhiteSmoke--) | Ruft eine systemdefinierte Farbe ab. |
+| [getYellow()](#getYellow--) | Ruft eine systemdefinierte Farbe ab. |
+| [getYellowGreen()](#getYellowGreen--) | Ruft eine systemdefinierte Farbe ab. |
+| [hashCode()](#hashCode--) | Gibt einen Hash‑Code für dieses Color‑Objekt zurück. |
+| [isEmpty()](#isEmpty--) | Gibt an, ob dieses Color‑Objekt nicht initialisiert ist. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toArgb()](#toArgb--) | Liefert den 32‑Bit‑ARGB‑Wert dieses Color‑Objekts. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Color() {#Color--}
+```
+public Color()
+```
+
+
+Konstruktorfunktion
+
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+Prüft, ob das angegebene Objekt ein Color‑Objekt ist und diesem Objekt entspricht.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| obj | java.lang.Object | Das zu testende Objekt. |
+
+**Returns:**
+boolescher Wert – true, wenn obj ein Color‑Objekt ist und diesem Color‑Objekt entspricht; andernfalls false.
+### fromArgb(int argb) {#fromArgb-int-}
+```
+public static Color fromArgb(int argb)
+```
+
+
+Erstellt ein Color‑Objekt aus einem 32‑Bit‑ARGB‑Wert.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| argb | int | Ein Wert, der den 32‑Bit‑ARGB‑Wert angibt. |
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - The Color object that this method creates.
+### fromArgb(int red, int green, int blue) {#fromArgb-int-int-int-}
+```
+public static Color fromArgb(int red, int green, int blue)
+```
+
+
+Erstellt ein Color‑Objekt aus den angegebenen 8‑Bit‑Farbwerten (Rot, Grün und Blau). Der Alpha‑Wert ist implizit 255 (vollständig undurchsichtig). Obwohl diese Methode es erlaubt, für jede Farbkomponente einen 32‑Bit‑Wert zu übergeben, ist der Wert jeder Komponente auf 8 Bit begrenzt.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Rot | int | Der Rot‑Komponentenwert für das neue Color‑Objekt. Gültige Werte liegen zwischen 0 und 255. |
+| grün | int | Der Grünkomponentenwert für das neue Color-Objekt. Gültige Werte liegen zwischen 0 und 255. |
+| blau | int | Der Blaukomponentenwert für das neue Color-Objekt. Gültige Werte liegen zwischen 0 und 255. |
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - The Color object that this method creates.
+### fromArgb(int alpha, int red, int green, int blue) {#fromArgb-int-int-int-int-}
+```
+public static Color fromArgb(int alpha, int red, int green, int blue)
+```
+
+
+Erstellt ein Color-Objekt aus den vier ARGB-Komponenten (Alpha, Rot, Grün und Blau). Obwohl diese Methode einen 32‑Bit‑Wert für jede Komponente zulässt, ist der Wert jeder Komponente auf 8 Bit begrenzt.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| alpha | int | Die Alpha‑Komponente. Gültige Werte liegen zwischen 0 und 255. |
+| Rot | int | Die Rot‑Komponente. Gültige Werte liegen zwischen 0 und 255. |
+| grün | int | Die Grün‑Komponente. Gültige Werte liegen zwischen 0 und 255. |
+| blau | int | Die Blau‑Komponente. Gültige Werte liegen zwischen 0 und 255. |
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - The Color object that this method creates.
+### getA() {#getA--}
+```
+public byte getA()
+```
+
+
+Liefert den Alpha‑Komponentenwert dieses Color‑Objekts.
+
+**Returns:**
+byte - Der Alpha‑Komponentenwert dieses Color-Objekts.
+### getAliceBlue() {#getAliceBlue--}
+```
+public static Color getAliceBlue()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getAntiqueWhite() {#getAntiqueWhite--}
+```
+public static Color getAntiqueWhite()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getAqua() {#getAqua--}
+```
+public static Color getAqua()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getAquamarine() {#getAquamarine--}
+```
+public static Color getAquamarine()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getAzure() {#getAzure--}
+```
+public static Color getAzure()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getB() {#getB--}
+```
+public byte getB()
+```
+
+
+Liefert den Blau‑Komponentenwert dieses Color‑Objekts.
+
+**Returns:**
+byte - Der Blau‑Komponentenwert dieses Color-Objekts.
+### getBeige() {#getBeige--}
+```
+public static Color getBeige()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getBisque() {#getBisque--}
+```
+public static Color getBisque()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getBlack() {#getBlack--}
+```
+public static Color getBlack()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getBlanchedAlmond() {#getBlanchedAlmond--}
+```
+public static Color getBlanchedAlmond()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getBlue() {#getBlue--}
+```
+public static Color getBlue()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getBlueViolet() {#getBlueViolet--}
+```
+public static Color getBlueViolet()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getBrown() {#getBrown--}
+```
+public static Color getBrown()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getBurlyWood() {#getBurlyWood--}
+```
+public static Color getBurlyWood()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getCadetBlue() {#getCadetBlue--}
+```
+public static Color getCadetBlue()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getChartreuse() {#getChartreuse--}
+```
+public static Color getChartreuse()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getChocolate() {#getChocolate--}
+```
+public static Color getChocolate()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCoral() {#getCoral--}
+```
+public static Color getCoral()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getCornflowerBlue() {#getCornflowerBlue--}
+```
+public static Color getCornflowerBlue()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getCornsilk() {#getCornsilk--}
+```
+public static Color getCornsilk()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getCrimson() {#getCrimson--}
+```
+public static Color getCrimson()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getCyan() {#getCyan--}
+```
+public static Color getCyan()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkBlue() {#getDarkBlue--}
+```
+public static Color getDarkBlue()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkCyan() {#getDarkCyan--}
+```
+public static Color getDarkCyan()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkGoldenrod() {#getDarkGoldenrod--}
+```
+public static Color getDarkGoldenrod()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkGray() {#getDarkGray--}
+```
+public static Color getDarkGray()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkGreen() {#getDarkGreen--}
+```
+public static Color getDarkGreen()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkKhaki() {#getDarkKhaki--}
+```
+public static Color getDarkKhaki()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkMagenta() {#getDarkMagenta--}
+```
+public static Color getDarkMagenta()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkOliveGreen() {#getDarkOliveGreen--}
+```
+public static Color getDarkOliveGreen()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkOrange() {#getDarkOrange--}
+```
+public static Color getDarkOrange()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkOrchid() {#getDarkOrchid--}
+```
+public static Color getDarkOrchid()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkRed() {#getDarkRed--}
+```
+public static Color getDarkRed()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkSalmon() {#getDarkSalmon--}
+```
+public static Color getDarkSalmon()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkSeaGreen() {#getDarkSeaGreen--}
+```
+public static Color getDarkSeaGreen()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkSlateBlue() {#getDarkSlateBlue--}
+```
+public static Color getDarkSlateBlue()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkSlateGray() {#getDarkSlateGray--}
+```
+public static Color getDarkSlateGray()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkTurquoise() {#getDarkTurquoise--}
+```
+public static Color getDarkTurquoise()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkViolet() {#getDarkViolet--}
+```
+public static Color getDarkViolet()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDeepPink() {#getDeepPink--}
+```
+public static Color getDeepPink()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDeepSkyBlue() {#getDeepSkyBlue--}
+```
+public static Color getDeepSkyBlue()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDimGray() {#getDimGray--}
+```
+public static Color getDimGray()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDodgerBlue() {#getDodgerBlue--}
+```
+public static Color getDodgerBlue()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getEmpty() {#getEmpty--}
+```
+public static Color getEmpty()
+```
+
+
+Ruft eine systemdefinierte leere Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getFirebrick() {#getFirebrick--}
+```
+public static Color getFirebrick()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getFloralWhite() {#getFloralWhite--}
+```
+public static Color getFloralWhite()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getForestGreen() {#getForestGreen--}
+```
+public static Color getForestGreen()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getFuchsia() {#getFuchsia--}
+```
+public static Color getFuchsia()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getG() {#getG--}
+```
+public byte getG()
+```
+
+
+Liefert den Grün‑Komponentenwert dieses Color‑Objekts.
+
+**Returns:**
+byte - Der Grün‑Komponentenwert dieses Color-Objekts.
+### getGainsboro() {#getGainsboro--}
+```
+public static Color getGainsboro()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getGhostWhite() {#getGhostWhite--}
+```
+public static Color getGhostWhite()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getGold() {#getGold--}
+```
+public static Color getGold()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getGoldenrod() {#getGoldenrod--}
+```
+public static Color getGoldenrod()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getGray() {#getGray--}
+```
+public static Color getGray()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getGreen() {#getGreen--}
+```
+public static Color getGreen()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getGreenYellow() {#getGreenYellow--}
+```
+public static Color getGreenYellow()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getHoneydew() {#getHoneydew--}
+```
+public static Color getHoneydew()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getHotPink() {#getHotPink--}
+```
+public static Color getHotPink()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getIndianRed() {#getIndianRed--}
+```
+public static Color getIndianRed()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getIndigo() {#getIndigo--}
+```
+public static Color getIndigo()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getIvory() {#getIvory--}
+```
+public static Color getIvory()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getKhaki() {#getKhaki--}
+```
+public static Color getKhaki()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLavender() {#getLavender--}
+```
+public static Color getLavender()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLavenderBlush() {#getLavenderBlush--}
+```
+public static Color getLavenderBlush()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLawnGreen() {#getLawnGreen--}
+```
+public static Color getLawnGreen()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLemonChiffon() {#getLemonChiffon--}
+```
+public static Color getLemonChiffon()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightBlue() {#getLightBlue--}
+```
+public static Color getLightBlue()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightCoral() {#getLightCoral--}
+```
+public static Color getLightCoral()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightCyan() {#getLightCyan--}
+```
+public static Color getLightCyan()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightGoldenrodYellow() {#getLightGoldenrodYellow--}
+```
+public static Color getLightGoldenrodYellow()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightGray() {#getLightGray--}
+```
+public static Color getLightGray()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightGreen() {#getLightGreen--}
+```
+public static Color getLightGreen()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightPink() {#getLightPink--}
+```
+public static Color getLightPink()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightSalmon() {#getLightSalmon--}
+```
+public static Color getLightSalmon()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightSeaGreen() {#getLightSeaGreen--}
+```
+public static Color getLightSeaGreen()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightSkyBlue() {#getLightSkyBlue--}
+```
+public static Color getLightSkyBlue()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightSlateGray() {#getLightSlateGray--}
+```
+public static Color getLightSlateGray()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightSteelBlue() {#getLightSteelBlue--}
+```
+public static Color getLightSteelBlue()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightYellow() {#getLightYellow--}
+```
+public static Color getLightYellow()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLime() {#getLime--}
+```
+public static Color getLime()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLimeGreen() {#getLimeGreen--}
+```
+public static Color getLimeGreen()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLinen() {#getLinen--}
+```
+public static Color getLinen()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMagenta() {#getMagenta--}
+```
+public static Color getMagenta()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMaroon() {#getMaroon--}
+```
+public static Color getMaroon()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMediumAquamarine() {#getMediumAquamarine--}
+```
+public static Color getMediumAquamarine()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMediumBlue() {#getMediumBlue--}
+```
+public static Color getMediumBlue()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMediumOrchid() {#getMediumOrchid--}
+```
+public static Color getMediumOrchid()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMediumPurple() {#getMediumPurple--}
+```
+public static Color getMediumPurple()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMediumSeaGreen() {#getMediumSeaGreen--}
+```
+public static Color getMediumSeaGreen()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMediumSlateBlue() {#getMediumSlateBlue--}
+```
+public static Color getMediumSlateBlue()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMediumSpringGreen() {#getMediumSpringGreen--}
+```
+public static Color getMediumSpringGreen()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMediumTurquoise() {#getMediumTurquoise--}
+```
+public static Color getMediumTurquoise()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMediumVioletRed() {#getMediumVioletRed--}
+```
+public static Color getMediumVioletRed()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMidnightBlue() {#getMidnightBlue--}
+```
+public static Color getMidnightBlue()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMintCream() {#getMintCream--}
+```
+public static Color getMintCream()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMistyRose() {#getMistyRose--}
+```
+public static Color getMistyRose()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMoccasin() {#getMoccasin--}
+```
+public static Color getMoccasin()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getNavajoWhite() {#getNavajoWhite--}
+```
+public static Color getNavajoWhite()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getNavy() {#getNavy--}
+```
+public static Color getNavy()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getOldLace() {#getOldLace--}
+```
+public static Color getOldLace()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getOlive() {#getOlive--}
+```
+public static Color getOlive()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getOliveDrab() {#getOliveDrab--}
+```
+public static Color getOliveDrab()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getOrange() {#getOrange--}
+```
+public static Color getOrange()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getOrangeRed() {#getOrangeRed--}
+```
+public static Color getOrangeRed()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getOrchid() {#getOrchid--}
+```
+public static Color getOrchid()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPaleGoldenrod() {#getPaleGoldenrod--}
+```
+public static Color getPaleGoldenrod()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPaleGreen() {#getPaleGreen--}
+```
+public static Color getPaleGreen()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPaleTurquoise() {#getPaleTurquoise--}
+```
+public static Color getPaleTurquoise()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPaleVioletRed() {#getPaleVioletRed--}
+```
+public static Color getPaleVioletRed()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPapayaWhip() {#getPapayaWhip--}
+```
+public static Color getPapayaWhip()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPeachPuff() {#getPeachPuff--}
+```
+public static Color getPeachPuff()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPeru() {#getPeru--}
+```
+public static Color getPeru()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPink() {#getPink--}
+```
+public static Color getPink()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPlum() {#getPlum--}
+```
+public static Color getPlum()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPowderBlue() {#getPowderBlue--}
+```
+public static Color getPowderBlue()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPurple() {#getPurple--}
+```
+public static Color getPurple()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getR() {#getR--}
+```
+public byte getR()
+```
+
+
+Liefert den Rot‑Komponentenwert dieses Color‑Objekts.
+
+**Returns:**
+byte - Der Rot‑Komponentenwert dieses Color-Objekts.
+### getRed() {#getRed--}
+```
+public static Color getRed()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getRosyBrown() {#getRosyBrown--}
+```
+public static Color getRosyBrown()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getRoyalBlue() {#getRoyalBlue--}
+```
+public static Color getRoyalBlue()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSaddleBrown() {#getSaddleBrown--}
+```
+public static Color getSaddleBrown()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSalmon() {#getSalmon--}
+```
+public static Color getSalmon()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSandyBrown() {#getSandyBrown--}
+```
+public static Color getSandyBrown()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSeaGreen() {#getSeaGreen--}
+```
+public static Color getSeaGreen()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSeaShell() {#getSeaShell--}
+```
+public static Color getSeaShell()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSienna() {#getSienna--}
+```
+public static Color getSienna()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSilver() {#getSilver--}
+```
+public static Color getSilver()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSkyBlue() {#getSkyBlue--}
+```
+public static Color getSkyBlue()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSlateBlue() {#getSlateBlue--}
+```
+public static Color getSlateBlue()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSlateGray() {#getSlateGray--}
+```
+public static Color getSlateGray()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSnow() {#getSnow--}
+```
+public static Color getSnow()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSpringGreen() {#getSpringGreen--}
+```
+public static Color getSpringGreen()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSteelBlue() {#getSteelBlue--}
+```
+public static Color getSteelBlue()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getTan() {#getTan--}
+```
+public static Color getTan()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getTeal() {#getTeal--}
+```
+public static Color getTeal()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getThistle() {#getThistle--}
+```
+public static Color getThistle()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getTomato() {#getTomato--}
+```
+public static Color getTomato()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getTransparent() {#getTransparent--}
+```
+public static Color getTransparent()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getTurquoise() {#getTurquoise--}
+```
+public static Color getTurquoise()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getViolet() {#getViolet--}
+```
+public static Color getViolet()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getWheat() {#getWheat--}
+```
+public static Color getWheat()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getWhite() {#getWhite--}
+```
+public static Color getWhite()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getWhiteSmoke() {#getWhiteSmoke--}
+```
+public static Color getWhiteSmoke()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getYellow() {#getYellow--}
+```
+public static Color getYellow()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getYellowGreen() {#getYellowGreen--}
+```
+public static Color getYellowGreen()
+```
+
+
+Ruft eine systemdefinierte Farbe ab.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Gibt einen Hash‑Code für dieses Color‑Objekt zurück.
+
+**Returns:**
+int - Ein ganzzahliger Wert, der den Hash‑Code für dieses Color-Objekt angibt.
+### isEmpty() {#isEmpty--}
+```
+public boolean isEmpty()
+```
+
+
+Gibt an, ob dieses Color‑Objekt nicht initialisiert ist.
+
+**Returns:**
+boolean - Diese Eigenschaft liefert true, wenn diese Farbe nicht initialisiert ist; andernfalls false.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toArgb() {#toArgb--}
+```
+public int toArgb()
+```
+
+
+Liefert den 32‑Bit‑ARGB‑Wert dieses Color‑Objekts.
+
+**Returns:**
+int - Der 32‑Bit‑ARGB‑Wert dieses Color-Objekts.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/colorentry/_index.md
+++ b/german/java/com.aspose.diagram/colorentry/_index.md
@@ -1,0 +1,188 @@
+---
+title: ColorEntry
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält einen Eintrag in der Farbpalette.
+type: docs
+weight: 52
+url: /de/java/com.aspose.diagram/colorentry/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ColorEntry
+```
+
+Enthält einen Eintrag in der Farbpalette. Jeder Farbpaletteneintrag gibt eine Standardfarbe an, die für die Anwendung auf Objekte wie Formen, Text und Ebenen im Dokument verfügbar ist.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [ColorEntry()](#ColorEntry--) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getColor()](#getColor--) | Stellt eine ARGB-Farbe dar. |
+| [getIX()](#getIX--) | Erforderliche int. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setColor(Color value)](#setColor-com.aspose.diagram.Color-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getColor()](../../com.aspose.diagram/colorentry\#getColor--) |
+| [setIX(int value)](#setIX-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getIX()](../../com.aspose.diagram/colorentry\#getIX--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ColorEntry() {#ColorEntry--}
+```
+public ColorEntry()
+```
+
+
+Konstruktor.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColor() {#getColor--}
+```
+public Color getColor()
+```
+
+
+Stellt eine ARGB-Farbe dar.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color)
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Erforderliche int. Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setColor(Color value) {#setColor-com.aspose.diagram.Color-}
+```
+public void setColor(Color value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getColor()](../../com.aspose.diagram/colorentry\#getColor--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [Color](../../com.aspose.diagram/color) |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getIX()](../../com.aspose.diagram/colorentry\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/colorentrycollection/_index.md
+++ b/german/java/com.aspose.diagram/colorentrycollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: ColorEntryCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält die Farbtabelle des Dokuments.
+type: docs
+weight: 53
+url: /de/java/com.aspose.diagram/colorentrycollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ColorEntryCollection extends Collection
+```
+
+Enthält die Farbtabelle des Dokuments. Jedes Dokument enthält eine einzelne Farbtabelle, die die 24 Standardfarben auflistet, die für Objekte wie Formen, Text und Ebenen im Dokument verwendet werden können.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [add(ColorEntry color)](#add-com.aspose.diagram.ColorEntry-) | Fügt das Color-Objekt zur Sammlung hinzu. |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(ColorEntry color)](#remove-com.aspose.diagram.ColorEntry-) | Entfernt das Color-Objekt aus der Sammlung. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(ColorEntry color) {#add-com.aspose.diagram.ColorEntry-}
+```
+public int add(ColorEntry color)
+```
+
+
+Fügt das Color-Objekt zur Sammlung hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| color | [ColorEntry](../../com.aspose.diagram/colorentry) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public ColorEntry get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[ColorEntry](../../com.aspose.diagram/colorentry) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(ColorEntry color) {#remove-com.aspose.diagram.ColorEntry-}
+```
+public void remove(ColorEntry color)
+```
+
+
+Entfernt das Color-Objekt aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| color | [ColorEntry](../../com.aspose.diagram/colorentry) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/colorvalue/_index.md
+++ b/german/java/com.aspose.diagram/colorvalue/_index.md
@@ -1,0 +1,205 @@
+---
+title: ColorValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt einen Farbwert dar
+type: docs
+weight: 54
+url: /de/java/com.aspose.diagram/colorvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ColorValue
+```
+
+Stellt einen Farbwert dar
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [ColorValue(String value, int unit)](#ColorValue-java.lang.String-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Attribute eines Elements. |
+| [getValue()](#getValue--) | Farbwert. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | Für die Beschreibung dieser Eigenschaft siehe [getUfe()](../../com.aspose.diagram/colorvalue\#getUfe--) |
+| [setValue(String value)](#setValue-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe [getValue()](../../com.aspose.diagram/colorvalue\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ColorValue(String value, int unit) {#ColorValue-java.lang.String-int-}
+```
+public ColorValue(String value, int unit)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+| Einheit | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Attribute eines Elements.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+Farbwert. Um die Farbe festzulegen, geben Sie eine Zahl von 0 bis 23 oder den RGB-Wert in hexadezimaler Schreibweise ein.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getUfe()](../../com.aspose.diagram/colorvalue\#getUfe--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(String value) {#setValue-java.lang.String-}
+```
+public void setValue(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getValue()](../../com.aspose.diagram/colorvalue\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/comboboxactivexcontrol/_index.md
+++ b/german/java/com.aspose.diagram/comboboxactivexcontrol/_index.md
@@ -1,0 +1,972 @@
+---
+title: ComboBoxActiveXControl
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt ein ComboBox-ActiveX-Steuerelement dar.
+type: docs
+weight: 55
+url: /de/java/com.aspose.diagram/comboboxactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class ComboBoxActiveXControl extends ActiveXControl
+```
+
+Stellt ein ComboBox-ActiveX-Steuerelement dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBackOleColor()](#getBackOleColor--) | die OLE‑Farbe des Hintergrunds. |
+| [getBorderOleColor()](#getBorderOleColor--) | die OLE‑Farbe des Hintergrunds. |
+| [getBorderStyle()](#getBorderStyle--) | der von dem Steuerelement verwendete Randtyp. |
+| [getBoundColumn()](#getBoundColumn--) | Gibt an, wie die Value‑Eigenschaft für ein ComboBox‑ oder ListBox‑Steuerelement bestimmt wird, wenn der Wert der MultiSelect‑Eigenschaft (fmMultiSelectSingle) ist. |
+| [getClass()](#getClass--) |  |
+| [getColumnCount()](#getColumnCount--) | Gibt die Anzahl der Spalten an, die in einem ComboBox‑ oder ListBox‑Steuerelement angezeigt werden. |
+| [getColumnWidths()](#getColumnWidths--) | die Breite der Spalte. |
+| [getData()](#getData--) | die Binärdaten des Steuerelements. |
+| [getDropButtonStyle()](#getDropButtonStyle--) | Gibt das Symbol an, das auf dem Dropdown‑Button angezeigt wird. |
+| [getEnterFieldBehavior()](#getEnterFieldBehavior--) | Gibt das Auswahlverhalten beim Betreten des Steuerelements an. |
+| [getForeOleColor()](#getForeOleColor--) | die OLE‑Farbe des Vordergrunds. |
+| [getHeight()](#getHeight--) | die Höhe des Steuerelements in Punkt‑Einheiten. |
+| [getHideSelection()](#getHideSelection--) | Gibt an, ob ausgewählter Text im Steuerelement hervorgehoben wird, wenn das Steuerelement keinen Fokus hat. |
+| [getIMEMode()](#getIMEMode--) | der Standard‑Laufzeitmodus des Input Method Editors für das Steuerelement, wenn es den Fokus erhält. |
+| [getListRows()](#getListRows--) | Stellt die maximale Anzahl von Zeilen dar, die in der Liste angezeigt werden sollen. |
+| [getListStyle()](#getListStyle--) | das visuelle Erscheinungsbild. |
+| [getListWidth()](#getListWidth--) | die Breite in Punkt-Einheiten. |
+| [getMatchEntry()](#getMatchEntry--) | Gibt an, wie eine ListBox oder ComboBox ihre Liste durchsucht, während der Benutzer tippt. |
+| [getMaxLength()](#getMaxLength--) | die maximale Anzahl von Zeichen |
+| [getMouseIcon()](#getMouseIcon--) | ein benutzerdefiniertes Symbol, das als Mauszeiger für das Steuerelement angezeigt wird. |
+| [getMousePointer()](#getMousePointer--) | der Typ des als Mauszeiger für das Steuerelement angezeigten Symbols. |
+| [getSelectionMargin()](#getSelectionMargin--) | Gibt an, ob der Benutzer eine Textzeile auswählen kann, indem er im Bereich links vom Text klickt. |
+| [getShowColumnHeads()](#getShowColumnHeads--) | Gibt an, ob Spaltenüberschriften angezeigt werden. |
+| [getShowDropButtonTypeWhen()](#getShowDropButtonTypeWhen--) | Gibt das Symbol an, das auf dem Dropdown‑Button angezeigt wird. |
+| [getSpecialEffect()](#getSpecialEffect--) | der Spezialeffekt des Steuerelements. |
+| [getTextColumn()](#getTextColumn--) | Stellt die Spalte in einer ComboBox oder ListBox dar, die dem Benutzer angezeigt wird. |
+| [getType()](#getType--) | Ermittelt den Typ des ActiveX-Steuerelements. |
+| [getValue()](#getValue--) | der Wert des Steuerelements. |
+| [getWidth()](#getWidth--) | die Breite des Steuerelements in Punkt-Einheiten. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | Gibt an, ob das Steuerelement automatisch die Größe ändert, um seinen gesamten Inhalt anzuzeigen. |
+| [isAutoWordSelected()](#isAutoWordSelected--) | Gibt die Basiseinheit an, die zum Erweitern einer Auswahl verwendet wird. |
+| [isDragBehaviorEnabled()](#isDragBehaviorEnabled--) | Gibt an, ob Ziehen und Ablegen für das Steuerelement aktiviert ist. |
+| [isEditable()](#isEditable--) | Gibt an, ob der Benutzer in das Steuerelement tippen kann. |
+| [isEnabled()](#isEnabled--) | Gibt an, ob das Steuerelement den Fokus erhalten und auf benutzergenerierte Ereignisse reagieren kann. |
+| [isLocked()](#isLocked--) | Gibt an, ob Daten im Steuerelement für die Bearbeitung gesperrt sind. |
+| [isTransparent()](#isTransparent--) | Gibt an, ob das Steuerelement transparent ist. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) |
+| [setAutoWordSelected(boolean value)](#setAutoWordSelected-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isAutoWordSelected()](../../com.aspose.diagram/comboboxactivexcontrol\#isAutoWordSelected--) |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setBorderOleColor(int value)](#setBorderOleColor-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getBorderOleColor()](../../com.aspose.diagram/comboboxactivexcontrol\#getBorderOleColor--) |
+| [setBorderStyle(int value)](#setBorderStyle-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getBorderStyle()](../../com.aspose.diagram/comboboxactivexcontrol\#getBorderStyle--) |
+| [setBoundColumn(int value)](#setBoundColumn-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getBoundColumn()](../../com.aspose.diagram/comboboxactivexcontrol\#getBoundColumn--) |
+| [setColumnCount(int value)](#setColumnCount-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getColumnCount()](../../com.aspose.diagram/comboboxactivexcontrol\#getColumnCount--) |
+| [setColumnWidths(double value)](#setColumnWidths-double-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getColumnWidths()](../../com.aspose.diagram/comboboxactivexcontrol\#getColumnWidths--) |
+| [setDragBehaviorEnabled(boolean value)](#setDragBehaviorEnabled-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isDragBehaviorEnabled()](../../com.aspose.diagram/comboboxactivexcontrol\#isDragBehaviorEnabled--) |
+| [setDropButtonStyle(int value)](#setDropButtonStyle-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDropButtonStyle()](../../com.aspose.diagram/comboboxactivexcontrol\#getDropButtonStyle--) |
+| [setEditable(boolean value)](#setEditable-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isEditable()](../../com.aspose.diagram/comboboxactivexcontrol\#isEditable--) |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) |
+| [setEnterFieldBehavior(boolean value)](#setEnterFieldBehavior-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getEnterFieldBehavior()](../../com.aspose.diagram/comboboxactivexcontrol\#getEnterFieldBehavior--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setHeight(double value)](#setHeight-double-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setHideSelection(boolean value)](#setHideSelection-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getHideSelection()](../../com.aspose.diagram/comboboxactivexcontrol\#getHideSelection--) |
+| [setIMEMode(int value)](#setIMEMode-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) |
+| [setListRows(int value)](#setListRows-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getListRows()](../../com.aspose.diagram/comboboxactivexcontrol\#getListRows--) |
+| [setListStyle(int value)](#setListStyle-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getListStyle()](../../com.aspose.diagram/comboboxactivexcontrol\#getListStyle--) |
+| [setListWidth(double value)](#setListWidth-double-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getListWidth()](../../com.aspose.diagram/comboboxactivexcontrol\#getListWidth--) |
+| [setLocked(boolean value)](#setLocked-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) |
+| [setMatchEntry(int value)](#setMatchEntry-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getMatchEntry()](../../com.aspose.diagram/comboboxactivexcontrol\#getMatchEntry--) |
+| [setMaxLength(int value)](#setMaxLength-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getMaxLength()](../../com.aspose.diagram/comboboxactivexcontrol\#getMaxLength--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | Für die Beschreibung dieser Eigenschaft siehe bitte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setSelectionMargin(boolean value)](#setSelectionMargin-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getSelectionMargin()](../../com.aspose.diagram/comboboxactivexcontrol\#getSelectionMargin--) |
+| [setShowColumnHeads(boolean value)](#setShowColumnHeads-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getShowColumnHeads()](../../com.aspose.diagram/comboboxactivexcontrol\#getShowColumnHeads--) |
+| [setShowDropButtonTypeWhen(int value)](#setShowDropButtonTypeWhen-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getShowDropButtonTypeWhen()](../../com.aspose.diagram/comboboxactivexcontrol\#getShowDropButtonTypeWhen--) |
+| [setSpecialEffect(int value)](#setSpecialEffect-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getSpecialEffect()](../../com.aspose.diagram/comboboxactivexcontrol\#getSpecialEffect--) |
+| [setTextColumn(int value)](#setTextColumn-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getTextColumn()](../../com.aspose.diagram/comboboxactivexcontrol\#getTextColumn--) |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) |
+| [setValue(String value)](#setValue-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/comboboxactivexcontrol\#getValue--) |
+| [setWidth(double value)](#setWidth-double-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+die OLE‑Farbe des Hintergrunds.
+
+**Returns:**
+int
+### getBorderOleColor() {#getBorderOleColor--}
+```
+public int getBorderOleColor()
+```
+
+
+die OLE‑Farbe des Hintergrunds.
+
+**Returns:**
+int
+### getBorderStyle() {#getBorderStyle--}
+```
+public int getBorderStyle()
+```
+
+
+der von dem Steuerelement verwendete Randtyp.
+
+**Returns:**
+int
+### getBoundColumn() {#getBoundColumn--}
+```
+public int getBoundColumn()
+```
+
+
+Gibt an, wie die Value‑Eigenschaft für ein ComboBox‑ oder ListBox‑Steuerelement bestimmt wird, wenn der Wert der MultiSelect‑Eigenschaft (fmMultiSelectSingle) ist.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColumnCount() {#getColumnCount--}
+```
+public int getColumnCount()
+```
+
+
+Gibt die Anzahl der Spalten an, die in einem ComboBox‑ oder ListBox‑Steuerelement angezeigt werden.
+
+**Returns:**
+int
+### getColumnWidths() {#getColumnWidths--}
+```
+public double getColumnWidths()
+```
+
+
+die Breite der Spalte.
+
+**Returns:**
+double
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+die Binärdaten des Steuerelements.
+
+**Returns:**
+byte[]
+### getDropButtonStyle() {#getDropButtonStyle--}
+```
+public int getDropButtonStyle()
+```
+
+
+Gibt das Symbol an, das auf dem Dropdown‑Button angezeigt wird.
+
+**Returns:**
+int
+### getEnterFieldBehavior() {#getEnterFieldBehavior--}
+```
+public boolean getEnterFieldBehavior()
+```
+
+
+Gibt das Auswahlverhalten beim Betreten des Steuerelements an. True gibt an, dass die Auswahl unverändert bleibt seit dem letzten Mal, als das Steuerelement aktiv war. False gibt an, dass der gesamte Text im Steuerelement beim Betreten ausgewählt wird.
+
+**Returns:**
+boolean
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+Die OLE-Farbe des Vordergrunds. Gilt nicht für das Image-Steuerelement.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+die Höhe des Steuerelements in Punkt‑Einheiten.
+
+**Returns:**
+double
+### getHideSelection() {#getHideSelection--}
+```
+public boolean getHideSelection()
+```
+
+
+Gibt an, ob ausgewählter Text im Steuerelement hervorgehoben wird, wenn das Steuerelement keinen Fokus hat.
+
+**Returns:**
+boolean
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+der Standard‑Laufzeitmodus des Input Method Editors für das Steuerelement, wenn es den Fokus erhält.
+
+**Returns:**
+int
+### getListRows() {#getListRows--}
+```
+public int getListRows()
+```
+
+
+Stellt die maximale Anzahl von Zeilen dar, die in der Liste angezeigt werden sollen.
+
+**Returns:**
+int
+### getListStyle() {#getListStyle--}
+```
+public int getListStyle()
+```
+
+
+das visuelle Erscheinungsbild.
+
+**Returns:**
+int
+### getListWidth() {#getListWidth--}
+```
+public double getListWidth()
+```
+
+
+die Breite in Punkt-Einheiten.
+
+**Returns:**
+double
+### getMatchEntry() {#getMatchEntry--}
+```
+public int getMatchEntry()
+```
+
+
+Gibt an, wie eine ListBox oder ComboBox ihre Liste durchsucht, während der Benutzer tippt.
+
+**Returns:**
+int
+### getMaxLength() {#getMaxLength--}
+```
+public int getMaxLength()
+```
+
+
+die maximale Anzahl von Zeichen
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+ein benutzerdefiniertes Symbol, das als Mauszeiger für das Steuerelement angezeigt wird.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+der Typ des als Mauszeiger für das Steuerelement angezeigten Symbols.
+
+**Returns:**
+int
+### getSelectionMargin() {#getSelectionMargin--}
+```
+public boolean getSelectionMargin()
+```
+
+
+Gibt an, ob der Benutzer eine Textzeile auswählen kann, indem er im Bereich links vom Text klickt.
+
+**Returns:**
+boolean
+### getShowColumnHeads() {#getShowColumnHeads--}
+```
+public boolean getShowColumnHeads()
+```
+
+
+Gibt an, ob Spaltenüberschriften angezeigt werden.
+
+**Returns:**
+boolean
+### getShowDropButtonTypeWhen() {#getShowDropButtonTypeWhen--}
+```
+public int getShowDropButtonTypeWhen()
+```
+
+
+Gibt das Symbol an, das auf dem Dropdown‑Button angezeigt wird.
+
+**Returns:**
+int
+### getSpecialEffect() {#getSpecialEffect--}
+```
+public int getSpecialEffect()
+```
+
+
+der Spezialeffekt des Steuerelements.
+
+**Returns:**
+int
+### getTextColumn() {#getTextColumn--}
+```
+public int getTextColumn()
+```
+
+
+Stellt die Spalte in einer ComboBox oder ListBox dar, die dem Benutzer angezeigt wird.
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Ermittelt den Typ des ActiveX-Steuerelements.
+
+**Returns:**
+int
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+der Wert des Steuerelements.
+
+**Returns:**
+java.lang.String
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+die Breite des Steuerelements in Punkt-Einheiten.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+Gibt an, ob das Steuerelement automatisch die Größe ändert, um seinen gesamten Inhalt anzuzeigen.
+
+**Returns:**
+boolean
+### isAutoWordSelected() {#isAutoWordSelected--}
+```
+public boolean isAutoWordSelected()
+```
+
+
+Gibt die Basiseinheit an, die zum Erweitern einer Auswahl verwendet wird. True gibt an, dass die Basiseinheit ein einzelnes Zeichen ist. false gibt an, dass die Basiseinheit ein ganzes Wort ist.
+
+**Returns:**
+boolean
+### isDragBehaviorEnabled() {#isDragBehaviorEnabled--}
+```
+public boolean isDragBehaviorEnabled()
+```
+
+
+Gibt an, ob Ziehen und Ablegen für das Steuerelement aktiviert ist.
+
+**Returns:**
+boolean
+### isEditable() {#isEditable--}
+```
+public boolean isEditable()
+```
+
+
+Gibt an, ob der Benutzer in das Steuerelement tippen kann.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+Gibt an, ob das Steuerelement den Fokus erhalten und auf benutzergenerierte Ereignisse reagieren kann.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+Gibt an, ob Daten im Steuerelement für die Bearbeitung gesperrt sind.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+Gibt an, ob das Steuerelement transparent ist.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setAutoWordSelected(boolean value) {#setAutoWordSelected-boolean-}
+```
+public void setAutoWordSelected(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isAutoWordSelected()](../../com.aspose.diagram/comboboxactivexcontrol\#isAutoWordSelected--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setBorderOleColor(int value) {#setBorderOleColor-int-}
+```
+public void setBorderOleColor(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getBorderOleColor()](../../com.aspose.diagram/comboboxactivexcontrol\#getBorderOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setBorderStyle(int value) {#setBorderStyle-int-}
+```
+public void setBorderStyle(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getBorderStyle()](../../com.aspose.diagram/comboboxactivexcontrol\#getBorderStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setBoundColumn(int value) {#setBoundColumn-int-}
+```
+public void setBoundColumn(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getBoundColumn()](../../com.aspose.diagram/comboboxactivexcontrol\#getBoundColumn--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setColumnCount(int value) {#setColumnCount-int-}
+```
+public void setColumnCount(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getColumnCount()](../../com.aspose.diagram/comboboxactivexcontrol\#getColumnCount--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setColumnWidths(double value) {#setColumnWidths-double-}
+```
+public void setColumnWidths(double value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getColumnWidths()](../../com.aspose.diagram/comboboxactivexcontrol\#getColumnWidths--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double |  |
+
+### setDragBehaviorEnabled(boolean value) {#setDragBehaviorEnabled-boolean-}
+```
+public void setDragBehaviorEnabled(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isDragBehaviorEnabled()](../../com.aspose.diagram/comboboxactivexcontrol\#isDragBehaviorEnabled--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setDropButtonStyle(int value) {#setDropButtonStyle-int-}
+```
+public void setDropButtonStyle(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDropButtonStyle()](../../com.aspose.diagram/comboboxactivexcontrol\#getDropButtonStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setEditable(boolean value) {#setEditable-boolean-}
+```
+public void setEditable(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isEditable()](../../com.aspose.diagram/comboboxactivexcontrol\#isEditable--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setEnterFieldBehavior(boolean value) {#setEnterFieldBehavior-boolean-}
+```
+public void setEnterFieldBehavior(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getEnterFieldBehavior()](../../com.aspose.diagram/comboboxactivexcontrol\#getEnterFieldBehavior--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double |  |
+
+### setHideSelection(boolean value) {#setHideSelection-boolean-}
+```
+public void setHideSelection(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getHideSelection()](../../com.aspose.diagram/comboboxactivexcontrol\#getHideSelection--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setListRows(int value) {#setListRows-int-}
+```
+public void setListRows(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getListRows()](../../com.aspose.diagram/comboboxactivexcontrol\#getListRows--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setListStyle(int value) {#setListStyle-int-}
+```
+public void setListStyle(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getListStyle()](../../com.aspose.diagram/comboboxactivexcontrol\#getListStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setListWidth(double value) {#setListWidth-double-}
+```
+public void setListWidth(double value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getListWidth()](../../com.aspose.diagram/comboboxactivexcontrol\#getListWidth--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setMatchEntry(int value) {#setMatchEntry-int-}
+```
+public void setMatchEntry(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getMatchEntry()](../../com.aspose.diagram/comboboxactivexcontrol\#getMatchEntry--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setMaxLength(int value) {#setMaxLength-int-}
+```
+public void setMaxLength(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getMaxLength()](../../com.aspose.diagram/comboboxactivexcontrol\#getMaxLength--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setSelectionMargin(boolean value) {#setSelectionMargin-boolean-}
+```
+public void setSelectionMargin(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getSelectionMargin()](../../com.aspose.diagram/comboboxactivexcontrol\#getSelectionMargin--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setShowColumnHeads(boolean value) {#setShowColumnHeads-boolean-}
+```
+public void setShowColumnHeads(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getShowColumnHeads()](../../com.aspose.diagram/comboboxactivexcontrol\#getShowColumnHeads--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setShowDropButtonTypeWhen(int value) {#setShowDropButtonTypeWhen-int-}
+```
+public void setShowDropButtonTypeWhen(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getShowDropButtonTypeWhen()](../../com.aspose.diagram/comboboxactivexcontrol\#getShowDropButtonTypeWhen--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setSpecialEffect(int value) {#setSpecialEffect-int-}
+```
+public void setSpecialEffect(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getSpecialEffect()](../../com.aspose.diagram/comboboxactivexcontrol\#getSpecialEffect--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setTextColumn(int value) {#setTextColumn-int-}
+```
+public void setTextColumn(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getTextColumn()](../../com.aspose.diagram/comboboxactivexcontrol\#getTextColumn--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setValue(String value) {#setValue-java.lang.String-}
+```
+public void setValue(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/comboboxactivexcontrol\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/commandbuttonactivexcontrol/_index.md
+++ b/german/java/com.aspose.diagram/commandbuttonactivexcontrol/_index.md
@@ -1,0 +1,572 @@
+---
+title: CommandButtonActiveXControl
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt eine Befehlsschaltfläche dar.
+type: docs
+weight: 56
+url: /de/java/com.aspose.diagram/commandbuttonactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class CommandButtonActiveXControl extends ActiveXControl
+```
+
+Stellt eine Befehlsschaltfläche dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAccelerator()](#getAccelerator--) | Die Beschleunigungstaste für das Steuerelement. |
+| [getBackOleColor()](#getBackOleColor--) | die OLE‑Farbe des Hintergrunds. |
+| [getCaption()](#getCaption--) | Der beschreibende Text, der auf einem Steuerelement erscheint. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | die Binärdaten des Steuerelements. |
+| [getForeOleColor()](#getForeOleColor--) | die OLE‑Farbe des Vordergrunds. |
+| [getHeight()](#getHeight--) | die Höhe des Steuerelements in Punkt‑Einheiten. |
+| [getIMEMode()](#getIMEMode--) | der Standard‑Laufzeitmodus des Input Method Editors für das Steuerelement, wenn es den Fokus erhält. |
+| [getMouseIcon()](#getMouseIcon--) | ein benutzerdefiniertes Symbol, das als Mauszeiger für das Steuerelement angezeigt wird. |
+| [getMousePointer()](#getMousePointer--) | der Typ des als Mauszeiger für das Steuerelement angezeigten Symbols. |
+| [getPicture()](#getPicture--) | Die Daten des Bildes. |
+| [getPicturePosition()](#getPicturePosition--) | Der Ort des Bildes des Steuerelements relativ zu seiner Beschriftung. |
+| [getTakeFocusOnClick()](#getTakeFocusOnClick--) | Gibt an, ob das Steuerelement den Fokus erhält, wenn es angeklickt wird. |
+| [getType()](#getType--) | Ermittelt den Typ des ActiveX-Steuerelements. |
+| [getWidth()](#getWidth--) | die Breite des Steuerelements in Punkt-Einheiten. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | Gibt an, ob das Steuerelement automatisch die Größe ändert, um seinen gesamten Inhalt anzuzeigen. |
+| [isEnabled()](#isEnabled--) | Gibt an, ob das Steuerelement den Fokus erhalten und auf benutzergenerierte Ereignisse reagieren kann. |
+| [isLocked()](#isLocked--) | Gibt an, ob Daten im Steuerelement für die Bearbeitung gesperrt sind. |
+| [isTransparent()](#isTransparent--) | Gibt an, ob das Steuerelement transparent ist. |
+| [isWordWrapped()](#isWordWrapped--) | Gibt an, ob der Inhalt des Steuerelements am Zeilenende automatisch umbrochen wird. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAccelerator(char value)](#setAccelerator-char-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getAccelerator()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getAccelerator--) |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setCaption(String value)](#setCaption-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getCaption()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getCaption--) |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setHeight(double value)](#setHeight-double-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setIMEMode(int value)](#setIMEMode-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) |
+| [setLocked(boolean value)](#setLocked-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | Für die Beschreibung dieser Eigenschaft siehe bitte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setPicture(byte[] value)](#setPicture-byte---) | Für die Beschreibung dieser Eigenschaft siehe bitte [getPicture()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getPicture--) |
+| [setPicturePosition(int value)](#setPicturePosition-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getPicturePosition()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getPicturePosition--) |
+| [setTakeFocusOnClick(boolean value)](#setTakeFocusOnClick-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getTakeFocusOnClick()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getTakeFocusOnClick--) |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) |
+| [setWidth(double value)](#setWidth-double-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [setWordWrapped(boolean value)](#setWordWrapped-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isWordWrapped()](../../com.aspose.diagram/commandbuttonactivexcontrol\#isWordWrapped--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAccelerator() {#getAccelerator--}
+```
+public char getAccelerator()
+```
+
+
+Die Beschleunigungstaste für das Steuerelement.
+
+**Returns:**
+char
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+die OLE‑Farbe des Hintergrunds.
+
+**Returns:**
+int
+### getCaption() {#getCaption--}
+```
+public String getCaption()
+```
+
+
+Der beschreibende Text, der auf einem Steuerelement erscheint.
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+die Binärdaten des Steuerelements.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+Die OLE-Farbe des Vordergrunds. Gilt nicht für das Image-Steuerelement.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+die Höhe des Steuerelements in Punkt‑Einheiten.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+der Standard‑Laufzeitmodus des Input Method Editors für das Steuerelement, wenn es den Fokus erhält.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+ein benutzerdefiniertes Symbol, das als Mauszeiger für das Steuerelement angezeigt wird.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+der Typ des als Mauszeiger für das Steuerelement angezeigten Symbols.
+
+**Returns:**
+int
+### getPicture() {#getPicture--}
+```
+public byte[] getPicture()
+```
+
+
+Die Daten des Bildes.
+
+**Returns:**
+byte[]
+### getPicturePosition() {#getPicturePosition--}
+```
+public int getPicturePosition()
+```
+
+
+Der Ort des Bildes des Steuerelements relativ zu seiner Beschriftung.
+
+**Returns:**
+int
+### getTakeFocusOnClick() {#getTakeFocusOnClick--}
+```
+public boolean getTakeFocusOnClick()
+```
+
+
+Gibt an, ob das Steuerelement den Fokus erhält, wenn es angeklickt wird.
+
+**Returns:**
+boolean
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Ermittelt den Typ des ActiveX-Steuerelements.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+die Breite des Steuerelements in Punkt-Einheiten.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+Gibt an, ob das Steuerelement automatisch die Größe ändert, um seinen gesamten Inhalt anzuzeigen.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+Gibt an, ob das Steuerelement den Fokus erhalten und auf benutzergenerierte Ereignisse reagieren kann.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+Gibt an, ob Daten im Steuerelement für die Bearbeitung gesperrt sind.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+Gibt an, ob das Steuerelement transparent ist.
+
+**Returns:**
+boolean
+### isWordWrapped() {#isWordWrapped--}
+```
+public boolean isWordWrapped()
+```
+
+
+Gibt an, ob der Inhalt des Steuerelements am Zeilenende automatisch umbrochen wird.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAccelerator(char value) {#setAccelerator-char-}
+```
+public void setAccelerator(char value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getAccelerator()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getAccelerator--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | char |  |
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setCaption(String value) {#setCaption-java.lang.String-}
+```
+public void setCaption(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getCaption()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getCaption--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setPicture(byte[] value) {#setPicture-byte---}
+```
+public void setPicture(byte[] value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getPicture()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getPicture--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | byte[] |  |
+
+### setPicturePosition(int value) {#setPicturePosition-int-}
+```
+public void setPicturePosition(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getPicturePosition()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getPicturePosition--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setTakeFocusOnClick(boolean value) {#setTakeFocusOnClick-boolean-}
+```
+public void setTakeFocusOnClick(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getTakeFocusOnClick()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getTakeFocusOnClick--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double |  |
+
+### setWordWrapped(boolean value) {#setWordWrapped-boolean-}
+```
+public void setWordWrapped(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isWordWrapped()](../../com.aspose.diagram/commandbuttonactivexcontrol\#isWordWrapped--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/compositingquality/_index.md
+++ b/german/java/com.aspose.diagram/compositingquality/_index.md
@@ -1,0 +1,183 @@
+---
+title: CompositingQuality
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt die Qualitätsstufe an, die beim Compositing verwendet werden soll.
+type: docs
+weight: 57
+url: /de/java/com.aspose.diagram/compositingquality/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class CompositingQuality
+```
+
+Gibt die Qualitätsstufe an, die beim Compositing verwendet werden soll.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [ASSUME_LINEAR](#ASSUME-LINEAR) | Lineare Werte annehmen. |
+| [DEFAULT](#DEFAULT) | Standardqualität. |
+| [GAMMA_CORRECTED](#GAMMA-CORRECTED) | Gamma-Korrektur wird verwendet. |
+| [HIGH_QUALITY](#HIGH-QUALITY) | Hohe Qualität, niedrige Geschwindigkeit beim Compositing. |
+| [HIGH_SPEED](#HIGH-SPEED) | Hohe Geschwindigkeit, niedrige Qualität. |
+| [INVALID](#INVALID) | Ungültige Qualität. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ASSUME_LINEAR {#ASSUME-LINEAR}
+```
+public static final int ASSUME_LINEAR
+```
+
+
+Lineare Werte annehmen.
+
+### DEFAULT {#DEFAULT}
+```
+public static final int DEFAULT
+```
+
+
+Standardqualität.
+
+### GAMMA_CORRECTED {#GAMMA-CORRECTED}
+```
+public static final int GAMMA_CORRECTED
+```
+
+
+Gamma-Korrektur wird verwendet.
+
+### HIGH_QUALITY {#HIGH-QUALITY}
+```
+public static final int HIGH_QUALITY
+```
+
+
+Hohe Qualität, niedrige Geschwindigkeit beim Compositing.
+
+### HIGH_SPEED {#HIGH-SPEED}
+```
+public static final int HIGH_SPEED
+```
+
+
+Hohe Geschwindigkeit, niedrige Qualität.
+
+### INVALID {#INVALID}
+```
+public static final int INVALID
+```
+
+
+Ungültige Qualität.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/compoundtype/_index.md
+++ b/german/java/com.aspose.diagram/compoundtype/_index.md
@@ -1,0 +1,179 @@
+---
+title: CompoundType
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt die Größe der Pfeilspitze der Linie an.
+type: docs
+weight: 58
+url: /de/java/com.aspose.diagram/compoundtype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class CompoundType
+```
+
+Gibt die Größe der Pfeilspitze der Linie an.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [CompoundType(int value)](#CompoundType-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Gibt die Größe der Pfeilspitze der Linie an. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/compoundtype\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CompoundType(int value) {#CompoundType-int-}
+```
+public CompoundType(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Gibt die Größe der Pfeilspitze der Linie an.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/compoundtype\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/compoundtypevalue/_index.md
+++ b/german/java/com.aspose.diagram/compoundtypevalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: CompoundTypeValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt den Stil zum Zeichnen von Linien dar.
+type: docs
+weight: 59
+url: /de/java/com.aspose.diagram/compoundtypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class CompoundTypeValue
+```
+
+Stellt den Stil zum Zeichnen von Linien dar.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [SINGLE](#SINGLE) | Einzelne Linie (mit Breite lineWidth) |
+| [THICK_BETWEEN_THIN](#THICK-BETWEEN-THIN) | Drei Linien, dünn, dick, dünn |
+| [THICK_THIN](#THICK-THIN) | Doppelte Linien, eine dick, eine dünn |
+| [THIN_THICK](#THIN-THICK) | Doppelte Linien, eine dünn, eine dick |
+| [THIN_THIN](#THIN-THIN) | Doppelte Linien gleicher Breite |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SINGLE {#SINGLE}
+```
+public static final int SINGLE
+```
+
+
+Einzelne Linie (mit Breite lineWidth)
+
+### THICK_BETWEEN_THIN {#THICK-BETWEEN-THIN}
+```
+public static final int THICK_BETWEEN_THIN
+```
+
+
+Drei Linien, dünn, dick, dünn
+
+### THICK_THIN {#THICK-THIN}
+```
+public static final int THICK_THIN
+```
+
+
+Doppelte Linien, eine dick, eine dünn
+
+### THIN_THICK {#THIN-THICK}
+```
+public static final int THIN_THICK
+```
+
+
+Doppelte Linien, eine dünn, eine dick
+
+### THIN_THIN {#THIN-THIN}
+```
+public static final int THIN_THIN
+```
+
+
+Doppelte Linien gleicher Breite
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/compressiontype/_index.md
+++ b/german/java/com.aspose.diagram/compressiontype/_index.md
@@ -1,0 +1,183 @@
+---
+title: CompressionType
+second_title: Aspose.Diagram for Java API-Referenz
+description: Dieses Attribut ist nur sinnvoll, wenn die Fremddaten ein rasterbasiertes Fremdobjekt wie eine DIB-, JPG-, PNG-, TIFF- oder GIF-Datei sind.
+type: docs
+weight: 60
+url: /de/java/com.aspose.diagram/compressiontype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class CompressionType
+```
+
+Dieses Attribut ist nur sinnvoll, wenn die Fremddaten ein rasterbasiertes Fremdobjekt sind, wie z. B. eine DIB-, JPG-, PNG-, TIFF- oder GIF-Datei. Der Wert gibt den Typ der auf die Datei angewendeten Kompression an.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [GIF](#GIF) | GIF-Kompression. |
+| [JPEG](#JPEG) | JPEG-Kompression. |
+| [NO](#NO) | Keine Kompression (Standard). |
+| [PNG](#PNG) | PNG-Kompression. |
+| [TIFF](#TIFF) | TIFF-Kompression. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GIF {#GIF}
+```
+public static final int GIF
+```
+
+
+GIF-Kompression.
+
+### JPEG {#JPEG}
+```
+public static final int JPEG
+```
+
+
+JPEG-Kompression.
+
+### NO {#NO}
+```
+public static final int NO
+```
+
+
+Keine Kompression (Standard).
+
+### PNG {#PNG}
+```
+public static final int PNG
+```
+
+
+PNG-Kompression.
+
+### TIFF {#TIFF}
+```
+public static final int TIFF
+```
+
+
+TIFF-Kompression.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/confixedcode/_index.md
+++ b/german/java/com.aspose.diagram/confixedcode/_index.md
@@ -1,0 +1,179 @@
+---
+title: ConFixedCode
+second_title: Aspose.Diagram for Java API-Referenz
+description: Bestimmt, wann ein Connector umgeleitet wird.
+type: docs
+weight: 61
+url: /de/java/com.aspose.diagram/confixedcode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ConFixedCode
+```
+
+Bestimmt, wann ein Connector umgeleitet wird.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [ConFixedCode(int value)](#ConFixedCode-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Bestimmt, wann ein Connector umgeleitet wird. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft, bitte siehe [getValue()](../../com.aspose.diagram/confixedcode\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ConFixedCode(int value) {#ConFixedCode-int-}
+```
+public ConFixedCode(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Bestimmt, wann ein Connector umgeleitet wird.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft, bitte siehe [getValue()](../../com.aspose.diagram/confixedcode\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/confixedcodevalue/_index.md
+++ b/german/java/com.aspose.diagram/confixedcodevalue/_index.md
@@ -1,0 +1,201 @@
+---
+title: ConFixedCodeValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Bestimmt, wann ein Connector umgeleitet wird.
+type: docs
+weight: 62
+url: /de/java/com.aspose.diagram/confixedcodevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConFixedCodeValue
+```
+
+Bestimmt, wann ein Connector umgeleitet wird.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [NEVER_REROUTE](#NEVER-REROUTE) | Nie umleiten. |
+| [REROUTE_FREELY](#REROUTE-FREELY) | Frei umleiten. |
+| [REROUTE_NEEDED](#REROUTE-NEEDED) | Umleiten bei Bedarf. |
+| [REROUTE_ON_CROSSOVER](#REROUTE-ON-CROSSOVER) | Umleiten bei Kreuzung. |
+| [RESERVED_1](#RESERVED-1) | Nur für den internen Gebrauch reserviert. |
+| [RESERVED_2](#RESERVED-2) | Nur für den internen Gebrauch reserviert. |
+| [RESERVED_3](#RESERVED-3) | Nur für den internen Gebrauch reserviert. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### NEVER_REROUTE {#NEVER-REROUTE}
+```
+public static final int NEVER_REROUTE
+```
+
+
+Nie umleiten.
+
+### REROUTE_FREELY {#REROUTE-FREELY}
+```
+public static final int REROUTE_FREELY
+```
+
+
+Frei umleiten.
+
+### REROUTE_NEEDED {#REROUTE-NEEDED}
+```
+public static final int REROUTE_NEEDED
+```
+
+
+Umleiten bei Bedarf.
+
+### REROUTE_ON_CROSSOVER {#REROUTE-ON-CROSSOVER}
+```
+public static final int REROUTE_ON_CROSSOVER
+```
+
+
+Umleiten bei Kreuzung.
+
+### RESERVED_1 {#RESERVED-1}
+```
+public static final int RESERVED_1
+```
+
+
+Nur für den internen Gebrauch reserviert.
+
+### RESERVED_2 {#RESERVED-2}
+```
+public static final int RESERVED_2
+```
+
+
+Nur für den internen Gebrauch reserviert.
+
+### RESERVED_3 {#RESERVED-3}
+```
+public static final int RESERVED_3
+```
+
+
+Nur für den internen Gebrauch reserviert.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/conlinejumpcode/_index.md
+++ b/german/java/com.aspose.diagram/conlinejumpcode/_index.md
@@ -1,0 +1,179 @@
+---
+title: ConLineJumpCode
+second_title: Aspose.Diagram for Java API-Referenz
+description: Bestimmt, ob ein Connector springt, wenn zwei Connectoren sich kreuzen.
+type: docs
+weight: 63
+url: /de/java/com.aspose.diagram/conlinejumpcode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ConLineJumpCode
+```
+
+Bestimmt, ob ein Connector springt, wenn zwei Connectoren sich kreuzen.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [ConLineJumpCode(int value)](#ConLineJumpCode-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Bestimmt, ob ein Connector springt, wenn zwei Connectoren sich kreuzen. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/conlinejumpcode\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ConLineJumpCode(int value) {#ConLineJumpCode-int-}
+```
+public ConLineJumpCode(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Bestimmt, ob ein Connector springt, wenn zwei Connectoren sich kreuzen.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/conlinejumpcode\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/conlinejumpcodevalue/_index.md
+++ b/german/java/com.aspose.diagram/conlinejumpcodevalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: ConLineJumpCodeValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Bestimmt, ob ein Connector springt, wenn zwei Connectoren sich kreuzen.
+type: docs
+weight: 64
+url: /de/java/com.aspose.diagram/conlinejumpcodevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConLineJumpCodeValue
+```
+
+Bestimmt, ob ein Connector springt, wenn zwei Connectoren sich kreuzen.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [ALWAYS](#ALWAYS) | Immer |
+| [NEITHER_CONNECTOR_JUMPS](#NEITHER-CONNECTOR-JUMPS) | Kein Verbindungs­sprung. |
+| [NEVER](#NEVER) | Niemals. |
+| [OTHER_CONNECTOR_JUMPS](#OTHER-CONNECTOR-JUMPS) | Andere Verbindungs­sprünge. |
+| [PAGE_DEFAULT](#PAGE-DEFAULT) | Seitenstandard. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALWAYS {#ALWAYS}
+```
+public static final int ALWAYS
+```
+
+
+Immer
+
+### NEITHER_CONNECTOR_JUMPS {#NEITHER-CONNECTOR-JUMPS}
+```
+public static final int NEITHER_CONNECTOR_JUMPS
+```
+
+
+Kein Verbindungs­sprung.
+
+### NEVER {#NEVER}
+```
+public static final int NEVER
+```
+
+
+Niemals.
+
+### OTHER_CONNECTOR_JUMPS {#OTHER-CONNECTOR-JUMPS}
+```
+public static final int OTHER_CONNECTOR_JUMPS
+```
+
+
+Andere Verbindungs­sprünge.
+
+### PAGE_DEFAULT {#PAGE-DEFAULT}
+```
+public static final int PAGE_DEFAULT
+```
+
+
+Seitenstandard.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/conlinejumpdirx/_index.md
+++ b/german/java/com.aspose.diagram/conlinejumpdirx/_index.md
@@ -1,0 +1,179 @@
+---
+title: ConLineJumpDirX
+second_title: Aspose.Diagram for Java API-Referenz
+description: Bestimmt die Sprungrichtung für Linien, die auf einem horizontalen Segment eines dynamischen Connectors auftreten.
+type: docs
+weight: 65
+url: /de/java/com.aspose.diagram/conlinejumpdirx/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ConLineJumpDirX
+```
+
+Bestimmt die Sprungrichtung für Linien, die auf einem horizontalen Segment eines dynamischen Connectors auftreten.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [ConLineJumpDirX(int value)](#ConLineJumpDirX-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Bestimmt die Sprungrichtung für Linien, die auf einem horizontalen Segment eines dynamischen Connectors auftreten. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/conlinejumpdirx\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ConLineJumpDirX(int value) {#ConLineJumpDirX-int-}
+```
+public ConLineJumpDirX(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Bestimmt die Sprungrichtung für Linien, die auf einem horizontalen Segment eines dynamischen Connectors auftreten.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/conlinejumpdirx\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/conlinejumpdirxvalue/_index.md
+++ b/german/java/com.aspose.diagram/conlinejumpdirxvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: ConLineJumpDirXValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Bestimmt die Sprungrichtung für Linien, die auf einem horizontalen Segment eines dynamischen Connectors auftreten.
+type: docs
+weight: 66
+url: /de/java/com.aspose.diagram/conlinejumpdirxvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConLineJumpDirXValue
+```
+
+Bestimmt die Sprungrichtung für Linien, die auf einem horizontalen Segment eines dynamischen Connectors auftreten.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [DOWN](#DOWN) | Nach unten. |
+| [PAGE_DEFAULT](#PAGE-DEFAULT) | Seitenstandard. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+| [UP](#UP) | Nach oben. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DOWN {#DOWN}
+```
+public static final int DOWN
+```
+
+
+Nach unten.
+
+### PAGE_DEFAULT {#PAGE-DEFAULT}
+```
+public static final int PAGE_DEFAULT
+```
+
+
+Seitenstandard.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### UP {#UP}
+```
+public static final int UP
+```
+
+
+Nach oben.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/conlinejumpdiry/_index.md
+++ b/german/java/com.aspose.diagram/conlinejumpdiry/_index.md
@@ -1,0 +1,179 @@
+---
+title: ConLineJumpDirY
+second_title: Aspose.Diagram for Java API-Referenz
+description: Bestimmt die Sprungrichtung für Linien, die auf einem vertikalen Segment eines dynamischen Connectors auftreten.
+type: docs
+weight: 67
+url: /de/java/com.aspose.diagram/conlinejumpdiry/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ConLineJumpDirY
+```
+
+Bestimmt die Sprungrichtung für Linien, die auf einem vertikalen Segment eines dynamischen Connectors auftreten.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [ConLineJumpDirY(int value)](#ConLineJumpDirY-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Bestimmt die Sprungrichtung für Linien, die auf einem vertikalen Segment eines dynamischen Connectors auftreten. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/conlinejumpdiry\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ConLineJumpDirY(int value) {#ConLineJumpDirY-int-}
+```
+public ConLineJumpDirY(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Bestimmt die Sprungrichtung für Linien, die auf einem vertikalen Segment eines dynamischen Connectors auftreten.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/conlinejumpdiry\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/conlinejumpdiryvalue/_index.md
+++ b/german/java/com.aspose.diagram/conlinejumpdiryvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: ConLineJumpDirYValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Bestimmt die Sprungrichtung für Linien, die auf einem vertikalen Segment eines dynamischen Connectors auftreten.
+type: docs
+weight: 68
+url: /de/java/com.aspose.diagram/conlinejumpdiryvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConLineJumpDirYValue
+```
+
+Bestimmt die Sprungrichtung für Linien, die auf einem vertikalen Segment eines dynamischen Connectors auftreten.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [LEFT](#LEFT) | Links. |
+| [PAGE_DEFAULT](#PAGE-DEFAULT) | Seitenstandard. |
+| [RIGHT](#RIGHT) | Rechts. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LEFT {#LEFT}
+```
+public static final int LEFT
+```
+
+
+Links.
+
+### PAGE_DEFAULT {#PAGE-DEFAULT}
+```
+public static final int PAGE_DEFAULT
+```
+
+
+Seitenstandard.
+
+### RIGHT {#RIGHT}
+```
+public static final int RIGHT
+```
+
+
+Rechts.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/conlinejumpstyle/_index.md
+++ b/german/java/com.aspose.diagram/conlinejumpstyle/_index.md
@@ -1,0 +1,179 @@
+---
+title: ConLineJumpStyle
+second_title: Aspose.Diagram for Java API-Referenz
+description: Bestimmt den Sprungstil für Linien auf einem dynamischen Connector.
+type: docs
+weight: 69
+url: /de/java/com.aspose.diagram/conlinejumpstyle/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ConLineJumpStyle
+```
+
+Bestimmt den Sprungstil für Linien auf einem dynamischen Connector.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [ConLineJumpStyle(int value)](#ConLineJumpStyle-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Bestimmt den Sprungstil für Linien auf einem dynamischen Connector. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/conlinejumpstyle\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ConLineJumpStyle(int value) {#ConLineJumpStyle-int-}
+```
+public ConLineJumpStyle(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Bestimmt den Sprungstil für Linien auf einem dynamischen Connector.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/conlinejumpstyle\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/conlinejumpstylevalue/_index.md
+++ b/german/java/com.aspose.diagram/conlinejumpstylevalue/_index.md
@@ -1,0 +1,228 @@
+---
+title: ConLineJumpStyleValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Bestimmt den Sprungstil für Linien auf einem dynamischen Connector.
+type: docs
+weight: 70
+url: /de/java/com.aspose.diagram/conlinejumpstylevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConLineJumpStyleValue
+```
+
+Bestimmt den Sprungstil für Linien auf einem dynamischen Connector.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [ARC](#ARC) | Bogen. |
+| [GAP](#GAP) | Lücke. |
+| [PAGE_DEFAULT](#PAGE-DEFAULT) | Seitenstandard. |
+| [SIDES_2](#SIDES-2) | Sides2. |
+| [SIDES_3](#SIDES-3) | Sides3. |
+| [SIDES_4](#SIDES-4) | Sides4. |
+| [SIDES_5](#SIDES-5) | Sides5. |
+| [SIDES_6](#SIDES-6) | Sides6. |
+| [SIDES_7](#SIDES-7) | Sides7 |
+| [SQUARE](#SQUARE) | Quadrat. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ARC {#ARC}
+```
+public static final int ARC
+```
+
+
+Bogen.
+
+### GAP {#GAP}
+```
+public static final int GAP
+```
+
+
+Lücke.
+
+### PAGE_DEFAULT {#PAGE-DEFAULT}
+```
+public static final int PAGE_DEFAULT
+```
+
+
+Seitenstandard.
+
+### SIDES_2 {#SIDES-2}
+```
+public static final int SIDES_2
+```
+
+
+Sides2.
+
+### SIDES_3 {#SIDES-3}
+```
+public static final int SIDES_3
+```
+
+
+Sides3.
+
+### SIDES_4 {#SIDES-4}
+```
+public static final int SIDES_4
+```
+
+
+Sides4.
+
+### SIDES_5 {#SIDES-5}
+```
+public static final int SIDES_5
+```
+
+
+Sides5.
+
+### SIDES_6 {#SIDES-6}
+```
+public static final int SIDES_6
+```
+
+
+Sides6.
+
+### SIDES_7 {#SIDES-7}
+```
+public static final int SIDES_7
+```
+
+
+Sides7
+
+### SQUARE {#SQUARE}
+```
+public static final int SQUARE
+```
+
+
+Quadrat.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/conlinerouteext/_index.md
+++ b/german/java/com.aspose.diagram/conlinerouteext/_index.md
@@ -1,0 +1,179 @@
+---
+title: ConLineRouteExt
+second_title: Aspose.Diagram for Java API-Referenz
+description: Bestimmt das Erscheinungsbild eines Connectors.
+type: docs
+weight: 71
+url: /de/java/com.aspose.diagram/conlinerouteext/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ConLineRouteExt
+```
+
+Bestimmt das Erscheinungsbild eines Connectors.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [ConLineRouteExt(int value)](#ConLineRouteExt-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Bestimmt das Erscheinungsbild eines Connectors. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | For the description of this property, please see [getValue()](../../com.aspose.diagram/conlinerouteext\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ConLineRouteExt(int value) {#ConLineRouteExt-int-}
+```
+public ConLineRouteExt(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Bestimmt das Erscheinungsbild eines Connectors.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+For the description of this property, please see [getValue()](../../com.aspose.diagram/conlinerouteext\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/conlinerouteextvalue/_index.md
+++ b/german/java/com.aspose.diagram/conlinerouteextvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: ConLineRouteExtValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Bestimmt das Erscheinungsbild eines Connectors.
+type: docs
+weight: 72
+url: /de/java/com.aspose.diagram/conlinerouteextvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConLineRouteExtValue
+```
+
+Bestimmt das Erscheinungsbild eines Connectors.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [CURVED](#CURVED) | Gekrümmt. |
+| [PAGE_DEFAULT](#PAGE-DEFAULT) | Seitenstandard. |
+| [STRAIGHT](#STRAIGHT) | Gerade. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CURVED {#CURVED}
+```
+public static final int CURVED
+```
+
+
+Gekrümmt.
+
+### PAGE_DEFAULT {#PAGE-DEFAULT}
+```
+public static final int PAGE_DEFAULT
+```
+
+
+Seitenstandard.
+
+### STRAIGHT {#STRAIGHT}
+```
+public static final int STRAIGHT
+```
+
+
+Gerade.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/connect/_index.md
+++ b/german/java/com.aspose.diagram/connect/_index.md
@@ -1,0 +1,299 @@
+---
+title: Connect
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt eine Verbindung zwischen zwei Formen in einer Zeichnung dar, wie z. B. eine Linie und ein Feld in einem Organigramm.
+type: docs
+weight: 75
+url: /de/java/com.aspose.diagram/connect/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Connect
+```
+
+Stellt eine Verbindung zwischen zwei Formen in einer Zeichnung dar, z. B. eine Linie und ein Feld in einem Organigramm.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [Connect()](#Connect--) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFromCell()](#getFromCell--) | Die Zelle, von der aus eine Verbindung hergestellt wird. |
+| [getFromPart()](#getFromPart--) | Die Zelle, aus der eine Verbindung entsteht. |
+| [getFromSheet()](#getFromSheet--) | Die ID der Form, von der eine Verbindung oder mehrere Verbindungen ausgehen. |
+| [getToCell()](#getToCell--) | Die Zelle, zu der eine Verbindung hergestellt wird. |
+| [getToPart()](#getToPart--) | Der Teil einer Form, zu dem eine Verbindung hergestellt wird. |
+| [getToSheet()](#getToSheet--) | Die ID der Form, zu der eine oder mehrere Verbindungen hergestellt werden. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setFromCell(String value)](#setFromCell-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getFromCell()](../../com.aspose.diagram/connect\#getFromCell--) |
+| [setFromPart(int value)](#setFromPart-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getFromPart()](../../com.aspose.diagram/connect\#getFromPart--) |
+| [setFromSheet(long value)](#setFromSheet-long-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getFromSheet()](../../com.aspose.diagram/connect\#getFromSheet--) |
+| [setToCell(String value)](#setToCell-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getToCell()](../../com.aspose.diagram/connect\#getToCell--) |
+| [setToPart(int value)](#setToPart-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getToPart()](../../com.aspose.diagram/connect\#getToPart--) |
+| [setToSheet(long value)](#setToSheet-long-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getToSheet()](../../com.aspose.diagram/connect\#getToSheet--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Connect() {#Connect--}
+```
+public Connect()
+```
+
+
+Konstruktor.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFromCell() {#getFromCell--}
+```
+public String getFromCell()
+```
+
+
+Die Zelle, von der aus eine Verbindung hergestellt wird.
+
+**Returns:**
+java.lang.String
+### getFromPart() {#getFromPart--}
+```
+public int getFromPart()
+```
+
+
+Die Zelle, aus der eine Verbindung entsteht.
+
+**Returns:**
+int
+### getFromSheet() {#getFromSheet--}
+```
+public long getFromSheet()
+```
+
+
+Die ID der Form, von der eine Verbindung oder mehrere Verbindungen ausgehen.
+
+**Returns:**
+long
+### getToCell() {#getToCell--}
+```
+public String getToCell()
+```
+
+
+Die Zelle, zu der eine Verbindung hergestellt wird.
+
+**Returns:**
+java.lang.String
+### getToPart() {#getToPart--}
+```
+public int getToPart()
+```
+
+
+Der Teil einer Form, zu dem eine Verbindung hergestellt wird.
+
+**Returns:**
+int
+### getToSheet() {#getToSheet--}
+```
+public long getToSheet()
+```
+
+
+Die ID der Form, zu der eine oder mehrere Verbindungen hergestellt werden.
+
+**Returns:**
+long
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setFromCell(String value) {#setFromCell-java.lang.String-}
+```
+public void setFromCell(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getFromCell()](../../com.aspose.diagram/connect\#getFromCell--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setFromPart(int value) {#setFromPart-int-}
+```
+public void setFromPart(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getFromPart()](../../com.aspose.diagram/connect\#getFromPart--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setFromSheet(long value) {#setFromSheet-long-}
+```
+public void setFromSheet(long value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getFromSheet()](../../com.aspose.diagram/connect\#getFromSheet--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | long |  |
+
+### setToCell(String value) {#setToCell-java.lang.String-}
+```
+public void setToCell(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getToCell()](../../com.aspose.diagram/connect\#getToCell--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setToPart(int value) {#setToPart-int-}
+```
+public void setToPart(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getToPart()](../../com.aspose.diagram/connect\#getToPart--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setToSheet(long value) {#setToSheet-long-}
+```
+public void setToSheet(long value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getToSheet()](../../com.aspose.diagram/connect\#getToSheet--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | long |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/connectcollection/_index.md
+++ b/german/java/com.aspose.diagram/connectcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: ConnectCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: Connect‑Sammlung.
+type: docs
+weight: 76
+url: /de/java/com.aspose.diagram/connectcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ConnectCollection extends Collection
+```
+
+Connect‑Sammlung.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [add(Connect connect)](#add-com.aspose.diagram.Connect-) | Füge die Verbindung zur Sammlung hinzu. |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Connect connect)](#remove-com.aspose.diagram.Connect-) | Entferne die Verbindung aus der Sammlung. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Connect connect) {#add-com.aspose.diagram.Connect-}
+```
+public int add(Connect connect)
+```
+
+
+Füge die Verbindung zur Sammlung hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| connect | [Connect](../../com.aspose.diagram/connect) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Connect get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[Connect](../../com.aspose.diagram/connect) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Connect connect) {#remove-com.aspose.diagram.Connect-}
+```
+public void remove(Connect connect)
+```
+
+
+Entferne die Verbindung aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| connect | [Connect](../../com.aspose.diagram/connect) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/connectedshapesflags/_index.md
+++ b/german/java/com.aspose.diagram/connectedshapesflags/_index.md
@@ -1,0 +1,156 @@
+---
+title: ConnectedShapesFlags
+second_title: Aspose.Diagram for Java API-Referenz
+description: Filtert das Array der zurückgegebenen Shape-IDs nach der Richtung der Connectoren.
+type: docs
+weight: 77
+url: /de/java/com.aspose.diagram/connectedshapesflags/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConnectedShapesFlags
+```
+
+Filtert das Array der zurückgegebenen Shape-IDs nach der Richtung der Connectoren.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [CONNECTED_SHAPES_ALL_NODES](#CONNECTED-SHAPES-ALL-NODES) | Gibt IDs von Formen zurück, die sowohl mit eingehenden als auch ausgehenden Verbindungen verknüpft sind. |
+| [CONNECTED_SHAPES_INCOMING_NODES](#CONNECTED-SHAPES-INCOMING-NODES) | Gibt IDs von Formen zurück, die mit eingehenden Verbindungen verknüpft sind. |
+| [CONNECTED_SHAPES_OUTGOING_NODES](#CONNECTED-SHAPES-OUTGOING-NODES) | Gibt IDs von Formen zurück, die mit ausgehenden Verbindungen verknüpft sind. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CONNECTED_SHAPES_ALL_NODES {#CONNECTED-SHAPES-ALL-NODES}
+```
+public static final int CONNECTED_SHAPES_ALL_NODES
+```
+
+
+Gibt IDs von Formen zurück, die sowohl mit eingehenden als auch ausgehenden Verbindungen verknüpft sind.
+
+### CONNECTED_SHAPES_INCOMING_NODES {#CONNECTED-SHAPES-INCOMING-NODES}
+```
+public static final int CONNECTED_SHAPES_INCOMING_NODES
+```
+
+
+Gibt IDs von Formen zurück, die mit eingehenden Verbindungen verknüpft sind.
+
+### CONNECTED_SHAPES_OUTGOING_NODES {#CONNECTED-SHAPES-OUTGOING-NODES}
+```
+public static final int CONNECTED_SHAPES_OUTGOING_NODES
+```
+
+
+Gibt IDs von Formen zurück, die mit ausgehenden Verbindungen verknüpft sind.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/connection/_index.md
+++ b/german/java/com.aspose.diagram/connection/_index.md
@@ -1,0 +1,351 @@
+---
+title: Verbindung
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält Elemente für einen für die Form definierten Verbindungspunkt.
+type: docs
+weight: 78
+url: /de/java/com.aspose.diagram/connection/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Connection
+```
+
+Enthält Elemente für einen für die Form definierten Verbindungspunkt.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [Connection()](#Connection--) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAutoGen()](#getAutoGen--) | Gibt an, ob der Verbindungspunkt automatisch erzeugt wird. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getDirX()](#getDirX--) | Gibt die x‑Komponente des erforderlichen Ausrichtungsvektors eines passenden Verbindungspunkts an. |
+| [getDirY()](#getDirY--) | Gibt die y‑Komponente des erforderlichen Ausrichtungsvektors eines passenden Verbindungspunkts an. |
+| [getID()](#getID--) | Die eindeutige ID des Elements innerhalb seines übergeordneten Elements. |
+| [getIX()](#getIX--) | Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements. |
+| [getName()](#getName--) | Der Name des Elements. |
+| [getNameU()](#getNameU--) | Der universelle Name des Elements. |
+| [getPrompt()](#getPrompt--) | Enthält unterschiedliche Eingabeaufforderungsinformationen, basierend auf dem Element, in dem es enthalten ist. |
+| [getType()](#getType--) | Gibt verschiedene Typen an, basierend auf dem Element, in dem es enthalten ist. |
+| [getX()](#getX--) | Gibt eine x-Koordinate eines Shapes in lokalen Koordinaten an. |
+| [getY()](#getY--) | Gibt eine y-Koordinate eines Shapes in lokalen Koordinaten an. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/connection\#getDel--) |
+| [setID(int value)](#setID-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getID()](../../com.aspose.diagram/connection\#getID--) |
+| [setIX(int value)](#setIX-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getIX()](../../com.aspose.diagram/connection\#getIX--) |
+| [setName(String value)](#setName-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getName()](../../com.aspose.diagram/connection\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getNameU()](../../com.aspose.diagram/connection\#getNameU--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Connection() {#Connection--}
+```
+public Connection()
+```
+
+
+Konstruktor.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAutoGen() {#getAutoGen--}
+```
+public BoolValue getAutoGen()
+```
+
+
+Gibt an, ob der Verbindungspunkt automatisch erzeugt wird. Ein Wert von 1 bedeutet, dass der Verbindungspunkt automatisch erzeugt wird.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getDirX() {#getDirX--}
+```
+public DoubleValue getDirX()
+```
+
+
+Gibt die x‑Komponente des erforderlichen Ausrichtungsvektors eines passenden Verbindungspunkts an. Das DirX‑Element wird ebenfalls verwendet, um das angeschlossene Bein eines dynamischen Connectors auszurichten.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDirY() {#getDirY--}
+```
+public DoubleValue getDirY()
+```
+
+
+Gibt die y‑Komponente des erforderlichen Ausrichtungsvektors eines passenden Verbindungspunkts an. Das DirY‑Element wird ebenfalls verwendet, um das angeschlossene Bein eines dynamischen Connectors auszurichten.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+Die eindeutige ID des Elements innerhalb seines übergeordneten Elements.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements.
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Der Name des Elements.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+Der universelle Name des Elements.
+
+**Returns:**
+java.lang.String
+### getPrompt() {#getPrompt--}
+```
+public Str2Value getPrompt()
+```
+
+
+Enthält unterschiedliche Eingabeaufforderungsinformationen, basierend auf dem Element, in dem es enthalten ist.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getType() {#getType--}
+```
+public TypeConnection getType()
+```
+
+
+Gibt verschiedene Typen an, basierend auf dem Element, in dem es enthalten ist.
+
+**Returns:**
+[TypeConnection](../../com.aspose.diagram/typeconnection)
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+Gibt eine x-Koordinate eines Shapes in lokalen Koordinaten an.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+Gibt eine y-Koordinate eines Objekts in lokalen Koordinaten an. Lokale Koordinaten sind solche, deren Bezugspunkt das Objekt und nicht die Seite ist.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/connection\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getID()](../../com.aspose.diagram/connection\#getID--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getIX()](../../com.aspose.diagram/connection\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getName()](../../com.aspose.diagram/connection\#getName--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getNameU()](../../com.aspose.diagram/connection\#getNameU--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/connectionabcd/_index.md
+++ b/german/java/com.aspose.diagram/connectionabcd/_index.md
@@ -1,0 +1,340 @@
+---
+title: ConnectionABCD
+second_title: Aspose.Diagram for Java API-Referenz
+description: Das Element ConnectionABCD ist eine veraltete Version des Elements Connection und existiert nur aus Gründen der Rückwärtskompatibilität.
+type: docs
+weight: 79
+url: /de/java/com.aspose.diagram/connectionabcd/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ConnectionABCD
+```
+
+Das Element ConnectionABCD ist eine veraltete Version des Elements Connection und existiert nur aus Gründen der Rückwärtskompatibilität.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [ConnectionABCD()](#ConnectionABCD--) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | Stellt unterschiedliche Informationen abhängig von seinem übergeordneten Element dar. |
+| [getB()](#getB--) | Stellt unterschiedliche Informationen abhängig von seinem übergeordneten Element dar. |
+| [getC()](#getC--) | Stellt unterschiedliche Informationen basierend auf seinem übergeordneten Element dar. |
+| [getClass()](#getClass--) |  |
+| [getD()](#getD--) | Stellt unterschiedliche Informationen basierend auf seinem übergeordneten Element dar. |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getID()](#getID--) | Die eindeutige ID des Elements innerhalb seines übergeordneten Elements. |
+| [getIX()](#getIX--) | Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements. |
+| [getName()](#getName--) | Der Name des Elements. |
+| [getNameU()](#getNameU--) | Der universelle Name des Elements. |
+| [getX()](#getX--) | Gibt eine x-Koordinate eines Shapes in lokalen Koordinaten an. |
+| [getY()](#getY--) | Gibt eine y-Koordinate eines Shapes in lokalen Koordinaten an. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/connectionabcd\#getDel--) |
+| [setID(int value)](#setID-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getID()](../../com.aspose.diagram/connectionabcd\#getID--) |
+| [setIX(int value)](#setIX-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getIX()](../../com.aspose.diagram/connectionabcd\#getIX--) |
+| [setName(String value)](#setName-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getName()](../../com.aspose.diagram/connectionabcd\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getNameU()](../../com.aspose.diagram/connectionabcd\#getNameU--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ConnectionABCD() {#ConnectionABCD--}
+```
+public ConnectionABCD()
+```
+
+
+Konstruktor.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+Stellt unterschiedliche Informationen abhängig von seinem übergeordneten Element dar.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getB() {#getB--}
+```
+public DoubleValue getB()
+```
+
+
+Stellt unterschiedliche Informationen abhängig von seinem übergeordneten Element dar.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getC() {#getC--}
+```
+public DoubleValue getC()
+```
+
+
+Stellt unterschiedliche Informationen basierend auf seinem übergeordneten Element dar.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getD() {#getD--}
+```
+public DoubleValue getD()
+```
+
+
+Stellt unterschiedliche Informationen basierend auf seinem übergeordneten Element dar.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+Die eindeutige ID des Elements innerhalb seines übergeordneten Elements.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements.
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Der Name des Elements.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+Der universelle Name des Elements.
+
+**Returns:**
+java.lang.String
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+Gibt eine x-Koordinate eines Objekts in lokalen Koordinaten an. Die folgende Tabelle beschreibt das X-Element basierend auf dem Element, das es enthält.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+Gibt eine y-Koordinate eines Objekts in lokalen Koordinaten an. Lokale Koordinaten sind solche, deren Bezugspunkt das Objekt und nicht die Seite ist.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/connectionabcd\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getID()](../../com.aspose.diagram/connectionabcd\#getID--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getIX()](../../com.aspose.diagram/connectionabcd\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getName()](../../com.aspose.diagram/connectionabcd\#getName--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getNameU()](../../com.aspose.diagram/connectionabcd\#getNameU--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/connectionabcdcollection/_index.md
+++ b/german/java/com.aspose.diagram/connectionabcdcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: ConnectionABCDCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: ConnectionABCD‑Sammlung.
+type: docs
+weight: 80
+url: /de/java/com.aspose.diagram/connectionabcdcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ConnectionABCDCollection extends Collection
+```
+
+ConnectionABCD‑Sammlung.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [add(ConnectionABCD item)](#add-com.aspose.diagram.ConnectionABCD-) | Füge das ConnectionABCD-Objekt zur Sammlung hinzu. |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(ConnectionABCD item)](#remove-com.aspose.diagram.ConnectionABCD-) | Entferne das ConnectionABCD-Objekt aus der Sammlung. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(ConnectionABCD item) {#add-com.aspose.diagram.ConnectionABCD-}
+```
+public int add(ConnectionABCD item)
+```
+
+
+Füge das ConnectionABCD-Objekt zur Sammlung hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [ConnectionABCD](../../com.aspose.diagram/connectionabcd) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public ConnectionABCD get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[ConnectionABCD](../../com.aspose.diagram/connectionabcd) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(ConnectionABCD item) {#remove-com.aspose.diagram.ConnectionABCD-}
+```
+public void remove(ConnectionABCD item)
+```
+
+
+Entferne das ConnectionABCD-Objekt aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [ConnectionABCD](../../com.aspose.diagram/connectionabcd) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/connectioncollection/_index.md
+++ b/german/java/com.aspose.diagram/connectioncollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: ConnectionCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: Connection‑Sammlung.
+type: docs
+weight: 81
+url: /de/java/com.aspose.diagram/connectioncollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ConnectionCollection extends Collection
+```
+
+Connection‑Sammlung.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [add(Connection item)](#add-com.aspose.diagram.Connection-) | Fügen Sie das Connection-Objekt zur Sammlung hinzu. |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Connection item)](#remove-com.aspose.diagram.Connection-) | Entfernen Sie das Connection-Objekt aus der Sammlung. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Connection item) {#add-com.aspose.diagram.Connection-}
+```
+public int add(Connection item)
+```
+
+
+Fügen Sie das Connection-Objekt zur Sammlung hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [Connection](../../com.aspose.diagram/connection) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Connection get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[Connection](../../com.aspose.diagram/connection) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Connection item) {#remove-com.aspose.diagram.Connection-}
+```
+public void remove(Connection item)
+```
+
+
+Entfernen Sie das Connection-Objekt aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [Connection](../../com.aspose.diagram/connection) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/connectionpointplace/_index.md
+++ b/german/java/com.aspose.diagram/connectionpointplace/_index.md
@@ -1,0 +1,174 @@
+---
+title: ConnectionPointPlace
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt den Ort auf der Form an, an dem der Connector verbunden wird.
+type: docs
+weight: 82
+url: /de/java/com.aspose.diagram/connectionpointplace/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConnectionPointPlace
+```
+
+Gibt den Ort auf der Form an, an dem der Connector verbunden wird.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [BOTTOM](#BOTTOM) | Unterseite der Form. |
+| [CENTER](#CENTER) | Mitte der Form. |
+| [LEFT](#LEFT) | Links von der Form. |
+| [RIGHT](#RIGHT) | Rechts von der Form. |
+| [TOP](#TOP) | Oben der Form. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOTTOM {#BOTTOM}
+```
+public static final int BOTTOM
+```
+
+
+Unterseite der Form.
+
+### CENTER {#CENTER}
+```
+public static final int CENTER
+```
+
+
+Mitte der Form.
+
+### LEFT {#LEFT}
+```
+public static final int LEFT
+```
+
+
+Links von der Form.
+
+### RIGHT {#RIGHT}
+```
+public static final int RIGHT
+```
+
+
+Rechts von der Form.
+
+### TOP {#TOP}
+```
+public static final int TOP
+```
+
+
+Oben der Form.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/connectorrule/_index.md
+++ b/german/java/com.aspose.diagram/connectorrule/_index.md
@@ -1,0 +1,169 @@
+---
+title: ConnectorRule
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt die ConnectorRule zwischen zwei Formen mit einem connectorIncluding dar, welcher den Verbindungspunkt der jeweiligen Form angibt, von dem aus die Verbindung zur Endform und deren Verbindungspunkt startet.
+type: docs
+weight: 83
+url: /de/java/com.aspose.diagram/connectorrule/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ConnectorRule
+```
+
+Stellt die Connector‑Regel zwischen zwei Formen mit einem Connector dar, einschließlich des Verbindungspunkts, von dem aus die Verbindung startet, der Ziel‑Form und deren Verbindungspunkt.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getEndShapeConnection()](#getEndShapeConnection--) | Die Verbindung der Form, zu der eine Verbindung hergestellt wird. |
+| [getEndShapeId()](#getEndShapeId--) | Die Form, zu der eine Verbindung hergestellt wird. |
+| [getStartShapeConnection()](#getStartShapeConnection--) | Die Verbindung der Form, von der eine Verbindung ausgeht. |
+| [getStartShapeId()](#getStartShapeId--) | Die Form, von der eine Verbindung ausgeht. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getEndShapeConnection() {#getEndShapeConnection--}
+```
+public Connection getEndShapeConnection()
+```
+
+
+Die Verbindung der Form, zu der eine Verbindung hergestellt wird.
+
+**Returns:**
+[Connection](../../com.aspose.diagram/connection)
+### getEndShapeId() {#getEndShapeId--}
+```
+public long getEndShapeId()
+```
+
+
+Die Form, zu der eine Verbindung hergestellt wird.
+
+**Returns:**
+long
+### getStartShapeConnection() {#getStartShapeConnection--}
+```
+public Connection getStartShapeConnection()
+```
+
+
+Die Verbindung der Form, von der eine Verbindung ausgeht.
+
+**Returns:**
+[Connection](../../com.aspose.diagram/connection)
+### getStartShapeId() {#getStartShapeId--}
+```
+public long getStartShapeId()
+```
+
+
+Die Form, von der eine Verbindung ausgeht.
+
+**Returns:**
+long
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/connectorstypevalue/_index.md
+++ b/german/java/com.aspose.diagram/connectorstypevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: ConnectorsTypeValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Kann einer der folgenden Werte sein: RightAngle StraightLines oder CurvedLines.
+type: docs
+weight: 84
+url: /de/java/com.aspose.diagram/connectorstypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConnectorsTypeValue
+```
+
+Kann einer der folgenden Werte sein: RightAngle, StraightLines oder CurvedLines. Nur relevant, wenn WindowType als Drawing oder Sheet angegeben ist.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [CURVED_LINES](#CURVED-LINES) | CurvedLines. |
+| [RIGHT_ANGLE](#RIGHT-ANGLE) | RightAngle. |
+| [STRAIGHT_LINES](#STRAIGHT-LINES) | StraightLines. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CURVED_LINES {#CURVED-LINES}
+```
+public static final int CURVED_LINES
+```
+
+
+CurvedLines.
+
+### RIGHT_ANGLE {#RIGHT-ANGLE}
+```
+public static final int RIGHT_ANGLE
+```
+
+
+RightAngle.
+
+### STRAIGHT_LINES {#STRAIGHT-LINES}
+```
+public static final int STRAIGHT_LINES
+```
+
+
+StraightLines.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/containertypevalue/_index.md
+++ b/german/java/com.aspose.diagram/containertypevalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: ContainerTypeValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Kann einer der folgenden Werte sein: Dokument, Seite oder Master.
+type: docs
+weight: 85
+url: /de/java/com.aspose.diagram/containertypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ContainerTypeValue
+```
+
+Kann einer der folgenden Werte sein: Dokument, Seite oder Master. Nur relevant, wenn WindowType als Zeichnung oder Blatt angegeben ist.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [DOCUMENT](#DOCUMENT) | Dokument. |
+| [MASTER](#MASTER) | Master. |
+| [PAGE](#PAGE) | Seite. |
+| [STYLE](#STYLE) | Master. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DOCUMENT {#DOCUMENT}
+```
+public static final int DOCUMENT
+```
+
+
+Dokument.
+
+### MASTER {#MASTER}
+```
+public static final int MASTER
+```
+
+
+Master.
+
+### PAGE {#PAGE}
+```
+public static final int PAGE
+```
+
+
+Seite.
+
+### STYLE {#STYLE}
+```
+public static final int STYLE
+```
+
+
+Master.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/contexttypevalue/_index.md
+++ b/german/java/com.aspose.diagram/contexttypevalue/_index.md
@@ -1,0 +1,255 @@
+---
+title: ContextTypeValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt die Eigenschaften der Gruppe oder Form an, die für den Vergleich verwendet werden sollen.
+type: docs
+weight: 86
+url: /de/java/com.aspose.diagram/contexttypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ContextTypeValue
+```
+
+Gibt die Eigenschaften der Gruppe oder Form an, die für den Vergleich verwendet werden sollen. Mögliche Werte sind in der folgenden Tabelle aufgeführt.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [DATA_1](#DATA-1) | Data1. |
+| [DATA_2](#DATA-2) | Data2. |
+| [DATA_3](#DATA-3) | Data3. |
+| [GEOMETRY_ANGLE](#GEOMETRY-ANGLE) | Geometriewinkel. |
+| [GEOMETRY_HEIGHT](#GEOMETRY-HEIGHT) | Geometriehöhe. |
+| [GEOMETRY_WIDTH](#GEOMETRY-WIDTH) | Geometriebreite. |
+| [MASTER_NAME](#MASTER-NAME) | Mastername. |
+| [SHAPE_DATA_ITEM_CUSTOM_PROPERTY_LABEL](#SHAPE-DATA-ITEM-CUSTOM-PROPERTY-LABEL) | Shape-data-item (benutzerdefinierte Eigenschaft) Bezeichnung. |
+| [SHAPE_ID](#SHAPE-ID) | Shape-ID. |
+| [SHAPE_LOCAL_NAME](#SHAPE-LOCAL-NAME) | Lokaler Shape-Name. |
+| [SHAPE_TEXT](#SHAPE-TEXT) | Shape-Text. |
+| [SHAPE_TYPE](#SHAPE-TYPE) | Shape-Typ. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+| [USER_CELL_LOCAL_ROW_NAME](#USER-CELL-LOCAL-ROW-NAME) | Lokaler Zeilenname der Benutzerzelle. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DATA_1 {#DATA-1}
+```
+public static final int DATA_1
+```
+
+
+Data1.
+
+### DATA_2 {#DATA-2}
+```
+public static final int DATA_2
+```
+
+
+Data2.
+
+### DATA_3 {#DATA-3}
+```
+public static final int DATA_3
+```
+
+
+Data3.
+
+### GEOMETRY_ANGLE {#GEOMETRY-ANGLE}
+```
+public static final int GEOMETRY_ANGLE
+```
+
+
+Geometriewinkel.
+
+### GEOMETRY_HEIGHT {#GEOMETRY-HEIGHT}
+```
+public static final int GEOMETRY_HEIGHT
+```
+
+
+Geometriehöhe.
+
+### GEOMETRY_WIDTH {#GEOMETRY-WIDTH}
+```
+public static final int GEOMETRY_WIDTH
+```
+
+
+Geometriebreite.
+
+### MASTER_NAME {#MASTER-NAME}
+```
+public static final int MASTER_NAME
+```
+
+
+Mastername.
+
+### SHAPE_DATA_ITEM_CUSTOM_PROPERTY_LABEL {#SHAPE-DATA-ITEM-CUSTOM-PROPERTY-LABEL}
+```
+public static final int SHAPE_DATA_ITEM_CUSTOM_PROPERTY_LABEL
+```
+
+
+Shape-data-item (benutzerdefinierte Eigenschaft) Bezeichnung.
+
+### SHAPE_ID {#SHAPE-ID}
+```
+public static final int SHAPE_ID
+```
+
+
+Shape-ID.
+
+### SHAPE_LOCAL_NAME {#SHAPE-LOCAL-NAME}
+```
+public static final int SHAPE_LOCAL_NAME
+```
+
+
+Lokaler Shape-Name.
+
+### SHAPE_TEXT {#SHAPE-TEXT}
+```
+public static final int SHAPE_TEXT
+```
+
+
+Shape-Text.
+
+### SHAPE_TYPE {#SHAPE-TYPE}
+```
+public static final int SHAPE_TYPE
+```
+
+
+Shape-Typ.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### USER_CELL_LOCAL_ROW_NAME {#USER-CELL-LOCAL-ROW-NAME}
+```
+public static final int USER_CELL_LOCAL_ROW_NAME
+```
+
+
+Lokaler Zeilenname der Benutzerzelle.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/control/_index.md
+++ b/german/java/com.aspose.diagram/control/_index.md
@@ -1,0 +1,474 @@
+---
+title: Steuerung
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält Elemente für die x- und y-Koordinaten jedes für eine Form definierten Steuerungspunkts sowie Elemente, die die Art und Weise festlegen, wie sich der Steuerungspunkt verhalten soll.
+type: docs
+weight: 87
+url: /de/java/com.aspose.diagram/control/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Control
+```
+
+Enthält Elemente für die x‑ und y‑Koordinaten jedes für eine Form definierten Steuergriffs sowie Elemente, die angeben, wie sich der Steuergriff verhalten soll.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [Control()](#Control--) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [canGlue()](#canGlue--) | Bestimmt, ob ein Steuerungspunkt an andere Formen angeheftet werden kann. |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getID()](#getID--) | Die eindeutige ID des Elements innerhalb seines übergeordneten Elements. |
+| [getIX()](#getIX--) | Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements. |
+| [getName()](#getName--) | Der Name des Elements. |
+| [getNameU()](#getNameU--) | Der universelle Name des Elements. |
+| [getPrompt()](#getPrompt--) | Das Prompt-Element gibt den beschreibenden Text an, der als Tooltip angezeigt wird, wenn der Mauszeiger über dem Steuerungspunkt einer Form verweilt. |
+| [getX()](#getX--) | Die x-Koordinate, die den Ort des Steuerungspunkts einer Form angibt. |
+| [getXCon()](#getXCon--) | Gibt den Verhaltenstyp an, den die x-Koordinate des Steuerungspunkts nach dem Verschieben des Punktes zeigt. |
+| [getXDyn()](#getXDyn--) | Gibt die x-Koordinate des Ankerpunkts eines Steuerungspunkts in lokalen Koordinaten an. |
+| [getY()](#getY--) | Die y-Koordinate, die den Ort des Steuerungspunkts einer Form angibt. |
+| [getYCon()](#getYCon--) | Gibt den Verhaltenstyp an, den die x-Koordinate des Steuerungspunkts nach dem Verschieben des Punktes zeigt. |
+| [getYDyn()](#getYDyn--) | Gibt die y-Koordinate des Ankerpunkts eines Steuerungspunkts in lokalen Koordinaten an. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCanGlue(BoolValue value)](#setCanGlue-com.aspose.diagram.BoolValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [canGlue()](../../com.aspose.diagram/control\#canGlue--) |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/control\#getDel--) |
+| [setID(int value)](#setID-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getID()](../../com.aspose.diagram/control\#getID--) |
+| [setIX(int value)](#setIX-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getIX()](../../com.aspose.diagram/control\#getIX--) |
+| [setName(String value)](#setName-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getName()](../../com.aspose.diagram/control\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getNameU()](../../com.aspose.diagram/control\#getNameU--) |
+| [setPrompt(Str2Value value)](#setPrompt-com.aspose.diagram.Str2Value-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getPrompt()](../../com.aspose.diagram/control\#getPrompt--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getX()](../../com.aspose.diagram/control\#getX--) |
+| [setXCon(ConType value)](#setXCon-com.aspose.diagram.ConType-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getXCon()](../../com.aspose.diagram/control\#getXCon--) |
+| [setXDyn(DoubleValue value)](#setXDyn-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getXDyn()](../../com.aspose.diagram/control\#getXDyn--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getY()](../../com.aspose.diagram/control\#getY--) |
+| [setYCon(ConType value)](#setYCon-com.aspose.diagram.ConType-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getYCon()](../../com.aspose.diagram/control\#getYCon--) |
+| [setYDyn(DoubleValue value)](#setYDyn-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getYDyn()](../../com.aspose.diagram/control\#getYDyn--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Control() {#Control--}
+```
+public Control()
+```
+
+
+Konstruktor.
+
+### canGlue() {#canGlue--}
+```
+public BoolValue canGlue()
+```
+
+
+Bestimmt, ob ein Steuerungspunkt an andere Formen angeheftet werden kann.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+Die eindeutige ID des Elements innerhalb seines übergeordneten Elements.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements.
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Der Name des Elements.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+Der universelle Name des Elements.
+
+**Returns:**
+java.lang.String
+### getPrompt() {#getPrompt--}
+```
+public Str2Value getPrompt()
+```
+
+
+Das Prompt-Element gibt den beschreibenden Text an, der als Tooltip angezeigt wird, wenn der Mauszeiger über dem Steuerungspunkt einer Form verweilt.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+Die x-Koordinate, die den Ort des Steuerungspunkts einer Form angibt.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getXCon() {#getXCon--}
+```
+public ConType getXCon()
+```
+
+
+Gibt den Verhaltenstyp an, den die x-Koordinate des Steuerungspunkts nach dem Verschieben des Punktes zeigt.
+
+**Returns:**
+[ConType](../../com.aspose.diagram/contype)
+### getXDyn() {#getXDyn--}
+```
+public DoubleValue getXDyn()
+```
+
+
+Gibt die x‑Koordinate des Ankerpunkts eines Steuerungshandgriffs in lokalen Koordinaten an. Der Ankerpunkt wird für das Rubber‑Banding während der Dynamik verwendet.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+Die y-Koordinate, die den Ort des Steuerungspunkts einer Form angibt.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getYCon() {#getYCon--}
+```
+public ConType getYCon()
+```
+
+
+Gibt den Verhaltenstyp an, den die x-Koordinate des Steuerungspunkts nach dem Verschieben des Punktes zeigt.
+
+**Returns:**
+[ConType](../../com.aspose.diagram/contype)
+### getYDyn() {#getYDyn--}
+```
+public DoubleValue getYDyn()
+```
+
+
+Gibt die y‑Koordinate des Ankerpunkts eines Steuerungshandgriffs in lokalen Koordinaten an. Der Ankerpunkt wird für das Rubber‑Banding während der Dynamik verwendet.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCanGlue(BoolValue value) {#setCanGlue-com.aspose.diagram.BoolValue-}
+```
+public void setCanGlue(BoolValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [canGlue()](../../com.aspose.diagram/control\#canGlue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/control\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getID()](../../com.aspose.diagram/control\#getID--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getIX()](../../com.aspose.diagram/control\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getName()](../../com.aspose.diagram/control\#getName--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getNameU()](../../com.aspose.diagram/control\#getNameU--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setPrompt(Str2Value value) {#setPrompt-com.aspose.diagram.Str2Value-}
+```
+public void setPrompt(Str2Value value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getPrompt()](../../com.aspose.diagram/control\#getPrompt--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [Str2Value](../../com.aspose.diagram/str2value) |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getX()](../../com.aspose.diagram/control\#getX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setXCon(ConType value) {#setXCon-com.aspose.diagram.ConType-}
+```
+public void setXCon(ConType value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getXCon()](../../com.aspose.diagram/control\#getXCon--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [ConType](../../com.aspose.diagram/contype) |  |
+
+### setXDyn(DoubleValue value) {#setXDyn-com.aspose.diagram.DoubleValue-}
+```
+public void setXDyn(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getXDyn()](../../com.aspose.diagram/control\#getXDyn--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getY()](../../com.aspose.diagram/control\#getY--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setYCon(ConType value) {#setYCon-com.aspose.diagram.ConType-}
+```
+public void setYCon(ConType value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getYCon()](../../com.aspose.diagram/control\#getYCon--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [ConType](../../com.aspose.diagram/contype) |  |
+
+### setYDyn(DoubleValue value) {#setYDyn-com.aspose.diagram.DoubleValue-}
+```
+public void setYDyn(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getYDyn()](../../com.aspose.diagram/control\#getYDyn--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/controlbordertype/_index.md
+++ b/german/java/com.aspose.diagram/controlbordertype/_index.md
@@ -1,0 +1,147 @@
+---
+title: ControlBorderType
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt den Rahmentyp des ActiveX‑Steuerelements dar.
+type: docs
+weight: 88
+url: /de/java/com.aspose.diagram/controlbordertype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlBorderType
+```
+
+Stellt den Rahmentyp des ActiveX‑Steuerelements dar.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [NONE](#NONE) | Kein Rahmen. |
+| [SINGLE](#SINGLE) | Die einzelne Linie. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Kein Rahmen.
+
+### SINGLE {#SINGLE}
+```
+public static final int SINGLE
+```
+
+
+Die einzelne Linie.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/controlcaptionalignmenttype/_index.md
+++ b/german/java/com.aspose.diagram/controlcaptionalignmenttype/_index.md
@@ -1,0 +1,147 @@
+---
+title: ControlCaptionAlignmentType
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt die Position der Beschriftung relativ zum Steuerelement dar.
+type: docs
+weight: 89
+url: /de/java/com.aspose.diagram/controlcaptionalignmenttype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlCaptionAlignmentType
+```
+
+Stellt die Position der Beschriftung relativ zum Steuerelement dar.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [LEFT](#LEFT) | Die linke Seite des Steuerelements. |
+| [RIGHT](#RIGHT) | Die rechte Seite des Steuerelements. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LEFT {#LEFT}
+```
+public static final int LEFT
+```
+
+
+Die linke Seite des Steuerelements.
+
+### RIGHT {#RIGHT}
+```
+public static final int RIGHT
+```
+
+
+Die rechte Seite des Steuerelements.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/controlcollection/_index.md
+++ b/german/java/com.aspose.diagram/controlcollection/_index.md
@@ -1,0 +1,266 @@
+---
+title: ControlCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: Control‑Sammlung.
+type: docs
+weight: 90
+url: /de/java/com.aspose.diagram/controlcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ControlCollection extends Collection
+```
+
+Control‑Sammlung.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [add(Control item)](#add-com.aspose.diagram.Control-) | Füge das Control-Objekt zur Sammlung hinzu. |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [getClass()](#getClass--) |  |
+| [getControl(int IX)](#getControl-int-) | Gibt das Element am angegebenen Index IX zurück. |
+| [getControlFromId(int ID)](#getControlFromId-int-) | Liefert das Element mit der angegebenen ID. |
+| [getControlFromName(String name)](#getControlFromName-java.lang.String-) | Liefert das Element mit dem angegebenen Namen. |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Control item)](#remove-com.aspose.diagram.Control-) | Entferne das Control-Objekt aus der Sammlung. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Control item) {#add-com.aspose.diagram.Control-}
+```
+public int add(Control item)
+```
+
+
+Füge das Control-Objekt zur Sammlung hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [Control](../../com.aspose.diagram/control) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Control get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[Control](../../com.aspose.diagram/control) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getControl(int IX) {#getControl-int-}
+```
+public Control getControl(int IX)
+```
+
+
+Gibt das Element am angegebenen Index IX zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| IX | int |  |
+
+**Returns:**
+[Control](../../com.aspose.diagram/control) - 
+### getControlFromId(int ID) {#getControlFromId-int-}
+```
+public Control getControlFromId(int ID)
+```
+
+
+Liefert das Element mit der angegebenen ID.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| ID | int |  |
+
+**Returns:**
+[Control](../../com.aspose.diagram/control) - 
+### getControlFromName(String name) {#getControlFromName-java.lang.String-}
+```
+public Control getControlFromName(String name)
+```
+
+
+Liefert das Element mit dem angegebenen Namen.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Name | java.lang.String |  |
+
+**Returns:**
+[Control](../../com.aspose.diagram/control) - 
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Control item) {#remove-com.aspose.diagram.Control-}
+```
+public void remove(Control item)
+```
+
+
+Entferne das Control-Objekt aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [Control](../../com.aspose.diagram/control) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/controlliststyle/_index.md
+++ b/german/java/com.aspose.diagram/controlliststyle/_index.md
@@ -1,0 +1,147 @@
+---
+title: ControlListStyle
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt das visuelle Erscheinungsbild der Liste in einer ListBox oder ComboBox dar.
+type: docs
+weight: 91
+url: /de/java/com.aspose.diagram/controlliststyle/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlListStyle
+```
+
+Stellt das visuelle Erscheinungsbild der Liste in einer ListBox oder ComboBox dar.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [OPTION](#OPTION) | Zeigt eine Liste an, in der neben jedem Eintrag ein Optionsfeld oder ein Kontrollkästchen den Auswahlstatus dieses Elements anzeigt. |
+| [PLAIN](#PLAIN) | Zeigt eine Liste an, in der der Hintergrund eines Elements hervorgehoben wird, wenn es ausgewählt ist. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### OPTION {#OPTION}
+```
+public static final int OPTION
+```
+
+
+Zeigt eine Liste an, in der neben jedem Eintrag ein Optionsfeld oder ein Kontrollkästchen den Auswahlstatus dieses Elements anzeigt.
+
+### PLAIN {#PLAIN}
+```
+public static final int PLAIN
+```
+
+
+Zeigt eine Liste an, in der der Hintergrund eines Elements hervorgehoben wird, wenn es ausgewählt ist.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/controlmatchentrytype/_index.md
+++ b/german/java/com.aspose.diagram/controlmatchentrytype/_index.md
@@ -1,0 +1,156 @@
+---
+title: ControlMatchEntryType
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt dar, wie ein ListBox oder ComboBox seine Liste durchsucht, während der Benutzer tippt.
+type: docs
+weight: 92
+url: /de/java/com.aspose.diagram/controlmatchentrytype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlMatchEntryType
+```
+
+Stellt dar, wie ein ListBox oder ComboBox seine Liste durchsucht, während der Benutzer tippt.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [COMPLETE](#COMPLETE) | Während jedes Zeichen eingegeben wird, sucht das Steuerelement nach einem Eintrag, der allen eingegebenen Zeichen entspricht. |
+| [FIRST_LETTER](#FIRST-LETTER) | Das Steuerelement sucht nach dem nächsten Eintrag, der mit dem eingegebenen Zeichen beginnt. |
+| [NONE](#NONE) | Die Liste wird nicht durchsucht, wenn Zeichen eingegeben werden. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### COMPLETE {#COMPLETE}
+```
+public static final int COMPLETE
+```
+
+
+Während jedes Zeichen eingegeben wird, sucht das Steuerelement nach einem Eintrag, der allen eingegebenen Zeichen entspricht.
+
+### FIRST_LETTER {#FIRST-LETTER}
+```
+public static final int FIRST_LETTER
+```
+
+
+Das Steuerelement sucht nach dem nächsten Eintrag, der mit dem eingegebenen Zeichen beginnt. Durch wiederholtes Eingeben desselben Buchstabens wird durch alle Einträge, die mit diesem Buchstaben beginnen, geschaltet.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Die Liste wird nicht durchsucht, wenn Zeichen eingegeben werden.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/controlmousepointertype/_index.md
+++ b/german/java/com.aspose.diagram/controlmousepointertype/_index.md
@@ -1,0 +1,264 @@
+---
+title: ControlMousePointerType
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt den Typ des Symbols dar, das als Mauszeiger für das Steuerelement angezeigt wird.
+type: docs
+weight: 93
+url: /de/java/com.aspose.diagram/controlmousepointertype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlMousePointerType
+```
+
+Stellt den Typ des Symbols dar, das als Mauszeiger für das Steuerelement angezeigt wird.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [APP_STARTING](#APP-STARTING) | Pfeil mit Sanduhr. |
+| [ARROW](#ARROW) | Pfeil. |
+| [CROSS](#CROSS) | Fadenkreuzzeiger. |
+| [CUSTOM](#CUSTOM) | Verwendet das Symbol, das durch die MouseIcon-Eigenschaft angegeben ist. |
+| [DEFAULT](#DEFAULT) | Standardzeiger. |
+| [HELP](#HELP) | Pfeil mit Fragezeichen. |
+| [HOUR_GLASS](#HOUR-GLASS) | Stundenglas. |
+| [I_BEAM](#I-BEAM) | I‑Balken. |
+| [NO_DROP](#NO-DROP) | \\u9225\\u6de3ot\\u9225? |
+| [SIZE_ALL](#SIZE-ALL) | \\u9225\\u6deaize-all\\u9225? |
+| [SIZE_NESW](#SIZE-NESW) | Doppelter Pfeil, der nach Nordost und Südwest zeigt. |
+| [SIZE_NS](#SIZE-NS) | Doppelter Pfeil, der nach Norden und Süden zeigt. |
+| [SIZE_NWSE](#SIZE-NWSE) | Doppelter Pfeil, der nach Nordwest und Südost zeigt. |
+| [SIZE_WE](#SIZE-WE) | Doppelter Pfeil, der nach Westen und Osten zeigt. |
+| [UP_ARROW](#UP-ARROW) | Aufwärtspfeil. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### APP_STARTING {#APP-STARTING}
+```
+public static final int APP_STARTING
+```
+
+
+Pfeil mit Sanduhr.
+
+### ARROW {#ARROW}
+```
+public static final int ARROW
+```
+
+
+Pfeil.
+
+### CROSS {#CROSS}
+```
+public static final int CROSS
+```
+
+
+Fadenkreuzzeiger.
+
+### CUSTOM {#CUSTOM}
+```
+public static final int CUSTOM
+```
+
+
+Verwendet das Symbol, das durch die MouseIcon-Eigenschaft angegeben ist.
+
+### DEFAULT {#DEFAULT}
+```
+public static final int DEFAULT
+```
+
+
+Standardzeiger.
+
+### HELP {#HELP}
+```
+public static final int HELP
+```
+
+
+Pfeil mit Fragezeichen.
+
+### HOUR_GLASS {#HOUR-GLASS}
+```
+public static final int HOUR_GLASS
+```
+
+
+Stundenglas.
+
+### I_BEAM {#I-BEAM}
+```
+public static final int I_BEAM
+```
+
+
+I‑Balken.
+
+### NO_DROP {#NO-DROP}
+```
+public static final int NO_DROP
+```
+
+
+\\u9225\\u6de3ot\\u9225?symbol (Kreis mit einem diagonalen Strich) oben auf dem gezogenen Objekt.
+
+### SIZE_ALL {#SIZE-ALL}
+```
+public static final int SIZE_ALL
+```
+
+
+\\u9225\\u6deaize-all\\u9225?cursor (Pfeile, die nach Norden, Süden, Osten und Westen zeigen).
+
+### SIZE_NESW {#SIZE-NESW}
+```
+public static final int SIZE_NESW
+```
+
+
+Doppelter Pfeil, der nach Nordost und Südwest zeigt.
+
+### SIZE_NS {#SIZE-NS}
+```
+public static final int SIZE_NS
+```
+
+
+Doppelter Pfeil, der nach Norden und Süden zeigt.
+
+### SIZE_NWSE {#SIZE-NWSE}
+```
+public static final int SIZE_NWSE
+```
+
+
+Doppelter Pfeil, der nach Nordwest und Südost zeigt.
+
+### SIZE_WE {#SIZE-WE}
+```
+public static final int SIZE_WE
+```
+
+
+Doppelter Pfeil, der nach Westen und Osten zeigt.
+
+### UP_ARROW {#UP-ARROW}
+```
+public static final int UP_ARROW
+```
+
+
+Aufwärtspfeil.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/controlpicturealignmenttype/_index.md
+++ b/german/java/com.aspose.diagram/controlpicturealignmenttype/_index.md
@@ -1,0 +1,174 @@
+---
+title: ControlPictureAlignmentType
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt die Ausrichtung des Bildes innerhalb des Formulars oder Bildes dar.
+type: docs
+weight: 94
+url: /de/java/com.aspose.diagram/controlpicturealignmenttype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlPictureAlignmentType
+```
+
+Stellt die Ausrichtung des Bildes innerhalb des Formulars oder Bildes dar.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [BOTTOM_LEFT](#BOTTOM-LEFT) | Die untere linke Ecke. |
+| [BOTTOM_RIGHT](#BOTTOM-RIGHT) | Die untere rechte Ecke. |
+| [CENTER](#CENTER) | Die Mitte. |
+| [TOP_LEFT](#TOP-LEFT) | Die obere linke Ecke. |
+| [TOP_RIGHT](#TOP-RIGHT) | Die obere rechte Ecke. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOTTOM_LEFT {#BOTTOM-LEFT}
+```
+public static final int BOTTOM_LEFT
+```
+
+
+Die untere linke Ecke.
+
+### BOTTOM_RIGHT {#BOTTOM-RIGHT}
+```
+public static final int BOTTOM_RIGHT
+```
+
+
+Die untere rechte Ecke.
+
+### CENTER {#CENTER}
+```
+public static final int CENTER
+```
+
+
+Die Mitte.
+
+### TOP_LEFT {#TOP-LEFT}
+```
+public static final int TOP_LEFT
+```
+
+
+Die obere linke Ecke.
+
+### TOP_RIGHT {#TOP-RIGHT}
+```
+public static final int TOP_RIGHT
+```
+
+
+Die obere rechte Ecke.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/controlpicturepositiontype/_index.md
+++ b/german/java/com.aspose.diagram/controlpicturepositiontype/_index.md
@@ -1,0 +1,246 @@
+---
+title: ControlPicturePositionType
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt die Position des Bildes der Steuerung relativ zu ihrer Beschriftung an.
+type: docs
+weight: 95
+url: /de/java/com.aspose.diagram/controlpicturepositiontype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlPicturePositionType
+```
+
+Stellt den Ort des Bildes des Steuerelements relativ zu seiner Beschriftung dar.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [ABOVE_CENTER](#ABOVE-CENTER) | Das Bild erscheint über der Beschriftung. |
+| [ABOVE_LEFT](#ABOVE-LEFT) | Das Bild erscheint über der Beschriftung. |
+| [ABOVE_RIGHT](#ABOVE-RIGHT) | Das Bild erscheint über der Beschriftung. |
+| [BELOW_CENTER](#BELOW-CENTER) | Das Bild erscheint unter der Beschriftung. |
+| [BELOW_LEFT](#BELOW-LEFT) | Das Bild erscheint unter der Beschriftung. |
+| [BELOW_RIGHT](#BELOW-RIGHT) | Das Bild erscheint unter der Beschriftung. |
+| [CENTER](#CENTER) | Das Bild erscheint in der Mitte der Steuerung. |
+| [LEFT_BOTTOM](#LEFT-BOTTOM) | Das Bild erscheint links von der Beschriftung. |
+| [LEFT_CENTER](#LEFT-CENTER) | Das Bild erscheint links von der Beschriftung. |
+| [LEFT_TOP](#LEFT-TOP) | Das Bild erscheint links von der Beschriftung. |
+| [RIGHT_BOTTOM](#RIGHT-BOTTOM) | Das Bild erscheint rechts von der Beschriftung. |
+| [RIGHT_CENTER](#RIGHT-CENTER) | Das Bild erscheint rechts von der Beschriftung. |
+| [RIGHT_TOP](#RIGHT-TOP) | Das Bild erscheint rechts von der Beschriftung. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ABOVE_CENTER {#ABOVE-CENTER}
+```
+public static final int ABOVE_CENTER
+```
+
+
+Das Bild erscheint über der Beschriftung. Die Beschriftung ist zentriert unter dem Bild.
+
+### ABOVE_LEFT {#ABOVE-LEFT}
+```
+public static final int ABOVE_LEFT
+```
+
+
+Das Bild erscheint über der Beschriftung. Die Beschriftung ist am linken Rand des Bildes ausgerichtet.
+
+### ABOVE_RIGHT {#ABOVE-RIGHT}
+```
+public static final int ABOVE_RIGHT
+```
+
+
+Das Bild erscheint über der Beschriftung. Die Beschriftung ist am rechten Rand des Bildes ausgerichtet.
+
+### BELOW_CENTER {#BELOW-CENTER}
+```
+public static final int BELOW_CENTER
+```
+
+
+Das Bild erscheint unter der Beschriftung. Die Beschriftung ist zentriert über dem Bild.
+
+### BELOW_LEFT {#BELOW-LEFT}
+```
+public static final int BELOW_LEFT
+```
+
+
+Das Bild erscheint unter der Beschriftung. Die Beschriftung ist am linken Rand des Bildes ausgerichtet.
+
+### BELOW_RIGHT {#BELOW-RIGHT}
+```
+public static final int BELOW_RIGHT
+```
+
+
+Das Bild erscheint unter der Beschriftung. Die Beschriftung ist am rechten Rand des Bildes ausgerichtet.
+
+### CENTER {#CENTER}
+```
+public static final int CENTER
+```
+
+
+Das Bild erscheint in der Mitte des Steuerelements. Die Beschriftung ist horizontal und vertikal über dem Bild zentriert.
+
+### LEFT_BOTTOM {#LEFT-BOTTOM}
+```
+public static final int LEFT_BOTTOM
+```
+
+
+Das Bild erscheint links von der Beschriftung. Die Beschriftung ist am unteren Rand des Bildes ausgerichtet.
+
+### LEFT_CENTER {#LEFT-CENTER}
+```
+public static final int LEFT_CENTER
+```
+
+
+Das Bild erscheint links von der Beschriftung. Die Beschriftung ist relativ zum Bild zentriert.
+
+### LEFT_TOP {#LEFT-TOP}
+```
+public static final int LEFT_TOP
+```
+
+
+Das Bild erscheint links von der Beschriftung. Die Beschriftung ist am oberen Rand des Bildes ausgerichtet.
+
+### RIGHT_BOTTOM {#RIGHT-BOTTOM}
+```
+public static final int RIGHT_BOTTOM
+```
+
+
+Das Bild erscheint rechts von der Beschriftung. Die Beschriftung ist am unteren Rand des Bildes ausgerichtet.
+
+### RIGHT_CENTER {#RIGHT-CENTER}
+```
+public static final int RIGHT_CENTER
+```
+
+
+Das Bild erscheint rechts von der Beschriftung. Die Beschriftung ist relativ zum Bild zentriert.
+
+### RIGHT_TOP {#RIGHT-TOP}
+```
+public static final int RIGHT_TOP
+```
+
+
+Das Bild erscheint rechts von der Beschriftung. Die Beschriftung ist am oberen Rand des Bildes ausgerichtet.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/controlpicturesizemode/_index.md
+++ b/german/java/com.aspose.diagram/controlpicturesizemode/_index.md
@@ -1,0 +1,156 @@
+---
+title: ControlPictureSizeMode
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt dar, wie das Bild angezeigt wird.
+type: docs
+weight: 96
+url: /de/java/com.aspose.diagram/controlpicturesizemode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlPictureSizeMode
+```
+
+Stellt dar, wie das Bild angezeigt wird.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [CLIP](#CLIP) | Beschneidet jeden Teil des Bildes, der größer als die Grenzen des Steuerelements ist. |
+| [STRETCH](#STRETCH) | Streckt das Bild, um den Bereich des Steuerelements auszufüllen. |
+| [ZOOM](#ZOOM) | Vergrößert das Bild, verzerrt es jedoch weder horizontal noch vertikal. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CLIP {#CLIP}
+```
+public static final int CLIP
+```
+
+
+Beschneidet jeden Teil des Bildes, der größer als die Grenzen des Steuerelements ist.
+
+### STRETCH {#STRETCH}
+```
+public static final int STRETCH
+```
+
+
+Streckt das Bild, um den Bereich des Steuerelements auszufüllen. Diese Einstellung verzerrt das Bild sowohl horizontal als auch vertikal.
+
+### ZOOM {#ZOOM}
+```
+public static final int ZOOM
+```
+
+
+Vergrößert das Bild, verzerrt es jedoch weder horizontal noch vertikal.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/controlscrollbartype/_index.md
+++ b/german/java/com.aspose.diagram/controlscrollbartype/_index.md
@@ -1,0 +1,165 @@
+---
+title: ControlScrollBarType
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt den Typ der Bildlaufleiste dar.
+type: docs
+weight: 97
+url: /de/java/com.aspose.diagram/controlscrollbartype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlScrollBarType
+```
+
+Stellt den Typ der Bildlaufleiste dar.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [BARS_BOTH](#BARS-BOTH) | Zeigt sowohl eine horizontale als auch eine vertikale Bildlaufleiste an. |
+| [BARS_VERTICAL](#BARS-VERTICAL) | Zeigt eine vertikale Bildlaufleiste an. |
+| [HORIZONTAL](#HORIZONTAL) | Zeigt eine horizontale Bildlaufleiste an. |
+| [NONE](#NONE) | Zeigt keine Bildlaufleisten an. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BARS_BOTH {#BARS-BOTH}
+```
+public static final int BARS_BOTH
+```
+
+
+Zeigt sowohl eine horizontale als auch eine vertikale Bildlaufleiste an.
+
+### BARS_VERTICAL {#BARS-VERTICAL}
+```
+public static final int BARS_VERTICAL
+```
+
+
+Zeigt eine vertikale Bildlaufleiste an.
+
+### HORIZONTAL {#HORIZONTAL}
+```
+public static final int HORIZONTAL
+```
+
+
+Zeigt eine horizontale Bildlaufleiste an.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Zeigt keine Bildlaufleisten an.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/controlscrollorientation/_index.md
+++ b/german/java/com.aspose.diagram/controlscrollorientation/_index.md
@@ -1,0 +1,156 @@
+---
+title: ControlScrollOrientation
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt den Typ der Bildlauforientierung dar
+type: docs
+weight: 98
+url: /de/java/com.aspose.diagram/controlscrollorientation/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlScrollOrientation
+```
+
+Stellt den Typ der Bildlauforientierung dar
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [AUTO](#AUTO) | Das Steuerelement wird horizontal dargestellt, wenn die Breite des Steuerelements größer ist als seine Höhe. |
+| [HORIZONTAL](#HORIZONTAL) | Das Steuerelement wird horizontal dargestellt. |
+| [VERTICAL](#VERTICAL) | Das Steuerelement wird vertikal dargestellt. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AUTO {#AUTO}
+```
+public static final int AUTO
+```
+
+
+Das Steuerelement wird horizontal dargestellt, wenn die Breite des Steuerelements größer als seine Höhe ist. Andernfalls wird das Steuerelement vertikal dargestellt.
+
+### HORIZONTAL {#HORIZONTAL}
+```
+public static final int HORIZONTAL
+```
+
+
+Das Steuerelement wird horizontal dargestellt.
+
+### VERTICAL {#VERTICAL}
+```
+public static final int VERTICAL
+```
+
+
+Das Steuerelement wird vertikal dargestellt.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/controlspecialeffecttype/_index.md
+++ b/german/java/com.aspose.diagram/controlspecialeffecttype/_index.md
@@ -1,0 +1,174 @@
+---
+title: ControlSpecialEffectType
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt den Typ des Spezialeffekts dar.
+type: docs
+weight: 99
+url: /de/java/com.aspose.diagram/controlspecialeffecttype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlSpecialEffectType
+```
+
+Stellt den Typ des Spezialeffekts dar.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [BUMP](#BUMP) | Bump |
+| [ETCHED](#ETCHED) | Etched |
+| [FLAT](#FLAT) | Flat |
+| [RAISED](#RAISED) | Raised |
+| [SUNKEN](#SUNKEN) | Sunken |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BUMP {#BUMP}
+```
+public static final int BUMP
+```
+
+
+Bump
+
+### ETCHED {#ETCHED}
+```
+public static final int ETCHED
+```
+
+
+Etched
+
+### FLAT {#FLAT}
+```
+public static final int FLAT
+```
+
+
+Flat
+
+### RAISED {#RAISED}
+```
+public static final int RAISED
+```
+
+
+Raised
+
+### SUNKEN {#SUNKEN}
+```
+public static final int SUNKEN
+```
+
+
+Sunken
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/controltype/_index.md
+++ b/german/java/com.aspose.diagram/controltype/_index.md
@@ -1,0 +1,237 @@
+---
+title: ControlType
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt alle Typen von ActiveX-Steuerelementen dar.
+type: docs
+weight: 100
+url: /de/java/com.aspose.diagram/controltype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlType
+```
+
+Stellt alle Typen von ActiveX-Steuerelementen dar.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [CHECK_BOX](#CHECK-BOX) | CheckBox |
+| [COMBO_BOX](#COMBO-BOX) | ComboBox |
+| [COMMAND_BUTTON](#COMMAND-BUTTON) | Button |
+| [IMAGE](#IMAGE) | Bild |
+| [LABEL](#LABEL) | Label |
+| [LIST_BOX](#LIST-BOX) | ListBox |
+| [RADIO_BUTTON](#RADIO-BUTTON) | RadioButton |
+| [SCROLL_BAR](#SCROLL-BAR) | ScrollBar |
+| [SPIN_BUTTON](#SPIN-BUTTON) | Spinner |
+| [TEXT_BOX](#TEXT-BOX) | TextBox |
+| [TOGGLE_BUTTON](#TOGGLE-BUTTON) | ToggleButton |
+| [UNKNOWN](#UNKNOWN) | Unknown |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CHECK_BOX {#CHECK-BOX}
+```
+public static final int CHECK_BOX
+```
+
+
+CheckBox
+
+### COMBO_BOX {#COMBO-BOX}
+```
+public static final int COMBO_BOX
+```
+
+
+ComboBox
+
+### COMMAND_BUTTON {#COMMAND-BUTTON}
+```
+public static final int COMMAND_BUTTON
+```
+
+
+Button
+
+### IMAGE {#IMAGE}
+```
+public static final int IMAGE
+```
+
+
+Bild
+
+### LABEL {#LABEL}
+```
+public static final int LABEL
+```
+
+
+Label
+
+### LIST_BOX {#LIST-BOX}
+```
+public static final int LIST_BOX
+```
+
+
+ListBox
+
+### RADIO_BUTTON {#RADIO-BUTTON}
+```
+public static final int RADIO_BUTTON
+```
+
+
+RadioButton
+
+### SCROLL_BAR {#SCROLL-BAR}
+```
+public static final int SCROLL_BAR
+```
+
+
+ScrollBar
+
+### SPIN_BUTTON {#SPIN-BUTTON}
+```
+public static final int SPIN_BUTTON
+```
+
+
+Spinner
+
+### TEXT_BOX {#TEXT-BOX}
+```
+public static final int TEXT_BOX
+```
+
+
+TextBox
+
+### TOGGLE_BUTTON {#TOGGLE-BUTTON}
+```
+public static final int TOGGLE_BUTTON
+```
+
+
+ToggleButton
+
+### UNKNOWN {#UNKNOWN}
+```
+public static final int UNKNOWN
+```
+
+
+Unknown
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/contype/_index.md
+++ b/german/java/com.aspose.diagram/contype/_index.md
@@ -1,0 +1,204 @@
+---
+title: ConType
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt den Verhaltenstyp der x- oder y-Koordinate des Steuergriffs an, der nach dem Verschieben des Griffs auftritt.
+type: docs
+weight: 73
+url: /de/java/com.aspose.diagram/contype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ConType
+```
+
+Gibt den Verhaltenstyp der x- oder y-Koordinate des Steuergriffs an, der nach dem Verschieben des Griffs auftritt.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [ConType(int value)](#ConType-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Gibt den Verhaltenstyp der x- oder y-Koordinate des Steuergriffs an, der nach dem Verschieben des Griffs auftritt. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getUfe()](../../com.aspose.diagram/contype\#getUfe--) |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/contype\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ConType(int value) {#ConType-int-}
+```
+public ConType(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Gibt den Verhaltenstyp der x- oder y-Koordinate des Steuergriffs an, der nach dem Verschieben des Griffs auftritt.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getUfe()](../../com.aspose.diagram/contype\#getUfe--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/contype\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/convalue/_index.md
+++ b/german/java/com.aspose.diagram/convalue/_index.md
@@ -1,0 +1,228 @@
+---
+title: ConValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt den Verhaltenstyp der x- oder y-Koordinate des Steuergriffs an, der nach dem Verschieben des Griffs auftritt.
+type: docs
+weight: 74
+url: /de/java/com.aspose.diagram/convalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConValue
+```
+
+Gibt den Verhaltenstyp der x- oder y-Koordinate des Steuergriffs an, der nach dem Verschieben des Griffs auftritt.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [OFFSET_FROM_CENTER](#OFFSET-FROM-CENTER) | Versatz vom Zentrum. |
+| [OFFSET_FROM_CENTER_HIDDEN](#OFFSET-FROM-CENTER-HIDDEN) | Versatz vom Zentrum, verborgen. |
+| [OFFSET_FROM_LEFT_EDGE](#OFFSET-FROM-LEFT-EDGE) | Versatz vom linken Rand. |
+| [OFFSET_FROM_LEFT_EDGE_HIDDEN](#OFFSET-FROM-LEFT-EDGE-HIDDEN) | Versatz vom linken Rand, verborgen. |
+| [OFFSET_FROM_RIGHT_EDGE](#OFFSET-FROM-RIGHT-EDGE) | Versatz vom rechten Rand. |
+| [OFFSET_FROM_RIGHT_EDGE_HIDDEN](#OFFSET-FROM-RIGHT-EDGE-HIDDEN) | Versatz vom rechten Rand, ausgeblendet. |
+| [PROPORTIONAL](#PROPORTIONAL) | Proportional. |
+| [PROPORTIONAL_HIDDEN](#PROPORTIONAL-HIDDEN) | Proportional, ausgeblendet.Gleich wie 0, aber der Steuergriff ist nicht sichtbar. |
+| [PROPORTIONAL_LOCKED](#PROPORTIONAL-LOCKED) | Proportional gesperrt. |
+| [PROPORTIONAL_LOCKED_HIDDEN](#PROPORTIONAL-LOCKED-HIDDEN) | Proportional gesperrt, ausgeblendet. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### OFFSET_FROM_CENTER {#OFFSET-FROM-CENTER}
+```
+public static final int OFFSET_FROM_CENTER
+```
+
+
+Versatz vom Mittelpunkt. Der Steuergriff ist um einen konstanten Abstand vom Mittelpunkt der Form versetzt.
+
+### OFFSET_FROM_CENTER_HIDDEN {#OFFSET-FROM-CENTER-HIDDEN}
+```
+public static final int OFFSET_FROM_CENTER_HIDDEN
+```
+
+
+Versatz vom Mittelpunkt, ausgeblendet. Gleich wie 3, aber der Steuergriff ist nicht sichtbar.
+
+### OFFSET_FROM_LEFT_EDGE {#OFFSET-FROM-LEFT-EDGE}
+```
+public static final int OFFSET_FROM_LEFT_EDGE
+```
+
+
+Versatz vom linken Rand. Der Steuergriff ist um einen konstanten Abstand von der linken Seite der Form versetzt.
+
+### OFFSET_FROM_LEFT_EDGE_HIDDEN {#OFFSET-FROM-LEFT-EDGE-HIDDEN}
+```
+public static final int OFFSET_FROM_LEFT_EDGE_HIDDEN
+```
+
+
+Versatz vom linken Rand, ausgeblendet. Gleich wie 2, aber der Steuergriff ist nicht sichtbar.
+
+### OFFSET_FROM_RIGHT_EDGE {#OFFSET-FROM-RIGHT-EDGE}
+```
+public static final int OFFSET_FROM_RIGHT_EDGE
+```
+
+
+Versatz vom rechten Rand. Der Steuergriff ist um einen konstanten Abstand von der rechten Seite der Form versetzt.
+
+### OFFSET_FROM_RIGHT_EDGE_HIDDEN {#OFFSET-FROM-RIGHT-EDGE-HIDDEN}
+```
+public static final int OFFSET_FROM_RIGHT_EDGE_HIDDEN
+```
+
+
+Versatz vom rechten Rand, ausgeblendet. Gleich wie 4, aber der Steuergriff ist nicht sichtbar.
+
+### PROPORTIONAL {#PROPORTIONAL}
+```
+public static final int PROPORTIONAL
+```
+
+
+Proportional. Der Steuergriff kann bewegt werden und bewegt sich ebenfalls proportional zur Form, wenn diese gedehnt wird.
+
+### PROPORTIONAL_HIDDEN {#PROPORTIONAL-HIDDEN}
+```
+public static final int PROPORTIONAL_HIDDEN
+```
+
+
+Proportional, ausgeblendet.Gleich wie 0, aber der Steuergriff ist nicht sichtbar.
+
+### PROPORTIONAL_LOCKED {#PROPORTIONAL-LOCKED}
+```
+public static final int PROPORTIONAL_LOCKED
+```
+
+
+Proportional gesperrt. Der Steuergriff bewegt sich proportional zur Form, aber der Steuergriff selbst kann nicht bewegt werden.
+
+### PROPORTIONAL_LOCKED_HIDDEN {#PROPORTIONAL-LOCKED-HIDDEN}
+```
+public static final int PROPORTIONAL_LOCKED_HIDDEN
+```
+
+
+Proportional gesperrt, ausgeblendet. Gleich wie 1, aber der Steuergriff ist nicht sichtbar.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/coordinate/_index.md
+++ b/german/java/com.aspose.diagram/coordinate/_index.md
@@ -1,0 +1,197 @@
+---
+title: Koordinate
+second_title: Aspose.Diagram for Java API-Referenz
+description: Abstrakte Klasse für die x- und y-Koordinaten.
+type: docs
+weight: 101
+url: /de/java/com.aspose.diagram/coordinate/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public abstract class Coordinate
+```
+
+Abstrakte Klasse für die x- und y-Koordinaten.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [Coordinate()](#Coordinate--) |  |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getIX()](#getIX--) | Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft siehe @PREF1\_ |
+| [setIX(int value)](#setIX-int-) | Für die Beschreibung dieser Eigenschaft siehe @PREF0\_ |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Coordinate() {#Coordinate--}
+```
+public Coordinate()
+```
+
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public abstract int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public abstract int getIX()
+```
+
+
+Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public abstract void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe @PREF1\_
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public abstract void setIX(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe @PREF0\_
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/coordinatecollection/_index.md
+++ b/german/java/com.aspose.diagram/coordinatecollection/_index.md
@@ -1,0 +1,833 @@
+---
+title: CoordinateCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: Koordinatensammlung.
+type: docs
+weight: 102
+url: /de/java/com.aspose.diagram/coordinatecollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class CoordinateCollection extends Collection
+```
+
+Koordinatensammlung.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [add(ArcTo item)](#add-com.aspose.diagram.ArcTo-) | Fügt das ArcTo-Objekt zur Sammlung hinzu. |
+| [add(Coordinate item)](#add-com.aspose.diagram.Coordinate-) | Fügt das Coordinate-Objekt zur Sammlung hinzu. |
+| [add(Ellipse item)](#add-com.aspose.diagram.Ellipse-) | Fügt das Ellipse-Objekt zur Sammlung hinzu. |
+| [add(EllipticalArcTo item)](#add-com.aspose.diagram.EllipticalArcTo-) | Fügt das EllipticalArcTo-Objekt zur Sammlung hinzu. |
+| [add(InfiniteLine item)](#add-com.aspose.diagram.InfiniteLine-) | Fügt das InfiniteLine-Objekt zur Sammlung hinzu. |
+| [add(LineTo item)](#add-com.aspose.diagram.LineTo-) | Fügt das LineTo-Objekt zur Sammlung hinzu. |
+| [add(MoveTo item)](#add-com.aspose.diagram.MoveTo-) | Fügt das MoveTo-Objekt zur Sammlung hinzu. |
+| [add(NURBSTo item)](#add-com.aspose.diagram.NURBSTo-) | Fügt das NURBSTo-Objekt zur Sammlung hinzu. |
+| [add(PolylineTo item)](#add-com.aspose.diagram.PolylineTo-) | Fügt das PolylineTo-Objekt zur Sammlung hinzu. |
+| [add(RelCubBezTo item)](#add-com.aspose.diagram.RelCubBezTo-) | Fügt das RelCubBezTo-Objekt zur Sammlung hinzu. |
+| [add(RelEllipticalArcTo item)](#add-com.aspose.diagram.RelEllipticalArcTo-) | Füge das RelEllipticalArcTo-Objekt zur Sammlung hinzu. |
+| [add(RelLineTo item)](#add-com.aspose.diagram.RelLineTo-) | Füge das RelLineTo-Objekt zur Sammlung hinzu. |
+| [add(RelMoveTo item)](#add-com.aspose.diagram.RelMoveTo-) | Füge das RelMoveTo-Objekt zur Sammlung hinzu. |
+| [add(RelQuadBezTo item)](#add-com.aspose.diagram.RelQuadBezTo-) | Füge das RelQuadBezTo-Objekt zur Sammlung hinzu. |
+| [add(SplineKnot item)](#add-com.aspose.diagram.SplineKnot-) | Füge das SplineKnot-Objekt zur Sammlung hinzu. |
+| [add(SplineStart item)](#add-com.aspose.diagram.SplineStart-) | Füge das SplineStart-Objekt zur Sammlung hinzu. |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [getArcToCol()](#getArcToCol--) | Enthält die x- und y-Koordinaten sowie die Krümmung eines Kreisbogens, die jeweils durch die Elemente X, Y und A dargestellt werden. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [getEllipseCol()](#getEllipseCol--) | Enthält Elemente, die die x- und y-Koordinaten des Mittelpunktes der Ellipse sowie zwei Punkte auf der Ellipse angeben. |
+| [getEllipticalArcToCol()](#getEllipticalArcToCol--) | Enthält Elemente, die Informationen über einen elliptischen Bogen angeben. |
+| [getInfiniteLineCol()](#getInfiniteLineCol--) | Enthält Elemente, die die x- und y-Koordinaten von zwei Punkten auf einer unendlichen Linie angeben. |
+| [getLineToCol()](#getLineToCol--) | Enthält die x- und y-Koordinaten des Endknotens eines geraden Liniensegments. |
+| [getMoveToCol()](#getMoveToCol--) | Enthält die x- und y-Koordinaten des ersten Scheitelpunkts einer Form oder die x- und y-Koordinaten des ersten Scheitelpunkts nach einem Pfadunterbruch. |
+| [getNURBSToCol()](#getNURBSToCol--) | Enthält die x- und y-Koordinaten, die Position des vorletzten Knoten, die Position des letzten Gewichts, die Position des ersten Knotens, die Position des ersten Gewichts sowie die Formel für einen nicht-uniformen rationalen B-Spline (NURBS). |
+| [getPolylineToCol()](#getPolylineToCol--) | Enthält x- und y-Koordinaten des letzten Punktes einer Polylinie und einer Polylinienformel. |
+| [getRelCubBezToCol()](#getRelCubBezToCol--) | Enthält x- und y-Koordinaten für die Punkte eines RelCubBezTo. Koordinaten werden als relative Koordinaten angegeben. |
+| [getRelEllipticalArcToCol()](#getRelEllipticalArcToCol--) | Enthält Elemente, die Informationen über einen elliptischen Bogen angeben. Koordinaten werden als relative Koordinaten angegeben. |
+| [getRelLineToCol()](#getRelLineToCol--) | Enthält die x- und y-Koordinaten des Endknotens eines geraden Liniensegments. |
+| [getRelMoveToCol()](#getRelMoveToCol--) | Enthält die x- und y-Koordinaten des ersten Scheitelpunkts einer Form oder die x- und y-Koordinaten des ersten Scheitelpunkts nach einem Unterbrechung im Pfad. Koordinaten werden als relative Koordinaten angegeben. |
+| [getRelQuadBezToCol()](#getRelQuadBezToCol--) | Enthält x- und y-Koordinaten für die Punkte eines RelQuadBezTo. Koordinaten werden als relative Koordinaten angegeben. |
+| [getSplineKnotCol()](#getSplineKnotCol--) | Enthält X‑ und Y‑Koordinaten für den Kontrollpunkt einer Spline und den Knoten einer Spline, dargestellt durch die Elemente X, Y bzw. A. |
+| [getSplineStartCol()](#getSplineStartCol--) | Enthält X‑ und Y‑Koordinaten für den zweiten Kontrollpunkt einer Spline, ihren zweiten Knoten, ihren ersten Knoten, den letzten Knoten und den Grad der Spline. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(ArcTo item)](#remove-com.aspose.diagram.ArcTo-) | Entferne das ArcTo-Objekt aus der Sammlung. |
+| [remove(Coordinate item)](#remove-com.aspose.diagram.Coordinate-) | Entferne das Coordinate-Objekt aus der Sammlung. |
+| [remove(Ellipse item)](#remove-com.aspose.diagram.Ellipse-) | Entferne das Ellipse-Objekt aus der Sammlung. |
+| [remove(EllipticalArcTo item)](#remove-com.aspose.diagram.EllipticalArcTo-) | Entferne das EllipticalArcTo-Objekt aus der Sammlung. |
+| [remove(InfiniteLine item)](#remove-com.aspose.diagram.InfiniteLine-) | Entferne das InfiniteLine-Objekt aus der Sammlung. |
+| [remove(LineTo item)](#remove-com.aspose.diagram.LineTo-) | Entferne das LineTo-Objekt aus der Sammlung. |
+| [remove(MoveTo item)](#remove-com.aspose.diagram.MoveTo-) | Entferne das MoveTo-Objekt aus der Sammlung. |
+| [remove(NURBSTo item)](#remove-com.aspose.diagram.NURBSTo-) | Entferne das NURBSTo-Objekt aus der Sammlung. |
+| [remove(PolylineTo item)](#remove-com.aspose.diagram.PolylineTo-) | Entferne das PolylineTo-Objekt aus der Sammlung. |
+| [remove(RelCubBezTo item)](#remove-com.aspose.diagram.RelCubBezTo-) | Entferne das RelCubBezTo-Objekt aus der Sammlung. |
+| [remove(RelEllipticalArcTo item)](#remove-com.aspose.diagram.RelEllipticalArcTo-) | Entferne das RelEllipticalArcTo-Objekt aus der Sammlung. |
+| [remove(RelLineTo item)](#remove-com.aspose.diagram.RelLineTo-) | Entferne das RelLineTo-Objekt aus der Sammlung. |
+| [remove(RelMoveTo item)](#remove-com.aspose.diagram.RelMoveTo-) | Entferne das RelMoveTo-Objekt aus der Sammlung. |
+| [remove(RelQuadBezTo item)](#remove-com.aspose.diagram.RelQuadBezTo-) | Entferne das RelQuadBezTo-Objekt aus der Sammlung. |
+| [remove(SplineKnot item)](#remove-com.aspose.diagram.SplineKnot-) | Entferne das SplineKnot-Objekt aus der Sammlung. |
+| [remove(SplineStart item)](#remove-com.aspose.diagram.SplineStart-) | Entferne das SplineStart-Objekt aus der Sammlung. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(ArcTo item) {#add-com.aspose.diagram.ArcTo-}
+```
+public int add(ArcTo item)
+```
+
+
+Fügt das ArcTo-Objekt zur Sammlung hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [ArcTo](../../com.aspose.diagram/arcto) |  |
+
+**Returns:**
+int -
+### add(Coordinate item) {#add-com.aspose.diagram.Coordinate-}
+```
+public int add(Coordinate item)
+```
+
+
+Fügt das Coordinate-Objekt zur Sammlung hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [Coordinate](../../com.aspose.diagram/coordinate) |  |
+
+**Returns:**
+int
+### add(Ellipse item) {#add-com.aspose.diagram.Ellipse-}
+```
+public int add(Ellipse item)
+```
+
+
+Fügt das Ellipse-Objekt zur Sammlung hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [Ellipse](../../com.aspose.diagram/ellipse) |  |
+
+**Returns:**
+int -
+### add(EllipticalArcTo item) {#add-com.aspose.diagram.EllipticalArcTo-}
+```
+public int add(EllipticalArcTo item)
+```
+
+
+Fügt das EllipticalArcTo-Objekt zur Sammlung hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [EllipticalArcTo](../../com.aspose.diagram/ellipticalarcto) |  |
+
+**Returns:**
+int -
+### add(InfiniteLine item) {#add-com.aspose.diagram.InfiniteLine-}
+```
+public int add(InfiniteLine item)
+```
+
+
+Fügt das InfiniteLine-Objekt zur Sammlung hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [InfiniteLine](../../com.aspose.diagram/infiniteline) |  |
+
+**Returns:**
+int -
+### add(LineTo item) {#add-com.aspose.diagram.LineTo-}
+```
+public int add(LineTo item)
+```
+
+
+Fügt das LineTo-Objekt zur Sammlung hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [LineTo](../../com.aspose.diagram/lineto) |  |
+
+**Returns:**
+int -
+### add(MoveTo item) {#add-com.aspose.diagram.MoveTo-}
+```
+public int add(MoveTo item)
+```
+
+
+Fügt das MoveTo-Objekt zur Sammlung hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [MoveTo](../../com.aspose.diagram/moveto) |  |
+
+**Returns:**
+int -
+### add(NURBSTo item) {#add-com.aspose.diagram.NURBSTo-}
+```
+public int add(NURBSTo item)
+```
+
+
+Fügt das NURBSTo-Objekt zur Sammlung hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [NURBSTo](../../com.aspose.diagram/nurbsto) |  |
+
+**Returns:**
+int -
+### add(PolylineTo item) {#add-com.aspose.diagram.PolylineTo-}
+```
+public int add(PolylineTo item)
+```
+
+
+Fügt das PolylineTo-Objekt zur Sammlung hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [PolylineTo](../../com.aspose.diagram/polylineto) |  |
+
+**Returns:**
+int -
+### add(RelCubBezTo item) {#add-com.aspose.diagram.RelCubBezTo-}
+```
+public int add(RelCubBezTo item)
+```
+
+
+Fügt das RelCubBezTo-Objekt zur Sammlung hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [RelCubBezTo](../../com.aspose.diagram/relcubbezto) |  |
+
+**Returns:**
+int -
+### add(RelEllipticalArcTo item) {#add-com.aspose.diagram.RelEllipticalArcTo-}
+```
+public int add(RelEllipticalArcTo item)
+```
+
+
+Füge das RelEllipticalArcTo-Objekt zur Sammlung hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [RelEllipticalArcTo](../../com.aspose.diagram/relellipticalarcto) |  |
+
+**Returns:**
+int -
+### add(RelLineTo item) {#add-com.aspose.diagram.RelLineTo-}
+```
+public int add(RelLineTo item)
+```
+
+
+Füge das RelLineTo-Objekt zur Sammlung hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [RelLineTo](../../com.aspose.diagram/rellineto) |  |
+
+**Returns:**
+int -
+### add(RelMoveTo item) {#add-com.aspose.diagram.RelMoveTo-}
+```
+public int add(RelMoveTo item)
+```
+
+
+Füge das RelMoveTo-Objekt zur Sammlung hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [RelMoveTo](../../com.aspose.diagram/relmoveto) |  |
+
+**Returns:**
+int -
+### add(RelQuadBezTo item) {#add-com.aspose.diagram.RelQuadBezTo-}
+```
+public int add(RelQuadBezTo item)
+```
+
+
+Füge das RelQuadBezTo-Objekt zur Sammlung hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [RelQuadBezTo](../../com.aspose.diagram/relquadbezto) |  |
+
+**Returns:**
+int -
+### add(SplineKnot item) {#add-com.aspose.diagram.SplineKnot-}
+```
+public int add(SplineKnot item)
+```
+
+
+Füge das SplineKnot-Objekt zur Sammlung hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [SplineKnot](../../com.aspose.diagram/splineknot) |  |
+
+**Returns:**
+int -
+### add(SplineStart item) {#add-com.aspose.diagram.SplineStart-}
+```
+public int add(SplineStart item)
+```
+
+
+Füge das SplineStart-Objekt zur Sammlung hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [SplineStart](../../com.aspose.diagram/splinestart) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Coordinate get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[Coordinate](../../com.aspose.diagram/coordinate) - 
+### getArcToCol() {#getArcToCol--}
+```
+public ArcToCollection getArcToCol()
+```
+
+
+Enthält die x- und y-Koordinaten sowie die Krümmung eines Kreisbogens, die jeweils durch die Elemente X, Y und A dargestellt werden.
+
+**Returns:**
+[ArcToCollection](../../com.aspose.diagram/arctocollection)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### getEllipseCol() {#getEllipseCol--}
+```
+public EllipseCollection getEllipseCol()
+```
+
+
+Enthält Elemente, die die x- und y-Koordinaten des Mittelpunktes der Ellipse sowie zwei Punkte auf der Ellipse angeben.
+
+**Returns:**
+[EllipseCollection](../../com.aspose.diagram/ellipsecollection)
+### getEllipticalArcToCol() {#getEllipticalArcToCol--}
+```
+public EllipticalArcToCollection getEllipticalArcToCol()
+```
+
+
+Enthält Elemente, die Informationen über einen elliptischen Bogen angeben.
+
+**Returns:**
+[EllipticalArcToCollection](../../com.aspose.diagram/ellipticalarctocollection)
+### getInfiniteLineCol() {#getInfiniteLineCol--}
+```
+public InfiniteLineCollection getInfiniteLineCol()
+```
+
+
+Enthält Elemente, die die x- und y-Koordinaten von zwei Punkten auf einer unendlichen Linie angeben. Die X- und Y-Elemente geben die x- und y-Koordinaten des ersten Punktes an, und die A- und B-Elemente geben die x- und y-Koordinaten des zweiten Punktes an.
+
+**Returns:**
+[InfiniteLineCollection](../../com.aspose.diagram/infinitelinecollection)
+### getLineToCol() {#getLineToCol--}
+```
+public LineToCollection getLineToCol()
+```
+
+
+Enthält x- und y-Koordinaten des Endknotens eines geraden Liniensegments. Diese Koordinaten sind jeweils in den X- und Y-Elementen enthalten.
+
+**Returns:**
+[LineToCollection](../../com.aspose.diagram/linetocollection)
+### getMoveToCol() {#getMoveToCol--}
+```
+public MoveToCollection getMoveToCol()
+```
+
+
+Enthält die x- und y-Koordinaten des ersten Scheitelpunkts einer Form oder die x- und y-Koordinaten des ersten Scheitelpunkts nach einem Pfadunterbruch.
+
+**Returns:**
+[MoveToCollection](../../com.aspose.diagram/movetocollection)
+### getNURBSToCol() {#getNURBSToCol--}
+```
+public NURBSToCollection getNURBSToCol()
+```
+
+
+Enthält die x- und y-Koordinaten, die Position des vorletzten Knotens, die Position des letzten Gewichts, die Position des ersten Knotens, die Position des ersten Gewichts und die Formel für einen nicht-uniform rationalen B-Spline (NURBS). Diese Informationen sind jeweils in den Elementen X, Y, A, B, C, D und E angegeben.
+
+**Returns:**
+[NURBSToCollection](../../com.aspose.diagram/nurbstocollection)
+### getPolylineToCol() {#getPolylineToCol--}
+```
+public PolylineToCollection getPolylineToCol()
+```
+
+
+Enthält x- und y-Koordinaten des letzten Punktes einer Polylinie und eine Polylinien-Formel. Die Koordinaten werden in den X- und Y-Elementen angegeben, und die Formel wird im A-Element angegeben.
+
+**Returns:**
+[PolylineToCollection](../../com.aspose.diagram/polylinetocollection)
+### getRelCubBezToCol() {#getRelCubBezToCol--}
+```
+public RelCubBezToCollection getRelCubBezToCol()
+```
+
+
+Enthält x- und y-Koordinaten für die Punkte eines RelCubBezTo. Koordinaten werden als relative Koordinaten angegeben.
+
+**Returns:**
+[RelCubBezToCollection](../../com.aspose.diagram/relcubbeztocollection)
+### getRelEllipticalArcToCol() {#getRelEllipticalArcToCol--}
+```
+public RelEllipticalArcToCollection getRelEllipticalArcToCol()
+```
+
+
+Enthält Elemente, die Informationen über einen elliptischen Bogen angeben. Koordinaten werden als relative Koordinaten angegeben.
+
+**Returns:**
+[RelEllipticalArcToCollection](../../com.aspose.diagram/relellipticalarctocollection)
+### getRelLineToCol() {#getRelLineToCol--}
+```
+public RelLineToCollection getRelLineToCol()
+```
+
+
+Enthält x- und y-Koordinaten des Endknotens eines geraden Liniensegments. Diese Koordinaten sind jeweils in den X- und Y-Elementen enthalten. Koordinaten werden als relative Koordinaten angegeben.
+
+**Returns:**
+[RelLineToCollection](../../com.aspose.diagram/rellinetocollection)
+### getRelMoveToCol() {#getRelMoveToCol--}
+```
+public RelMoveToCollection getRelMoveToCol()
+```
+
+
+Enthält die x- und y-Koordinaten des ersten Scheitelpunkts einer Form oder die x- und y-Koordinaten des ersten Scheitelpunkts nach einem Unterbrechung im Pfad. Koordinaten werden als relative Koordinaten angegeben.
+
+**Returns:**
+[RelMoveToCollection](../../com.aspose.diagram/relmovetocollection)
+### getRelQuadBezToCol() {#getRelQuadBezToCol--}
+```
+public RelQuadBezToCollection getRelQuadBezToCol()
+```
+
+
+Enthält x- und y-Koordinaten für die Punkte eines RelQuadBezTo. Koordinaten werden als relative Koordinaten angegeben.
+
+**Returns:**
+[RelQuadBezToCollection](../../com.aspose.diagram/relquadbeztocollection)
+### getSplineKnotCol() {#getSplineKnotCol--}
+```
+public SplineKnotCollection getSplineKnotCol()
+```
+
+
+Enthält X‑ und Y‑Koordinaten für den Kontrollpunkt einer Spline und den Knoten einer Spline, dargestellt durch die Elemente X, Y bzw. A.
+
+**Returns:**
+[SplineKnotCollection](../../com.aspose.diagram/splineknotcollection)
+### getSplineStartCol() {#getSplineStartCol--}
+```
+public SplineStartCollection getSplineStartCol()
+```
+
+
+Enthält x- und y-Koordinaten für den zweiten Steuerpunkt einer Spline, ihren zweiten Knoten, ihren ersten Knoten, den letzten Knoten und den Grad der Spline. Diese Informationen sind in den Elementen X, Y, A, B, C und D jeweils enthalten.
+
+**Returns:**
+[SplineStartCollection](../../com.aspose.diagram/splinestartcollection)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(ArcTo item) {#remove-com.aspose.diagram.ArcTo-}
+```
+public void remove(ArcTo item)
+```
+
+
+Entferne das ArcTo-Objekt aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [ArcTo](../../com.aspose.diagram/arcto) |  |
+
+### remove(Coordinate item) {#remove-com.aspose.diagram.Coordinate-}
+```
+public void remove(Coordinate item)
+```
+
+
+Entferne das Coordinate-Objekt aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [Coordinate](../../com.aspose.diagram/coordinate) |  |
+
+### remove(Ellipse item) {#remove-com.aspose.diagram.Ellipse-}
+```
+public void remove(Ellipse item)
+```
+
+
+Entferne das Ellipse-Objekt aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [Ellipse](../../com.aspose.diagram/ellipse) |  |
+
+### remove(EllipticalArcTo item) {#remove-com.aspose.diagram.EllipticalArcTo-}
+```
+public void remove(EllipticalArcTo item)
+```
+
+
+Entferne das EllipticalArcTo-Objekt aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [EllipticalArcTo](../../com.aspose.diagram/ellipticalarcto) |  |
+
+### remove(InfiniteLine item) {#remove-com.aspose.diagram.InfiniteLine-}
+```
+public void remove(InfiniteLine item)
+```
+
+
+Entferne das InfiniteLine-Objekt aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [InfiniteLine](../../com.aspose.diagram/infiniteline) |  |
+
+### remove(LineTo item) {#remove-com.aspose.diagram.LineTo-}
+```
+public void remove(LineTo item)
+```
+
+
+Entferne das LineTo-Objekt aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [LineTo](../../com.aspose.diagram/lineto) |  |
+
+### remove(MoveTo item) {#remove-com.aspose.diagram.MoveTo-}
+```
+public void remove(MoveTo item)
+```
+
+
+Entferne das MoveTo-Objekt aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [MoveTo](../../com.aspose.diagram/moveto) |  |
+
+### remove(NURBSTo item) {#remove-com.aspose.diagram.NURBSTo-}
+```
+public void remove(NURBSTo item)
+```
+
+
+Entferne das NURBSTo-Objekt aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [NURBSTo](../../com.aspose.diagram/nurbsto) |  |
+
+### remove(PolylineTo item) {#remove-com.aspose.diagram.PolylineTo-}
+```
+public void remove(PolylineTo item)
+```
+
+
+Entferne das PolylineTo-Objekt aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [PolylineTo](../../com.aspose.diagram/polylineto) |  |
+
+### remove(RelCubBezTo item) {#remove-com.aspose.diagram.RelCubBezTo-}
+```
+public void remove(RelCubBezTo item)
+```
+
+
+Entferne das RelCubBezTo-Objekt aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [RelCubBezTo](../../com.aspose.diagram/relcubbezto) |  |
+
+### remove(RelEllipticalArcTo item) {#remove-com.aspose.diagram.RelEllipticalArcTo-}
+```
+public void remove(RelEllipticalArcTo item)
+```
+
+
+Entferne das RelEllipticalArcTo-Objekt aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [RelEllipticalArcTo](../../com.aspose.diagram/relellipticalarcto) |  |
+
+### remove(RelLineTo item) {#remove-com.aspose.diagram.RelLineTo-}
+```
+public void remove(RelLineTo item)
+```
+
+
+Entferne das RelLineTo-Objekt aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [RelLineTo](../../com.aspose.diagram/rellineto) |  |
+
+### remove(RelMoveTo item) {#remove-com.aspose.diagram.RelMoveTo-}
+```
+public void remove(RelMoveTo item)
+```
+
+
+Entferne das RelMoveTo-Objekt aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [RelMoveTo](../../com.aspose.diagram/relmoveto) |  |
+
+### remove(RelQuadBezTo item) {#remove-com.aspose.diagram.RelQuadBezTo-}
+```
+public void remove(RelQuadBezTo item)
+```
+
+
+Entferne das RelQuadBezTo-Objekt aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [RelQuadBezTo](../../com.aspose.diagram/relquadbezto) |  |
+
+### remove(SplineKnot item) {#remove-com.aspose.diagram.SplineKnot-}
+```
+public void remove(SplineKnot item)
+```
+
+
+Entferne das SplineKnot-Objekt aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [SplineKnot](../../com.aspose.diagram/splineknot) |  |
+
+### remove(SplineStart item) {#remove-com.aspose.diagram.SplineStart-}
+```
+public void remove(SplineStart item)
+```
+
+
+Entferne das SplineStart-Objekt aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [SplineStart](../../com.aspose.diagram/splinestart) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/countrycode/_index.md
+++ b/german/java/com.aspose.diagram/countrycode/_index.md
@@ -1,0 +1,579 @@
+---
+title: CountryCode
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt Diagramm-Länderkürzel dar.
+type: docs
+weight: 103
+url: /de/java/com.aspose.diagram/countrycode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class CountryCode
+```
+
+Stellt Diagramm-Länderkürzel dar.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [ALGERIA](#ALGERIA) | Algerien |
+| [AUSTRALIA](#AUSTRALIA) | Australien |
+| [AUSTRIA](#AUSTRIA) | Österreich |
+| [BELGIUM](#BELGIUM) | Belgien |
+| [BRAZIL](#BRAZIL) | Brasilien |
+| [CANADA](#CANADA) | Kanada |
+| [CHINA](#CHINA) | Volksrepublik China |
+| [CZECH](#CZECH) | Tschechische Republik |
+| [DEFAULT](#DEFAULT) |  |
+| [DENMARK](#DENMARK) | Dänemark |
+| [EGYPT](#EGYPT) | Ägypten |
+| [FINLAND](#FINLAND) | Finnland |
+| [FRANCE](#FRANCE) | Frankreich |
+| [GERMANY](#GERMANY) | Deutschland |
+| [GREECE](#GREECE) | Griechenland |
+| [HUNGARY](#HUNGARY) | Ungarn |
+| [ICELAND](#ICELAND) | Island |
+| [INDIA](#INDIA) | Indien |
+| [IRAN](#IRAN) | Iran |
+| [IRAQ](#IRAQ) | Irak |
+| [ISRAEL](#ISRAEL) | Israel |
+| [ITALY](#ITALY) | Italien |
+| [JAPAN](#JAPAN) | Japan |
+| [JORDAN](#JORDAN) | Jordanien |
+| [KUWAIT](#KUWAIT) | Kuwait |
+| [LATIN_AMERIC](#LATIN-AMERIC) | Lateinamerika, außer Brasilien |
+| [LEBANON](#LEBANON) | Libanon |
+| [LIBYA](#LIBYA) | Libyen |
+| [MEXICO](#MEXICO) | Mexiko |
+| [MOROCCO](#MOROCCO) | Morocco |
+| [NETHERLANDS](#NETHERLANDS) | Netherlands |
+| [NEW_ZEALAND](#NEW-ZEALAND) | New Zealand |
+| [NORWAY](#NORWAY) | Norway |
+| [POLAND](#POLAND) | Poland |
+| [PORTUGAL](#PORTUGAL) | Portugal |
+| [QATAR](#QATAR) | Qatar |
+| [RUSSIA](#RUSSIA) | Russia |
+| [SAUDI](#SAUDI) | Saudi Arabia |
+| [SOUTH_KOREA](#SOUTH-KOREA) | SouthKorea |
+| [SPAIN](#SPAIN) | Spain |
+| [SWEDEN](#SWEDEN) | Sweden |
+| [SWITZERLAND](#SWITZERLAND) | Switzerland |
+| [SYRIA](#SYRIA) | Syria |
+| [TAIWAN](#TAIWAN) | Taiwan |
+| [THAILAND](#THAILAND) | Thailand |
+| [TURKEY](#TURKEY) | Turkey |
+| [UNITED_ARAB_EMIRATES](#UNITED-ARAB-EMIRATES) | United Arab Emirates |
+| [UNITED_KINGDOM](#UNITED-KINGDOM) | United Kingdom |
+| [USA](#USA) | United States |
+| [VIET_NAM](#VIET-NAM) | Viet Nam |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALGERIA {#ALGERIA}
+```
+public static final int ALGERIA
+```
+
+
+Algerien
+
+### AUSTRALIA {#AUSTRALIA}
+```
+public static final int AUSTRALIA
+```
+
+
+Australien
+
+### AUSTRIA {#AUSTRIA}
+```
+public static final int AUSTRIA
+```
+
+
+Österreich
+
+### BELGIUM {#BELGIUM}
+```
+public static final int BELGIUM
+```
+
+
+Belgien
+
+### BRAZIL {#BRAZIL}
+```
+public static final int BRAZIL
+```
+
+
+Brasilien
+
+### CANADA {#CANADA}
+```
+public static final int CANADA
+```
+
+
+Kanada
+
+### CHINA {#CHINA}
+```
+public static final int CHINA
+```
+
+
+Volksrepublik China
+
+### CZECH {#CZECH}
+```
+public static final int CZECH
+```
+
+
+Tschechische Republik
+
+### DEFAULT {#DEFAULT}
+```
+public static final int DEFAULT
+```
+
+
+
+
+### DENMARK {#DENMARK}
+```
+public static final int DENMARK
+```
+
+
+Dänemark
+
+### EGYPT {#EGYPT}
+```
+public static final int EGYPT
+```
+
+
+Ägypten
+
+### FINLAND {#FINLAND}
+```
+public static final int FINLAND
+```
+
+
+Finnland
+
+### FRANCE {#FRANCE}
+```
+public static final int FRANCE
+```
+
+
+Frankreich
+
+### GERMANY {#GERMANY}
+```
+public static final int GERMANY
+```
+
+
+Deutschland
+
+### GREECE {#GREECE}
+```
+public static final int GREECE
+```
+
+
+Griechenland
+
+### HUNGARY {#HUNGARY}
+```
+public static final int HUNGARY
+```
+
+
+Ungarn
+
+### ICELAND {#ICELAND}
+```
+public static final int ICELAND
+```
+
+
+Island
+
+### INDIA {#INDIA}
+```
+public static final int INDIA
+```
+
+
+Indien
+
+### IRAN {#IRAN}
+```
+public static final int IRAN
+```
+
+
+Iran
+
+### IRAQ {#IRAQ}
+```
+public static final int IRAQ
+```
+
+
+Irak
+
+### ISRAEL {#ISRAEL}
+```
+public static final int ISRAEL
+```
+
+
+Israel
+
+### ITALY {#ITALY}
+```
+public static final int ITALY
+```
+
+
+Italien
+
+### JAPAN {#JAPAN}
+```
+public static final int JAPAN
+```
+
+
+Japan
+
+### JORDAN {#JORDAN}
+```
+public static final int JORDAN
+```
+
+
+Jordanien
+
+### KUWAIT {#KUWAIT}
+```
+public static final int KUWAIT
+```
+
+
+Kuwait
+
+### LATIN_AMERIC {#LATIN-AMERIC}
+```
+public static final int LATIN_AMERIC
+```
+
+
+Lateinamerika, außer Brasilien
+
+### LEBANON {#LEBANON}
+```
+public static final int LEBANON
+```
+
+
+Libanon
+
+### LIBYA {#LIBYA}
+```
+public static final int LIBYA
+```
+
+
+Libyen
+
+### MEXICO {#MEXICO}
+```
+public static final int MEXICO
+```
+
+
+Mexiko
+
+### MOROCCO {#MOROCCO}
+```
+public static final int MOROCCO
+```
+
+
+Morocco
+
+### NETHERLANDS {#NETHERLANDS}
+```
+public static final int NETHERLANDS
+```
+
+
+Netherlands
+
+### NEW_ZEALAND {#NEW-ZEALAND}
+```
+public static final int NEW_ZEALAND
+```
+
+
+New Zealand
+
+### NORWAY {#NORWAY}
+```
+public static final int NORWAY
+```
+
+
+Norway
+
+### POLAND {#POLAND}
+```
+public static final int POLAND
+```
+
+
+Poland
+
+### PORTUGAL {#PORTUGAL}
+```
+public static final int PORTUGAL
+```
+
+
+Portugal
+
+### QATAR {#QATAR}
+```
+public static final int QATAR
+```
+
+
+Qatar
+
+### RUSSIA {#RUSSIA}
+```
+public static final int RUSSIA
+```
+
+
+Russia
+
+### SAUDI {#SAUDI}
+```
+public static final int SAUDI
+```
+
+
+Saudi Arabia
+
+### SOUTH_KOREA {#SOUTH-KOREA}
+```
+public static final int SOUTH_KOREA
+```
+
+
+SouthKorea
+
+### SPAIN {#SPAIN}
+```
+public static final int SPAIN
+```
+
+
+Spain
+
+### SWEDEN {#SWEDEN}
+```
+public static final int SWEDEN
+```
+
+
+Sweden
+
+### SWITZERLAND {#SWITZERLAND}
+```
+public static final int SWITZERLAND
+```
+
+
+Switzerland
+
+### SYRIA {#SYRIA}
+```
+public static final int SYRIA
+```
+
+
+Syria
+
+### TAIWAN {#TAIWAN}
+```
+public static final int TAIWAN
+```
+
+
+Taiwan
+
+### THAILAND {#THAILAND}
+```
+public static final int THAILAND
+```
+
+
+Thailand
+
+### TURKEY {#TURKEY}
+```
+public static final int TURKEY
+```
+
+
+Turkey
+
+### UNITED_ARAB_EMIRATES {#UNITED-ARAB-EMIRATES}
+```
+public static final int UNITED_ARAB_EMIRATES
+```
+
+
+United Arab Emirates
+
+### UNITED_KINGDOM {#UNITED-KINGDOM}
+```
+public static final int UNITED_KINGDOM
+```
+
+
+United Kingdom
+
+### USA {#USA}
+```
+public static final int USA
+```
+
+
+United States
+
+### VIET_NAM {#VIET-NAM}
+```
+public static final int VIET_NAM
+```
+
+
+Viet Nam
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/cp/_index.md
+++ b/german/java/com.aspose.diagram/cp/_index.md
@@ -1,0 +1,154 @@
+---
+title: Cp
+second_title: Aspose.Diagram for Java API-Referenz
+description: Markiert den Beginn eines Zeichen-Eigenschaftslaufs, der gemäß dem entsprechenden Char-Element formatiert ist.
+type: docs
+weight: 104
+url: /de/java/com.aspose.diagram/cp/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.FormatTxt](../../com.aspose.diagram/formattxt)
+```
+public class Cp extends FormatTxt
+```
+
+Markiert den Beginn eines Zeichen‑Eigenschaftslaufs, der gemäß dem entsprechenden Char‑Element formatiert ist. Der Lauf ist bis zum Ende des Textes oder bis zum nächsten definiert.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [Cp(int IX)](#Cp-int-) | Konstruktor |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getValue()](#getValue--) | Value |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Cp(int IX) {#Cp-int-}
+```
+public Cp(int IX)
+```
+
+
+Konstruktor
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| IX | int | Der Index des Char‑Elements, den dieser Eigenschaftslauf darstellt. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+Value
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/customprop/_index.md
+++ b/german/java/com.aspose.diagram/customprop/_index.md
@@ -1,0 +1,211 @@
+---
+title: CustomProp
+second_title: Aspose.Diagram for Java API-Referenz
+description: CustomProp-Struktur.
+type: docs
+weight: 105
+url: /de/java/com.aspose.diagram/customprop/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class CustomProp
+```
+
+CustomProp-Struktur.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [CustomProp()](#CustomProp--) |  |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCustomValue()](#getCustomValue--) | Wert der Eigenschaft. |
+| [getName()](#getName--) | Der Name der benutzerdefinierten Eigenschaft. |
+| [getPropType()](#getPropType--) | Der Datentyp der benutzerdefinierten Eigenschaft. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCustomValue(CustomValue value)](#setCustomValue-com.aspose.diagram.CustomValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getCustomValue()](../../com.aspose.diagram/customprop\#getCustomValue--) |
+| [setName(String value)](#setName-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getName()](../../com.aspose.diagram/customprop\#getName--) |
+| [setPropType(int value)](#setPropType-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getPropType()](../../com.aspose.diagram/customprop\#getPropType--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CustomProp() {#CustomProp--}
+```
+public CustomProp()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCustomValue() {#getCustomValue--}
+```
+public CustomValue getCustomValue()
+```
+
+
+Wert der Eigenschaft.
+
+**Returns:**
+[CustomValue](../../com.aspose.diagram/customvalue)
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Der Name der benutzerdefinierten Eigenschaft.
+
+**Returns:**
+java.lang.String
+### getPropType() {#getPropType--}
+```
+public int getPropType()
+```
+
+
+Der Datentyp der benutzerdefinierten Eigenschaft.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCustomValue(CustomValue value) {#setCustomValue-com.aspose.diagram.CustomValue-}
+```
+public void setCustomValue(CustomValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getCustomValue()](../../com.aspose.diagram/customprop\#getCustomValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [CustomValue](../../com.aspose.diagram/customvalue) |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getName()](../../com.aspose.diagram/customprop\#getName--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setPropType(int value) {#setPropType-int-}
+```
+public void setPropType(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getPropType()](../../com.aspose.diagram/customprop\#getPropType--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/custompropcollection/_index.md
+++ b/german/java/com.aspose.diagram/custompropcollection/_index.md
@@ -1,0 +1,231 @@
+---
+title: CustomPropCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: CustomProps-Sammlung.
+type: docs
+weight: 106
+url: /de/java/com.aspose.diagram/custompropcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class CustomPropCollection extends Collection
+```
+
+CustomProps-Sammlung.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [CustomPropCollection()](#CustomPropCollection--) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [add(CustomProp customProp)](#add-com.aspose.diagram.CustomProp-) | Fügen Sie das CustomProp‑Objekt zur Sammlung hinzu. |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ruft das Element am angegebenen Index ab. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(CustomProp customProp)](#remove-com.aspose.diagram.CustomProp-) | Entfernen Sie das CustomProp‑Objekt aus der Sammlung. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CustomPropCollection() {#CustomPropCollection--}
+```
+public CustomPropCollection()
+```
+
+
+Konstruktor.
+
+### add(CustomProp customProp) {#add-com.aspose.diagram.CustomProp-}
+```
+public int add(CustomProp customProp)
+```
+
+
+Fügen Sie das CustomProp‑Objekt zur Sammlung hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| customProp | [CustomProp](../../com.aspose.diagram/customprop) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public CustomProp get(int index)
+```
+
+
+Ruft das Element am angegebenen Index ab.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[CustomProp](../../com.aspose.diagram/customprop) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(CustomProp customProp) {#remove-com.aspose.diagram.CustomProp-}
+```
+public void remove(CustomProp customProp)
+```
+
+
+Entfernen Sie das CustomProp‑Objekt aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| customProp | [CustomProp](../../com.aspose.diagram/customprop) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/customvalue/_index.md
+++ b/german/java/com.aspose.diagram/customvalue/_index.md
@@ -1,0 +1,236 @@
+---
+title: CustomValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Wert der Eigenschaft.
+type: docs
+weight: 107
+url: /de/java/com.aspose.diagram/customvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class CustomValue
+```
+
+Wert der Eigenschaft.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [CustomValue()](#CustomValue--) |  |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getValueBool()](#getValueBool--) | Boolescher Wert. |
+| [getValueDate()](#getValueDate--) | Datum- und Uhrzeitwert. |
+| [getValueNumber()](#getValueNumber--) | Zahlenwert. |
+| [getValueString()](#getValueString--) | String-Wert. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValueBool(boolean value)](#setValueBool-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValueBool()](../../com.aspose.diagram/customvalue\#getValueBool--) |
+| [setValueDate(DateTime value)](#setValueDate-com.aspose.diagram.DateTime-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValueDate()](../../com.aspose.diagram/customvalue\#getValueDate--) |
+| [setValueNumber(double value)](#setValueNumber-double-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValueNumber()](../../com.aspose.diagram/customvalue\#getValueNumber--) |
+| [setValueString(String value)](#setValueString-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValueString()](../../com.aspose.diagram/customvalue\#getValueString--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CustomValue() {#CustomValue--}
+```
+public CustomValue()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getValueBool() {#getValueBool--}
+```
+public boolean getValueBool()
+```
+
+
+Boolescher Wert.
+
+**Returns:**
+boolean
+### getValueDate() {#getValueDate--}
+```
+public DateTime getValueDate()
+```
+
+
+Datum- und Uhrzeitwert.
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### getValueNumber() {#getValueNumber--}
+```
+public double getValueNumber()
+```
+
+
+Zahlenwert.
+
+**Returns:**
+double
+### getValueString() {#getValueString--}
+```
+public String getValueString()
+```
+
+
+String-Wert.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValueBool(boolean value) {#setValueBool-boolean-}
+```
+public void setValueBool(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValueBool()](../../com.aspose.diagram/customvalue\#getValueBool--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setValueDate(DateTime value) {#setValueDate-com.aspose.diagram.DateTime-}
+```
+public void setValueDate(DateTime value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValueDate()](../../com.aspose.diagram/customvalue\#getValueDate--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setValueNumber(double value) {#setValueNumber-double-}
+```
+public void setValueNumber(double value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValueNumber()](../../com.aspose.diagram/customvalue\#getValueNumber--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double |  |
+
+### setValueString(String value) {#setValueString-java.lang.String-}
+```
+public void setValueString(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValueString()](../../com.aspose.diagram/customvalue\#getValueString--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/datacolumn/_index.md
+++ b/german/java/com.aspose.diagram/datacolumn/_index.md
@@ -1,0 +1,488 @@
+---
+title: DataColumn
+second_title: Aspose.Diagram for Java API-Referenz
+description: Definiert, wie eine Datenspalte im Fenster Externe Daten in der Visio-Benutzeroberfläche angezeigt wird und qualifiziert die Daten in der Spalte, indem ihr Datentyp und Formatierung festgelegt werden.
+type: docs
+weight: 108
+url: /de/java/com.aspose.diagram/datacolumn/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DataColumn
+```
+
+Definiert, wie eine Datenspalte im Fenster Externe Daten in der Visio-Benutzeroberfläche angezeigt wird und qualifiziert die Daten in der Spalte, indem ihr Datentyp und Formatierung festgelegt werden.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [DataColumn()](#DataColumn--) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCalendar()](#getCalendar--) | Kalender-ID der Daten­spalte. |
+| [getClass()](#getClass--) |  |
+| [getColumnNameID()](#getColumnNameID--) | Externer Name der Daten­spalte. |
+| [getCurrency()](#getCurrency--) | Währungs-ID der Daten­spalte. |
+| [getDataType()](#getDataType--) | Typ der Daten in der Daten­spalte. |
+| [getDegree()](#getDegree--) | Gibt den Grad (die Potenz) der Einheiten an, zum Beispiel quadratisch oder kubisch. |
+| [getDisplayOrder()](#getDisplayOrder--) | Definiert die Anzeigeposition der Daten­spalte im Fenster 'Externe Daten', von der linken Spalte (0) bis zur rechten Spalte (größter Wert). |
+| [getDisplayWidth()](#getDisplayWidth--) | Breite der Daten­spalte im Fenster 'Externe Daten'. |
+| [getHyperlink()](#getHyperlink--) | Ob die Daten­spalte einen Hyperlink in einer Form erstellt, wenn die Form mit Daten verknüpft ist. |
+| [getLabel()](#getLabel--) | Bezeichnung der Daten­spalte. |
+| [getLangID()](#getLangID--) | Die Sprach-ID der Daten­spalte |
+| [getMapped()](#getMapped--) | Gibt an, ob die Spalte im Fenster 'Externe Daten' sichtbar ist. |
+| [getName()](#getName--) | Interner Name der Daten­spalte. |
+| [getOrigLabel()](#getOrigLabel--) | Spaltenbeschriftung, die von der zugrunde liegenden ADO-Schnittstelle an Visio zurückgegeben wird. |
+| [getUnitType()](#getUnitType--) | Einheitstyp der Daten in der Datenspalte. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCalendar(int value)](#setCalendar-int-) | Für die Beschreibung dieser Eigenschaft siehe \{@link DataColumn\#(getCalendar() & 0xFFFF)\} |
+| [setColumnNameID(String value)](#setColumnNameID-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe [getColumnNameID()](../../com.aspose.diagram/datacolumn\#getColumnNameID--) |
+| [setCurrency(int value)](#setCurrency-int-) | Für die Beschreibung dieser Eigenschaft siehe \{@link DataColumn\#(getCurrency() & 0xFFFF)\} |
+| [setDataType(int value)](#setDataType-int-) | Für die Beschreibung dieser Eigenschaft siehe \{@link DataColumn\#(getDataType() & 0xFFFF)\} |
+| [setDegree(long value)](#setDegree-long-) | Für die Beschreibung dieser Eigenschaft siehe [getDegree()](../../com.aspose.diagram/datacolumn\#getDegree--) |
+| [setDisplayOrder(long value)](#setDisplayOrder-long-) | Für die Beschreibung dieser Eigenschaft siehe [getDisplayOrder()](../../com.aspose.diagram/datacolumn\#getDisplayOrder--) |
+| [setDisplayWidth(long value)](#setDisplayWidth-long-) | Für die Beschreibung dieser Eigenschaft siehe [getDisplayWidth()](../../com.aspose.diagram/datacolumn\#getDisplayWidth--) |
+| [setHyperlink(int value)](#setHyperlink-int-) | Für die Beschreibung dieser Eigenschaft siehe [getHyperlink()](../../com.aspose.diagram/datacolumn\#getHyperlink--) |
+| [setLabel(String value)](#setLabel-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe [getLabel()](../../com.aspose.diagram/datacolumn\#getLabel--) |
+| [setLangID(long value)](#setLangID-long-) | Für die Beschreibung dieser Eigenschaft siehe [getLangID()](../../com.aspose.diagram/datacolumn\#getLangID--) |
+| [setMapped(int value)](#setMapped-int-) | Für die Beschreibung dieser Eigenschaft siehe [getMapped()](../../com.aspose.diagram/datacolumn\#getMapped--) |
+| [setName(String value)](#setName-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe [getName()](../../com.aspose.diagram/datacolumn\#getName--) |
+| [setOrigLabel(String value)](#setOrigLabel-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe [getOrigLabel()](../../com.aspose.diagram/datacolumn\#getOrigLabel--) |
+| [setUnitType(String value)](#setUnitType-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe [getUnitType()](../../com.aspose.diagram/datacolumn\#getUnitType--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DataColumn() {#DataColumn--}
+```
+public DataColumn()
+```
+
+
+Konstruktor.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCalendar() {#getCalendar--}
+```
+public int getCalendar()
+```
+
+
+Kalender-ID der Daten­spalte.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColumnNameID() {#getColumnNameID--}
+```
+public String getColumnNameID()
+```
+
+
+Externer Name der Datenspalte. Wird in den Überschriften im Fenster Externe Daten und in Beschriftungen in Datengrafiken angezeigt.
+
+**Returns:**
+java.lang.String
+### getCurrency() {#getCurrency--}
+```
+public int getCurrency()
+```
+
+
+Währungs-ID der Daten­spalte.
+
+**Returns:**
+int
+### getDataType() {#getDataType--}
+```
+public int getDataType()
+```
+
+
+Typ der Daten in der Daten­spalte.
+
+**Returns:**
+int
+### getDegree() {#getDegree--}
+```
+public long getDegree()
+```
+
+
+Gibt den Grad (die Potenz) der Einheiten an, zum Beispiel quadratisch oder kubisch. Der Standardwert (Attribut fehlt) ist 1.
+
+**Returns:**
+long
+### getDisplayOrder() {#getDisplayOrder--}
+```
+public long getDisplayOrder()
+```
+
+
+Definiert die Anzeigeposition der Daten­spalte im Fenster 'Externe Daten', von der linken Spalte (0) bis zur rechten Spalte (größter Wert).
+
+**Returns:**
+long
+### getDisplayWidth() {#getDisplayWidth--}
+```
+public long getDisplayWidth()
+```
+
+
+Breite der Daten­spalte im Fenster 'Externe Daten'.
+
+**Returns:**
+long
+### getHyperlink() {#getHyperlink--}
+```
+public int getHyperlink()
+```
+
+
+Ob die Daten­spalte einen Hyperlink in einer Form erstellt, wenn die Form mit Daten verknüpft ist.
+
+**Returns:**
+int
+### getLabel() {#getLabel--}
+```
+public String getLabel()
+```
+
+
+Bezeichnung der Daten­spalte.
+
+**Returns:**
+java.lang.String
+### getLangID() {#getLangID--}
+```
+public long getLangID()
+```
+
+
+Die Sprach-ID der Daten­spalte
+
+**Returns:**
+long
+### getMapped() {#getMapped--}
+```
+public int getMapped()
+```
+
+
+Gibt an, ob die Spalte im Fenster Externe Daten sichtbar ist. Wahr (1), damit die Spalte sichtbar ist; falsch (0), damit die Spalte nicht sichtbar ist. Der Standardwert (Attribut fehlt) ist, dass die Spalte sichtbar ist.
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Interner Name der Datenspalte. Wird als Zeilenname für das Shape‑Daten‑Element (benutzerdefinierte Eigenschaft) verwendet, das einer Form hinzugefügt wird, wenn die Form mit einer Datenzeile verknüpft ist.
+
+**Returns:**
+java.lang.String
+### getOrigLabel() {#getOrigLabel--}
+```
+public String getOrigLabel()
+```
+
+
+Spaltenbeschriftung, die von der zugrunde liegenden ADO-Schnittstelle an Visio zurückgegeben wird.
+
+**Returns:**
+java.lang.String
+### getUnitType() {#getUnitType--}
+```
+public String getUnitType()
+```
+
+
+Einheitstyp der Daten in der Datenspalte.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCalendar(int value) {#setCalendar-int-}
+```
+public void setCalendar(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe \{@link DataColumn\#(getCalendar() & 0xFFFF)\}
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setColumnNameID(String value) {#setColumnNameID-java.lang.String-}
+```
+public void setColumnNameID(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getColumnNameID()](../../com.aspose.diagram/datacolumn\#getColumnNameID--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setCurrency(int value) {#setCurrency-int-}
+```
+public void setCurrency(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe \{@link DataColumn\#(getCurrency() & 0xFFFF)\}
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setDataType(int value) {#setDataType-int-}
+```
+public void setDataType(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe \{@link DataColumn\#(getDataType() & 0xFFFF)\}
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setDegree(long value) {#setDegree-long-}
+```
+public void setDegree(long value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getDegree()](../../com.aspose.diagram/datacolumn\#getDegree--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | long |  |
+
+### setDisplayOrder(long value) {#setDisplayOrder-long-}
+```
+public void setDisplayOrder(long value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getDisplayOrder()](../../com.aspose.diagram/datacolumn\#getDisplayOrder--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | long |  |
+
+### setDisplayWidth(long value) {#setDisplayWidth-long-}
+```
+public void setDisplayWidth(long value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getDisplayWidth()](../../com.aspose.diagram/datacolumn\#getDisplayWidth--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | long |  |
+
+### setHyperlink(int value) {#setHyperlink-int-}
+```
+public void setHyperlink(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getHyperlink()](../../com.aspose.diagram/datacolumn\#getHyperlink--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setLabel(String value) {#setLabel-java.lang.String-}
+```
+public void setLabel(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getLabel()](../../com.aspose.diagram/datacolumn\#getLabel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setLangID(long value) {#setLangID-long-}
+```
+public void setLangID(long value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getLangID()](../../com.aspose.diagram/datacolumn\#getLangID--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | long |  |
+
+### setMapped(int value) {#setMapped-int-}
+```
+public void setMapped(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getMapped()](../../com.aspose.diagram/datacolumn\#getMapped--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getName()](../../com.aspose.diagram/datacolumn\#getName--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setOrigLabel(String value) {#setOrigLabel-java.lang.String-}
+```
+public void setOrigLabel(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getOrigLabel()](../../com.aspose.diagram/datacolumn\#getOrigLabel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setUnitType(String value) {#setUnitType-java.lang.String-}
+```
+public void setUnitType(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getUnitType()](../../com.aspose.diagram/datacolumn\#getUnitType--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/datacolumncollection/_index.md
+++ b/german/java/com.aspose.diagram/datacolumncollection/_index.md
@@ -1,0 +1,268 @@
+---
+title: DataColumnCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: DataColumn-Sammlung.
+type: docs
+weight: 109
+url: /de/java/com.aspose.diagram/datacolumncollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class DataColumnCollection extends Collection
+```
+
+DataColumn-Sammlung.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [add(DataColumn dataColumn)](#add-com.aspose.diagram.DataColumn-) | Fügen Sie die dataColumn zur Sammlung hinzu. |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [getSortAsc()](#getSortAsc--) | Gibt an, ob die Spalte SortColumn aufsteigend (1) oder absteigend (0) sortiert werden soll. |
+| [getSortColumn()](#getSortColumn--) | Die Spalte, nach der die Daten sortiert werden sollen. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(DataColumn dataColumn)](#remove-com.aspose.diagram.DataColumn-) | Entfernen Sie die dataColumn aus der Sammlung. |
+| [setSortAsc(int value)](#setSortAsc-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getSortAsc()](../../com.aspose.diagram/datacolumncollection\#getSortAsc--) |
+| [setSortColumn(String value)](#setSortColumn-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getSortColumn()](../../com.aspose.diagram/datacolumncollection\#getSortColumn--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(DataColumn dataColumn) {#add-com.aspose.diagram.DataColumn-}
+```
+public int add(DataColumn dataColumn)
+```
+
+
+Fügen Sie die dataColumn zur Sammlung hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| dataColumn | [DataColumn](../../com.aspose.diagram/datacolumn) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public DataColumn get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[DataColumn](../../com.aspose.diagram/datacolumn) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### getSortAsc() {#getSortAsc--}
+```
+public int getSortAsc()
+```
+
+
+Gibt an, ob die Spalte SortColumn aufsteigend (1) oder absteigend (0) sortiert werden soll.
+
+**Returns:**
+int
+### getSortColumn() {#getSortColumn--}
+```
+public String getSortColumn()
+```
+
+
+Die Spalte, nach der die Daten sortiert werden sollen.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(DataColumn dataColumn) {#remove-com.aspose.diagram.DataColumn-}
+```
+public void remove(DataColumn dataColumn)
+```
+
+
+Entfernen Sie die dataColumn aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| dataColumn | [DataColumn](../../com.aspose.diagram/datacolumn) |  |
+
+### setSortAsc(int value) {#setSortAsc-int-}
+```
+public void setSortAsc(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getSortAsc()](../../com.aspose.diagram/datacolumncollection\#getSortAsc--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setSortColumn(String value) {#setSortColumn-java.lang.String-}
+```
+public void setSortColumn(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getSortColumn()](../../com.aspose.diagram/datacolumncollection\#getSortColumn--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/dataconnection/_index.md
+++ b/german/java/com.aspose.diagram/dataconnection/_index.md
@@ -1,0 +1,288 @@
+---
+title: DataConnection
+second_title: Aspose.Diagram for Java API-Referenz
+description: Abstrahiert die Kommunikation zwischen einem oder mehreren DataRecordset-Elementen und einer Nicht-XML-Datenquelle.
+type: docs
+weight: 110
+url: /de/java/com.aspose.diagram/dataconnection/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DataConnection
+```
+
+Abstrahiert die Kommunikation zwischen einem oder mehreren DataRecordset-Elementen und einer Nicht-XML-Datenquelle.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [DataConnection()](#DataConnection--) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAlwaysUseConnectionFile()](#getAlwaysUseConnectionFile--) | Der Standardwert ist falsch. |
+| [getClass()](#getClass--) |  |
+| [getCommand()](#getCommand--) | Die Befehlszeichenfolge, die zum Abfragen der Datenquelle verwendet wird. |
+| [getConnectionString()](#getConnectionString--) | Die Verbindungszeichenfolge, die die zum Herstellen einer Verbindung mit einer Datenquelle erforderlichen Parameter definiert. |
+| [getFileName()](#getFileName--) | Der Name der Verbindungsdatei. |
+| [getID()](#getID--) | Die von Visio zugewiesene ID für eine gegebene Verbindung, eindeutig innerhalb des Dokuments. |
+| [getTimeout()](#getTimeout--) | Wartezeit in Minuten beim Versuch, eine Verbindung herzustellen, bevor der Versuch abgebrochen wird. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAlwaysUseConnectionFile(int value)](#setAlwaysUseConnectionFile-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getAlwaysUseConnectionFile()](../../com.aspose.diagram/dataconnection\#getAlwaysUseConnectionFile--) |
+| [setCommand(String value)](#setCommand-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getCommand()](../../com.aspose.diagram/dataconnection\#getCommand--) |
+| [setConnectionString(String value)](#setConnectionString-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getConnectionString()](../../com.aspose.diagram/dataconnection\#getConnectionString--) |
+| [setFileName(String value)](#setFileName-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getFileName()](../../com.aspose.diagram/dataconnection\#getFileName--) |
+| [setID(long value)](#setID-long-) | Für die Beschreibung dieser Eigenschaft siehe bitte \{@link DataConnection\#(getID() & 0xFFFFFFFFL)\} |
+| [setTimeout(long value)](#setTimeout-long-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getTimeout()](../../com.aspose.diagram/dataconnection\#getTimeout--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DataConnection() {#DataConnection--}
+```
+public DataConnection()
+```
+
+
+Konstruktor.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAlwaysUseConnectionFile() {#getAlwaysUseConnectionFile--}
+```
+public int getAlwaysUseConnectionFile()
+```
+
+
+Der Standardwert ist false. Siehe Anmerkungen für weitere Informationen.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCommand() {#getCommand--}
+```
+public String getCommand()
+```
+
+
+Die Befehlszeichenfolge, die zum Abfragen der Datenquelle verwendet wird.
+
+**Returns:**
+java.lang.String
+### getConnectionString() {#getConnectionString--}
+```
+public String getConnectionString()
+```
+
+
+Die Verbindungszeichenfolge, die die zum Herstellen einer Verbindung mit einer Datenquelle erforderlichen Parameter definiert.
+
+**Returns:**
+java.lang.String
+### getFileName() {#getFileName--}
+```
+public String getFileName()
+```
+
+
+Der Name der Verbindungsdatei. Siehe Anmerkungen für weitere Informationen.
+
+**Returns:**
+java.lang.String
+### getID() {#getID--}
+```
+public long getID()
+```
+
+
+Die von Visio zugewiesene ID für eine gegebene Verbindung, eindeutig innerhalb des Dokuments.
+
+**Returns:**
+long
+### getTimeout() {#getTimeout--}
+```
+public long getTimeout()
+```
+
+
+Wartezeit in Minuten beim Versuch, eine Verbindung herzustellen, bevor der Versuch abgebrochen wird.
+
+**Returns:**
+long
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAlwaysUseConnectionFile(int value) {#setAlwaysUseConnectionFile-int-}
+```
+public void setAlwaysUseConnectionFile(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getAlwaysUseConnectionFile()](../../com.aspose.diagram/dataconnection\#getAlwaysUseConnectionFile--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setCommand(String value) {#setCommand-java.lang.String-}
+```
+public void setCommand(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getCommand()](../../com.aspose.diagram/dataconnection\#getCommand--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setConnectionString(String value) {#setConnectionString-java.lang.String-}
+```
+public void setConnectionString(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getConnectionString()](../../com.aspose.diagram/dataconnection\#getConnectionString--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setFileName(String value) {#setFileName-java.lang.String-}
+```
+public void setFileName(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getFileName()](../../com.aspose.diagram/dataconnection\#getFileName--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setID(long value) {#setID-long-}
+```
+public void setID(long value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte \{@link DataConnection\#(getID() & 0xFFFFFFFFL)\}
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | long |  |
+
+### setTimeout(long value) {#setTimeout-long-}
+```
+public void setTimeout(long value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getTimeout()](../../com.aspose.diagram/dataconnection\#getTimeout--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | long |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/dataconnectioncollection/_index.md
+++ b/german/java/com.aspose.diagram/dataconnectioncollection/_index.md
@@ -1,0 +1,259 @@
+---
+title: DataConnectionCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: DataConnection-Sammlung.
+type: docs
+weight: 111
+url: /de/java/com.aspose.diagram/dataconnectioncollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class DataConnectionCollection extends Collection
+```
+
+DataConnection-Sammlung.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [add(DataConnection dataConnection)](#add-com.aspose.diagram.DataConnection-) | Füge die dataConnection zur Sammlung hinzu. |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [getDataConnection(long ID)](#getDataConnection-long-) | Liefert das Element mit der angegebenen ID. |
+| [getNextID()](#getNextID--) | Die nächste verfügbare ID für neue Verbindungen. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(DataConnection dataConnection)](#remove-com.aspose.diagram.DataConnection-) | Entferne die dataConnection aus der Sammlung. |
+| [setNextID(long value)](#setNextID-long-) | Für die Beschreibung dieser Eigenschaft, siehe bitte \{@link DataConnectionCollection\#(getNextID() & 0xFFFFFFFFL)\} |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(DataConnection dataConnection) {#add-com.aspose.diagram.DataConnection-}
+```
+public int add(DataConnection dataConnection)
+```
+
+
+Füge die dataConnection zur Sammlung hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| dataConnection | [DataConnection](../../com.aspose.diagram/dataconnection) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public DataConnection get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[DataConnection](../../com.aspose.diagram/dataconnection) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### getDataConnection(long ID) {#getDataConnection-long-}
+```
+public DataConnection getDataConnection(long ID)
+```
+
+
+Liefert das Element mit der angegebenen ID.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| ID | long | ID von DataConnectionUInt32. |
+
+**Returns:**
+[DataConnection](../../com.aspose.diagram/dataconnection) - DataConnection [DataConnection](../../com.aspose.diagram/dataconnection).
+### getNextID() {#getNextID--}
+```
+public long getNextID()
+```
+
+
+Die nächste verfügbare ID für neue Verbindungen.
+
+**Returns:**
+long
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(DataConnection dataConnection) {#remove-com.aspose.diagram.DataConnection-}
+```
+public void remove(DataConnection dataConnection)
+```
+
+
+Entferne die dataConnection aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| dataConnection | [DataConnection](../../com.aspose.diagram/dataconnection) |  |
+
+### setNextID(long value) {#setNextID-long-}
+```
+public void setNextID(long value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft, siehe bitte \{@link DataConnectionCollection\#(getNextID() & 0xFFFFFFFFL)\}
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | long |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/dataconnectiontype/_index.md
+++ b/german/java/com.aspose.diagram/dataconnectiontype/_index.md
@@ -1,0 +1,165 @@
+---
+title: DataConnectionType
+second_title: Aspose.Diagram for Java API-Referenz
+description: Ermöglicht das Konfigurieren von Optionen für die Verbindungen zur Datenbank.
+type: docs
+weight: 112
+url: /de/java/com.aspose.diagram/dataconnectiontype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class DataConnectionType
+```
+
+Ermöglicht das Konfigurieren von Optionen für die Verbindungen zur Datenbank.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [ODBC](#ODBC) | Verwendung System.Data.Odbc.OdbcConnection. |
+| [QLEDB](#QLEDB) | Verwendung System.Data.OleDb.OleDbConnection. |
+| [SQL](#SQL) | Verwendung System.Data.SqlClient.SqlConnection. |
+| [UNKNOWN](#UNKNOWN) | Unbekannter Verbindungstyp. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ODBC {#ODBC}
+```
+public static final int ODBC
+```
+
+
+Verwendung System.Data.Odbc.OdbcConnection.
+
+### QLEDB {#QLEDB}
+```
+public static final int QLEDB
+```
+
+
+Verwendung System.Data.OleDb.OleDbConnection.
+
+### SQL {#SQL}
+```
+public static final int SQL
+```
+
+
+Verwendung System.Data.SqlClient.SqlConnection.
+
+### UNKNOWN {#UNKNOWN}
+```
+public static final int UNKNOWN
+```
+
+
+Unbekannter Verbindungstyp.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/datarecordset/_index.md
+++ b/german/java/com.aspose.diagram/datarecordset/_index.md
@@ -1,0 +1,557 @@
+---
+title: DataRecordSet
+second_title: Aspose.Diagram for Java API-Referenz
+description: Speichert Formate, Aktualisierungen und stellt Daten bereit, die aus einer Datenbank in Microsoft Visio abgefragt wurden.
+type: docs
+weight: 113
+url: /de/java/com.aspose.diagram/datarecordset/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DataRecordSet
+```
+
+Speichert, formatiert, aktualisiert und stellt Daten bereit, die aus einer Datenbank in Microsoft Visio abgefragt wurden.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [DataRecordSet()](#DataRecordSet--) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getADOData()](#getADOData--) | Enthält XML, das dem klassischen ADO‑XML‑Schema für ein ADO‑Recordset entspricht und die Daten im Daten‑Recordset beschreibt. |
+| [getAutoLinkComparison()](#getAutoLinkComparison--) | Definiert eine Regel, die eine Spalte im übergeordneten DataRecordset‑Element mit einem Formulardaten‑Element aus der letzten erfolgreichen automatischen Verknüpfungsaktion vergleicht, die in der Benutzeroberfläche durchgeführt wurde. |
+| [getChecksum()](#getChecksum--) | Ein Prüfsummenwert, von Visio erzeugt und basierend auf den Eigenschaften des Daten‑Recordsets. |
+| [getClass()](#getClass--) |  |
+| [getCommand()](#getCommand--) | Der Befehlszeichenfolge, die zum Abfragen von Daten aus der Datenquelle verwendet wird. |
+| [getConnectionID()](#getConnectionID--) | Die Verbindungs‑ID für das zugehörige DataConnection‑Objekt. |
+| [getDataColumns()](#getDataColumns--) | Enthält alle DataColumn‑Elemente in einem Daten‑Recordset. |
+| [getID()](#getID--) | Die Daten‑Recordset‑ID, eindeutig innerhalb des Dokuments. |
+| [getName()](#getName--) | Der Anzeigen‑ (oder „freundliche“) Name des Daten‑Recordsets. |
+| [getNextRowID()](#getNextRowID--) | Die nächste verfügbare Visio‑Zeilen‑ID. |
+| [getOptions()](#getOptions--) | Optionen, die auf das Daten‑Recordset angewendet werden. |
+| [getPrimaryKeys()](#getPrimaryKeys--) | Identifiziert eine oder mehrere Primärschlüssel‑Spalten im Daten‑Recordset. |
+| [getRefreshConflicts()](#getRefreshConflicts--) | Zeigt eine Zeile im Daten‑Recordset an, die mit einer Form verknüpft ist, die nach dem Aktualisieren des Daten‑Recordsets im Konflikt steht. |
+| [getRefreshInterval()](#getRefreshInterval--) | Wie oft (in Minuten) Visio das Daten‑Recordset automatisch aktualisiert. |
+| [getRefreshNoReconciliationUI()](#getRefreshNoReconciliationUI--) | Ob die Benutzeroberfläche zur Datenabstimmung deaktiviert werden soll. |
+| [getRefreshOverwriteAll()](#getRefreshOverwriteAll--) | Ob Benutzeränderungen an Formdaten‑Elementen in Formen, die mit Daten verknüpft sind, beim Aktualisieren des Daten‑Recordsets überschrieben werden sollen. |
+| [getReplaceLinks()](#getReplaceLinks--) | Definiert, wie Form‑Daten‑Verknüpfungen behandelt werden, wenn Formen kopiert oder ausgeschnitten werden. 1, um vorhandene Verknüpfungen im Zielobjekt zu ersetzen. 0, um vorhandene Verknüpfungen im Zielobjekt beizubehalten. |
+| [getRowMaps()](#getRowMaps--) | Ordnet eine Daten‑Recordset‑Zeile einer Form zu. |
+| [getRowOrder()](#getRowOrder--) | Ob die Reihenfolge der Zeilen im Daten‑Recordset als Primärschlüssel verwendet werden soll. |
+| [getTimeRefreshed()](#getTimeRefreshed--) | Datum und Uhrzeit, zu der das Daten‑Recordset zuletzt aktualisiert wurde. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [refresh(int connectionType)](#refresh-int-) | Führt die mit dem verbundenen (nicht XML‑basierten) DataRecordset verknüpfte Abfragezeichenfolge aus und aktualisiert verknüpfte Formen mit neuen Daten aus der Datenquelle, die durch die Abfrage zurückgegeben werden. |
+| [setADOData(String value)](#setADOData-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getADOData()](../../com.aspose.diagram/datarecordset\#getADOData--) |
+| [setChecksum(long value)](#setChecksum-long-) | Für die Beschreibung dieser Eigenschaft siehe bitte \{@link DataRecordSet\#(getChecksum() & 0xFFFFFFFFL)\} |
+| [setCommand(String value)](#setCommand-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getCommand()](../../com.aspose.diagram/datarecordset\#getCommand--) |
+| [setConnectionID(long value)](#setConnectionID-long-) | Für die Beschreibung dieser Eigenschaft siehe bitte \{@link DataRecordSet\#(getConnectionID() & 0xFFFFFFFFL)\} |
+| [setID(long value)](#setID-long-) | Für die Beschreibung dieser Eigenschaft siehe bitte \{@link DataRecordSet\#(getID() & 0xFFFFFFFFL)\} |
+| [setName(String value)](#setName-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getName()](../../com.aspose.diagram/datarecordset\#getName--) |
+| [setNextRowID(long value)](#setNextRowID-long-) | Für die Beschreibung dieser Eigenschaft siehe bitte \{@link DataRecordSet\#(getNextRowID() & 0xFFFFFFFFL)\} |
+| [setOptions(int value)](#setOptions-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getOptions()](../../com.aspose.diagram/datarecordset\#getOptions--) |
+| [setRefreshInterval(long value)](#setRefreshInterval-long-) | Für die Beschreibung dieser Eigenschaft siehe bitte \{@link DataRecordSet\#(getRefreshInterval() & 0xFFFFFFFFL)\} |
+| [setRefreshNoReconciliationUI(int value)](#setRefreshNoReconciliationUI-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getRefreshNoReconciliationUI()](../../com.aspose.diagram/datarecordset\#getRefreshNoReconciliationUI--) |
+| [setRefreshOverwriteAll(int value)](#setRefreshOverwriteAll-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getRefreshOverwriteAll()](../../com.aspose.diagram/datarecordset\#getRefreshOverwriteAll--) |
+| [setReplaceLinks(int value)](#setReplaceLinks-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getReplaceLinks()](../../com.aspose.diagram/datarecordset\#getReplaceLinks--) |
+| [setRowOrder(int value)](#setRowOrder-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getRowOrder()](../../com.aspose.diagram/datarecordset\#getRowOrder--) |
+| [setTimeRefreshed(DateTime value)](#setTimeRefreshed-com.aspose.diagram.DateTime-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getTimeRefreshed()](../../com.aspose.diagram/datarecordset\#getTimeRefreshed--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DataRecordSet() {#DataRecordSet--}
+```
+public DataRecordSet()
+```
+
+
+Konstruktor.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getADOData() {#getADOData--}
+```
+public String getADOData()
+```
+
+
+Enthält XML, das dem klassischen ADO‑XML‑Schema für ein ADO‑Recordset entspricht und die Daten im Daten‑Recordset beschreibt.
+
+**Returns:**
+java.lang.String
+### getAutoLinkComparison() {#getAutoLinkComparison--}
+```
+public AutoLinkComparison getAutoLinkComparison()
+```
+
+
+Definiert eine Regel, die eine Spalte im übergeordneten DataRecordset‑Element mit einem Formulardaten‑Element aus der letzten erfolgreichen automatischen Verknüpfungsaktion vergleicht, die in der Benutzeroberfläche durchgeführt wurde.
+
+**Returns:**
+[AutoLinkComparison](../../com.aspose.diagram/autolinkcomparison)
+### getChecksum() {#getChecksum--}
+```
+public long getChecksum()
+```
+
+
+Ein von Visio erzeugter Prüfsummenwert, basierend auf den Eigenschaften des Datenrecordsets. Setzen Sie dieses Attribut auf 0; Visio berechnet diesen Wert zur Laufzeit neu.
+
+**Returns:**
+long
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCommand() {#getCommand--}
+```
+public String getCommand()
+```
+
+
+Der Befehlszeichenfolge, die zum Abfragen von Daten aus der Datenquelle verwendet wird.
+
+**Returns:**
+java.lang.String
+### getConnectionID() {#getConnectionID--}
+```
+public long getConnectionID()
+```
+
+
+Die Verbindungs-ID für das zugehörige DataConnection-Objekt. Existiert nicht für XML-Datenquellen.
+
+**Returns:**
+long
+### getDataColumns() {#getDataColumns--}
+```
+public DataColumnCollection getDataColumns()
+```
+
+
+Enthält alle DataColumn‑Elemente in einem Daten‑Recordset.
+
+**Returns:**
+[DataColumnCollection](../../com.aspose.diagram/datacolumncollection)
+### getID() {#getID--}
+```
+public long getID()
+```
+
+
+Die Daten‑Recordset‑ID, eindeutig innerhalb des Dokuments.
+
+**Returns:**
+long
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Der Anzeigen‑ (oder „freundliche“) Name des Daten‑Recordsets.
+
+**Returns:**
+java.lang.String
+### getNextRowID() {#getNextRowID--}
+```
+public long getNextRowID()
+```
+
+
+Die nächste verfügbare Visio‑Zeilen‑ID.
+
+**Returns:**
+long
+### getOptions() {#getOptions--}
+```
+public int getOptions()
+```
+
+
+Optionen, die auf das Datenrecordset angewendet werden. Mögliche Werte können beliebige Kombinationen von einem oder mehreren der in der folgenden Tabelle gezeigten Werte sein.
+
+**Returns:**
+int
+### getPrimaryKeys() {#getPrimaryKeys--}
+```
+public ArrayList<String> getPrimaryKeys()
+```
+
+
+Identifiziert eine oder mehrere Primärschlüssel‑Spalten im Daten‑Recordset.
+
+**Returns:**
+java.util.ArrayList<java.lang.String>
+### getRefreshConflicts() {#getRefreshConflicts--}
+```
+public RowCollection getRefreshConflicts()
+```
+
+
+Zeigt eine Zeile im Datenrecordset an, die mit einer Form verknüpft ist, die nach dem Aktualisieren des Datenrecordsets in Konflikt steht. RowID – Zeigt eine Zeile im Datenrecordset an, die mit einer Form verknüpft ist, die nach dem Aktualisieren des Datenrecordsets in Konflikt steht. ShapeID – Shape-ID der an dem Konflikt beteiligten Form. PageID – Seiten-ID der an dem Konflikt beteiligten Form.
+
+**Returns:**
+[RowCollection](../../com.aspose.diagram/rowcollection)
+### getRefreshInterval() {#getRefreshInterval--}
+```
+public long getRefreshInterval()
+```
+
+
+Wie oft (in Minuten) Visio das Datenrecordset automatisch aktualisiert. Dieser Wert muss mindestens 1 sein.
+
+**Returns:**
+long
+### getRefreshNoReconciliationUI() {#getRefreshNoReconciliationUI--}
+```
+public int getRefreshNoReconciliationUI()
+```
+
+
+Ob die Datenabgleich-Benutzeroberfläche deaktiviert werden soll. True (1) zum Deaktivieren der Benutzeroberfläche (UI). False (0) zum Aktivieren der UI.
+
+**Returns:**
+int
+### getRefreshOverwriteAll() {#getRefreshOverwriteAll--}
+```
+public int getRefreshOverwriteAll()
+```
+
+
+Ob Benutzeränderungen an Formdaten‑Elementen in Formen, die mit Daten verknüpft sind, beim Aktualisieren des Daten‑Recordsets überschrieben werden sollen.
+
+**Returns:**
+int
+### getReplaceLinks() {#getReplaceLinks--}
+```
+public int getReplaceLinks()
+```
+
+
+Definiert, wie Shape‑Daten‑Links behandelt werden, wenn Formen kopiert oder ausgeschnitten werden. 1, um vorhandene Links in der Ziel‑Form zu ersetzen. 0, um vorhandene Links in der Ziel‑Form beizubehalten. Wenn dieses Attribut fehlt, fragt Visio den Benutzer, ob Links beim Kopieren oder Ausschneiden ersetzt werden sollen.
+
+**Returns:**
+int
+### getRowMaps() {#getRowMaps--}
+```
+public RowCollection getRowMaps()
+```
+
+
+Ordnet eine Zeile des Datenrecordsets einer Form zu. RowID – Zeilen‑ID der Zeile, eindeutig innerhalb des Datenrecordsets. ShapeID – Shape‑ID der Form, die mit den Daten der durch RowID identifizierten Zeile des Datenrecordsets verknüpft ist. PageID – Seiten‑ID der Form, die mit den Daten der durch RowID identifizierten Zeile des Datenrecordsets verknüpft ist.
+
+**Returns:**
+[RowCollection](../../com.aspose.diagram/rowcollection)
+### getRowOrder() {#getRowOrder--}
+```
+public int getRowOrder()
+```
+
+
+Ob die Reihenfolge der Zeilen im Datenrecordset als Primärschlüssel verwendet werden soll. True (1), wenn Zeilen‑IDs durch die Zeilenreihenfolge bestimmt werden. False (0), wenn Zeilen‑IDs durch Werte in den Primärschlüssel‑Spalten des Datenrecordsets bestimmt werden.
+
+**Returns:**
+int
+### getTimeRefreshed() {#getTimeRefreshed--}
+```
+public DateTime getTimeRefreshed()
+```
+
+
+Datum und Uhrzeit, zu der das Daten‑Recordset zuletzt aktualisiert wurde.
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### refresh(int connectionType) {#refresh-int-}
+```
+public void refresh(int connectionType)
+```
+
+
+Führt die mit dem verbundenen (nicht XML‑basierten) DataRecordset verknüpfte Abfragezeichenfolge aus und aktualisiert verknüpfte Formen mit neuen Daten aus der Datenquelle, die durch die Abfrage zurückgegeben werden.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| connectionType | int | Der Typ des Anbieters, der für connectionAspose.Diagram.Manipulation.DataConnectionType verwendet wird. |
+
+### setADOData(String value) {#setADOData-java.lang.String-}
+```
+public void setADOData(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getADOData()](../../com.aspose.diagram/datarecordset\#getADOData--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setChecksum(long value) {#setChecksum-long-}
+```
+public void setChecksum(long value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte \{@link DataRecordSet\#(getChecksum() & 0xFFFFFFFFL)\}
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | long |  |
+
+### setCommand(String value) {#setCommand-java.lang.String-}
+```
+public void setCommand(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getCommand()](../../com.aspose.diagram/datarecordset\#getCommand--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setConnectionID(long value) {#setConnectionID-long-}
+```
+public void setConnectionID(long value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte \{@link DataRecordSet\#(getConnectionID() & 0xFFFFFFFFL)\}
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | long |  |
+
+### setID(long value) {#setID-long-}
+```
+public void setID(long value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte \{@link DataRecordSet\#(getID() & 0xFFFFFFFFL)\}
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | long |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getName()](../../com.aspose.diagram/datarecordset\#getName--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setNextRowID(long value) {#setNextRowID-long-}
+```
+public void setNextRowID(long value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte \{@link DataRecordSet\#(getNextRowID() & 0xFFFFFFFFL)\}
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | long |  |
+
+### setOptions(int value) {#setOptions-int-}
+```
+public void setOptions(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getOptions()](../../com.aspose.diagram/datarecordset\#getOptions--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setRefreshInterval(long value) {#setRefreshInterval-long-}
+```
+public void setRefreshInterval(long value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte \{@link DataRecordSet\#(getRefreshInterval() & 0xFFFFFFFFL)\}
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | long |  |
+
+### setRefreshNoReconciliationUI(int value) {#setRefreshNoReconciliationUI-int-}
+```
+public void setRefreshNoReconciliationUI(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getRefreshNoReconciliationUI()](../../com.aspose.diagram/datarecordset\#getRefreshNoReconciliationUI--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setRefreshOverwriteAll(int value) {#setRefreshOverwriteAll-int-}
+```
+public void setRefreshOverwriteAll(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getRefreshOverwriteAll()](../../com.aspose.diagram/datarecordset\#getRefreshOverwriteAll--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setReplaceLinks(int value) {#setReplaceLinks-int-}
+```
+public void setReplaceLinks(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getReplaceLinks()](../../com.aspose.diagram/datarecordset\#getReplaceLinks--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setRowOrder(int value) {#setRowOrder-int-}
+```
+public void setRowOrder(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getRowOrder()](../../com.aspose.diagram/datarecordset\#getRowOrder--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setTimeRefreshed(DateTime value) {#setTimeRefreshed-com.aspose.diagram.DateTime-}
+```
+public void setTimeRefreshed(DateTime value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getTimeRefreshed()](../../com.aspose.diagram/datarecordset\#getTimeRefreshed--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/datarecordsetcollection/_index.md
+++ b/german/java/com.aspose.diagram/datarecordsetcollection/_index.md
@@ -1,0 +1,268 @@
+---
+title: DataRecordSetCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: DataRecordSet-Sammlung.
+type: docs
+weight: 114
+url: /de/java/com.aspose.diagram/datarecordsetcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class DataRecordSetCollection extends Collection
+```
+
+DataRecordSet-Sammlung.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [add(DataRecordSet dataRecordSet)](#add-com.aspose.diagram.DataRecordSet-) | Fügen Sie das dataRecordSet zur Sammlung hinzu. |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [getActiveRecordsetId()](#getActiveRecordsetId--) | ActiveRecordsetID |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [getNextId()](#getNextId--) | NextID |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(DataRecordSet dataRecordSet)](#remove-com.aspose.diagram.DataRecordSet-) | Entfernen Sie das dataRecordSet aus der Sammlung. |
+| [setActiveRecordsetId(String value)](#setActiveRecordsetId-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getActiveRecordsetId()](../../com.aspose.diagram/datarecordsetcollection\#getActiveRecordsetId--) |
+| [setNextId(String value)](#setNextId-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getNextId()](../../com.aspose.diagram/datarecordsetcollection\#getNextId--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(DataRecordSet dataRecordSet) {#add-com.aspose.diagram.DataRecordSet-}
+```
+public int add(DataRecordSet dataRecordSet)
+```
+
+
+Fügen Sie das dataRecordSet zur Sammlung hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| dataRecordSet | [DataRecordSet](../../com.aspose.diagram/datarecordset) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public DataRecordSet get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[DataRecordSet](../../com.aspose.diagram/datarecordset) - 
+### getActiveRecordsetId() {#getActiveRecordsetId--}
+```
+public String getActiveRecordsetId()
+```
+
+
+ActiveRecordsetID
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### getNextId() {#getNextId--}
+```
+public String getNextId()
+```
+
+
+NextID
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(DataRecordSet dataRecordSet) {#remove-com.aspose.diagram.DataRecordSet-}
+```
+public void remove(DataRecordSet dataRecordSet)
+```
+
+
+Entfernen Sie das dataRecordSet aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| dataRecordSet | [DataRecordSet](../../com.aspose.diagram/datarecordset) |  |
+
+### setActiveRecordsetId(String value) {#setActiveRecordsetId-java.lang.String-}
+```
+public void setActiveRecordsetId(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getActiveRecordsetId()](../../com.aspose.diagram/datarecordsetcollection\#getActiveRecordsetId--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setNextId(String value) {#setNextId-java.lang.String-}
+```
+public void setNextId(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getNextId()](../../com.aspose.diagram/datarecordsetcollection\#getNextId--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/datetime/_index.md
+++ b/german/java/com.aspose.diagram/datetime/_index.md
@@ -1,0 +1,510 @@
+---
+title: DateTime
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt einen Zeitpunkt dar, der typischerweise als Datum und Tageszeit ausgedrückt wird.
+type: docs
+weight: 115
+url: /de/java/com.aspose.diagram/datetime/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DateTime
+```
+
+Stellt einen Zeitpunkt dar, typischerweise ausgedrückt als Datum und Uhrzeit.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [DateTime(int year, int month, int day)](#DateTime-int-int-int-) | Initialisiert eine neue Instanz des DateTime-Objekts mit dem angegebenen Jahr, Monat und Tag. |
+| [DateTime(int year, int month, int day, int hour, int minute, int second)](#DateTime-int-int-int-int-int-int-) | Initialisiert eine neue Instanz des DateTime-Objekts mit dem angegebenen Jahr, Monat, Tag, Stunde, Minute und Sekunde. |
+| [DateTime(int year, int month, int day, int hour, int minute, int second, int millisecond)](#DateTime-int-int-int-int-int-int-int-) | Initialisiert eine neue Instanz des DateTime-Objekts mit dem angegebenen Jahr, Monat, Tag, Stunde, Minute, Sekunde und Millisekunde. |
+| [DateTime(Date date)](#DateTime-java.util.Date-) | Initialisiert eine neue Instanz des DateTime-Objekts mit dem angegebenen Date-Objekt |
+| [DateTime(Calendar cld)](#DateTime-java.util.Calendar-) | Initialisiert eine neue Instanz des DateTime-Objekts mit dem angegebenen Calendar-Objekt |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [addDays(double value)](#addDays-double-) | Addiert die angegebene Anzahl von Tagen zum Wert dieser Instanz. |
+| [addHours(double value)](#addHours-double-) | Addiert die angegebene Anzahl von Stunden zum Wert dieser Instanz. |
+| [addMilliseconds(double value)](#addMilliseconds-double-) | Addiert die angegebene Anzahl von Millisekunden zum Wert dieser Instanz. |
+| [addMinutes(double value)](#addMinutes-double-) | Addiert die angegebene Anzahl von Minuten zum Wert dieser Instanz. |
+| [addMonths(int months)](#addMonths-int-) | Addiert die angegebene Anzahl von Monaten zum Wert dieser Instanz. |
+| [addSeconds(double value)](#addSeconds-double-) | Addiert die angegebene Anzahl von Sekunden zum Wert dieser Instanz. |
+| [addYears(int value)](#addYears-int-) | Addiert die angegebene Anzahl von Jahren zum Wert dieser Instanz. |
+| [compareTo(DateTime value)](#compareTo-com.aspose.diagram.DateTime-) | Vergleicht den Wert dieser Instanz mit einem angegebenen DateTime-Wert und gibt eine Ganzzahl zurück, die angibt, ob diese Instanz früher, gleich oder später als der angegebene DateTime-Wert ist. |
+| [compareTo(Object value)](#compareTo-java.lang.Object-) | Vergleicht den Wert dieser Instanz mit einem angegebenen Objekt, das einen DateTime-Wert enthält, und gibt eine Ganzzahl zurück, die angibt, ob diese Instanz früher, gleich oder später als der angegebene DateTime-Wert ist. |
+| [equals(Object value)](#equals-java.lang.Object-) | Gibt einen Wert zurück, der angibt, ob diese Instanz einem angegebenen Objekt gleich ist. |
+| [getClass()](#getClass--) |  |
+| [getDay()](#getDay--) | Ermittelt den Tag des Monats, der von dieser Instanz dargestellt wird. |
+| [getDayOfWeek()](#getDayOfWeek--) | Ermittelt den Wochentag, der von dieser Instanz dargestellt wird. |
+| [getDayOfYear()](#getDayOfYear--) | Ermittelt den Tag des Jahres, der von dieser Instanz dargestellt wird. |
+| [getHour()](#getHour--) | Ermittelt die Stundenkomponente des Datums, das von dieser Instanz dargestellt wird. |
+| [getMillisecond()](#getMillisecond--) | Ermittelt die Millisekundenkomponente des Datums, das von dieser Instanz dargestellt wird. |
+| [getMinute()](#getMinute--) | Ermittelt die Minutenkomponente des Datums, das von dieser Instanz dargestellt wird. |
+| [getMonth()](#getMonth--) | Ermittelt die Monatskomponente des Datums, das von dieser Instanz dargestellt wird. |
+| [getNow()](#getNow--) | Ermittelt ein DateTime-Objekt, das auf das aktuelle Datum und die aktuelle Uhrzeit dieses Computers eingestellt ist und als lokale Zeit ausgedrückt wird. |
+| [getSecond()](#getSecond--) | Ermittelt die Sekundenkomponente des Datums, das von dieser Instanz dargestellt wird. |
+| [getYear()](#getYear--) | Ermittelt die Jahreskomponente des Datums, das von dieser Instanz dargestellt wird. |
+| [hashCode()](#hashCode--) | Gibt den Hashcode für diese Instanz zurück. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toCalendar()](#toCalendar--) | Konvertiert den Wert des aktuellen DateTime-Objekts in ein Calendar-Objekt. |
+| [toDate()](#toDate--) | Konvertiert den Wert des aktuellen DateTime-Objekts in ein Date-Objekt. |
+| [toLocalTime()](#toLocalTime--) | Konvertiert den Wert des aktuellen DateTime-Objekts in die lokale Zeit. |
+| [toString()](#toString--) | Konvertiert den Wert des aktuellen DateTime-Objekts in seine äquivalente Zeichenkettenrepräsentation. |
+| [toUniversalTime()](#toUniversalTime--) | Konvertiert den Wert des aktuellen DateTime-Objekts in die koordinierte Weltzeit (UTC). |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DateTime(int year, int month, int day) {#DateTime-int-int-int-}
+```
+public DateTime(int year, int month, int day)
+```
+
+
+Initialisiert eine neue Instanz des DateTime-Objekts mit dem angegebenen Jahr, Monat und Tag.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Jahr | int | Das Jahr (1 bis 9999). |
+| Monat | int | Der Monat (1 bis 12). |
+| Tag | int | Der Tag (1 bis zur Anzahl der Tage im Monat). |
+
+### DateTime(int year, int month, int day, int hour, int minute, int second) {#DateTime-int-int-int-int-int-int-}
+```
+public DateTime(int year, int month, int day, int hour, int minute, int second)
+```
+
+
+Initialisiert eine neue Instanz des DateTime-Objekts mit dem angegebenen Jahr, Monat, Tag, Stunde, Minute und Sekunde.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Jahr | int | Das Jahr (1 bis 9999). |
+| Monat | int | Der Monat (1 bis 12). |
+| Tag | int | Der Tag (1 bis zur Anzahl der Tage im Monat). |
+| Stunde | int | Die Stunden (0 bis 23). |
+| Minute | int | Die Minuten (0 bis 59). |
+| Sekunde | int | Die Sekunden (0 bis 59). |
+
+### DateTime(int year, int month, int day, int hour, int minute, int second, int millisecond) {#DateTime-int-int-int-int-int-int-int-}
+```
+public DateTime(int year, int month, int day, int hour, int minute, int second, int millisecond)
+```
+
+
+Initialisiert eine neue Instanz des DateTime-Objekts mit dem angegebenen Jahr, Monat, Tag, Stunde, Minute, Sekunde und Millisekunde.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Jahr | int | Das Jahr (1 bis 9999). |
+| Monat | int | Der Monat (1 bis 12). |
+| Tag | int | Der Tag (1 bis zur Anzahl der Tage im Monat). |
+| Stunde | int | Die Stunden (0 bis 23). |
+| Minute | int | Die Minuten (0 bis 59). |
+| Sekunde | int | Die Sekunden (0 bis 59). |
+| Millisekunde | int | Die Millisekunden (0 bis 999). |
+
+### DateTime(Date date) {#DateTime-java.util.Date-}
+```
+public DateTime(Date date)
+```
+
+
+Initialisiert eine neue Instanz des DateTime-Objekts mit dem angegebenen Date-Objekt
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Datum | java.util.Date | Das Date-Objekt |
+
+### DateTime(Calendar cld) {#DateTime-java.util.Calendar-}
+```
+public DateTime(Calendar cld)
+```
+
+
+Initialisiert eine neue Instanz des DateTime-Objekts mit dem angegebenen Calendar-Objekt
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| cld | java.util.Calendar | Das Calendar-Objekt |
+
+### addDays(double value) {#addDays-double-}
+```
+public DateTime addDays(double value)
+```
+
+
+Addiert die angegebene Anzahl von Tagen zum Wert dieser Instanz.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double | Eine Anzahl von ganzen und gebrochenen Tagen. Der Wertparameter kann negativ oder positiv sein. |
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object whose value is the sum of the date and time represented by this instance and the number of days represented by value.
+### addHours(double value) {#addHours-double-}
+```
+public DateTime addHours(double value)
+```
+
+
+Addiert die angegebene Anzahl von Stunden zum Wert dieser Instanz.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double | Eine Anzahl von ganzen und gebrochenen Stunden. Der Wertparameter kann negativ oder positiv sein. |
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object whose value is the sum of the date and time represented by this instance and the number of hours represented by value.
+### addMilliseconds(double value) {#addMilliseconds-double-}
+```
+public DateTime addMilliseconds(double value)
+```
+
+
+Addiert die angegebene Anzahl von Millisekunden zum Wert dieser Instanz.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double | Eine Anzahl von ganzen und gebrochenen Millisekunden. Der Wertparameter kann negativ oder positiv sein. Hinweis: Dieser Wert wird auf die nächste ganze Zahl gerundet. |
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object whose value is the sum of the date and time represented by this instance and the number of milliseconds represented by value.
+### addMinutes(double value) {#addMinutes-double-}
+```
+public DateTime addMinutes(double value)
+```
+
+
+Addiert die angegebene Anzahl von Minuten zum Wert dieser Instanz.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double | Eine Anzahl von ganzen und gebrochenen Minuten. Der Wertparameter kann negativ oder positiv sein. |
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object whose value is the sum of the date and time represented by this instance and the number of minutes represented by value.
+### addMonths(int months) {#addMonths-int-}
+```
+public DateTime addMonths(int months)
+```
+
+
+Addiert die angegebene Anzahl von Monaten zum Wert dieser Instanz.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Monate | int | Eine Anzahl von Monaten. Der months-Parameter kann negativ oder positiv sein. |
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object whose value is the sum of the date and time represented by this instance and months.
+### addSeconds(double value) {#addSeconds-double-}
+```
+public DateTime addSeconds(double value)
+```
+
+
+Addiert die angegebene Anzahl von Sekunden zum Wert dieser Instanz.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double | Eine Anzahl von ganzen und gebrochenen Sekunden. Der Wertparameter kann negativ oder positiv sein. |
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object whose value is the sum of the date and time represented by this instance and the number of seconds represented by value.
+### addYears(int value) {#addYears-int-}
+```
+public DateTime addYears(int value)
+```
+
+
+Addiert die angegebene Anzahl von Jahren zum Wert dieser Instanz.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int | Eine Anzahl von Jahren. Der Wertparameter kann negativ oder positiv sein. |
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object whose value is the sum of the date and time represented by this instance and the number of years represented by value.
+### compareTo(DateTime value) {#compareTo-com.aspose.diagram.DateTime-}
+```
+public int compareTo(DateTime value)
+```
+
+
+Vergleicht den Wert dieser Instanz mit einem angegebenen DateTime-Wert und gibt eine Ganzzahl zurück, die angibt, ob diese Instanz früher, gleich oder später als der angegebene DateTime-Wert ist.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) | Ein DateTime-Objekt zum Vergleichen. |
+
+**Returns:**
+int - Eine vorzeichenbehaftete Zahl, die die relativen Werte dieser Instanz und des value-Parameters angibt. Wertbeschreibung Weniger als null Diese Instanz liegt vor dem Wert. Null Diese Instanz ist gleich dem Wert. Größer als null Diese Instanz liegt nach dem Wert.
+### compareTo(Object value) {#compareTo-java.lang.Object-}
+```
+public int compareTo(Object value)
+```
+
+
+Vergleicht den Wert dieser Instanz mit einem angegebenen Objekt, das einen DateTime-Wert enthält, und gibt eine Ganzzahl zurück, die angibt, ob diese Instanz früher, gleich oder später als der angegebene DateTime-Wert ist.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object | Ein verpacktes DateTime-Objekt zum Vergleichen oder null. |
+
+**Returns:**
+int - Eine vorzeichenbehaftete Zahl, die die relativen Werte dieser Instanz und value angibt. Wertbeschreibung Weniger als null Diese Instanz liegt vor dem Wert. Null Diese Instanz ist gleich dem Wert. Größer als null Diese Instanz liegt nach dem Wert, oder value ist null.
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gibt einen Wert zurück, der angibt, ob diese Instanz einem angegebenen Objekt gleich ist.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object | Ein Objekt zum Vergleich mit dieser Instanz. |
+
+**Returns:**
+boolean - true, wenn value eine Instanz von DateTime ist und dem Wert dieser Instanz entspricht; andernfalls false.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDay() {#getDay--}
+```
+public int getDay()
+```
+
+
+Ermittelt den Tag des Monats, der von dieser Instanz dargestellt wird.
+
+**Returns:**
+int - Die Tageskomponente, ausgedrückt als ein Wert zwischen 1 und 31.
+### getDayOfWeek() {#getDayOfWeek--}
+```
+public int getDayOfWeek()
+```
+
+
+Ermittelt den Wochentag, der von dieser Instanz dargestellt wird.
+
+**Returns:**
+int - Der Wochentag dieses DateTime-Werts.
+### getDayOfYear() {#getDayOfYear--}
+```
+public int getDayOfYear()
+```
+
+
+Ermittelt den Tag des Jahres, der von dieser Instanz dargestellt wird.
+
+**Returns:**
+int - Der Tag des Jahres, ausgedrückt als ein Wert zwischen 1 und 366.
+### getHour() {#getHour--}
+```
+public int getHour()
+```
+
+
+Ermittelt die Stundenkomponente des Datums, das von dieser Instanz dargestellt wird.
+
+**Returns:**
+int - Die Stundenkomponente, ausgedrückt als ein Wert zwischen 0 und 23.
+### getMillisecond() {#getMillisecond--}
+```
+public int getMillisecond()
+```
+
+
+Ermittelt die Millisekundenkomponente des Datums, das von dieser Instanz dargestellt wird.
+
+**Returns:**
+int - Die Millisekundenkomponente, ausgedrückt als ein Wert zwischen 0 und 999.
+### getMinute() {#getMinute--}
+```
+public int getMinute()
+```
+
+
+Ermittelt die Minutenkomponente des Datums, das von dieser Instanz dargestellt wird.
+
+**Returns:**
+int - Die Minutenkomponente, ausgedrückt als ein Wert zwischen 0 und 59.
+### getMonth() {#getMonth--}
+```
+public int getMonth()
+```
+
+
+Ermittelt die Monatskomponente des Datums, das von dieser Instanz dargestellt wird.
+
+**Returns:**
+int - Die Monatskomponente, ausgedrückt als ein Wert zwischen 1 und 12.
+### getNow() {#getNow--}
+```
+public static DateTime getNow()
+```
+
+
+Ermittelt ein DateTime-Objekt, das auf das aktuelle Datum und die aktuelle Uhrzeit dieses Computers eingestellt ist und als lokale Zeit ausgedrückt wird.
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object whose value is the current local date and time.
+### getSecond() {#getSecond--}
+```
+public int getSecond()
+```
+
+
+Ermittelt die Sekundenkomponente des Datums, das von dieser Instanz dargestellt wird.
+
+**Returns:**
+int - Die Sekunden, zwischen 0 und 59.
+### getYear() {#getYear--}
+```
+public int getYear()
+```
+
+
+Ermittelt die Jahreskomponente des Datums, das von dieser Instanz dargestellt wird.
+
+**Returns:**
+int - Das Jahr, zwischen 1 und 9999.
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Gibt den Hashcode für diese Instanz zurück.
+
+**Returns:**
+int - Ein 32‑Bit vorzeichenbehafteter Ganzzahl‑Hashcode.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toCalendar() {#toCalendar--}
+```
+public Calendar toCalendar()
+```
+
+
+Konvertiert den Wert des aktuellen DateTime-Objekts in ein Calendar-Objekt.
+
+**Returns:**
+[Calendar](../../java.util/calendar) - Calendar object
+### toDate() {#toDate--}
+```
+public Date toDate()
+```
+
+
+Konvertiert den Wert des aktuellen DateTime-Objekts in ein Date-Objekt.
+
+**Returns:**
+java.util.Date - Datumsobjekt
+### toLocalTime() {#toLocalTime--}
+```
+public DateTime toLocalTime()
+```
+
+
+Konvertiert den Wert des aktuellen DateTime-Objekts in die lokale Zeit.
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object of local
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+Konvertiert den Wert des aktuellen DateTime-Objekts in seine äquivalente Zeichenkettenrepräsentation.
+
+**Returns:**
+java.lang.String - Eine Zeichenkettenrepräsentation des Werts des aktuellen DateTime‑Objekts.
+### toUniversalTime() {#toUniversalTime--}
+```
+public DateTime toUniversalTime()
+```
+
+
+Konvertiert den Wert des aktuellen DateTime-Objekts in die koordinierte Weltzeit (UTC).
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object of UTC
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/datevalue/_index.md
+++ b/german/java/com.aspose.diagram/datevalue/_index.md
@@ -1,0 +1,180 @@
+---
+title: DateValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Datum- und Uhrzeitwert.
+type: docs
+weight: 116
+url: /de/java/com.aspose.diagram/datevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DateValue
+```
+
+Datum- und Uhrzeitwert.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [DateValue(DateTime value, int unit)](#DateValue-com.aspose.diagram.DateTime-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Attribute eines Elements. |
+| [getValue()](#getValue--) | Datum- und Uhrzeitwert. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(DateTime value)](#setValue-com.aspose.diagram.DateTime-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/datevalue\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DateValue(DateTime value, int unit) {#DateValue-com.aspose.diagram.DateTime-int-}
+```
+public DateValue(DateTime value, int unit)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+| Einheit | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Attribute eines Elements.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public DateTime getValue()
+```
+
+
+Datum- und Uhrzeitwert.
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(DateTime value) {#setValue-com.aspose.diagram.DateTime-}
+```
+public void setValue(DateTime value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/datevalue\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/diagram/_index.md
+++ b/german/java/com.aspose.diagram/diagram/_index.md
@@ -1,0 +1,1130 @@
+---
+title: Diagramm
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stammelement der Visio-Objekthierarchie.
+type: docs
+weight: 117
+url: /de/java/com.aspose.diagram/diagram/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Diagram
+```
+
+Stammelement der Visio-Objekthierarchie.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [Diagram()](#Diagram--) |  |
+| [Diagram(String filename)](#Diagram-java.lang.String-) | Öffentlicher Klassenkonstruktor, lädt das Diagramm aus der Datei. |
+| [Diagram(InputStream stream)](#Diagram-java.io.InputStream-) | Öffentlicher Klassenkonstruktor, lädt das Diagramm aus dem Stream. |
+| [Diagram(InputStream stream, int format)](#Diagram-java.io.InputStream-int-) | Öffentlicher Klassenkonstruktor, lädt das Diagramm aus dem Stream unter Verwendung eines vordefinierten Formats. |
+| [Diagram(InputStream stream, LoadOptions options)](#Diagram-java.io.InputStream-com.aspose.diagram.LoadOptions-) | Öffentlicher Klassenkonstruktor, lädt das Diagramm aus dem Stream unter Verwendung vordefinierter Ladeoptionen. |
+| [Diagram(String filename, int format)](#Diagram-java.lang.String-int-) | Öffentlicher Klassenkonstruktor, lädt das Diagramm aus der Datei unter Verwendung eines vordefinierten Formats. |
+| [Diagram(String filename, LoadOptions options)](#Diagram-java.lang.String-com.aspose.diagram.LoadOptions-) | Öffentlicher Klassenkonstruktor, lädt das Diagramm aus der Datei unter Verwendung vordefinierter Ladeoptionen. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [addMaster(Diagram srcDiagram, String masterName)](#addMaster-com.aspose.diagram.Diagram-java.lang.String-) | Fügt dem Diagramm ein Master aus dem Quelldiagramm anhand des Namens oder NameU des Masters hinzu. |
+| [addMaster(InputStream templateStream, int masterID)](#addMaster-java.io.InputStream-int-) | Fügt dem Diagramm ein Master aus dem Vorlagen-Stream anhand der ID des Masters hinzu. |
+| [addMaster(InputStream templateStream, String masterName)](#addMaster-java.io.InputStream-java.lang.String-) | Fügt dem Diagramm ein Master aus dem Vorlagen-Stream anhand des Namens oder NameU des Masters hinzu. |
+| [addMaster(String templateFilePath, int masterID)](#addMaster-java.lang.String-int-) | Fügt dem Diagramm ein Master aus der Vorlagendatei anhand der ID des Masters hinzu. |
+| [addMaster(String templateFilePath, String masterName)](#addMaster-java.lang.String-java.lang.String-) | Fügt dem Diagramm ein Master aus der Vorlagendatei anhand des Namens oder NameU des Masters hinzu. |
+| [addShape(Shape newShape, String masterName, int pageNumber)](#addShape-com.aspose.diagram.Shape-java.lang.String-int-) | Fügt ein vom Master erstelltes Shape zu einer bestimmten Seite hinzu. |
+| [addShape(double pinX, double pinY, double width, double height, String masterName, int pageNumber)](#addShape-double-double-double-double-java.lang.String-int-) | Fügt ein vom Master erstelltes Shape auf einer Seite mit definierten PinX, PinY, Breite und Höhe hinzu. |
+| [addShape(double pinX, double pinY, String masterName, int pageNumber)](#addShape-double-double-java.lang.String-int-) | Fügt ein vom Master erstelltes Shape auf einer Seite mit definierten PinX und PinY hinzu. |
+| [combine(Diagram secondDiagram)](#combine-com.aspose.diagram.Diagram-) | Kombiniert ein weiteres Diagrammobjekt. |
+| [copyTheme(Diagram source)](#copyTheme-com.aspose.diagram.Diagram-) | Kopiert das Theme aus einem Quell-Diagramm. |
+| [dispose()](#dispose--) | Führt anwendungsspezifische Aufgaben aus, die mit dem Freigeben, Freisetzen oder Zurücksetzen nicht verwalteter Ressourcen verbunden sind. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [export(InputStream inputVsd, InputStream outputVdw)](#export-java.io.InputStream-java.io.InputStream-) | Exportiert das Diagramm vom VSD-Stream in das VDW-Stream-Format. |
+| [export(InputStream inputVsd, String outputVdw)](#export-java.io.InputStream-java.lang.String-) | Exportiert das Diagramm vom VSD-Stream in das *.vdw-Dateiformat. |
+| [export(String inputVsd, InputStream outputVdw)](#export-java.lang.String-java.io.InputStream-) | Exportiert das Diagramm von einer VSD-Datei in das VDW-Stream-Format. |
+| [export(String inputVsd, String outputVdw)](#export-java.lang.String-java.lang.String-) | Exportiert das Diagramm von VSD nach VDW. |
+| [getActivePage()](#getActivePage--) | Gibt die aktive Seite an |
+| [getBuildnum()](#getBuildnum--) | Die Build-Nummer der Visio-Instanz, die zum Erstellen des Dokuments verwendet wurde. |
+| [getClass()](#getClass--) |  |
+| [getColors()](#getColors--) | Enthält die Farbpalette des Dokuments. |
+| [getDataConnections()](#getDataConnections--) | Enthält die DataConnection-Elemente für das Dokument. |
+| [getDataRecordSets()](#getDataRecordSets--) | Die Sammlung von DataRecordset-Objekten, die mit einem Document-Objekt verknüpft sind. |
+| [getDefaultFontDir()](#getDefaultFontDir--) | Rufe den Pfad des Standard-Schriftartenordners ab |
+| [getDocLangID()](#getDocLangID--) | Die eindeutige ID der Benutzeroberflächensprache, die der Benutzer in den Microsoft Office 2010 Language Preferences angegeben hat. |
+| [getDocumentProps()](#getDocumentProps--) | Enthält Dokumenteigenschaftselemente wie den Titel, den Autor usw. des Dokuments. |
+| [getDocumentSettings()](#getDocumentSettings--) | Enthält Elemente, die Dokumenteinstellungen festlegen. |
+| [getDocumentSheet()](#getDocumentSheet--) | Gibt die ShapeSheet-Struktur eines Dokuments an. |
+| [getEmailRoutingData()](#getEmailRoutingData--) | Enthält einen MIME (Multipurpose Internet Mail Extensions) codierten MAPI-E-Mail-Routing-Slip für das Dokument. |
+| [getEventItems()](#getEventItems--) | Enthält ein EventItem-Element für jedes Ereignis, auf das ein Objekt reagieren soll. |
+| [getFonts()](#getFonts--) | Enthält eine Sammlung von Font-Elementen |
+| [getHeaderFooter()](#getHeaderFooter--) | Enthält Elemente für die Kopf- und Fußzeile eines Dokuments. |
+| [getInterruptMonitor()](#getInterruptMonitor--) | der Interrupt-Monitor. |
+| [getKey()](#getKey--) | Gibt an, ob das Dokument außerhalb von Visio geändert wurde. |
+| [getMasters()](#getMasters--) | Sammlung von Master-Objekten. |
+| [getMetric()](#getMetric--) | Ob im Diagramm metrische Einheiten verwendet werden sollen. |
+| [getPages()](#getPages--) | Sammlung von Page-Objekten. |
+| [getRibbonX()](#getRibbonX--) | Der Ribbon-XML-String, der an das Dokument übergeben wird, um die Ribbon-Benutzeroberfläche anzupassen. |
+| [getSolutionXMLs()](#getSolutionXMLs--) | XML-Wert. |
+| [getStart()](#getStart--) | Gibt an, ob das Dokument außerhalb von Visio geändert wurde. |
+| [getStyleSheets()](#getStyleSheets--) | Sammlung von StyleSheet-Objekten. |
+| [getUnusedStyles()](#getUnusedStyles--) | Unbenutzte Stile abrufen |
+| [getUserCustomUI()](#getUserCustomUI--) | Der Ribbon-XML-String, der an das Dokument übergeben wird, um die Symbolleiste für den Schnellzugriff oder das Ribbon anzupassen. |
+| [getValidation()](#getValidation--) | Speichert Informationen zur Diagrammvalidierung für das Dokument. |
+| [getVbProjectData()](#getVbProjectData--) | Enthält die Microsoft Visual Basic for Applications-Projektdaten im MIME (Multipurpose Internet Mail Extensions)-kodierten Format. |
+| [getVbaProject()](#getVbaProject--) | Ruft das VbaProject[getVbaProject()](../../com.aspose.diagram/diagram\#getVbaProject--) ab. |
+| [getVersion()](#getVersion--) | Die Versionsnummer der Visio-Instanz. |
+| [getWindows()](#getWindows--) | Enthält die Window-Elemente für ein Dokument. |
+| [hasHiddenInfo()](#hasHiddenInfo--) | Gibt an, ob dieses Diagramm versteckte Informationen enthält. |
+| [hashCode()](#hashCode--) |  |
+| [layout(LayoutOptions options)](#layout-com.aspose.diagram.LayoutOptions-) | Ordnet die Formen an und/oder leitet die Verbinder für alle Seiten des Diagramms neu. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [print(String printerName)](#print-java.lang.String-) | Druckt das gesamte Dokument auf dem angegebenen Drucker, wobei der Standard‑Druckcontroller (keine Benutzeroberfläche) verwendet wird. |
+| [print(String printerName, PrintSaveOptions options)](#print-java.lang.String-com.aspose.diagram.PrintSaveOptions-) | Druckt das gesamte Dokument auf dem angegebenen Drucker, wobei der Standard‑Druckcontroller (keine Benutzeroberfläche) verwendet wird. |
+| [print(String printerName, String documentName)](#print-java.lang.String-java.lang.String-) | Druckt das Dokument, wobei der Standard‑Druckcontroller (keine Benutzeroberfläche) und ein Dokumentname verwendet werden. |
+| [print(String printerName, String documentName, PrintSaveOptions options)](#print-java.lang.String-java.lang.String-com.aspose.diagram.PrintSaveOptions-) | Druckt das Dokument, wobei der Standard‑Druckcontroller (keine Benutzeroberfläche) und ein Dokumentname verwendet werden. |
+| [removeHiddenInformation(int item)](#removeHiddenInformation-int-) | Unbenutzte Informationen entfernen |
+| [removeMacro()](#removeMacro--) | Entfernt VBA/Makro aus diesem Diagramm. |
+| [save(OutputStream stream, SaveOptions saveOptions)](#save-java.io.OutputStream-com.aspose.diagram.SaveOptions-) | Speichert das Diagramm im Stream. |
+| [save(OutputStream stream, int format)](#save-java.io.OutputStream-int-) | Speichert das Diagramm im Stream. |
+| [save(String filename, SaveOptions options)](#save-java.lang.String-com.aspose.diagram.SaveOptions-) | Speichert das Dokument in einer Datei unter Verwendung der angegebenen Speicheroptionen. |
+| [save(String filename, int format)](#save-java.lang.String-int-) | Speichert die Diagrammdaten in der Datei. |
+| [setBuildnum(long value)](#setBuildnum-long-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getBuildnum()](../../com.aspose.diagram/diagram\#getBuildnum--) |
+| [setDocLangID(int value)](#setDocLangID-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDocLangID()](../../com.aspose.diagram/diagram\#getDocLangID--) |
+| [setEmailRoutingData(byte[] value)](#setEmailRoutingData-byte---) | Für die Beschreibung dieser Eigenschaft siehe bitte [getEmailRoutingData()](../../com.aspose.diagram/diagram\#getEmailRoutingData--) |
+| [setFontDirs(String[] value)](#setFontDirs-java.lang.String---) | Gibt den Pfad des Schriftartenordners an |
+| [setInterruptMonitor(AbstractInterruptMonitor value)](#setInterruptMonitor-com.aspose.diagram.AbstractInterruptMonitor-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getInterruptMonitor()](../../com.aspose.diagram/diagram\#getInterruptMonitor--) |
+| [setKey(String value)](#setKey-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getKey()](../../com.aspose.diagram/diagram\#getKey--) |
+| [setMetric(int value)](#setMetric-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getMetric()](../../com.aspose.diagram/diagram\#getMetric--) |
+| [setRibbonX(String value)](#setRibbonX-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getRibbonX()](../../com.aspose.diagram/diagram\#getRibbonX--) |
+| [setStart(long value)](#setStart-long-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getStart()](../../com.aspose.diagram/diagram\#getStart--) |
+| [setUserCustomUI(String value)](#setUserCustomUI-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getUserCustomUI()](../../com.aspose.diagram/diagram\#getUserCustomUI--) |
+| [setVbProjectData(byte[] value)](#setVbProjectData-byte---) | Für die Beschreibung dieser Eigenschaft siehe bitte [getVbProjectData()](../../com.aspose.diagram/diagram\#getVbProjectData--) |
+| [setVersion(String value)](#setVersion-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getVersion()](../../com.aspose.diagram/diagram\#getVersion--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Diagram() {#Diagram--}
+```
+public Diagram()
+```
+
+
+### Diagram(String filename) {#Diagram-java.lang.String-}
+```
+public Diagram(String filename)
+```
+
+
+Öffentlicher Klassenkonstruktor, lädt das Diagramm aus der Datei.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Dateiname | java.lang.String | Der Dateiname. |
+
+### Diagram(InputStream stream) {#Diagram-java.io.InputStream-}
+```
+public Diagram(InputStream stream)
+```
+
+
+Öffentlicher Klassenkonstruktor, lädt das Diagramm aus dem Stream.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| stream | java.io.InputStream | Der Datenstrom. |
+
+### Diagram(InputStream stream, int format) {#Diagram-java.io.InputStream-int-}
+```
+public Diagram(InputStream stream, int format)
+```
+
+
+Öffentlicher Klassenkonstruktor, lädt das Diagramm aus dem Stream unter Verwendung eines vordefinierten Formats.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| stream | java.io.InputStream | Der Datenstrom. |
+| Format | int | Die Daten Aspose.Diagram.LoadFileFormat. |
+
+### Diagram(InputStream stream, LoadOptions options) {#Diagram-java.io.InputStream-com.aspose.diagram.LoadOptions-}
+```
+public Diagram(InputStream stream, LoadOptions options)
+```
+
+
+Öffentlicher Klassenkonstruktor, lädt das Diagramm aus dem Stream unter Verwendung vordefinierter Ladeoptionen.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| stream | java.io.InputStream | Der Datenstrom. |
+| options | [LoadOptions](../../com.aspose.diagram/loadoptions) | Die Daten [LoadOptions](../../com.aspose.diagram/loadoptions). |
+
+### Diagram(String filename, int format) {#Diagram-java.lang.String-int-}
+```
+public Diagram(String filename, int format)
+```
+
+
+Öffentlicher Klassenkonstruktor, lädt das Diagramm aus der Datei unter Verwendung eines vordefinierten Formats.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Dateiname | java.lang.String | Der Dateiname. |
+| Format | int | Das Dateiformat. |
+
+### Diagram(String filename, LoadOptions options) {#Diagram-java.lang.String-com.aspose.diagram.LoadOptions-}
+```
+public Diagram(String filename, LoadOptions options)
+```
+
+
+Öffentlicher Klassenkonstruktor, lädt das Diagramm aus der Datei unter Verwendung vordefinierter Ladeoptionen.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Dateiname | java.lang.String | Der Dateiname. |
+| options | [LoadOptions](../../com.aspose.diagram/loadoptions) | Die Daten [LoadOptions](../../com.aspose.diagram/loadoptions). |
+
+### addMaster(Diagram srcDiagram, String masterName) {#addMaster-com.aspose.diagram.Diagram-java.lang.String-}
+```
+public int addMaster(Diagram srcDiagram, String masterName)
+```
+
+
+Fügt dem Diagramm ein Master aus dem Quelldiagramm anhand des Namens oder NameU des Masters hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| srcDiagram | [Diagram](../../com.aspose.diagram/diagram) | Quell-Diagramm. |
+| masterName | java.lang.String | Name des Masters oder NameU. |
+
+**Returns:**
+int – Die eindeutige ID des Masters innerhalb der Masters‑Sammlung in diesem Diagramm.
+### addMaster(InputStream templateStream, int masterID) {#addMaster-java.io.InputStream-int-}
+```
+public int addMaster(InputStream templateStream, int masterID)
+```
+
+
+Fügt dem Diagramm ein Master aus dem Vorlagen-Stream anhand der ID des Masters hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| templateStream | java.io.InputStream | Template-Stream. |
+| masterID | int | Die eindeutige ID des Masters innerhalb der Masters‑Sammlung in der Vorlage. |
+
+**Returns:**
+int – Die eindeutige ID des Masters innerhalb der Masters‑Sammlung in diesem Diagramm.
+### addMaster(InputStream templateStream, String masterName) {#addMaster-java.io.InputStream-java.lang.String-}
+```
+public int addMaster(InputStream templateStream, String masterName)
+```
+
+
+Fügt dem Diagramm ein Master aus dem Vorlagen-Stream anhand des Namens oder NameU des Masters hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| templateStream | java.io.InputStream | Template-Stream. |
+| masterName | java.lang.String | Name des Masters oder NameU. |
+
+**Returns:**
+int – Die eindeutige ID des Masters innerhalb der Masters‑Sammlung in diesem Diagramm.
+### addMaster(String templateFilePath, int masterID) {#addMaster-java.lang.String-int-}
+```
+public int addMaster(String templateFilePath, int masterID)
+```
+
+
+Fügt dem Diagramm ein Master aus der Vorlagendatei anhand der ID des Masters hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| templateFilePath | java.lang.String | Pfad zur Vorlagendatei(kann das Format vdx, vst oder vsd sein). |
+| masterID | int | Die eindeutige ID des Masters innerhalb der Masters‑Sammlung in der Vorlage. |
+
+**Returns:**
+int – Die eindeutige ID des Masters innerhalb der Masters‑Sammlung in diesem Diagramm.
+### addMaster(String templateFilePath, String masterName) {#addMaster-java.lang.String-java.lang.String-}
+```
+public int addMaster(String templateFilePath, String masterName)
+```
+
+
+Fügt dem Diagramm ein Master aus der Vorlagendatei anhand des Namens oder NameU des Masters hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| templateFilePath | java.lang.String | Pfad zur Vorlagendatei(kann das Format vdx, vst oder vsd sein). |
+| masterName | java.lang.String | Name des Masters oder NameU. |
+
+**Returns:**
+int – Die eindeutige ID des Masters innerhalb der Masters‑Sammlung in diesem Diagramm.
+### addShape(Shape newShape, String masterName, int pageNumber) {#addShape-com.aspose.diagram.Shape-java.lang.String-int-}
+```
+public long addShape(Shape newShape, String masterName, int pageNumber)
+```
+
+
+Fügt ein vom Master erstelltes Shape zu einer bestimmten Seite hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| newShape | [Shape](../../com.aspose.diagram/shape) | Neues Formobjekt[Shape](../../com.aspose.diagram/shape). |
+| masterName | java.lang.String | Name des Masters. |
+| pageNumber | int | Index der Seite. |
+
+**Returns:**
+long - Die eindeutige ID der Form innerhalb der Formensammlung auf der angegebenen Seite.
+### addShape(double pinX, double pinY, double width, double height, String masterName, int pageNumber) {#addShape-double-double-double-double-java.lang.String-int-}
+```
+public long addShape(double pinX, double pinY, double width, double height, String masterName, int pageNumber)
+```
+
+
+Fügt ein vom Master erstelltes Shape auf einer Seite mit definierten PinX, PinY, Breite und Höhe hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| pinX | double | Gibt die x‑Koordinate des Pins der Form (Rotationszentrum) in Bezug auf die Seite an. |
+| pinY | double | Gibt die y‑Koordinate des Pins der Form (Rotationszentrum) in Bezug auf die Seite an. |
+| Breite | double | Gibt die Breite der Form in Zoll an. |
+| Höhe | double | Gibt die Höhe der Form in Zoll an. |
+| masterName | java.lang.String | Name des Masters. |
+| pageNumber | int | Index der Seite. |
+
+**Returns:**
+long - Die eindeutige ID der Form innerhalb der Formensammlung auf der angegebenen Seite.
+### addShape(double pinX, double pinY, String masterName, int pageNumber) {#addShape-double-double-java.lang.String-int-}
+```
+public long addShape(double pinX, double pinY, String masterName, int pageNumber)
+```
+
+
+Fügt ein vom Master erstelltes Shape auf einer Seite mit definierten PinX und PinY hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| pinX | double | Gibt die x‑Koordinate des Pins der Form (Rotationszentrum) in Bezug auf die Seite an. |
+| pinY | double | Gibt die y‑Koordinate des Pins der Form (Rotationszentrum) in Bezug auf die Seite an. |
+| masterName | java.lang.String | Name des Masters. |
+| pageNumber | int | Index der Seite. |
+
+**Returns:**
+long - Die eindeutige ID der Form innerhalb der Formensammlung auf der angegebenen Seite.
+### combine(Diagram secondDiagram) {#combine-com.aspose.diagram.Diagram-}
+```
+public void combine(Diagram secondDiagram)
+```
+
+
+Kombiniert ein weiteres Diagrammobjekt.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| secondDiagram | [Diagram](../../com.aspose.diagram/diagram) | Ein weiteres Diagramm-Objekt. |
+
+### copyTheme(Diagram source) {#copyTheme-com.aspose.diagram.Diagram-}
+```
+public void copyTheme(Diagram source)
+```
+
+
+Kopiert das Theme aus einem Quell-Diagramm.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| source | [Diagram](../../com.aspose.diagram/diagram) | Quell-Diagramm. |
+
+### dispose() {#dispose--}
+```
+public void dispose()
+```
+
+
+Führt anwendungsspezifische Aufgaben aus, die mit dem Freigeben, Freisetzen oder Zurücksetzen nicht verwalteter Ressourcen verbunden sind.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### export(InputStream inputVsd, InputStream outputVdw) {#export-java.io.InputStream-java.io.InputStream-}
+```
+public static void export(InputStream inputVsd, InputStream outputVdw)
+```
+
+
+Exportiert das Diagramm vom vsd-Stream in das vdw-Stream-Format. Noch nicht implementiert.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| inputVsd | java.io.InputStream | vsd-Stream. |
+| outputVdw | java.io.InputStream | vdw-Stream. |
+
+### export(InputStream inputVsd, String outputVdw) {#export-java.io.InputStream-java.lang.String-}
+```
+public static void export(InputStream inputVsd, String outputVdw)
+```
+
+
+Exportiert das Diagramm vom vsd-Stream in das \*.vdw-Dateiformat. Noch nicht implementiert.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| inputVsd | java.io.InputStream | \*.vsd-Dateiname. |
+| outputVdw | java.lang.String | vdw-Stream. |
+
+### export(String inputVsd, InputStream outputVdw) {#export-java.lang.String-java.io.InputStream-}
+```
+public static void export(String inputVsd, InputStream outputVdw)
+```
+
+
+Exportiert das Diagramm von einer vsd-Datei in das vdw-Stream-Format. Noch nicht implementiert.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| inputVsd | java.lang.String | \*.vsd-Dateiname. |
+| outputVdw | java.io.InputStream | vdw-Stream. |
+
+### export(String inputVsd, String outputVdw) {#export-java.lang.String-java.lang.String-}
+```
+public static void export(String inputVsd, String outputVdw)
+```
+
+
+Exportiert das Diagramm von vsd nach vdw-Format. Noch nicht implementiert.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| inputVsd | java.lang.String | \*.vsd-Dateiname. |
+| outputVdw | java.lang.String | \*.vdw-Dateiname. |
+
+### getActivePage() {#getActivePage--}
+```
+public Page getActivePage()
+```
+
+
+Gibt die aktive Seite an
+
+**Returns:**
+[Page](../../com.aspose.diagram/page)
+### getBuildnum() {#getBuildnum--}
+```
+public long getBuildnum()
+```
+
+
+Die Build-Nummer der Visio-Instanz, die zum Erstellen des Dokuments verwendet wurde.
+
+**Returns:**
+long
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColors() {#getColors--}
+```
+public ColorEntryCollection getColors()
+```
+
+
+Enthält die Farbtabelle des Dokuments. Jedes Dokument enthält eine einzelne Farbtabelle, die die 24 Standardfarben auflistet, die für Objekte wie Formen, Text und Ebenen im Dokument verwendet werden können.
+
+**Returns:**
+[ColorEntryCollection](../../com.aspose.diagram/colorentrycollection)
+### getDataConnections() {#getDataConnections--}
+```
+public DataConnectionCollection getDataConnections()
+```
+
+
+Enthält die DataConnection-Elemente für das Dokument.
+
+**Returns:**
+[DataConnectionCollection](../../com.aspose.diagram/dataconnectioncollection)
+### getDataRecordSets() {#getDataRecordSets--}
+```
+public DataRecordSetCollection getDataRecordSets()
+```
+
+
+Die Sammlung von DataRecordset-Objekten, die mit einem Document-Objekt verknüpft sind.
+
+**Returns:**
+[DataRecordSetCollection](../../com.aspose.diagram/datarecordsetcollection)
+### getDefaultFontDir() {#getDefaultFontDir--}
+```
+public String getDefaultFontDir()
+```
+
+
+Rufe den Pfad des Standard-Schriftartenordners ab
+
+**Returns:**
+java.lang.String
+### getDocLangID() {#getDocLangID--}
+```
+public int getDocLangID()
+```
+
+
+Die eindeutige ID der Benutzeroberflächensprache, die der Benutzer in den Microsoft Office 2010 Language Preferences angegeben hat.
+
+**Returns:**
+int
+### getDocumentProps() {#getDocumentProps--}
+```
+public DocumentProperties getDocumentProps()
+```
+
+
+Enthält Dokumenteigenschaftselemente wie den Titel, den Autor usw. des Dokuments.
+
+**Returns:**
+[DocumentProperties](../../com.aspose.diagram/documentproperties)
+### getDocumentSettings() {#getDocumentSettings--}
+```
+public DocumentSettings getDocumentSettings()
+```
+
+
+Enthält Elemente, die Dokumenteinstellungen festlegen.
+
+**Returns:**
+[DocumentSettings](../../com.aspose.diagram/documentsettings)
+### getDocumentSheet() {#getDocumentSheet--}
+```
+public DocumentSheet getDocumentSheet()
+```
+
+
+Gibt die ShapeSheet-Struktur eines Dokuments an.
+
+**Returns:**
+[DocumentSheet](../../com.aspose.diagram/documentsheet)
+### getEmailRoutingData() {#getEmailRoutingData--}
+```
+public byte[] getEmailRoutingData()
+```
+
+
+Enthält einen MIME (Multipurpose Internet Mail Extensions) codierten MAPI-E-Mail-Routing-Slip für das Dokument.
+
+**Returns:**
+byte[]
+### getEventItems() {#getEventItems--}
+```
+public EventItemCollection getEventItems()
+```
+
+
+Enthält ein EventItem-Element für jedes Ereignis, auf das ein Objekt reagieren soll.
+
+**Returns:**
+[EventItemCollection](../../com.aspose.diagram/eventitemcollection)
+### getFonts() {#getFonts--}
+```
+public FontCollection getFonts()
+```
+
+
+Enthält eine Sammlung von Font-Elementen
+
+**Returns:**
+[FontCollection](../../com.aspose.diagram/fontcollection)
+### getHeaderFooter() {#getHeaderFooter--}
+```
+public HeaderFooter getHeaderFooter()
+```
+
+
+Enthält Elemente für die Kopf- und Fußzeile eines Dokuments.
+
+**Returns:**
+[HeaderFooter](../../com.aspose.diagram/headerfooter)
+### getInterruptMonitor() {#getInterruptMonitor--}
+```
+public AbstractInterruptMonitor getInterruptMonitor()
+```
+
+
+der Interrupt-Monitor.
+
+**Returns:**
+[AbstractInterruptMonitor](../../com.aspose.diagram/abstractinterruptmonitor)
+### getKey() {#getKey--}
+```
+public String getKey()
+```
+
+
+Gibt an, ob das Dokument außerhalb von Visio geändert wurde. Falls vorhanden, prüft Visio den Inhalt der Datei vollständig. Für Dateien, die Sie außerhalb von Visio erstellen, weglassen.
+
+**Returns:**
+java.lang.String
+### getMasters() {#getMasters--}
+```
+public MasterCollection getMasters()
+```
+
+
+Sammlung von Master-Objekten.
+
+**Returns:**
+[MasterCollection](../../com.aspose.diagram/mastercollection)
+### getMetric() {#getMetric--}
+```
+public int getMetric()
+```
+
+
+Gibt an, ob im Diagramm metrische Einheiten verwendet werden sollen. Setzen Sie dieses Attribut auf True (1), um metrische Einheiten zu verwenden; setzen Sie es auf False (0), um englische Einheiten zu verwenden.
+
+**Returns:**
+int
+### getPages() {#getPages--}
+```
+public PageCollection getPages()
+```
+
+
+Sammlung von Page-Objekten.
+
+**Returns:**
+[PageCollection](../../com.aspose.diagram/pagecollection)
+### getRibbonX() {#getRibbonX--}
+```
+public String getRibbonX()
+```
+
+
+Der Ribbon-XML-String, der an das Dokument übergeben wird, um die Ribbon-Benutzeroberfläche anzupassen.
+
+**Returns:**
+java.lang.String
+### getSolutionXMLs() {#getSolutionXMLs--}
+```
+public SolutionXMLCollection getSolutionXMLs()
+```
+
+
+XML-Wert.
+
+**Returns:**
+[SolutionXMLCollection](../../com.aspose.diagram/solutionxmlcollection)
+### getStart() {#getStart--}
+```
+public long getStart()
+```
+
+
+Gibt an, ob das Dokument außerhalb von Visio geändert wurde. Falls vorhanden, prüft Visio den Inhalt der Datei vollständig. Für Dateien, die Sie außerhalb von Visio erstellen, weglassen.
+
+**Returns:**
+long
+### getStyleSheets() {#getStyleSheets--}
+```
+public StyleSheetCollection getStyleSheets()
+```
+
+
+Sammlung von StyleSheet-Objekten.
+
+**Returns:**
+[StyleSheetCollection](../../com.aspose.diagram/stylesheetcollection)
+### getUnusedStyles() {#getUnusedStyles--}
+```
+public StyleSheetCollection getUnusedStyles()
+```
+
+
+Unbenutzte Stile abrufen
+
+**Returns:**
+[StyleSheetCollection](../../com.aspose.diagram/stylesheetcollection)
+### getUserCustomUI() {#getUserCustomUI--}
+```
+public String getUserCustomUI()
+```
+
+
+Der Ribbon-XML-String, der an das Dokument übergeben wird, um die Symbolleiste für den Schnellzugriff oder das Ribbon anzupassen.
+
+**Returns:**
+java.lang.String
+### getValidation() {#getValidation--}
+```
+public Validation getValidation()
+```
+
+
+Speichert Informationen zur Diagrammvalidierung für das Dokument.
+
+**Returns:**
+[Validation](../../com.aspose.diagram/validation)
+### getVbProjectData() {#getVbProjectData--}
+```
+public byte[] getVbProjectData()
+```
+
+
+Enthält die Microsoft Visual Basic for Applications-Projektdaten im MIME (Multipurpose Internet Mail Extensions)-kodierten Format.
+
+**Returns:**
+byte[]
+### getVbaProject() {#getVbaProject--}
+```
+public VbaProject getVbaProject()
+```
+
+
+Ruft das VbaProject[getVbaProject()](../../com.aspose.diagram/diagram\#getVbaProject--) ab.
+
+**Returns:**
+[VbaProject](../../com.aspose.diagram/vbaproject)
+### getVersion() {#getVersion--}
+```
+public String getVersion()
+```
+
+
+Die Versionsnummer der Visio-Instanz. Microsoft Visio 2010 = 14.
+
+**Returns:**
+java.lang.String
+### getWindows() {#getWindows--}
+```
+public WindowCollection getWindows()
+```
+
+
+Enthält die Window-Elemente für ein Dokument.
+
+**Returns:**
+[WindowCollection](../../com.aspose.diagram/windowcollection)
+### hasHiddenInfo() {#hasHiddenInfo--}
+```
+public boolean hasHiddenInfo()
+```
+
+
+Gibt an, ob dieses Diagramm versteckte Informationen enthält.
+
+**Returns:**
+boolean
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### layout(LayoutOptions options) {#layout-com.aspose.diagram.LayoutOptions-}
+```
+public void layout(LayoutOptions options)
+```
+
+
+Ordnet die Formen an und/oder leitet die Verbinder für alle Seiten des Diagramms neu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| options | [LayoutOptions](../../com.aspose.diagram/layoutoptions) | Verwendung von [LayoutOptions](../../com.aspose.diagram/layoutoptions), um Layout‑Optionen zu konfigurieren. |
+
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### print(String printerName) {#print-java.lang.String-}
+```
+public void print(String printerName)
+```
+
+
+Druckt das gesamte Dokument an den angegebenen Drucker, wobei der Standard‑Druckcontroller (ohne Benutzeroberfläche) verwendet wird. Wenn printerName Null oder leer ist, wird der Standarddrucker verwendet.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| printerName | java.lang.String | Der Name des Druckers. Kann Null sein. |
+
+### print(String printerName, PrintSaveOptions options) {#print-java.lang.String-com.aspose.diagram.PrintSaveOptions-}
+```
+public void print(String printerName, PrintSaveOptions options)
+```
+
+
+Druckt das gesamte Dokument an den angegebenen Drucker, wobei der Standard‑Druckcontroller (ohne Benutzeroberfläche) verwendet wird. Wenn printerName Null oder leer ist, wird der Standarddrucker verwendet.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| printerName | java.lang.String | Der Name des Druckers. Kann Null sein. |
+| options | [PrintSaveOptions](../../com.aspose.diagram/printsaveoptions) | Die Druckoptionen. |
+
+### print(String printerName, String documentName) {#print-java.lang.String-java.lang.String-}
+```
+public void print(String printerName, String documentName)
+```
+
+
+Druckt das Dokument, wobei der Standard‑Druckcontroller (keine Benutzeroberfläche) und ein Dokumentname verwendet werden.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| printerName | java.lang.String | Der Name des Druckers. Kann Null sein. |
+| documentName | java.lang.String | Der Dokumentname, der beim Drucken des Dokuments angezeigt wird (z. B. in einem Druckstatus‑Dialogfeld oder in der Druckwarteschlange). |
+
+### print(String printerName, String documentName, PrintSaveOptions options) {#print-java.lang.String-java.lang.String-com.aspose.diagram.PrintSaveOptions-}
+```
+public void print(String printerName, String documentName, PrintSaveOptions options)
+```
+
+
+Druckt das Dokument, wobei der Standard‑Druckcontroller (keine Benutzeroberfläche) und ein Dokumentname verwendet werden.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| printerName | java.lang.String | Der Name des Druckers. Kann Null sein. |
+| documentName | java.lang.String | Der Dokumentname, der beim Drucken des Dokuments angezeigt wird (z. B. in einem Druckstatus‑Dialogfeld oder in der Druckwarteschlange). |
+| options | [PrintSaveOptions](../../com.aspose.diagram/printsaveoptions) | Die Druckoptionen. |
+
+### removeHiddenInformation(int item) {#removeHiddenInformation-int-}
+```
+public void removeHiddenInformation(int item)
+```
+
+
+Unbenutzte Informationen entfernen
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | int | RemoveHiddenInfoItem. |
+
+### removeMacro() {#removeMacro--}
+```
+public void removeMacro()
+```
+
+
+Entfernt VBA/Makro aus diesem Diagramm.
+
+### save(OutputStream stream, SaveOptions saveOptions) {#save-java.io.OutputStream-com.aspose.diagram.SaveOptions-}
+```
+public void save(OutputStream stream, SaveOptions saveOptions)
+```
+
+
+Speichert das Diagramm im Stream.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| stream | java.io.OutputStream | Der Dateistream. |
+| saveOptions | [SaveOptions](../../com.aspose.diagram/saveoptions) | Die Speicheroptionen. |
+
+### save(OutputStream stream, int format) {#save-java.io.OutputStream-int-}
+```
+public void save(OutputStream stream, int format)
+```
+
+
+Speichert das Diagramm im Stream.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| stream | java.io.OutputStream | Der Dateistream. |
+| Format | int |  |
+
+### save(String filename, SaveOptions options) {#save-java.lang.String-com.aspose.diagram.SaveOptions-}
+```
+public void save(String filename, SaveOptions options)
+```
+
+
+Speichert das Dokument in einer Datei unter Verwendung der angegebenen Speicheroptionen.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Dateiname | java.lang.String | Der Dateiname. |
+| options | [SaveOptions](../../com.aspose.diagram/saveoptions) | [SaveOptions](../../com.aspose.diagram/saveoptions) Diagrammspeicheroptionen. |
+
+### save(String filename, int format) {#save-java.lang.String-int-}
+```
+public void save(String filename, int format)
+```
+
+
+Speichert die Diagrammdaten in der Datei.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Dateiname | java.lang.String | Der Dateiname. |
+| Format | int | Aspose.Diagram.SaveFileFormat Speicherdateiformat. |
+
+### setBuildnum(long value) {#setBuildnum-long-}
+```
+public void setBuildnum(long value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getBuildnum()](../../com.aspose.diagram/diagram\#getBuildnum--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | long |  |
+
+### setDocLangID(int value) {#setDocLangID-int-}
+```
+public void setDocLangID(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDocLangID()](../../com.aspose.diagram/diagram\#getDocLangID--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setEmailRoutingData(byte[] value) {#setEmailRoutingData-byte---}
+```
+public void setEmailRoutingData(byte[] value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getEmailRoutingData()](../../com.aspose.diagram/diagram\#getEmailRoutingData--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | byte[] |  |
+
+### setFontDirs(String[] value) {#setFontDirs-java.lang.String---}
+```
+public void setFontDirs(String[] value)
+```
+
+
+Gibt den Pfad des Schriftartenordners an
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String[] |  |
+
+### setInterruptMonitor(AbstractInterruptMonitor value) {#setInterruptMonitor-com.aspose.diagram.AbstractInterruptMonitor-}
+```
+public void setInterruptMonitor(AbstractInterruptMonitor value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getInterruptMonitor()](../../com.aspose.diagram/diagram\#getInterruptMonitor--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [AbstractInterruptMonitor](../../com.aspose.diagram/abstractinterruptmonitor) |  |
+
+### setKey(String value) {#setKey-java.lang.String-}
+```
+public void setKey(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getKey()](../../com.aspose.diagram/diagram\#getKey--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setMetric(int value) {#setMetric-int-}
+```
+public void setMetric(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getMetric()](../../com.aspose.diagram/diagram\#getMetric--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setRibbonX(String value) {#setRibbonX-java.lang.String-}
+```
+public void setRibbonX(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getRibbonX()](../../com.aspose.diagram/diagram\#getRibbonX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setStart(long value) {#setStart-long-}
+```
+public void setStart(long value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getStart()](../../com.aspose.diagram/diagram\#getStart--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | long |  |
+
+### setUserCustomUI(String value) {#setUserCustomUI-java.lang.String-}
+```
+public void setUserCustomUI(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getUserCustomUI()](../../com.aspose.diagram/diagram\#getUserCustomUI--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setVbProjectData(byte[] value) {#setVbProjectData-byte---}
+```
+public void setVbProjectData(byte[] value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getVbProjectData()](../../com.aspose.diagram/diagram\#getVbProjectData--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | byte[] |  |
+
+### setVersion(String value) {#setVersion-java.lang.String-}
+```
+public void setVersion(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getVersion()](../../com.aspose.diagram/diagram\#getVersion--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/diagramexception/_index.md
+++ b/german/java/com.aspose.diagram/diagramexception/_index.md
@@ -1,0 +1,290 @@
+---
+title: DiagramException
+second_title: Aspose.Diagram for Java API-Referenz
+description: Basisklasse für alle Aspose.Diagram-Ausnahmen
+type: docs
+weight: 118
+url: /de/java/com.aspose.diagram/diagramexception/
+---
+
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception
+```
+public class DiagramException extends Exception
+```
+
+Basisklasse für alle Aspose.Diagram-Ausnahmen
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [DiagramException(String msg)](#DiagramException-java.lang.String-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DiagramException(String msg) {#DiagramException-java.lang.String-}
+```
+public DiagramException(String msg)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| msg | java.lang.String |  |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/diagramsaveoptions/_index.md
+++ b/german/java/com.aspose.diagram/diagramsaveoptions/_index.md
@@ -1,0 +1,268 @@
+---
+title: DiagramSaveOptions
+second_title: Aspose.Diagram for Java API-Referenz
+description: Kann verwendet werden, um zusätzliche Optionen beim Speichern eines Diagramms im Visio VDXVSX-Format anzugeben.
+type: docs
+weight: 119
+url: /de/java/com.aspose.diagram/diagramsaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.SaveOptions](../../com.aspose.diagram/saveoptions)
+```
+public class DiagramSaveOptions extends SaveOptions
+```
+
+Kann verwendet werden, um zusätzliche Optionen beim Speichern eines Diagramms im Visio (VDX\\VSX)-Format anzugeben. Derzeit wird nur die Eigenschaft SaveFormat bereitgestellt, aber in Zukunft werden weitere Optionen hinzugefügt.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [DiagramSaveOptions()](#DiagramSaveOptions--) | Initialisiert eine neue Instanz dieser Klasse, die zum Speichern eines Diagramms im VDX-Format verwendet werden kann. |
+| [DiagramSaveOptions(int saveFormat)](#DiagramSaveOptions-int-) | Initialisiert eine neue Instanz dieser Klasse, die zum Speichern eines Diagramms im VDX- oder VSX-Format verwendet werden kann. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | Erstellt ein Speicheroptionen-Objekt einer Klasse, die für das angegebene Speicherformat geeignet ist. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAutoFitPageToDrawingContent()](#getAutoFitPageToDrawingContent--) | Definiert, ob die Seite vergrößert werden muss, um den Zeicheninhalt anzupassen, oder nicht. |
+| [getClass()](#getClass--) |  |
+| [getDefaultFont()](#getDefaultFont--) | Wenn Zeichen im Diagramm Unicode sind und nicht mit dem korrekten Schriftwert gesetzt werden oder die Schriftart nicht lokal installiert ist, können sie in PDF, Bild oder XPS als Block erscheinen. |
+| [getSaveFormat()](#getSaveFormat--) | Gibt das Format an, in dem das gerenderte Diagramm gespeichert wird, wenn dieses Speicheroptionen-Objekt verwendet wird. |
+| [getWarningCallback()](#getWarningCallback--) | Warnungs-Callback. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAutoFitPageToDrawingContent(boolean value)](#setAutoFitPageToDrawingContent-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getAutoFitPageToDrawingContent()](../../com.aspose.diagram/diagramsaveoptions\#getAutoFitPageToDrawingContent--) |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDefaultFont()](../../com.aspose.diagram/saveoptions\\#getDefaultFont--) |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getSaveFormat()](../../com.aspose.diagram/diagramsaveoptions\#getSaveFormat--) |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DiagramSaveOptions() {#DiagramSaveOptions--}
+```
+public DiagramSaveOptions()
+```
+
+
+Initialisiert eine neue Instanz dieser Klasse, die zum Speichern eines Diagramms im VDX-Format verwendet werden kann.
+
+### DiagramSaveOptions(int saveFormat) {#DiagramSaveOptions-int-}
+```
+public DiagramSaveOptions(int saveFormat)
+```
+
+
+Initialisiert eine neue Instanz dieser Klasse, die zum Speichern eines Diagramms im VDX- oder VSX-Format verwendet werden kann.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| saveFormat | int |  |
+
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+Erstellt ein Speicheroptionen-Objekt einer Klasse, die für das angegebene Speicherformat geeignet ist.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| saveFormat | int | Das Aspose.Diagram.SaveFileFormat, für das ein Save-Optionen-Objekt erstellt werden soll. |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAutoFitPageToDrawingContent() {#getAutoFitPageToDrawingContent--}
+```
+public boolean getAutoFitPageToDrawingContent()
+```
+
+
+Definiert, ob die Seite vergrößert werden muss, um den Zeicheninhalt anzupassen, oder nicht. Der Standardwert ist false.
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+Wenn Zeichen im Diagramm Unicode sind und nicht mit dem korrekten Schriftwert gesetzt werden oder die Schriftart nicht lokal installiert ist, können sie im PDF, Bild oder XPS als Block erscheinen. Setzen Sie die DefaultFont, z. B. MingLiu oder MS Gothic, um diese Zeichen anzuzeigen.
+
+**Returns:**
+java.lang.String
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+Gibt das Format an, in dem das gerenderte Diagramm gespeichert wird, wenn dieses Speicheroptionen-Objekt verwendet wird. Kann Aspose.Diagram.SaveFileFormat oder Aspose.Diagram.SaveFileFormat sein.
+
+**Returns:**
+int
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+Warnungs-Callback.
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAutoFitPageToDrawingContent(boolean value) {#setAutoFitPageToDrawingContent-boolean-}
+```
+public void setAutoFitPageToDrawingContent(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getAutoFitPageToDrawingContent()](../../com.aspose.diagram/diagramsaveoptions\#getAutoFitPageToDrawingContent--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDefaultFont()](../../com.aspose.diagram/saveoptions\\#getDefaultFont--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getSaveFormat()](../../com.aspose.diagram/diagramsaveoptions\#getSaveFormat--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/displaymode/_index.md
+++ b/german/java/com.aspose.diagram/displaymode/_index.md
@@ -1,0 +1,179 @@
+---
+title: DisplayMode
+second_title: Aspose.Diagram for Java API-Referenz
+description: Wenn es in einem Group-Element enthalten ist, gibt das DisplayMode-Element an, wie ein Gruppen-Shape und seine Mitglieder angezeigt werden.
+type: docs
+weight: 120
+url: /de/java/com.aspose.diagram/displaymode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DisplayMode
+```
+
+Wenn es in einem Group-Element enthalten ist, gibt das DisplayMode-Element an, wie ein Gruppen-Shape und seine Mitglieder angezeigt werden. Wenn es in einem SmartTagDef-Element enthalten ist, bestimmt das DisplayMode-Element, ob das Smart-Tag erscheint, wenn der Benutzer die Maus über das Tag hält, wenn das Shape ausgewählt ist oder die ganze Zeit.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [DisplayMode(int value)](#DisplayMode-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Wenn es in einem Group-Element enthalten ist, gibt das DisplayMode-Element an, wie eine Gruppierung und ihre Mitglieder angezeigt werden. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/displaymode\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DisplayMode(int value) {#DisplayMode-int-}
+```
+public DisplayMode(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Wenn es in einem Group-Element enthalten ist, gibt das DisplayMode-Element an, wie ein Gruppen-Shape und seine Mitglieder angezeigt werden. Wenn es in einem SmartTagDef-Element enthalten ist, bestimmt das DisplayMode-Element, ob das Smart-Tag erscheint, wenn der Benutzer die Maus über das Tag hält, wenn das Shape ausgewählt ist oder die ganze Zeit.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/displaymode\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/displaymodesmarttagdef/_index.md
+++ b/german/java/com.aspose.diagram/displaymodesmarttagdef/_index.md
@@ -1,0 +1,179 @@
+---
+title: DisplayModeSmartTagDef
+second_title: Aspose.Diagram for Java API-Referenz
+description: Das DisplayMode-Element bestimmt, ob das Smart-Tag erscheint, wenn der Benutzer die Maus über das Tag hält, während die Form ausgewählt ist, oder die ganze Zeit.
+type: docs
+weight: 121
+url: /de/java/com.aspose.diagram/displaymodesmarttagdef/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DisplayModeSmartTagDef
+```
+
+Das DisplayMode-Element bestimmt, ob das Smart-Tag erscheint, wenn der Benutzer die Maus über das Tag hält, wenn die Form ausgewählt ist oder die ganze Zeit.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [DisplayModeSmartTagDef(int value)](#DisplayModeSmartTagDef-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Das DisplayMode-Element bestimmt, ob das Smart-Tag erscheint, wenn der Benutzer die Maus über das Tag hält, wenn die Form ausgewählt ist oder die ganze Zeit. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/displaymodesmarttagdef\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DisplayModeSmartTagDef(int value) {#DisplayModeSmartTagDef-int-}
+```
+public DisplayModeSmartTagDef(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Das DisplayMode-Element bestimmt, ob das Smart-Tag erscheint, wenn der Benutzer die Maus über das Tag hält, wenn die Form ausgewählt ist oder die ganze Zeit.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/displaymodesmarttagdef\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/displaymodesmarttagdefvalue/_index.md
+++ b/german/java/com.aspose.diagram/displaymodesmarttagdefvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: DisplayModeSmartTagDefValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Das DisplayMode-Element bestimmt, ob das Smart-Tag erscheint, wenn der Benutzer die Maus über das Tag hält, während die Form ausgewählt ist, oder die ganze Zeit.
+type: docs
+weight: 122
+url: /de/java/com.aspose.diagram/displaymodesmarttagdefvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class DisplayModeSmartTagDefValue
+```
+
+Das DisplayMode-Element bestimmt, ob das Smart-Tag erscheint, wenn der Benutzer die Maus über das Tag hält, wenn die Form ausgewählt ist oder die ganze Zeit.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [ALL_TIME](#ALL-TIME) | Zeigt die Gruppenform vor den Mitgliedsformen an. |
+| [MOUSE_IS_PAUSED](#MOUSE-IS-PAUSED) | Versteckt die Gruppenform und den Text. |
+| [SHAPE_IS_SELECTED](#SHAPE-IS-SELECTED) | Zeigt die Gruppenform hinter den Mitgliedsformen an. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALL_TIME {#ALL-TIME}
+```
+public static final int ALL_TIME
+```
+
+
+Zeigt die Gruppenform vor den Mitgliedsformen an.
+
+### MOUSE_IS_PAUSED {#MOUSE-IS-PAUSED}
+```
+public static final int MOUSE_IS_PAUSED
+```
+
+
+Versteckt die Gruppenform und den Text.
+
+### SHAPE_IS_SELECTED {#SHAPE-IS-SELECTED}
+```
+public static final int SHAPE_IS_SELECTED
+```
+
+
+Zeigt die Gruppenform hinter den Mitgliedsformen an.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/displaymodevalue/_index.md
+++ b/german/java/com.aspose.diagram/displaymodevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: DisplayModeValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Wenn es in einem Group-Element enthalten ist, gibt das DisplayMode-Element an, wie ein Gruppen-Shape und seine Mitglieder angezeigt werden.
+type: docs
+weight: 123
+url: /de/java/com.aspose.diagram/displaymodevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class DisplayModeValue
+```
+
+Wenn es in einem Group-Element enthalten ist, gibt das DisplayMode-Element an, wie ein Gruppen-Shape und seine Mitglieder angezeigt werden. Wenn es in einem SmartTagDef-Element enthalten ist, bestimmt das DisplayMode-Element, ob das Smart-Tag erscheint, wenn der Benutzer die Maus über das Tag hält, wenn das Shape ausgewählt ist oder die ganze Zeit.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [DISPLAYS_SHAPE_BEHIND_MEMBER_SHAPES](#DISPLAYS-SHAPE-BEHIND-MEMBER-SHAPES) | Zeigt die Gruppenform hinter den Mitgliedsformen an. |
+| [DISPLAYS_SHAPE_FRONT_MEMBER_SHAPES](#DISPLAYS-SHAPE-FRONT-MEMBER-SHAPES) | Zeigt die Gruppenform vor den Mitgliedsformen an. |
+| [HIDES_SHAPE_TEXT](#HIDES-SHAPE-TEXT) | Versteckt die Gruppenform und den Text. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DISPLAYS_SHAPE_BEHIND_MEMBER_SHAPES {#DISPLAYS-SHAPE-BEHIND-MEMBER-SHAPES}
+```
+public static final int DISPLAYS_SHAPE_BEHIND_MEMBER_SHAPES
+```
+
+
+Zeigt die Gruppenform hinter den Mitgliedsformen an.
+
+### DISPLAYS_SHAPE_FRONT_MEMBER_SHAPES {#DISPLAYS-SHAPE-FRONT-MEMBER-SHAPES}
+```
+public static final int DISPLAYS_SHAPE_FRONT_MEMBER_SHAPES
+```
+
+
+Zeigt die Gruppenform vor den Mitgliedsformen an.
+
+### HIDES_SHAPE_TEXT {#HIDES-SHAPE-TEXT}
+```
+public static final int HIDES_SHAPE_TEXT
+```
+
+
+Versteckt die Gruppenform und den Text.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/docprops/_index.md
+++ b/german/java/com.aspose.diagram/docprops/_index.md
@@ -1,0 +1,227 @@
+---
+title: DocProps
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält Elemente, die den Vorschaubereich der Dokumentqualität und das Ausgabeformat steuern.
+type: docs
+weight: 124
+url: /de/java/com.aspose.diagram/docprops/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DocProps
+```
+
+Enthält Elemente, die die Vorschauqualität, den Umfang und das Ausgabeformat des Dokuments steuern.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAddMarkup()](#getAddMarkup--) | Gibt an, ob das Dokument auf Markup überprüft wird. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getDocLangID()](#getDocLangID--) | Gibt die Standardsprache für das Dokument an. |
+| [getLockPreview()](#getLockPreview--) | Gibt an, ob bei jedem Speichern einer Zeichnung eine Vorschau gespeichert wird. |
+| [getOutputFormat()](#getOutputFormat--) | Gibt das Ausgabeformat für eine Zeichnung an. |
+| [getPreviewQuality()](#getPreviewQuality--) | Gibt an, ob die Zeichnungsvorschau in Entwurfsqualität oder detailliert ist. |
+| [getPreviewScope()](#getPreviewScope--) | Gibt an, ob das Dokument eine Vorschau enthält und, falls ja, ob die Vorschau nur die erste Seite oder alle Seiten im Dokument zeigt. |
+| [getViewMarkup()](#getViewMarkup--) | Bestimmt, ob Markup im Zeichenfenster angezeigt wird. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/docprops\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAddMarkup() {#getAddMarkup--}
+```
+public BoolValue getAddMarkup()
+```
+
+
+Gibt an, ob das Dokument auf Markup überprüft wird.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getDocLangID() {#getDocLangID--}
+```
+public IntValue getDocLangID()
+```
+
+
+Gibt die Standardsprache für das Dokument an.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getLockPreview() {#getLockPreview--}
+```
+public BoolValue getLockPreview()
+```
+
+
+Gibt an, ob bei jedem Speichern einer Zeichnung eine Vorschau gespeichert wird.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getOutputFormat() {#getOutputFormat--}
+```
+public OutputFormat getOutputFormat()
+```
+
+
+Gibt das Ausgabeformat für eine Zeichnung an.
+
+**Returns:**
+[OutputFormat](../../com.aspose.diagram/outputformat)
+### getPreviewQuality() {#getPreviewQuality--}
+```
+public BoolValue getPreviewQuality()
+```
+
+
+Gibt an, ob die Zeichnungsvorschau in Entwurfsqualität oder detailliert ist.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getPreviewScope() {#getPreviewScope--}
+```
+public PreviewScope getPreviewScope()
+```
+
+
+Gibt an, ob das Dokument eine Vorschau enthält und, falls ja, ob die Vorschau nur die erste Seite oder alle Seiten im Dokument zeigt.
+
+**Returns:**
+[PreviewScope](../../com.aspose.diagram/previewscope)
+### getViewMarkup() {#getViewMarkup--}
+```
+public BoolValue getViewMarkup()
+```
+
+
+Bestimmt, ob Markup im Zeichenfenster angezeigt wird.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/docprops\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/documentproperties/_index.md
+++ b/german/java/com.aspose.diagram/documentproperties/_index.md
@@ -1,0 +1,616 @@
+---
+title: DocumentProperties
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält Dokumenteigenschaftselemente wie den Titel des Dokuments, den Autor und so weiter.
+type: docs
+weight: 125
+url: /de/java/com.aspose.diagram/documentproperties/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DocumentProperties
+```
+
+Enthält Dokumenteigenschaftselemente wie den Titel, den Autor usw. des Dokuments.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAlternateNames()](#getAlternateNames--) | Gibt die alternativen Namen für ein Dokument an. |
+| [getBuildNumberCreated()](#getBuildNumberCreated--) | Enthält die vollständige Build-Nummer der Instanz, die zum Erstellen des Dokuments verwendet wurde. |
+| [getBuildNumberEdited()](#getBuildNumberEdited--) | Enthält die Build-Nummer der Instanz, die zuletzt zum Bearbeiten des Dokuments verwendet wurde. |
+| [getCategory()](#getCategory--) | Gibt den beschreibenden Text für den Zeichnungstyp an, z. B. Flussdiagramm oder Bürolayout. |
+| [getClass()](#getClass--) |  |
+| [getCompany()](#getCompany--) | Enthält vom Benutzer eingegebene Informationen, die das Unternehmen identifizieren, das die Zeichnung erstellt, oder das Unternehmen, für das die Zeichnung erstellt wird. |
+| [getCreator()](#getCreator--) | Identifiziert, wer die Datei erstellt oder zuletzt aktualisiert hat. |
+| [getCustomProps()](#getCustomProps--) | Sammlung von CustomProp. |
+| [getDesc()](#getDesc--) | Enthält eine beschreibende Textzeichenfolge für ein Dokument. |
+| [getHyperlinkBase()](#getHyperlinkBase--) | Enthält den Pfad, der für relative Hyperlinks verwendet werden soll (Hyperlinks, bei denen der Speicherort der verknüpften Datei in Bezug auf das Microsoft Visio-Diagramm beschrieben wird). |
+| [getKeywords()](#getKeywords--) | Enthält eine Textzeichenfolge, die Themen oder andere wichtige Informationen über die Datei identifiziert, wie Projektname, Kundenname oder Versionsnummer. |
+| [getLanguage()](#getLanguage--) | Gibt die Sprache an |
+| [getManager()](#getManager--) | Enthält eine vom Benutzer eingegebene Textzeichenfolge, die die für das Projekt oder die Abteilung verantwortliche Person identifiziert. |
+| [getPreviewPicture()](#getPreviewPicture--) | Enthält einen Metadatei‑Stream, der als Vorschau des Dokuments dient. |
+| [getSubject()](#getSubject--) | Enthält eine benutzerdefinierte Textzeichenfolge, die den Inhalt des Dokuments beschreibt. |
+| [getTemplate()](#getTemplate--) | Enthält einen Zeichenfolgenwert, der den Dateinamen der Vorlage angibt, aus der das Dokument erstellt wurde. |
+| [getTimeCreated()](#getTimeCreated--) | Enthält Datum‑ und Uhrzeitwert, der angibt, wann das Dokument erstellt wurde. |
+| [getTimeEdited()](#getTimeEdited--) | Enthält Datum‑ und Uhrzeitwert, der angibt, wann das Dokument zuletzt bearbeitet wurde. |
+| [getTimePrinted()](#getTimePrinted--) | Enthält Datum‑ und Uhrzeitwert, der angibt, wann das Dokument zuletzt gedruckt wurde. |
+| [getTimeSaved()](#getTimeSaved--) | Enthält Datum‑ und Uhrzeitwert, der angibt, wann das Dokument zuletzt gespeichert wurde. |
+| [getTitle()](#getTitle--) | Enthält eine benutzerdefinierte Textzeichenfolge, die als beschreibender Titel für das Dokument dient. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAlternateNames(String value)](#setAlternateNames-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getAlternateNames()](../../com.aspose.diagram/documentproperties\#getAlternateNames--) |
+| [setBuildNumberCreated(String value)](#setBuildNumberCreated-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getBuildNumberCreated()](../../com.aspose.diagram/documentproperties\#getBuildNumberCreated--) |
+| [setBuildNumberEdited(String value)](#setBuildNumberEdited-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getBuildNumberEdited()](../../com.aspose.diagram/documentproperties\#getBuildNumberEdited--) |
+| [setCategory(String value)](#setCategory-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getCategory()](../../com.aspose.diagram/documentproperties\#getCategory--) |
+| [setCompany(String value)](#setCompany-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getCompany()](../../com.aspose.diagram/documentproperties\#getCompany--) |
+| [setCreator(String value)](#setCreator-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getCreator()](../../com.aspose.diagram/documentproperties\#getCreator--) |
+| [setDesc(String value)](#setDesc-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDesc()](../../com.aspose.diagram/documentproperties\#getDesc--) |
+| [setHyperlinkBase(String value)](#setHyperlinkBase-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getHyperlinkBase()](../../com.aspose.diagram/documentproperties\#getHyperlinkBase--) |
+| [setKeywords(String value)](#setKeywords-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getKeywords()](../../com.aspose.diagram/documentproperties\#getKeywords--) |
+| [setLanguage(String value)](#setLanguage-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getLanguage()](../../com.aspose.diagram/documentproperties\#getLanguage--) |
+| [setManager(String value)](#setManager-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getManager()](../../com.aspose.diagram/documentproperties\#getManager--) |
+| [setPreviewPicture(byte[] value)](#setPreviewPicture-byte---) | Für die Beschreibung dieser Eigenschaft siehe bitte [getPreviewPicture()](../../com.aspose.diagram/documentproperties\#getPreviewPicture--) |
+| [setSubject(String value)](#setSubject-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getSubject()](../../com.aspose.diagram/documentproperties\#getSubject--) |
+| [setTemplate(String value)](#setTemplate-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getTemplate()](../../com.aspose.diagram/documentproperties\#getTemplate--) |
+| [setTimeCreated(DateTime value)](#setTimeCreated-com.aspose.diagram.DateTime-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getTimeCreated()](../../com.aspose.diagram/documentproperties\#getTimeCreated--) |
+| [setTimeEdited(DateTime value)](#setTimeEdited-com.aspose.diagram.DateTime-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getTimeEdited()](../../com.aspose.diagram/documentproperties\#getTimeEdited--) |
+| [setTimePrinted(DateTime value)](#setTimePrinted-com.aspose.diagram.DateTime-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getTimePrinted()](../../com.aspose.diagram/documentproperties\#getTimePrinted--) |
+| [setTimeSaved(DateTime value)](#setTimeSaved-com.aspose.diagram.DateTime-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getTimeSaved()](../../com.aspose.diagram/documentproperties\#getTimeSaved--) |
+| [setTitle(String value)](#setTitle-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getTitle()](../../com.aspose.diagram/documentproperties\#getTitle--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAlternateNames() {#getAlternateNames--}
+```
+public String getAlternateNames()
+```
+
+
+Gibt die alternativen Namen für ein Dokument an.
+
+**Returns:**
+java.lang.String
+### getBuildNumberCreated() {#getBuildNumberCreated--}
+```
+public String getBuildNumberCreated()
+```
+
+
+Enthält die vollständige Build-Nummer der Instanz, die zum Erstellen des Dokuments verwendet wurde.
+
+**Returns:**
+java.lang.String
+### getBuildNumberEdited() {#getBuildNumberEdited--}
+```
+public String getBuildNumberEdited()
+```
+
+
+Enthält die Build-Nummer der Instanz, die zuletzt zum Bearbeiten des Dokuments verwendet wurde.
+
+**Returns:**
+java.lang.String
+### getCategory() {#getCategory--}
+```
+public String getCategory()
+```
+
+
+Gibt den beschreibenden Text für den Zeichnungstyp an, z. B. Flussdiagramm oder Bürogrundriss. Dieser Text kann auch in der Microsoft Visio-Benutzeroberfläche im Feld Kategorie im Dialogfeld Eigenschaften eingegeben werden.
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCompany() {#getCompany--}
+```
+public String getCompany()
+```
+
+
+Enthält vom Benutzer eingegebene Informationen, die das Unternehmen identifizieren, das die Zeichnung erstellt, oder das Unternehmen, für das die Zeichnung erstellt wird. Die maximale Länge beträgt 63 Zeichen.
+
+**Returns:**
+java.lang.String
+### getCreator() {#getCreator--}
+```
+public String getCreator()
+```
+
+
+Identifiziert, wer die Datei erstellt oder zuletzt aktualisiert hat. Die maximale Länge beträgt 63 Zeichen.
+
+**Returns:**
+java.lang.String
+### getCustomProps() {#getCustomProps--}
+```
+public CustomPropCollection getCustomProps()
+```
+
+
+Sammlung von CustomProp.
+
+**Returns:**
+[CustomPropCollection](../../com.aspose.diagram/custompropcollection)
+### getDesc() {#getDesc--}
+```
+public String getDesc()
+```
+
+
+Enthält eine beschreibende Textzeichenfolge für ein Dokument. Verwenden Sie dieses Element, um wichtige Informationen über das Dokument zu speichern, z. B. dessen Zweck, kürzliche Änderungen oder ausstehende Änderungen. Die maximale Länge beträgt 191 Zeichen.
+
+**Returns:**
+java.lang.String
+### getHyperlinkBase() {#getHyperlinkBase--}
+```
+public String getHyperlinkBase()
+```
+
+
+Enthält den Pfad, der für relative Hyperlinks verwendet wird (Hyperlinks, bei denen der Speicherort der verknüpften Datei in Bezug auf das Microsoft Visio-Diagramm beschrieben wird). Standardmäßig ist ein Hyperlink-Pfad relativ zum aktuellen Dokument, sofern in diesem Element kein anderer Pfad angegeben ist. Die maximale Länge beträgt 256 Zeichen.
+
+**Returns:**
+java.lang.String
+### getKeywords() {#getKeywords--}
+```
+public String getKeywords()
+```
+
+
+Enthält eine Textzeichenfolge, die Themen oder andere wichtige Informationen über die Datei identifiziert, z. B. Projektname, Kundenname oder Versionsnummer. Die maximale Zeichenlänge beträgt 63 Zeichen.
+
+**Returns:**
+java.lang.String
+### getLanguage() {#getLanguage--}
+```
+public String getLanguage()
+```
+
+
+Gibt die Sprache an
+
+```
+setLanguage("en-GB");
+         setLanguage("en-US");
+```
+
+**Returns:**
+java.lang.String
+### getManager() {#getManager--}
+```
+public String getManager()
+```
+
+
+Enthält eine vom Benutzer eingegebene Textzeichenfolge, die die für das Projekt oder die Abteilung verantwortliche Person identifiziert. Die maximale Länge beträgt 63 Zeichen.
+
+**Returns:**
+java.lang.String
+### getPreviewPicture() {#getPreviewPicture--}
+```
+public byte[] getPreviewPicture()
+```
+
+
+Enthält einen Metadatei‑Stream, der als Vorschau des Dokuments dient.
+
+**Returns:**
+byte[]
+### getSubject() {#getSubject--}
+```
+public String getSubject()
+```
+
+
+Enthält eine benutzerdefinierte Textzeichenfolge, die den Inhalt des Dokuments beschreibt. Die maximale Länge beträgt 63 Zeichen.
+
+**Returns:**
+java.lang.String
+### getTemplate() {#getTemplate--}
+```
+public String getTemplate()
+```
+
+
+Enthält einen Zeichenfolgenwert, der den Dateinamen der Vorlage angibt, aus der das Dokument erstellt wurde.
+
+**Returns:**
+java.lang.String
+### getTimeCreated() {#getTimeCreated--}
+```
+public DateTime getTimeCreated()
+```
+
+
+Enthält Datum‑ und Uhrzeitwert, der angibt, wann das Dokument erstellt wurde.
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### getTimeEdited() {#getTimeEdited--}
+```
+public DateTime getTimeEdited()
+```
+
+
+Enthält Datum‑ und Uhrzeitwert, der angibt, wann das Dokument zuletzt bearbeitet wurde.
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### getTimePrinted() {#getTimePrinted--}
+```
+public DateTime getTimePrinted()
+```
+
+
+Enthält Datum‑ und Uhrzeitwert, der angibt, wann das Dokument zuletzt gedruckt wurde.
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### getTimeSaved() {#getTimeSaved--}
+```
+public DateTime getTimeSaved()
+```
+
+
+Enthält Datum‑ und Uhrzeitwert, der angibt, wann das Dokument zuletzt gespeichert wurde.
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### getTitle() {#getTitle--}
+```
+public String getTitle()
+```
+
+
+Enthält eine benutzerdefinierte Textzeichenfolge, die als beschreibender Titel für das Dokument dient. Die maximale Länge beträgt 63 Zeichen.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAlternateNames(String value) {#setAlternateNames-java.lang.String-}
+```
+public void setAlternateNames(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getAlternateNames()](../../com.aspose.diagram/documentproperties\#getAlternateNames--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setBuildNumberCreated(String value) {#setBuildNumberCreated-java.lang.String-}
+```
+public void setBuildNumberCreated(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getBuildNumberCreated()](../../com.aspose.diagram/documentproperties\#getBuildNumberCreated--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setBuildNumberEdited(String value) {#setBuildNumberEdited-java.lang.String-}
+```
+public void setBuildNumberEdited(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getBuildNumberEdited()](../../com.aspose.diagram/documentproperties\#getBuildNumberEdited--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setCategory(String value) {#setCategory-java.lang.String-}
+```
+public void setCategory(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getCategory()](../../com.aspose.diagram/documentproperties\#getCategory--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setCompany(String value) {#setCompany-java.lang.String-}
+```
+public void setCompany(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getCompany()](../../com.aspose.diagram/documentproperties\#getCompany--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setCreator(String value) {#setCreator-java.lang.String-}
+```
+public void setCreator(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getCreator()](../../com.aspose.diagram/documentproperties\#getCreator--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setDesc(String value) {#setDesc-java.lang.String-}
+```
+public void setDesc(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDesc()](../../com.aspose.diagram/documentproperties\#getDesc--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setHyperlinkBase(String value) {#setHyperlinkBase-java.lang.String-}
+```
+public void setHyperlinkBase(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getHyperlinkBase()](../../com.aspose.diagram/documentproperties\#getHyperlinkBase--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setKeywords(String value) {#setKeywords-java.lang.String-}
+```
+public void setKeywords(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getKeywords()](../../com.aspose.diagram/documentproperties\#getKeywords--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setLanguage(String value) {#setLanguage-java.lang.String-}
+```
+public void setLanguage(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getLanguage()](../../com.aspose.diagram/documentproperties\#getLanguage--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setManager(String value) {#setManager-java.lang.String-}
+```
+public void setManager(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getManager()](../../com.aspose.diagram/documentproperties\#getManager--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setPreviewPicture(byte[] value) {#setPreviewPicture-byte---}
+```
+public void setPreviewPicture(byte[] value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getPreviewPicture()](../../com.aspose.diagram/documentproperties\#getPreviewPicture--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | byte[] |  |
+
+### setSubject(String value) {#setSubject-java.lang.String-}
+```
+public void setSubject(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getSubject()](../../com.aspose.diagram/documentproperties\#getSubject--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setTemplate(String value) {#setTemplate-java.lang.String-}
+```
+public void setTemplate(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getTemplate()](../../com.aspose.diagram/documentproperties\#getTemplate--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setTimeCreated(DateTime value) {#setTimeCreated-com.aspose.diagram.DateTime-}
+```
+public void setTimeCreated(DateTime value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getTimeCreated()](../../com.aspose.diagram/documentproperties\#getTimeCreated--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setTimeEdited(DateTime value) {#setTimeEdited-com.aspose.diagram.DateTime-}
+```
+public void setTimeEdited(DateTime value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getTimeEdited()](../../com.aspose.diagram/documentproperties\#getTimeEdited--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setTimePrinted(DateTime value) {#setTimePrinted-com.aspose.diagram.DateTime-}
+```
+public void setTimePrinted(DateTime value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getTimePrinted()](../../com.aspose.diagram/documentproperties\#getTimePrinted--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setTimeSaved(DateTime value) {#setTimeSaved-com.aspose.diagram.DateTime-}
+```
+public void setTimeSaved(DateTime value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getTimeSaved()](../../com.aspose.diagram/documentproperties\#getTimeSaved--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setTitle(String value) {#setTitle-java.lang.String-}
+```
+public void setTitle(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getTitle()](../../com.aspose.diagram/documentproperties\#getTitle--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/documentsettings/_index.md
+++ b/german/java/com.aspose.diagram/documentsettings/_index.md
@@ -1,0 +1,550 @@
+---
+title: DocumentSettings
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält Elemente, die Dokumenteinstellungen festlegen.
+type: docs
+weight: 126
+url: /de/java/com.aspose.diagram/documentsettings/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DocumentSettings
+```
+
+Enthält Elemente, die Dokumenteinstellungen festlegen.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAttachedToolbars()](#getAttachedToolbars--) | Eine MIME (Multipurpose Internet Mail Extensions) codierte Microsoft Visio-Benutzeroberflächen‑Datei (VSU), die benutzerdefinierte Symbolleisten darstellt. |
+| [getClass()](#getClass--) |  |
+| [getCustomMenusFile()](#getCustomMenusFile--) | Enthält den Namen der Microsoft Visio-Benutzeroberflächen‑Datei (.vsu), die benutzerdefinierte Menüs und Tastenkombinationen für ein Dokument definiert. |
+| [getCustomToolbarsFile()](#getCustomToolbarsFile--) | Enthält den Namen der Microsoft Visio-Benutzeroberflächen‑Datei (.vsu), die benutzerdefinierte Symbolleisten und Statusleisten für ein Dokument definiert. |
+| [getDefaultFillStyle()](#getDefaultFillStyle--) | Gibt die ID eines StyleSheet-Elements an. |
+| [getDefaultGuideStyle()](#getDefaultGuideStyle--) | Gibt die ID eines StyleSheet-Elements an. |
+| [getDefaultLineStyle()](#getDefaultLineStyle--) | Gibt die ID eines StyleSheet-Elements an. |
+| [getDefaultTextStyle()](#getDefaultTextStyle--) | Gibt die ID eines StyleSheet-Elements an. |
+| [getDynamicGridEnabled()](#getDynamicGridEnabled--) | Gibt an, ob die dynamische Rasterfunktion für ein Dokument oder Fenster aktiviert ist. |
+| [getGlueSettings()](#getGlueSettings--) | Gibt die Objekte an, an die Formen geklebt werden, wenn Kleben im Dokument aktiviert ist. |
+| [getProtectBkgnds()](#getProtectBkgnds--) | Gibt an, ob der Benutzer daran gehindert wird, Hintergrundseiten zu löschen oder zu bearbeiten. |
+| [getProtectMasters()](#getProtectMasters--) | Gibt an, ob der Benutzer daran gehindert wird, Master zu erstellen, zu bearbeiten oder zu löschen. |
+| [getProtectShapes()](#getProtectShapes--) | Gibt an, ob der Benutzer daran gehindert wird, Formen auszuwählen, deren LockSelect-Element auf 1 gesetzt ist. |
+| [getProtectStyles()](#getProtectStyles--) | Gibt an, ob der Benutzer daran gehindert wird, Stile zu erstellen oder zu bearbeiten. |
+| [getSnapAngles()](#getSnapAngles--) | Enthält eine Sammlung von SnapAngle-Elementen. |
+| [getSnapExtensions()](#getSnapExtensions--) | Gibt an, ob eine bestimmte Snap‑Erweiterungseinstellung für das aktive Fenster aktiviert oder deaktiviert ist. |
+| [getSnapSettings()](#getSnapSettings--) | Gibt die Objekte an, an die Formen einrasten, wenn das Einrasten im Fenster aktiv ist. |
+| [getTopPage()](#getTopPage--) | Gibt die ID der Seite an, die angezeigt werden soll, wenn das Dokument von Microsoft Visio geöffnet wird. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAttachedToolbars(byte[] value)](#setAttachedToolbars-byte---) | Für die Beschreibung dieser Eigenschaft siehe bitte [getAttachedToolbars()](../../com.aspose.diagram/documentsettings\\#getAttachedToolbars--) |
+| [setCustomMenusFile(String value)](#setCustomMenusFile-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getCustomMenusFile()](../../com.aspose.diagram/documentsettings\\#getCustomMenusFile--) |
+| [setCustomToolbarsFile(String value)](#setCustomToolbarsFile-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getCustomToolbarsFile()](../../com.aspose.diagram/documentsettings\\#getCustomToolbarsFile--) |
+| [setDefaultFillStyle(int value)](#setDefaultFillStyle-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDefaultFillStyle()](../../com.aspose.diagram/documentsettings\\#getDefaultFillStyle--) |
+| [setDefaultGuideStyle(int value)](#setDefaultGuideStyle-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDefaultGuideStyle()](../../com.aspose.diagram/documentsettings\\#getDefaultGuideStyle--) |
+| [setDefaultLineStyle(int value)](#setDefaultLineStyle-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDefaultLineStyle()](../../com.aspose.diagram/documentsettings\\#getDefaultLineStyle--) |
+| [setDefaultTextStyle(int value)](#setDefaultTextStyle-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDefaultTextStyle()](../../com.aspose.diagram/documentsettings\\#getDefaultTextStyle--) |
+| [setDynamicGridEnabled(int value)](#setDynamicGridEnabled-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDynamicGridEnabled()](../../com.aspose.diagram/documentsettings\\#getDynamicGridEnabled--) |
+| [setGlueSettings(int value)](#setGlueSettings-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getGlueSettings()](../../com.aspose.diagram/documentsettings\\#getGlueSettings--) |
+| [setProtectBkgnds(int value)](#setProtectBkgnds-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getProtectBkgnds()](../../com.aspose.diagram/documentsettings\\#getProtectBkgnds--) |
+| [setProtectMasters(int value)](#setProtectMasters-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getProtectMasters()](../../com.aspose.diagram/documentsettings\\#getProtectMasters--) |
+| [setProtectShapes(int value)](#setProtectShapes-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getProtectShapes()](../../com.aspose.diagram/documentsettings\\#getProtectShapes--) |
+| [setProtectStyles(int value)](#setProtectStyles-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getProtectStyles()](../../com.aspose.diagram/documentsettings\\#getProtectStyles--) |
+| [setSnapAngles(FloatPointNumCollection value)](#setSnapAngles-com.aspose.diagram.FloatPointNumCollection-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getSnapAngles()](../../com.aspose.diagram/documentsettings\\#getSnapAngles--) |
+| [setSnapExtensions(int value)](#setSnapExtensions-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getSnapExtensions()](../../com.aspose.diagram/documentsettings\\#getSnapExtensions--) |
+| [setSnapSettings(int value)](#setSnapSettings-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getSnapSettings()](../../com.aspose.diagram/documentsettings\\#getSnapSettings--) |
+| [setTopPage(int value)](#setTopPage-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getTopPage()](../../com.aspose.diagram/documentsettings\\#getTopPage--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAttachedToolbars() {#getAttachedToolbars--}
+```
+public byte[] getAttachedToolbars()
+```
+
+
+Eine MIME (Multipurpose Internet Mail Extensions) codierte Microsoft Visio-Benutzeroberflächen‑Datei (VSU), die benutzerdefinierte Symbolleisten darstellt.
+
+**Returns:**
+byte[]
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCustomMenusFile() {#getCustomMenusFile--}
+```
+public String getCustomMenusFile()
+```
+
+
+Enthält den Namen der Microsoft Visio-Benutzeroberflächen‑Datei (.vsu), die benutzerdefinierte Menüs und Tastenkombinationen für ein Dokument definiert.
+
+**Returns:**
+java.lang.String
+### getCustomToolbarsFile() {#getCustomToolbarsFile--}
+```
+public String getCustomToolbarsFile()
+```
+
+
+Enthält den Namen der Microsoft Visio-Benutzeroberflächen‑Datei (.vsu), die benutzerdefinierte Symbolleisten und Statusleisten für ein Dokument definiert.
+
+**Returns:**
+java.lang.String
+### getDefaultFillStyle() {#getDefaultFillStyle--}
+```
+public int getDefaultFillStyle()
+```
+
+
+Gibt die ID eines StyleSheet-Elements an. Wenn der Benutzer das nächste Mal eine Form mit einem Zeichenwerkzeug erstellt, erbt die Form ihren Füllstil vom angegebenen StyleSheet-Element.
+
+**Returns:**
+int
+### getDefaultGuideStyle() {#getDefaultGuideStyle--}
+```
+public int getDefaultGuideStyle()
+```
+
+
+Gibt die ID eines StyleSheet-Elements an. Wenn der Benutzer das nächste Mal eine Führungslinie erstellt, erbt die Führungslinie ihren Führungsstil vom angegebenen StyleSheet-Element.
+
+**Returns:**
+int
+### getDefaultLineStyle() {#getDefaultLineStyle--}
+```
+public int getDefaultLineStyle()
+```
+
+
+Gibt die ID eines StyleSheet-Elements an. Wenn der Benutzer das nächste Mal eine Form mit einem Zeichenwerkzeug erstellt, erbt die Form ihren Linienstil vom angegebenen StyleSheet-Element.
+
+**Returns:**
+int
+### getDefaultTextStyle() {#getDefaultTextStyle--}
+```
+public int getDefaultTextStyle()
+```
+
+
+Gibt die ID eines StyleSheet-Elements an. Wenn der Benutzer das nächste Mal eine Form mit einem Zeichenwerkzeug erstellt, erbt die Form ihren Textstil vom angegebenen StyleSheet-Element.
+
+**Returns:**
+int
+### getDynamicGridEnabled() {#getDynamicGridEnabled--}
+```
+public int getDynamicGridEnabled()
+```
+
+
+Gibt an, ob die dynamische Rasterfunktion für ein Dokument oder Fenster aktiviert ist.
+
+**Returns:**
+int
+### getGlueSettings() {#getGlueSettings--}
+```
+public int getGlueSettings()
+```
+
+
+Gibt die Objekte an, an die Formen geklebt werden, wenn Kleben im Dokument aktiviert ist.
+
+**Returns:**
+int
+### getProtectBkgnds() {#getProtectBkgnds--}
+```
+public int getProtectBkgnds()
+```
+
+
+Gibt an, ob der Benutzer daran gehindert wird, Hintergrundseiten zu löschen oder zu bearbeiten.
+
+**Returns:**
+int
+### getProtectMasters() {#getProtectMasters--}
+```
+public int getProtectMasters()
+```
+
+
+Gibt an, ob der Benutzer daran gehindert wird, Master zu erstellen, zu bearbeiten oder zu löschen. Unabhängig von dieser Einstellung kann der Benutzer weiterhin Instanzen von Master erstellen.
+
+**Returns:**
+int
+### getProtectShapes() {#getProtectShapes--}
+```
+public int getProtectShapes()
+```
+
+
+Gibt an, ob der Benutzer daran gehindert wird, Formen auszuwählen, deren LockSelect-Element auf 1 gesetzt ist.
+
+**Returns:**
+int
+### getProtectStyles() {#getProtectStyles--}
+```
+public int getProtectStyles()
+```
+
+
+Gibt an, ob der Benutzer daran gehindert wird, Stile zu erstellen oder zu bearbeiten. Unabhängig von dieser Einstellung kann der Benutzer jedoch weiterhin Stile anwenden.
+
+**Returns:**
+int
+### getSnapAngles() {#getSnapAngles--}
+```
+public FloatPointNumCollection getSnapAngles()
+```
+
+
+Enthält eine Sammlung von SnapAngle-Elementen.
+
+**Returns:**
+[FloatPointNumCollection](../../com.aspose.diagram/floatpointnumcollection)
+### getSnapExtensions() {#getSnapExtensions--}
+```
+public int getSnapExtensions()
+```
+
+
+Gibt an, ob eine bestimmte Snap‑Erweiterungseinstellung für das aktive Fenster aktiviert oder deaktiviert ist.
+
+**Returns:**
+int
+### getSnapSettings() {#getSnapSettings--}
+```
+public int getSnapSettings()
+```
+
+
+Gibt die Objekte an, an die Formen einrasten, wenn das Einrasten im Fenster aktiv ist.
+
+**Returns:**
+int
+### getTopPage() {#getTopPage--}
+```
+public int getTopPage()
+```
+
+
+Gibt die ID der Seite an, die angezeigt werden soll, wenn das Dokument von Microsoft Visio geöffnet wird.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAttachedToolbars(byte[] value) {#setAttachedToolbars-byte---}
+```
+public void setAttachedToolbars(byte[] value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getAttachedToolbars()](../../com.aspose.diagram/documentsettings\\#getAttachedToolbars--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | byte[] |  |
+
+### setCustomMenusFile(String value) {#setCustomMenusFile-java.lang.String-}
+```
+public void setCustomMenusFile(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getCustomMenusFile()](../../com.aspose.diagram/documentsettings\\#getCustomMenusFile--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setCustomToolbarsFile(String value) {#setCustomToolbarsFile-java.lang.String-}
+```
+public void setCustomToolbarsFile(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getCustomToolbarsFile()](../../com.aspose.diagram/documentsettings\\#getCustomToolbarsFile--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setDefaultFillStyle(int value) {#setDefaultFillStyle-int-}
+```
+public void setDefaultFillStyle(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDefaultFillStyle()](../../com.aspose.diagram/documentsettings\\#getDefaultFillStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setDefaultGuideStyle(int value) {#setDefaultGuideStyle-int-}
+```
+public void setDefaultGuideStyle(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDefaultGuideStyle()](../../com.aspose.diagram/documentsettings\\#getDefaultGuideStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setDefaultLineStyle(int value) {#setDefaultLineStyle-int-}
+```
+public void setDefaultLineStyle(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDefaultLineStyle()](../../com.aspose.diagram/documentsettings\\#getDefaultLineStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setDefaultTextStyle(int value) {#setDefaultTextStyle-int-}
+```
+public void setDefaultTextStyle(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDefaultTextStyle()](../../com.aspose.diagram/documentsettings\\#getDefaultTextStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setDynamicGridEnabled(int value) {#setDynamicGridEnabled-int-}
+```
+public void setDynamicGridEnabled(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDynamicGridEnabled()](../../com.aspose.diagram/documentsettings\\#getDynamicGridEnabled--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setGlueSettings(int value) {#setGlueSettings-int-}
+```
+public void setGlueSettings(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getGlueSettings()](../../com.aspose.diagram/documentsettings\\#getGlueSettings--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setProtectBkgnds(int value) {#setProtectBkgnds-int-}
+```
+public void setProtectBkgnds(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getProtectBkgnds()](../../com.aspose.diagram/documentsettings\\#getProtectBkgnds--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setProtectMasters(int value) {#setProtectMasters-int-}
+```
+public void setProtectMasters(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getProtectMasters()](../../com.aspose.diagram/documentsettings\\#getProtectMasters--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setProtectShapes(int value) {#setProtectShapes-int-}
+```
+public void setProtectShapes(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getProtectShapes()](../../com.aspose.diagram/documentsettings\\#getProtectShapes--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setProtectStyles(int value) {#setProtectStyles-int-}
+```
+public void setProtectStyles(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getProtectStyles()](../../com.aspose.diagram/documentsettings\\#getProtectStyles--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setSnapAngles(FloatPointNumCollection value) {#setSnapAngles-com.aspose.diagram.FloatPointNumCollection-}
+```
+public void setSnapAngles(FloatPointNumCollection value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getSnapAngles()](../../com.aspose.diagram/documentsettings\\#getSnapAngles--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [FloatPointNumCollection](../../com.aspose.diagram/floatpointnumcollection) |  |
+
+### setSnapExtensions(int value) {#setSnapExtensions-int-}
+```
+public void setSnapExtensions(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getSnapExtensions()](../../com.aspose.diagram/documentsettings\\#getSnapExtensions--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setSnapSettings(int value) {#setSnapSettings-int-}
+```
+public void setSnapSettings(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getSnapSettings()](../../com.aspose.diagram/documentsettings\\#getSnapSettings--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setTopPage(int value) {#setTopPage-int-}
+```
+public void setTopPage(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getTopPage()](../../com.aspose.diagram/documentsettings\\#getTopPage--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/documentsheet/_index.md
+++ b/german/java/com.aspose.diagram/documentsheet/_index.md
@@ -1,0 +1,396 @@
+---
+title: DocumentSheet
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt die ShapeSheet-Struktur eines Dokuments an.
+type: docs
+weight: 127
+url: /de/java/com.aspose.diagram/documentsheet/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DocumentSheet
+```
+
+Gibt die ShapeSheet-Struktur eines Dokuments an.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAnnotations()](#getAnnotations--) | Enthält Elemente, die Informationen über in einer Dokumentseite eingefügte Kommentare enthalten. |
+| [getClass()](#getClass--) |  |
+| [getConnectionABCDs()](#getConnectionABCDs--) | Enthält eine Sammlung von ConnectionABCD-Elementen. |
+| [getConnections()](#getConnections--) | Enthält eine Sammlung von Connection-Elementen. |
+| [getDocProps()](#getDocProps--) | Enthält Elemente, die die Vorschauqualität, den Umfang und das Ausgabeformat des Dokuments steuern. |
+| [getFillStyle()](#getFillStyle--) | StyleSheet-Element, von dem dieser Stil die Füllformatierung erbt. |
+| [getForeign()](#getForeign--) | Enthält Elemente, die die Breite und Höhe eines Objekts aus einem anderen Programm angeben, das in einem Microsoft Visio-Dokument verwendet wird. |
+| [getForeignData()](#getForeignData--) | Enthält einen MIME (Multipurpose Internet Mail Extensions) codierten BLOB von Bilddaten, wie Windows-Metadatei, Bitmap oder OLE-Daten. |
+| [getHyperlinks()](#getHyperlinks--) | Enthält eine Sammlung von Hyperlink-Elementen. |
+| [getLineStyle()](#getLineStyle--) | StyleSheet-Element, von dem dieser Stil die Linienformatierung erbt. |
+| [getName()](#getName--) | Der Name des Elements. |
+| [getNameU()](#getNameU--) | Der universelle Name des Elements. |
+| [getProps()](#getProps--) | Enthält eine Sammlung von Prop-Elementen. |
+| [getReviewers()](#getReviewers--) | Enthält Elemente, die Identifizierungsinformationen über einen Dokumentprüfer enthalten. |
+| [getScratchs()](#getScratchs--) | Enthält eine Sammlung von Scratch-Elementen. |
+| [getTextStyle()](#getTextStyle--) | StyleSheet-Element, von dem dieser Stil die Textformatierung erbt. |
+| [getUniqueID()](#getUniqueID--) | Eine GUID (global eindeutiger Bezeichner), die die Form identifiziert. |
+| [getUsers()](#getUsers--) | Enthält eine Sammlung von User-Elementen. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setFillStyle(StyleSheet value)](#setFillStyle-com.aspose.diagram.StyleSheet-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getFillStyle()](../../com.aspose.diagram/documentsheet\#getFillStyle--) |
+| [setLineStyle(StyleSheet value)](#setLineStyle-com.aspose.diagram.StyleSheet-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getLineStyle()](../../com.aspose.diagram/documentsheet\#getLineStyle--) |
+| [setName(String value)](#setName-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getName()](../../com.aspose.diagram/documentsheet\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getNameU()](../../com.aspose.diagram/documentsheet\#getNameU--) |
+| [setTextStyle(StyleSheet value)](#setTextStyle-com.aspose.diagram.StyleSheet-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getTextStyle()](../../com.aspose.diagram/documentsheet\#getTextStyle--) |
+| [setUniqueID(UUID value)](#setUniqueID-java.util.UUID-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getUniqueID()](../../com.aspose.diagram/documentsheet\#getUniqueID--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAnnotations() {#getAnnotations--}
+```
+public AnnotationCollection getAnnotations()
+```
+
+
+Enthält Elemente, die Informationen über in einer Dokumentseite eingefügte Kommentare enthalten.
+
+**Returns:**
+[AnnotationCollection](../../com.aspose.diagram/annotationcollection)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConnectionABCDs() {#getConnectionABCDs--}
+```
+public ConnectionABCDCollection getConnectionABCDs()
+```
+
+
+Enthält eine Sammlung von ConnectionABCD-Elementen.
+
+**Returns:**
+[ConnectionABCDCollection](../../com.aspose.diagram/connectionabcdcollection)
+### getConnections() {#getConnections--}
+```
+public ConnectionCollection getConnections()
+```
+
+
+Enthält eine Sammlung von Connection-Elementen.
+
+**Returns:**
+[ConnectionCollection](../../com.aspose.diagram/connectioncollection)
+### getDocProps() {#getDocProps--}
+```
+public DocProps getDocProps()
+```
+
+
+Enthält Elemente, die die Vorschauqualität, den Umfang und das Ausgabeformat des Dokuments steuern.
+
+**Returns:**
+[DocProps](../../com.aspose.diagram/docprops)
+### getFillStyle() {#getFillStyle--}
+```
+public StyleSheet getFillStyle()
+```
+
+
+StyleSheet-Element, von dem dieser Stil die Füllformatierung erbt.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getForeign() {#getForeign--}
+```
+public Foreign getForeign()
+```
+
+
+Enthält Elemente, die die Breite und Höhe eines aus einem anderen Programm stammenden Objekts in einem Microsoft Visio-Dokument angeben. Außerdem enthält es Elemente, die den Abstand angeben, um den das Bild des Objekts innerhalb seiner Ränder versetzt ist.
+
+**Returns:**
+[Foreign](../../com.aspose.diagram/foreign)
+### getForeignData() {#getForeignData--}
+```
+public ForeignData getForeignData()
+```
+
+
+Enthält einen MIME (Multipurpose Internet Mail Extensions) codierten BLOB von Bilddaten, wie Windows-Metadatei, Bitmap oder OLE-Daten.
+
+**Returns:**
+[ForeignData](../../com.aspose.diagram/foreigndata)
+### getHyperlinks() {#getHyperlinks--}
+```
+public HyperlinkCollection getHyperlinks()
+```
+
+
+Enthält eine Sammlung von Hyperlink-Elementen.
+
+**Returns:**
+[HyperlinkCollection](../../com.aspose.diagram/hyperlinkcollection)
+### getLineStyle() {#getLineStyle--}
+```
+public StyleSheet getLineStyle()
+```
+
+
+StyleSheet-Element, von dem dieser Stil die Linienformatierung erbt.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Der Name des Elements.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+Der universelle Name des Elements.
+
+**Returns:**
+java.lang.String
+### getProps() {#getProps--}
+```
+public PropCollection getProps()
+```
+
+
+Enthält eine Sammlung von Prop-Elementen.
+
+**Returns:**
+[PropCollection](../../com.aspose.diagram/propcollection)
+### getReviewers() {#getReviewers--}
+```
+public ReviewerCollection getReviewers()
+```
+
+
+Enthält Elemente, die Identifizierungsinformationen über einen Dokumentprüfer enthalten.
+
+**Returns:**
+[ReviewerCollection](../../com.aspose.diagram/reviewercollection)
+### getScratchs() {#getScratchs--}
+```
+public ScratchCollection getScratchs()
+```
+
+
+Enthält eine Sammlung von Scratch-Elementen.
+
+**Returns:**
+[ScratchCollection](../../com.aspose.diagram/scratchcollection)
+### getTextStyle() {#getTextStyle--}
+```
+public StyleSheet getTextStyle()
+```
+
+
+StyleSheet-Element, von dem dieser Stil die Textformatierung erbt.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getUniqueID() {#getUniqueID--}
+```
+public UUID getUniqueID()
+```
+
+
+Eine GUID (global eindeutiger Bezeichner), die die Form identifiziert.
+
+**Returns:**
+java.util.UUID
+### getUsers() {#getUsers--}
+```
+public UserCollection getUsers()
+```
+
+
+Enthält eine Sammlung von User-Elementen.
+
+**Returns:**
+[UserCollection](../../com.aspose.diagram/usercollection)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setFillStyle(StyleSheet value) {#setFillStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setFillStyle(StyleSheet value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getFillStyle()](../../com.aspose.diagram/documentsheet\#getFillStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setLineStyle(StyleSheet value) {#setLineStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setLineStyle(StyleSheet value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getLineStyle()](../../com.aspose.diagram/documentsheet\#getLineStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getName()](../../com.aspose.diagram/documentsheet\#getName--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getNameU()](../../com.aspose.diagram/documentsheet\#getNameU--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setTextStyle(StyleSheet value) {#setTextStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setTextStyle(StyleSheet value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getTextStyle()](../../com.aspose.diagram/documentsheet\#getTextStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setUniqueID(UUID value) {#setUniqueID-java.util.UUID-}
+```
+public void setUniqueID(UUID value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getUniqueID()](../../com.aspose.diagram/documentsheet\#getUniqueID--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.util.UUID |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/doublevalue/_index.md
+++ b/german/java/com.aspose.diagram/doublevalue/_index.md
@@ -1,0 +1,239 @@
+---
+title: DoubleValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Double-Wert
+type: docs
+weight: 128
+url: /de/java/com.aspose.diagram/doublevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DoubleValue
+```
+
+Double-Wert
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [DoubleValue(double value, int unit)](#DoubleValue-double-int-) | Konstruktor. |
+| [DoubleValue()](#DoubleValue--) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Attribute eines Elements. |
+| [getValue()](#getValue--) | Doppelwert. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [isThemed()](#isThemed--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setThemed(boolean value)](#setThemed-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isThemed()](../../com.aspose.diagram/doublevalue\#isThemed--) |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getUfe()](../../com.aspose.diagram/doublevalue\#getUfe--) |
+| [setValue(double value)](#setValue-double-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/doublevalue\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DoubleValue(double value, int unit) {#DoubleValue-double-int-}
+```
+public DoubleValue(double value, int unit)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double |  |
+| Einheit | int |  |
+
+### DoubleValue() {#DoubleValue--}
+```
+public DoubleValue()
+```
+
+
+Konstruktor.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Attribute eines Elements.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public double getValue()
+```
+
+
+Doppelwert.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### isThemed() {#isThemed--}
+```
+public boolean isThemed()
+```
+
+
+
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setThemed(boolean value) {#setThemed-boolean-}
+```
+public void setThemed(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isThemed()](../../com.aspose.diagram/doublevalue\#isThemed--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getUfe()](../../com.aspose.diagram/doublevalue\#getUfe--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(double value) {#setValue-double-}
+```
+public void setValue(double value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/doublevalue\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/drawingresizetype/_index.md
+++ b/german/java/com.aspose.diagram/drawingresizetype/_index.md
@@ -1,0 +1,179 @@
+---
+title: DrawingResizeType
+second_title: Aspose.Diagram for Java API-Referenz
+description: Bestimmt, ob die Zeichenfläche automatisch an das Diagramm angepasst wird.
+type: docs
+weight: 129
+url: /de/java/com.aspose.diagram/drawingresizetype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DrawingResizeType
+```
+
+Bestimmt, ob die Zeichenfläche automatisch an das Diagramm angepasst wird.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [DrawingResizeType(int value)](#DrawingResizeType-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Bestimmt, ob die Zeichenfläche automatisch an das Diagramm angepasst wird. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/drawingresizetype\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DrawingResizeType(int value) {#DrawingResizeType-int-}
+```
+public DrawingResizeType(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Bestimmt, ob die Zeichenfläche automatisch an das Diagramm angepasst wird.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/drawingresizetype\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/drawingresizetypevalue/_index.md
+++ b/german/java/com.aspose.diagram/drawingresizetypevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: DrawingResizeTypeValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Bestimmt, ob die Zeichenfläche automatisch an das Diagramm angepasst wird.
+type: docs
+weight: 130
+url: /de/java/com.aspose.diagram/drawingresizetypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class DrawingResizeTypeValue
+```
+
+Bestimmt, ob die Zeichenfläche automatisch an das Diagramm angepasst wird.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [AUTOMATICALLY](#AUTOMATICALLY) | Die Zeichenfläche wird automatisch skaliert. |
+| [DEPENDS_ON_DRAWING_SIZE_TYPE](#DEPENDS-ON-DRAWING-SIZE-TYPE) | Ob die Seite automatisch skaliert wird, hängt vom Wert der Zelle DrawingSizeType ab. |
+| [NOT_AUTOMATICALLY](#NOT-AUTOMATICALLY) | Die Zeichenfläche wird nicht automatisch skaliert. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AUTOMATICALLY {#AUTOMATICALLY}
+```
+public static final int AUTOMATICALLY
+```
+
+
+Die Zeichenfläche wird automatisch skaliert.
+
+### DEPENDS_ON_DRAWING_SIZE_TYPE {#DEPENDS-ON-DRAWING-SIZE-TYPE}
+```
+public static final int DEPENDS_ON_DRAWING_SIZE_TYPE
+```
+
+
+Ob die Seite automatisch skaliert wird, hängt vom Wert der Zelle DrawingSizeType ab. Wenn DrawingSizeType = 0 (die Größe der Zeichenfläche entspricht der Größe der gedruckten Seite), wird die Seite automatisch skaliert. Wenn der Wert von DrawingSizeType etwas anderes als Null (0) ist, wird die Seite nicht automatisch skaliert.
+
+### NOT_AUTOMATICALLY {#NOT-AUTOMATICALLY}
+```
+public static final int NOT_AUTOMATICALLY
+```
+
+
+Die Zeichenfläche wird nicht automatisch skaliert.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/drawingscaletype/_index.md
+++ b/german/java/com.aspose.diagram/drawingscaletype/_index.md
@@ -1,0 +1,179 @@
+---
+title: DrawingScaleType
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt den Typ der Zeichenmaßstabes an, der für eine Seite verwendet werden soll.
+type: docs
+weight: 131
+url: /de/java/com.aspose.diagram/drawingscaletype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DrawingScaleType
+```
+
+Gibt den Typ der Zeichenmaßstabes an, der für eine Seite verwendet werden soll.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [DrawingScaleType(int value)](#DrawingScaleType-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Gibt den Typ der Zeichenmaßstabes an, der für eine Seite verwendet werden soll. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/drawingscaletype\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DrawingScaleType(int value) {#DrawingScaleType-int-}
+```
+public DrawingScaleType(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Gibt den Typ der Zeichenmaßstabes an, der für eine Seite verwendet werden soll.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/drawingscaletype\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/drawingscaletypevalue/_index.md
+++ b/german/java/com.aspose.diagram/drawingscaletypevalue/_index.md
@@ -1,0 +1,192 @@
+---
+title: DrawingScaleTypeValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt den Typ der Zeichenmaßstabes an, der für eine Seite verwendet werden soll.
+type: docs
+weight: 132
+url: /de/java/com.aspose.diagram/drawingscaletypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class DrawingScaleTypeValue
+```
+
+Gibt den Typ der Zeichenmaßstabes an, der für eine Seite verwendet werden soll.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [ARCHITECTURAL_SCALE](#ARCHITECTURAL-SCALE) | Architekturskala. |
+| [CIVIL_ENGINEERING_SCALE](#CIVIL-ENGINEERING-SCALE) | Bauingenieurwesen-Skala. |
+| [CUSTOM_SCALE](#CUSTOM-SCALE) | Benutzerdefinierte Skala. |
+| [MECHANICAL_ENGINEERING_SCALE](#MECHANICAL-ENGINEERING-SCALE) | Maschinenbau-Skala. |
+| [METRIC_SCALE](#METRIC-SCALE) | Metrische Skala. |
+| [NO_SCALE](#NO-SCALE) | Keine Skala. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ARCHITECTURAL_SCALE {#ARCHITECTURAL-SCALE}
+```
+public static final int ARCHITECTURAL_SCALE
+```
+
+
+Architekturskala.
+
+### CIVIL_ENGINEERING_SCALE {#CIVIL-ENGINEERING-SCALE}
+```
+public static final int CIVIL_ENGINEERING_SCALE
+```
+
+
+Bauingenieurwesen-Skala.
+
+### CUSTOM_SCALE {#CUSTOM-SCALE}
+```
+public static final int CUSTOM_SCALE
+```
+
+
+Benutzerdefinierte Skala.
+
+### MECHANICAL_ENGINEERING_SCALE {#MECHANICAL-ENGINEERING-SCALE}
+```
+public static final int MECHANICAL_ENGINEERING_SCALE
+```
+
+
+Maschinenbau-Skala.
+
+### METRIC_SCALE {#METRIC-SCALE}
+```
+public static final int METRIC_SCALE
+```
+
+
+Metrische Skala.
+
+### NO_SCALE {#NO-SCALE}
+```
+public static final int NO_SCALE
+```
+
+
+Keine Skala.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/drawingsizetype/_index.md
+++ b/german/java/com.aspose.diagram/drawingsizetype/_index.md
@@ -1,0 +1,179 @@
+---
+title: DrawingSizeType
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt die Zeichenflächegröße einer Seite an.
+type: docs
+weight: 133
+url: /de/java/com.aspose.diagram/drawingsizetype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DrawingSizeType
+```
+
+Gibt die Zeichenflächegröße einer Seite an.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [DrawingSizeType(int value)](#DrawingSizeType-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Gibt die Zeichenflächegröße einer Seite an. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/drawingsizetype\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DrawingSizeType(int value) {#DrawingSizeType-int-}
+```
+public DrawingSizeType(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Gibt die Zeichenflächegröße einer Seite an.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/drawingsizetype\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/drawingsizetypevalue/_index.md
+++ b/german/java/com.aspose.diagram/drawingsizetypevalue/_index.md
@@ -1,0 +1,210 @@
+---
+title: DrawingSizeTypeValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt die Zeichenflächegröße einer Seite an.
+type: docs
+weight: 134
+url: /de/java/com.aspose.diagram/drawingsizetypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class DrawingSizeTypeValue
+```
+
+Gibt die Zeichenflächegröße einer Seite an.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [ANSI_ARCHITECTURAL](#ANSI-ARCHITECTURAL) | ANSI architectural. |
+| [ANSI_ENGINEERING](#ANSI-ENGINEERING) | ANSI engineering. |
+| [CUSTOM_PAGE_SIZE](#CUSTOM-PAGE-SIZE) | Custom page size. |
+| [CUSTOM_SCALED_DRAW_SIZE](#CUSTOM-SCALED-DRAW-SIZE) | Custom scaled drawing size. |
+| [FIT_PAGE_DRAW_CONTENTS](#FIT-PAGE-DRAW-CONTENTS) | Fit page to drawing contents. |
+| [METRIC_ISO](#METRIC-ISO) | Metric (ISO). |
+| [SAME_AS_PRINTER](#SAME-AS-PRINTER) | Wie der Drucker. |
+| [STANDARD](#STANDARD) | Standard. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ANSI_ARCHITECTURAL {#ANSI-ARCHITECTURAL}
+```
+public static final int ANSI_ARCHITECTURAL
+```
+
+
+ANSI architectural.
+
+### ANSI_ENGINEERING {#ANSI-ENGINEERING}
+```
+public static final int ANSI_ENGINEERING
+```
+
+
+ANSI engineering.
+
+### CUSTOM_PAGE_SIZE {#CUSTOM-PAGE-SIZE}
+```
+public static final int CUSTOM_PAGE_SIZE
+```
+
+
+Custom page size.
+
+### CUSTOM_SCALED_DRAW_SIZE {#CUSTOM-SCALED-DRAW-SIZE}
+```
+public static final int CUSTOM_SCALED_DRAW_SIZE
+```
+
+
+Custom scaled drawing size.
+
+### FIT_PAGE_DRAW_CONTENTS {#FIT-PAGE-DRAW-CONTENTS}
+```
+public static final int FIT_PAGE_DRAW_CONTENTS
+```
+
+
+Fit page to drawing contents.
+
+### METRIC_ISO {#METRIC-ISO}
+```
+public static final int METRIC_ISO
+```
+
+
+Metric (ISO).
+
+### SAME_AS_PRINTER {#SAME-AS-PRINTER}
+```
+public static final int SAME_AS_PRINTER
+```
+
+
+Wie der Drucker.
+
+### STANDARD {#STANDARD}
+```
+public static final int STANDARD
+```
+
+
+Standard.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/dropbuttonstyle/_index.md
+++ b/german/java/com.aspose.diagram/dropbuttonstyle/_index.md
@@ -1,0 +1,165 @@
+---
+title: DropButtonStyle
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt das Symbol dar, das auf der Dropdown-Schaltfläche angezeigt wird.
+type: docs
+weight: 135
+url: /de/java/com.aspose.diagram/dropbuttonstyle/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class DropButtonStyle
+```
+
+Stellt das Symbol dar, das auf der Dropdown-Schaltfläche angezeigt wird.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [ARROW](#ARROW) | Zeigt eine Schaltfläche mit einem nach unten zeigenden Pfeil an. |
+| [ELLIPSIS](#ELLIPSIS) | Zeigt eine Schaltfläche mit einer Auslassung (...). |
+| [PLAIN](#PLAIN) | Zeigt eine Schaltfläche ohne Symbol an. |
+| [REDUCE](#REDUCE) | Zeigt eine Schaltfläche mit einer horizontalen Linie, ähnlich einem Unterstrich, an. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ARROW {#ARROW}
+```
+public static final int ARROW
+```
+
+
+Zeigt eine Schaltfläche mit einem nach unten zeigenden Pfeil an.
+
+### ELLIPSIS {#ELLIPSIS}
+```
+public static final int ELLIPSIS
+```
+
+
+Zeigt eine Schaltfläche mit einer Auslassung (...).
+
+### PLAIN {#PLAIN}
+```
+public static final int PLAIN
+```
+
+
+Zeigt eine Schaltfläche ohne Symbol an.
+
+### REDUCE {#REDUCE}
+```
+public static final int REDUCE
+```
+
+
+Zeigt eine Schaltfläche mit einer horizontalen Linie, ähnlich einem Unterstrich, an.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/dynfeedback/_index.md
+++ b/german/java/com.aspose.diagram/dynfeedback/_index.md
@@ -1,0 +1,179 @@
+---
+title: DynFeedback
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt den Typ des visuellen Feedbacks an, das Benutzern beim Ziehen eines Connectors bereitgestellt wird.
+type: docs
+weight: 136
+url: /de/java/com.aspose.diagram/dynfeedback/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DynFeedback
+```
+
+Gibt den Typ des visuellen Feedbacks an, das Benutzern beim Ziehen eines Connectors bereitgestellt wird. Wenn die Maustaste losgelassen wird, wird die resultierende Connectorform nicht von dieser Einstellung beeinflusst. Dieses Element gilt nicht für routbare Connectoren.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [DynFeedback(int value)](#DynFeedback-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Gibt den Typ des visuellen Feedbacks an, das Benutzern beim Ziehen eines Connectors bereitgestellt wird. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/dynfeedback\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DynFeedback(int value) {#DynFeedback-int-}
+```
+public DynFeedback(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Gibt den Typ des visuellen Feedbacks an, das Benutzern beim Ziehen eines Connectors bereitgestellt wird. Wenn die Maustaste losgelassen wird, wird die resultierende Connectorform nicht von dieser Einstellung beeinflusst. Dieses Element gilt nicht für routbare Connectoren.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/dynfeedback\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/dynfeedbackvalue/_index.md
+++ b/german/java/com.aspose.diagram/dynfeedbackvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: DynFeedbackValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt den Typ des visuellen Feedbacks an, das Benutzern beim Ziehen eines Connectors bereitgestellt wird.
+type: docs
+weight: 137
+url: /de/java/com.aspose.diagram/dynfeedbackvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class DynFeedbackValue
+```
+
+Gibt den Typ des visuellen Feedbacks an, das Benutzern beim Ziehen eines Connectors bereitgestellt wird. Wenn die Maustaste losgelassen wird, wird die resultierende Connectorform nicht von dieser Einstellung beeinflusst. Dieses Element gilt nicht für routbare Connectoren.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [REMAIN_STRAIGHT](#REMAIN-STRAIGHT) | Gerade bleiben (keine Beine). |
+| [SHOW_FIVE_LEGS](#SHOW-FIVE-LEGS) | Zeige fünf Beine beim Ziehen. |
+| [SHOW_THREE_LEGS](#SHOW-THREE-LEGS) | Zeige drei Beine beim Ziehen. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### REMAIN_STRAIGHT {#REMAIN-STRAIGHT}
+```
+public static final int REMAIN_STRAIGHT
+```
+
+
+Gerade bleiben (keine Beine).
+
+### SHOW_FIVE_LEGS {#SHOW-FIVE-LEGS}
+```
+public static final int SHOW_FIVE_LEGS
+```
+
+
+Zeige fünf Beine beim Ziehen.
+
+### SHOW_THREE_LEGS {#SHOW-THREE-LEGS}
+```
+public static final int SHOW_THREE_LEGS
+```
+
+
+Zeige drei Beine beim Ziehen.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/ellipse/_index.md
+++ b/german/java/com.aspose.diagram/ellipse/_index.md
@@ -1,0 +1,349 @@
+---
+title: Ellipse
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält Elemente, die die x- und y-Koordinaten des Mittelpunktes der Ellipse sowie zwei Punkte auf der Ellipse angeben.
+type: docs
+weight: 138
+url: /de/java/com.aspose.diagram/ellipse/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class Ellipse extends Coordinate
+```
+
+Enthält Elemente, die die x- und y-Koordinaten des Mittelpunktes der Ellipse sowie zwei Punkte auf der Ellipse angeben.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [Ellipse()](#Ellipse--) | Erstellt eine Instanz der Klasse [Ellipse](../../com.aspose.diagram/ellipse). |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | Eine x-Koordinate eines Punktes auf der Ellipse, gekoppelt mit der y-Koordinate, die durch das B-Element dargestellt wird. |
+| [getB()](#getB--) | Eine y-Koordinate eines Punktes auf einer Ellipse, gekoppelt mit der x-Koordinate, die durch das A-Element dargestellt wird. |
+| [getC()](#getC--) | Eine x-Koordinate eines Punktes auf der Ellipse, gekoppelt mit der y-Koordinate, die durch das D-Element dargestellt wird. |
+| [getClass()](#getClass--) |  |
+| [getD()](#getD--) | Eine y-Koordinate eines Punktes auf der Ellipse, gekoppelt mit der x-Koordinate, die durch das C-Element dargestellt wird. |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getIX()](#getIX--) | Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements. |
+| [getX()](#getX--) | Die x-Koordinate des Mittelpunktes der Ellipse. |
+| [getY()](#getY--) | Die y-Koordinate des Mittelpunktes der Ellipse. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getA()](../../com.aspose.diagram/ellipse\#getA--) |
+| [setB(DoubleValue value)](#setB-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getB()](../../com.aspose.diagram/ellipse\#getB--) |
+| [setC(DoubleValue value)](#setC-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getC()](../../com.aspose.diagram/ellipse\#getC--) |
+| [setD(DoubleValue value)](#setD-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getD()](../../com.aspose.diagram/ellipse\\#getD--) |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/ellipse\\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getIX()](../../com.aspose.diagram/ellipse\\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getX()](../../com.aspose.diagram/ellipse\\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getY()](../../com.aspose.diagram/ellipse\\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Ellipse() {#Ellipse--}
+```
+public Ellipse()
+```
+
+
+Erstellt eine Instanz der Klasse [Ellipse](../../com.aspose.diagram/ellipse).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+Eine x-Koordinate eines Punktes auf der Ellipse, gekoppelt mit der y-Koordinate, die durch das B-Element dargestellt wird.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getB() {#getB--}
+```
+public DoubleValue getB()
+```
+
+
+Eine y-Koordinate eines Punktes auf einer Ellipse, gekoppelt mit der x-Koordinate, die durch das A-Element dargestellt wird.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getC() {#getC--}
+```
+public DoubleValue getC()
+```
+
+
+Eine x-Koordinate eines Punktes auf der Ellipse, gekoppelt mit der y-Koordinate, die durch das D-Element dargestellt wird.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getD() {#getD--}
+```
+public DoubleValue getD()
+```
+
+
+Eine y-Koordinate eines Punktes auf der Ellipse, gekoppelt mit der x-Koordinate, die durch das C-Element dargestellt wird.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+Die x-Koordinate des Mittelpunktes der Ellipse.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+Die y-Koordinate des Mittelpunktes der Ellipse.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getA()](../../com.aspose.diagram/ellipse\#getA--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setB(DoubleValue value) {#setB-com.aspose.diagram.DoubleValue-}
+```
+public void setB(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getB()](../../com.aspose.diagram/ellipse\#getB--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setC(DoubleValue value) {#setC-com.aspose.diagram.DoubleValue-}
+```
+public void setC(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getC()](../../com.aspose.diagram/ellipse\#getC--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setD(DoubleValue value) {#setD-com.aspose.diagram.DoubleValue-}
+```
+public void setD(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getD()](../../com.aspose.diagram/ellipse\\#getD--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/ellipse\\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getIX()](../../com.aspose.diagram/ellipse\\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getX()](../../com.aspose.diagram/ellipse\\#getX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getY()](../../com.aspose.diagram/ellipse\\#getY--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/ellipsecollection/_index.md
+++ b/german/java/com.aspose.diagram/ellipsecollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: EllipseCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: Ellipsensammlung.
+type: docs
+weight: 139
+url: /de/java/com.aspose.diagram/ellipsecollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class EllipseCollection extends Collection
+```
+
+Ellipsensammlung.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Ellipse get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[Ellipse](../../com.aspose.diagram/ellipse) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/ellipticalarcto/_index.md
+++ b/german/java/com.aspose.diagram/ellipticalarcto/_index.md
@@ -1,0 +1,349 @@
+---
+title: EllipticalArcTo
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält Elemente, die Informationen über einen elliptischen Bogen angeben.
+type: docs
+weight: 140
+url: /de/java/com.aspose.diagram/ellipticalarcto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class EllipticalArcTo extends Coordinate
+```
+
+Enthält Elemente, die Informationen über einen elliptischen Bogen angeben.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [EllipticalArcTo()](#EllipticalArcTo--) | Erstellt eine Instanz der Klasse [EllipticalArcTo](../../com.aspose.diagram/ellipticalarcto). |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | Die x‑Koordinate des Kontrollpunkts des Bogens. |
+| [getB()](#getB--) | Die y‑Koordinate des Kontrollpunkts eines Bogens. |
+| [getC()](#getC--) | Der Winkel der Hauptachse des Bogens relativ zur x‑Achse seines übergeordneten Elements. |
+| [getClass()](#getClass--) |  |
+| [getD()](#getD--) | Das Verhältnis der Hauptachse des Bogens zur Nebenachse. |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getIX()](#getIX--) | Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements. |
+| [getX()](#getX--) | Die x‑Koordinate des Endknotens eines elliptischen Bogens. |
+| [getY()](#getY--) | Die y‑Koordinate des Endknotens eines elliptischen Bogens. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getA()](../../com.aspose.diagram/ellipticalarcto\#getA--) |
+| [setB(DoubleValue value)](#setB-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getB()](../../com.aspose.diagram/ellipticalarcto\#getB--) |
+| [setC(DoubleValue value)](#setC-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getC()](../../com.aspose.diagram/ellipticalarcto\#getC--) |
+| [setD(DoubleValue value)](#setD-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getD()](../../com.aspose.diagram/ellipticalarcto\#getD--) |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/ellipticalarcto\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getIX()](../../com.aspose.diagram/ellipticalarcto\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getX()](../../com.aspose.diagram/ellipticalarcto\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft, siehe bitte [getY()](../../com.aspose.diagram/ellipticalarcto\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### EllipticalArcTo() {#EllipticalArcTo--}
+```
+public EllipticalArcTo()
+```
+
+
+Erstellt eine Instanz der Klasse [EllipticalArcTo](../../com.aspose.diagram/ellipticalarcto).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+Der x‑Koordinate des Kontrollpunkts des Bogens. Der Kontrollpunkt ist am besten etwa halbwegs zwischen dem Anfangs‑ und Endpunkt des Bogens positioniert. Andernfalls kann der Bogen zu einer extremen Größe anwachsen, um durch den Kontrollpunkt zu verlaufen, mit unvorhersehbaren Ergebnissen.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getB() {#getB--}
+```
+public DoubleValue getB()
+```
+
+
+Die y‑Koordinate des Kontrollpunkts eines Bogens.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getC() {#getC--}
+```
+public DoubleValue getC()
+```
+
+
+Der Winkel der Hauptachse des Bogens relativ zur x‑Achse seines übergeordneten Elements.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getD() {#getD--}
+```
+public DoubleValue getD()
+```
+
+
+Das Verhältnis der Hauptachse eines Bogens zu seiner Nebenachse. Trotz der üblichen Bedeutung dieser Wörter muss die Hauptachse nicht größer sein als die Nebenachse, sodass dieses Verhältnis nicht größer als 1 sein muss. Das Setzen dieses Elements auf einen Wert kleiner oder gleich 0 oder größer als 1000 kann zu unvorhersehbaren Ergebnissen führen.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+Die x‑Koordinate des Endknotens eines elliptischen Bogens.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+Die y‑Koordinate des Endknotens eines elliptischen Bogens.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getA()](../../com.aspose.diagram/ellipticalarcto\#getA--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setB(DoubleValue value) {#setB-com.aspose.diagram.DoubleValue-}
+```
+public void setB(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getB()](../../com.aspose.diagram/ellipticalarcto\#getB--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setC(DoubleValue value) {#setC-com.aspose.diagram.DoubleValue-}
+```
+public void setC(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getC()](../../com.aspose.diagram/ellipticalarcto\#getC--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setD(DoubleValue value) {#setD-com.aspose.diagram.DoubleValue-}
+```
+public void setD(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getD()](../../com.aspose.diagram/ellipticalarcto\#getD--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/ellipticalarcto\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getIX()](../../com.aspose.diagram/ellipticalarcto\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getX()](../../com.aspose.diagram/ellipticalarcto\#getX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft, siehe bitte [getY()](../../com.aspose.diagram/ellipticalarcto\#getY--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/ellipticalarctocollection/_index.md
+++ b/german/java/com.aspose.diagram/ellipticalarctocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: EllipticalArcToCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: EllipticalArcTo  Sammlung.
+type: docs
+weight: 141
+url: /de/java/com.aspose.diagram/ellipticalarctocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class EllipticalArcToCollection extends Collection
+```
+
+EllipticalArcTo-Sammlung.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public EllipticalArcTo get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[EllipticalArcTo](../../com.aspose.diagram/ellipticalarcto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/emfrendersetting/_index.md
+++ b/german/java/com.aspose.diagram/emfrendersetting/_index.md
@@ -1,0 +1,147 @@
+---
+title: EmfRenderSetting
+second_title: Aspose.Diagram for Java API-Referenz
+description: Einstellung zum Rendern von Emf-Metadateien.
+type: docs
+weight: 142
+url: /de/java/com.aspose.diagram/emfrendersetting/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class EmfRenderSetting
+```
+
+Einstellung zum Rendern von Emf-Metadateien.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [EMF_ONLY](#EMF-ONLY) | Nur Emf-Datensätze rendern. |
+| [EMF_PLUS_PREFER](#EMF-PLUS-PREFER) | Bevorzugen Sie das Rendern von EmfPlus-Datensätzen. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### EMF_ONLY {#EMF-ONLY}
+```
+public static final int EMF_ONLY
+```
+
+
+Nur Emf-Datensätze rendern.
+
+### EMF_PLUS_PREFER {#EMF-PLUS-PREFER}
+```
+public static final int EMF_PLUS_PREFER
+```
+
+
+Bevorzugen Sie das Rendern von EmfPlus-Datensätzen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/encoding/_index.md
+++ b/german/java/com.aspose.diagram/encoding/_index.md
@@ -1,0 +1,277 @@
+---
+title: Encoding
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt eine Zeichenkodierung dar.
+type: docs
+weight: 143
+url: /de/java/com.aspose.diagram/encoding/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Encoding
+```
+
+Stellt eine Zeichenkodierung dar.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [Encoding()](#Encoding--) |  |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Encoding other)](#equals-com.aspose.diagram.Encoding-) | Bestimmt, ob das angegebene Encoding-Objekt gleich der aktuellen Instanz ist. |
+| [equals(Object o)](#equals-java.lang.Object-) | Bestimmt, ob das angegebene Objekt gleich der aktuellen Instanz ist. |
+| [getASCII()](#getASCII--) | Ermittelt eine Kodierung für den ASCII-Zeichensatz (7-Bit). |
+| [getBigEndianUnicode()](#getBigEndianUnicode--) | Ermittelt eine Kodierung für das UTF-16-Format mit Big-Endian-Byte-Reihenfolge. |
+| [getClass()](#getClass--) |  |
+| [getDefault()](#getDefault--) | Ermittelt eine Kodierung für die aktuelle ANSI-Codepage des Betriebssystems. |
+| [getEncoding(int codePage)](#getEncoding-int-) | Gibt die Kodierung zurück, die mit der angegebenen Codepage-Kennung verknüpft ist. |
+| [getEncoding(String charsetName)](#getEncoding-java.lang.String-) | Gibt eine Kodierung zurück, die mit dem angegebenen Zeichensatznamen verknüpft ist. |
+| [getEncoding(Charset charset)](#getEncoding-java.nio.charset.Charset-) | Gibt eine Kodierung zurück, die mit dem angegebenen Zeichensatzobjekt verknüpft ist. |
+| [getUTF7()](#getUTF7--) | Ermittelt eine Kodierung für das UTF-7-Format. |
+| [getUTF8()](#getUTF8--) | Ermittelt eine Kodierung für das UTF-8-Format. |
+| [getUTF8NoBOM()](#getUTF8NoBOM--) | Ermittelt eine Kodierung für das UTF-8-Format ohne den UTF-8-Identifikator. |
+| [getUnicode()](#getUnicode--) | Ermittelt eine Kodierung für das UTF-16-Format mit Little-Endian-Byte-Reihenfolge. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Encoding() {#Encoding--}
+```
+public Encoding()
+```
+
+
+### equals(Encoding other) {#equals-com.aspose.diagram.Encoding-}
+```
+public boolean equals(Encoding other)
+```
+
+
+Bestimmt, ob das angegebene Encoding-Objekt gleich der aktuellen Instanz ist.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| other | [Encoding](../../com.aspose.diagram/encoding) | Das Encoding-Objekt zum Vergleich mit der aktuellen Instanz. |
+
+**Returns:**
+boolean - true, wenn der Wert gleich der aktuellen Instanz ist; andernfalls false.
+### equals(Object o) {#equals-java.lang.Object-}
+```
+public boolean equals(Object o)
+```
+
+
+Bestimmt, ob das angegebene Objekt gleich der aktuellen Instanz ist.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| o | java.lang.Object | Das Objekt zum Vergleich mit der aktuellen Instanz. |
+
+**Returns:**
+boolean - true, wenn der Wert eine Instanz von Encoding ist und der aktuellen Instanz entspricht; andernfalls false.
+### getASCII() {#getASCII--}
+```
+public static Encoding getASCII()
+```
+
+
+Ermittelt eine Kodierung für den ASCII-Zeichensatz (7-Bit).
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - A Encoding object for the ASCII (7-bit) character set.
+### getBigEndianUnicode() {#getBigEndianUnicode--}
+```
+public static Encoding getBigEndianUnicode()
+```
+
+
+Ermittelt eine Kodierung für das UTF-16-Format mit Big-Endian-Byte-Reihenfolge.
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - A Encoding object for the UTF-16 format using the big endian byte
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefault() {#getDefault--}
+```
+public static Encoding getDefault()
+```
+
+
+Ermittelt eine Kodierung für die aktuelle ANSI-Codepage des Betriebssystems.
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - An encoding for the operating system's current ANSI code page.
+### getEncoding(int codePage) {#getEncoding-int-}
+```
+public static Encoding getEncoding(int codePage)
+```
+
+
+Gibt die Kodierung zurück, die mit der angegebenen Codepage-Kennung verknüpft ist.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| codePage | int | Der Codepage-Bezeichner der bevorzugten Kodierung. -oder- 0, um die Standardkodierung zu verwenden. |
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - The Encoding object associated with the specified code page.
+### getEncoding(String charsetName) {#getEncoding-java.lang.String-}
+```
+public static Encoding getEncoding(String charsetName)
+```
+
+
+Gibt eine Kodierung zurück, die mit dem angegebenen Zeichensatznamen verknüpft ist.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| charsetName | java.lang.String | angegebener Zeichensatzname |
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - The Encoding object associated with the specified charset name.
+### getEncoding(Charset charset) {#getEncoding-java.nio.charset.Charset-}
+```
+public static Encoding getEncoding(Charset charset)
+```
+
+
+Gibt eine Kodierung zurück, die mit dem angegebenen Zeichensatzobjekt verknüpft ist.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| charset | java.nio.charset.Charset | angegebenes Zeichensatzobjekt |
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - The Encoding object associated with the specified charset object.
+### getUTF7() {#getUTF7--}
+```
+public static Encoding getUTF7()
+```
+
+
+Ermittelt eine Kodierung für das UTF-7-Format.
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - A Encoding object for the UTF-7 format.
+### getUTF8() {#getUTF8--}
+```
+public static Encoding getUTF8()
+```
+
+
+Ermittelt eine Kodierung für das UTF-8-Format.
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - A Encoding object for the UTF-8 format.
+### getUTF8NoBOM() {#getUTF8NoBOM--}
+```
+public static Encoding getUTF8NoBOM()
+```
+
+
+Ermittelt eine Kodierung für das UTF-8-Format ohne den UTF-8-Identifikator.
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - A Encoding object for the UTF-8 format without UTF-8 identifier.
+### getUnicode() {#getUnicode--}
+```
+public static Encoding getUnicode()
+```
+
+
+Ermittelt eine Kodierung für das UTF-16-Format mit Little-Endian-Byte-Reihenfolge.
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - A Encoding object for the UTF-16 format using the little endian byte
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/event/_index.md
+++ b/german/java/com.aspose.diagram/event/_index.md
@@ -1,0 +1,311 @@
+---
+title: Ereignis
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält Elemente, die Formeln angeben, die Formereignisse steuern.
+type: docs
+weight: 144
+url: /de/java/com.aspose.diagram/event/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Event
+```
+
+Enthält Elemente, die Formeln angeben, die Formereignisse steuern.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getEventDblClick()](#getEventDblClick--) | Ein Ereigniselement, das ausgewertet wird, wenn eine Form doppelt angeklickt wird. |
+| [getEventDrop()](#getEventDrop--) | Ein Ereigniselement, das ausgewertet wird, wenn eine Form auf die Zeichenfläche gezogen wird, entweder als Instanz oder wenn eine Form dupliziert oder eingefügt wird. |
+| [getEventMultiDrop()](#getEventMultiDrop--) | EventMultiDrop. |
+| [getEventXFMod()](#getEventXFMod--) | Ein Ereigniselement, das ausgewertet wird, wenn die Position oder Ausrichtung einer Form auf der Seite transformiert wird. |
+| [getTheData()](#getTheData--) | Für zukünftige Verwendung reserviert. |
+| [getTheText()](#getTheText--) | Ein Ereigniselement, das ausgewertet wird, wenn sich der Text oder die Textzusammensetzung einer Form ändert. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/event\#getDel--) |
+| [setEventDblClick(DoubleValue value)](#setEventDblClick-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getEventDblClick()](../../com.aspose.diagram/event\#getEventDblClick--) |
+| [setEventDrop(DoubleValue value)](#setEventDrop-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getEventDrop()](../../com.aspose.diagram/event\#getEventDrop--) |
+| [setEventMultiDrop(DoubleValue value)](#setEventMultiDrop-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getEventMultiDrop()](../../com.aspose.diagram/event\#getEventMultiDrop--) |
+| [setEventXFMod(DoubleValue value)](#setEventXFMod-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getEventXFMod()](../../com.aspose.diagram/event\#getEventXFMod--) |
+| [setTheData(DoubleValue value)](#setTheData-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getTheData()](../../com.aspose.diagram/event\#getTheData--) |
+| [setTheText(DoubleValue value)](#setTheText-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getTheText()](../../com.aspose.diagram/event\#getTheText--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getEventDblClick() {#getEventDblClick--}
+```
+public DoubleValue getEventDblClick()
+```
+
+
+Ein Ereigniselement, das ausgewertet wird, wenn eine Form doppelt angeklickt wird.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getEventDrop() {#getEventDrop--}
+```
+public DoubleValue getEventDrop()
+```
+
+
+Ein Ereigniselement, das ausgewertet wird, wenn eine Form auf die Zeichenfläche gezogen wird, entweder als Instanz oder wenn eine Form dupliziert oder eingefügt wird.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getEventMultiDrop() {#getEventMultiDrop--}
+```
+public DoubleValue getEventMultiDrop()
+```
+
+
+EventMultiDrop.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getEventXFMod() {#getEventXFMod--}
+```
+public DoubleValue getEventXFMod()
+```
+
+
+Ein Ereigniselement, das ausgewertet wird, wenn die Position oder Ausrichtung einer Form auf der Seite transformiert wird.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTheData() {#getTheData--}
+```
+public DoubleValue getTheData()
+```
+
+
+Für zukünftige Verwendung reserviert.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTheText() {#getTheText--}
+```
+public DoubleValue getTheText()
+```
+
+
+Ein Ereigniselement, das ausgewertet wird, wenn sich der Text oder die Textzusammensetzung einer Form ändert.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/event\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setEventDblClick(DoubleValue value) {#setEventDblClick-com.aspose.diagram.DoubleValue-}
+```
+public void setEventDblClick(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getEventDblClick()](../../com.aspose.diagram/event\#getEventDblClick--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setEventDrop(DoubleValue value) {#setEventDrop-com.aspose.diagram.DoubleValue-}
+```
+public void setEventDrop(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getEventDrop()](../../com.aspose.diagram/event\#getEventDrop--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setEventMultiDrop(DoubleValue value) {#setEventMultiDrop-com.aspose.diagram.DoubleValue-}
+```
+public void setEventMultiDrop(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getEventMultiDrop()](../../com.aspose.diagram/event\#getEventMultiDrop--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setEventXFMod(DoubleValue value) {#setEventXFMod-com.aspose.diagram.DoubleValue-}
+```
+public void setEventXFMod(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getEventXFMod()](../../com.aspose.diagram/event\#getEventXFMod--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTheData(DoubleValue value) {#setTheData-com.aspose.diagram.DoubleValue-}
+```
+public void setTheData(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getTheData()](../../com.aspose.diagram/event\#getTheData--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTheText(DoubleValue value) {#setTheText-com.aspose.diagram.DoubleValue-}
+```
+public void setTheText(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getTheText()](../../com.aspose.diagram/event\#getTheText--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/eventitem/_index.md
+++ b/german/java/com.aspose.diagram/eventitem/_index.md
@@ -1,0 +1,288 @@
+---
+title: EventItem
+second_title: Aspose.Diagram for Java API-Referenz
+description: Kapselt einen Ereigniscode.
+type: docs
+weight: 145
+url: /de/java/com.aspose.diagram/eventitem/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class EventItem
+```
+
+Kapselt einen Ereigniscode. Ein EventItem-Element kann zwei Arten von Aktionen auslösen: Es kann ein Add‑On ausführen oder eine Benachrichtigung des Ereignisses an das aufrufende Programm senden.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [EventItem()](#EventItem--) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAction()](#getAction--) | Gibt den Aktionscode des übergeordneten EventItem-Elements an. Damit ein EventItem-Element in einer DatadiagramML-Datei gespeichert werden kann, muss es persistierbar sein. |
+| [getClass()](#getClass--) |  |
+| [getEnabled()](#getEnabled--) | Stellt ein Flag dar, das angibt, ob das Ereignis aktiviert oder deaktiviert ist. |
+| [getEventCode()](#getEventCode--) | Ein Code, der das Ereignis angibt, das das Add‑On auslöst. |
+| [getID()](#getID--) | Die ID des Ereignisses. |
+| [getTarget()](#getTarget--) | Gibt das Ziel eines Ereignisses an. |
+| [getTargetArgs()](#getTargetArgs--) | Gibt eine Zeichenkette an, die Argumente enthält, die an das Ziel eines Ereignisses gesendet werden. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAction(int value)](#setAction-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getAction()](../../com.aspose.diagram/eventitem\#getAction--) |
+| [setEnabled(int value)](#setEnabled-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getEnabled()](../../com.aspose.diagram/eventitem\#getEnabled--) |
+| [setEventCode(int value)](#setEventCode-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getEventCode()](../../com.aspose.diagram/eventitem\#getEventCode--) |
+| [setID(int value)](#setID-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getID()](../../com.aspose.diagram/eventitem\#getID--) |
+| [setTarget(String value)](#setTarget-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getTarget()](../../com.aspose.diagram/eventitem\#getTarget--) |
+| [setTargetArgs(String value)](#setTargetArgs-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getTargetArgs()](../../com.aspose.diagram/eventitem\#getTargetArgs--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### EventItem() {#EventItem--}
+```
+public EventItem()
+```
+
+
+Konstruktor.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAction() {#getAction--}
+```
+public int getAction()
+```
+
+
+Gibt den Aktionscode des übergeordneten EventItem-Elements an. Damit ein EventItem-Element in einer DatadiagramML-Datei gespeichert werden kann, muss es persistierbar sein. Derzeit ist der einzige gültige Aktionscode, den ein persistierbares Ereignis haben kann, 1 (ONEVENT\_ACT\_RUNADDON).
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getEnabled() {#getEnabled--}
+```
+public int getEnabled()
+```
+
+
+Stellt ein Flag dar, das angibt, ob das Ereignis aktiviert oder deaktiviert ist.
+
+**Returns:**
+int
+### getEventCode() {#getEventCode--}
+```
+public int getEventCode()
+```
+
+
+Ein Code, der das Ereignis angibt, das das Add‑On auslöst. Weitere Informationen zu Ereigniscodes finden Sie in den Event Codes in der Microsoft Visio 2007 Automation Reference.
+
+**Returns:**
+int
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+Die ID des Ereignisses.
+
+**Returns:**
+int
+### getTarget() {#getTarget--}
+```
+public String getTarget()
+```
+
+
+Gibt das Ziel eines Ereignisses an.
+
+**Returns:**
+java.lang.String
+### getTargetArgs() {#getTargetArgs--}
+```
+public String getTargetArgs()
+```
+
+
+Gibt eine Zeichenkette an, die Argumente enthält, die an das Ziel eines Ereignisses gesendet werden.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAction(int value) {#setAction-int-}
+```
+public void setAction(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getAction()](../../com.aspose.diagram/eventitem\#getAction--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setEnabled(int value) {#setEnabled-int-}
+```
+public void setEnabled(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getEnabled()](../../com.aspose.diagram/eventitem\#getEnabled--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setEventCode(int value) {#setEventCode-int-}
+```
+public void setEventCode(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getEventCode()](../../com.aspose.diagram/eventitem\#getEventCode--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getID()](../../com.aspose.diagram/eventitem\#getID--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setTarget(String value) {#setTarget-java.lang.String-}
+```
+public void setTarget(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getTarget()](../../com.aspose.diagram/eventitem\#getTarget--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setTargetArgs(String value) {#setTargetArgs-java.lang.String-}
+```
+public void setTargetArgs(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getTargetArgs()](../../com.aspose.diagram/eventitem\#getTargetArgs--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/eventitemcollection/_index.md
+++ b/german/java/com.aspose.diagram/eventitemcollection/_index.md
@@ -1,0 +1,231 @@
+---
+title: EventItemCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: EventItem-Sammlung.
+type: docs
+weight: 146
+url: /de/java/com.aspose.diagram/eventitemcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class EventItemCollection extends Collection
+```
+
+EventItem-Sammlung.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [EventItemCollection()](#EventItemCollection--) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [add(EventItem eventItem)](#add-com.aspose.diagram.EventItem-) | Fügt das eventItem zur Sammlung hinzu. |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(EventItem eventItem)](#remove-com.aspose.diagram.EventItem-) | Entfernt das eventItem aus der Sammlung. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### EventItemCollection() {#EventItemCollection--}
+```
+public EventItemCollection()
+```
+
+
+Konstruktor.
+
+### add(EventItem eventItem) {#add-com.aspose.diagram.EventItem-}
+```
+public int add(EventItem eventItem)
+```
+
+
+Fügt das eventItem zur Sammlung hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| eventItem | [EventItem](../../com.aspose.diagram/eventitem) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public EventItem get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[EventItem](../../com.aspose.diagram/eventitem) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(EventItem eventItem) {#remove-com.aspose.diagram.EventItem-}
+```
+public void remove(EventItem eventItem)
+```
+
+
+Entfernt das eventItem aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| eventItem | [EventItem](../../com.aspose.diagram/eventitem) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/field/_index.md
+++ b/german/java/com.aspose.diagram/field/_index.md
@@ -1,0 +1,309 @@
+---
+title: Feld
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält Elemente, die Funktionen und Formeln angeben, die in den Text der Formen eingefügt wurden.
+type: docs
+weight: 147
+url: /de/java/com.aspose.diagram/field/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Field
+```
+
+Enthält Elemente, die Funktionen und Formeln angeben, die in den Text der Form eingefügt werden.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [Field()](#Field--) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCalendar()](#getCalendar--) | Bestimmt den Kalender, der für benutzerdefinierte Eigenschaften, Textfelder und Formeln von Elementen verwendet wird. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getDisplayValue()](#getDisplayValue--) | Liefert den formatierten Zeichenkettenwert dieses Feldes. |
+| [getEditMode()](#getEditMode--) | Für zukünftige Verwendung reserviert. |
+| [getFormat()](#getFormat--) | Das Formatelement gibt die Formatierung für ein Textfeld an, das eine Zeichenkette, Zahl, Datum oder Uhrzeit, Dauer oder Währung ist. |
+| [getIX()](#getIX--) | Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements. |
+| [getObjectKind()](#getObjectKind--) | Gibt den Typ des Textfelds an. |
+| [getType()](#getType--) | Typ gibt einen Datentyp für den Textfeldwert an. |
+| [getUICat()](#getUICat--) | Gibt die Kategorie eines eingefügten Feldes in Versionen von Microsoft Visio vor Visio 2000 an. |
+| [getUICod()](#getUICod--) | Gibt den Code eines eingefügten Feldes in Versionen von Microsoft Visio vor Visio 2000 an. |
+| [getUIFmt()](#getUIFmt--) | Gibt das Format eines eingefügten Feldes in Versionen von Microsoft Visio vor Visio 2000 an. |
+| [getValue()](#getValue--) | Es enthält den Wert für ein Textfeld. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/field\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getIX()](../../com.aspose.diagram/field\#getIX--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Field() {#Field--}
+```
+public Field()
+```
+
+
+Konstruktor.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCalendar() {#getCalendar--}
+```
+public Calendar getCalendar()
+```
+
+
+Bestimmt den Kalender, der für benutzerdefinierte Eigenschaften, Textfelder und Formeln von Elementen verwendet wird.
+
+**Returns:**
+[Calendar](../../com.aspose.diagram/calendar)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getDisplayValue() {#getDisplayValue--}
+```
+public String getDisplayValue()
+```
+
+
+Liefert den formatierten Zeichenkettenwert dieses Feldes.
+
+**Returns:**
+java.lang.String
+### getEditMode() {#getEditMode--}
+```
+public DoubleValue getEditMode()
+```
+
+
+Für zukünftige Verwendung reserviert.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getFormat() {#getFormat--}
+```
+public Value getFormat()
+```
+
+
+Das Format-Element gibt die Formatierung für ein Textfeld an, das ein String, eine Zahl, ein Datum oder eine Uhrzeit, eine Dauer oder eine Währung ist. Der Typ des Textfelds wird im entsprechenden Typ-Element angegeben.
+
+**Returns:**
+[Value](../../com.aspose.diagram/value)
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements.
+
+**Returns:**
+int
+### getObjectKind() {#getObjectKind--}
+```
+public ObjectKind getObjectKind()
+```
+
+
+Gibt den Typ des Textfelds an.
+
+**Returns:**
+[ObjectKind](../../com.aspose.diagram/objectkind)
+### getType() {#getType--}
+```
+public TypeField getType()
+```
+
+
+Typ gibt einen Datentyp für den Textfeldwert an.
+
+**Returns:**
+[TypeField](../../com.aspose.diagram/typefield)
+### getUICat() {#getUICat--}
+```
+public DoubleValue getUICat()
+```
+
+
+Gibt die Kategorie eines eingefügten Feldes in Versionen von Microsoft Visio vor Visio 2000 an.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getUICod() {#getUICod--}
+```
+public DoubleValue getUICod()
+```
+
+
+Gibt den Code eines eingefügten Feldes in Versionen von Microsoft Visio vor Visio 2000 an.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getUIFmt() {#getUIFmt--}
+```
+public DoubleValue getUIFmt()
+```
+
+
+Gibt das Format eines eingefügten Feldes in Versionen von Microsoft Visio vor Visio 2000 an.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getValue() {#getValue--}
+```
+public Value getValue()
+```
+
+
+Es enthält den Wert für ein Textfeld.
+
+**Returns:**
+[Value](../../com.aspose.diagram/value)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/field\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getIX()](../../com.aspose.diagram/field\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/fieldcollection/_index.md
+++ b/german/java/com.aspose.diagram/fieldcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: FieldCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: Feldsammlung.
+type: docs
+weight: 148
+url: /de/java/com.aspose.diagram/fieldcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class FieldCollection extends Collection
+```
+
+Feldsammlung.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [add(Field item)](#add-com.aspose.diagram.Field-) | Fügen Sie das Field-Objekt zur Sammlung hinzu. |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Field item)](#remove-com.aspose.diagram.Field-) | Entfernen Sie das Field-Objekt aus der Sammlung. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Field item) {#add-com.aspose.diagram.Field-}
+```
+public int add(Field item)
+```
+
+
+Fügen Sie das Field-Objekt zur Sammlung hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [Field](../../com.aspose.diagram/field) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Field get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[Field](../../com.aspose.diagram/field) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Field item) {#remove-com.aspose.diagram.Field-}
+```
+public void remove(Field item)
+```
+
+
+Entfernen Sie das Field-Objekt aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [Field](../../com.aspose.diagram/field) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/filefontsource/_index.md
+++ b/german/java/com.aspose.diagram/filefontsource/_index.md
@@ -1,0 +1,165 @@
+---
+title: FileFontSource
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt die einzelne TrueType-Schriftdatei dar, die im Dateisystem gespeichert ist.
+type: docs
+weight: 149
+url: /de/java/com.aspose.diagram/filefontsource/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.FontSourceBase](../../com.aspose.diagram/fontsourcebase)
+```
+public class FileFontSource extends FontSourceBase
+```
+
+Stellt die einzelne TrueType-Schriftdatei dar, die im Dateisystem gespeichert ist.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [FileFontSource(String filePath)](#FileFontSource-java.lang.String-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFilePath()](#getFilePath--) | Pfad zur Schriftdatei. |
+| [getType()](#getType--) | Gibt den Typ der Schriftquellen zurück. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FileFontSource(String filePath) {#FileFontSource-java.lang.String-}
+```
+public FileFontSource(String filePath)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| filePath | java.lang.String | Pfad zur Schriftdatei |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFilePath() {#getFilePath--}
+```
+public String getFilePath()
+```
+
+
+Pfad zur Schriftdatei.
+
+**Returns:**
+java.lang.String
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Gibt den Typ der Schriftquellen zurück.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/fileformatinfo/_index.md
+++ b/german/java/com.aspose.diagram/fileformatinfo/_index.md
@@ -1,0 +1,158 @@
+---
+title: FileFormatInfo
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält Daten, die von Dateiformaterkennungs‑Methoden zurückgegeben werden.
+type: docs
+weight: 150
+url: /de/java/com.aspose.diagram/fileformatinfo/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class FileFormatInfo
+```
+
+Enthält Daten, die von den Dateiformat-Erkennungsmethoden von [FileFormatUtil](../../com.aspose.diagram/fileformatutil) zurückgegeben werden.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [FileFormatInfo()](#FileFormatInfo--) |  |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFileFormatType()](#getFileFormatType--) | Liefert das erkannte Dateiformat. |
+| [getLoadFormat()](#getLoadFormat--) | Liefert das erkannte Ladeformat. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FileFormatInfo() {#FileFormatInfo--}
+```
+public FileFormatInfo()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFileFormatType() {#getFileFormatType--}
+```
+public int getFileFormatType()
+```
+
+
+Liefert das erkannte Dateiformat.
+
+**Returns:**
+int
+### getLoadFormat() {#getLoadFormat--}
+```
+public int getLoadFormat()
+```
+
+
+Liefert das erkannte Ladeformat.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/fileformattype/_index.md
+++ b/german/java/com.aspose.diagram/fileformattype/_index.md
@@ -1,0 +1,570 @@
+---
+title: FileFormatType
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enumeriert Tabellenkalkulationsdateiformattypen
+type: docs
+weight: 151
+url: /de/java/com.aspose.diagram/fileformattype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class FileFormatType
+```
+
+Enumeriert Tabellenkalkulationsdateiformattypen
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [CSV](#CSV) | Stellt eine CSV-Datei dar. |
+| [DIF](#DIF) | Daten-Austauschformat. |
+| [DOC](#DOC) | Stellt eine DOC-Datei dar. |
+| [DOCM](#DOCM) | Stellt eine DOCM-Datei dar. |
+| [DOCX](#DOCX) | Stellt eine DOCX-Datei dar. |
+| [DOTM](#DOTM) | Stellt eine dotm-Datei dar. |
+| [DOTX](#DOTX) | Stellt eine dotx-Datei dar. |
+| [EXCEL_2003_XML](#EXCEL-2003-XML) | Stellt eine Excel 2003-xml-Datei dar. |
+| [EXCEL_97_TO_2003](#EXCEL-97-TO-2003) | Stellt eine Excel97-2003-xls-Datei dar. |
+| [HTML](#HTML) | Stellt eine html-Datei dar. |
+| [MAPI_MESSAGE](#MAPI-MESSAGE) | Stellt eine E‑Mail-Datei dar. |
+| [MS_EQUATION](#MS-EQUATION) | Stellt das MS Equation 3.0-Objekt dar. |
+| [ODS](#ODS) | Stellt eine ods-Datei dar. |
+| [OLE_10_NATIVE](#OLE-10-NATIVE) | Stellt das eingebettete native Objekt dar. |
+| [OOXML](#OOXML) | Stellt eine Office Open XML‑Datei dar (wie xlsx, docx, pptx usw.). |
+| [PDF](#PDF) | Stellt eine PDF-Datei dar. |
+| [POTM](#POTM) | Stellt eine Potm-Datei dar. |
+| [POTX](#POTX) | Stellt eine Potx-Datei dar. |
+| [PPSM](#PPSM) | Stellt eine ppsm-Datei dar. |
+| [PPSX](#PPSX) | Stellt eine ppsx-Datei dar. |
+| [PPT](#PPT) | Stellt eine ppt-Datei dar. |
+| [PPTM](#PPTM) | Stellt eine pptm-Datei dar. |
+| [PPTX](#PPTX) | Stellt eine pptx-Datei dar. |
+| [SLDX](#SLDX) | Stellt eine sldx-Datei dar. |
+| [SVG](#SVG) | Stellt eine svg-Datei dar. |
+| [TAB_DELIMITED](#TAB-DELIMITED) | Stellt eine tabulatorgetrennte Textdatei dar. |
+| [TIFF](#TIFF) | Stellt eine TIFF-Datei dar. |
+| [UNKNOWN](#UNKNOWN) | Stellt ein nicht erkanntes Format dar, das nicht geladen werden kann. |
+| [VDW](#VDW) | MS Visio VDW-Webzeichnungsformat. |
+| [VDX](#VDX) | MS Visio VDX XML-Format. |
+| [VSD](#VSD) | MS Visio VSD-Binärformat. |
+| [VSDM](#VSDM) | MS Visio 2013 VSDM-Dateiformat. |
+| [VSDX](#VSDX) | MS Visio 2013 VSDX-Dateiformat. |
+| [VSS](#VSS) | MS Visio VSS Binär-Stencil-Format. |
+| [VSSM](#VSSM) | MS Visio 2013 VSSM-Dateiformat. |
+| [VSSX](#VSSX) | MS Visio 2013 VSSX-Dateiformat. |
+| [VST](#VST) | MS Visio VST Binär-Template-Format. |
+| [VSTM](#VSTM) | MS Visio 2013 VSTM-Dateiformat. |
+| [VSTX](#VSTX) | MS Visio 2013 VSTX-Template-Dateiformat. |
+| [VSX](#VSX) | MS Visio VSX XML-Stencil-Format. |
+| [VTX](#VTX) | MS Visio VTX XML-Template-Format. |
+| [XLAM](#XLAM) | Stellt eine addinMacro-aktivierte Template-xltm-Datei dar. |
+| [XLSB](#XLSB) | Stellt eine xlsb-Datei dar. |
+| [XLSM](#XLSM) | Stellt eine xlsm-Datei dar, die Makros aktiviert. |
+| [XLSX](#XLSX) | Stellt eine xlsx-Datei dar. |
+| [XLTM](#XLTM) | Stellt eine makroaktivierte Template-xltm-Datei dar. |
+| [XLTX](#XLTX) | Stellt eine Template-xltx-Datei dar. |
+| [XML](#XML) | Stellt eine einfache XML-Datei dar. |
+| [XPS](#XPS) | Stellt eine XPS-Datei dar. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CSV {#CSV}
+```
+public static final int CSV
+```
+
+
+Stellt eine CSV-Datei dar. Das Dateiformat wird nicht unterstützt, nur zur Erkennung des Dateityps.
+
+### DIF {#DIF}
+```
+public static final int DIF
+```
+
+
+Daten-Austauschformat.
+
+### DOC {#DOC}
+```
+public static final int DOC
+```
+
+
+Stellt eine doc-Datei dar. Das Dateiformat wird nicht unterstützt, nur zur Erkennung des Dateityps.
+
+### DOCM {#DOCM}
+```
+public static final int DOCM
+```
+
+
+Stellt eine docm-Datei dar. Das Dateiformat wird nicht unterstützt, nur zur Erkennung des Dateityps.
+
+### DOCX {#DOCX}
+```
+public static final int DOCX
+```
+
+
+Stellt eine docx-Datei dar. Das Dateiformat wird nicht unterstützt, nur zur Erkennung des Dateityps.
+
+### DOTM {#DOTM}
+```
+public static final int DOTM
+```
+
+
+Stellt eine dotm-Datei dar. Das Dateiformat wird nicht unterstützt, nur zur Erkennung des Dateityps.
+
+### DOTX {#DOTX}
+```
+public static final int DOTX
+```
+
+
+Stellt eine dotx-Datei dar. Das Dateiformat wird nicht unterstützt, nur zur Erkennung des Dateityps.
+
+### EXCEL_2003_XML {#EXCEL-2003-XML}
+```
+public static final int EXCEL_2003_XML
+```
+
+
+Stellt eine Excel 2003 XML-Datei dar. Das Dateiformat wird nicht unterstützt, nur zur Erkennung des Dateityps.
+
+### EXCEL_97_TO_2003 {#EXCEL-97-TO-2003}
+```
+public static final int EXCEL_97_TO_2003
+```
+
+
+Stellt eine Excel97-2003 xls-Datei dar. Das Dateiformat wird nicht unterstützt, nur zur Erkennung des Dateityps.
+
+### HTML {#HTML}
+```
+public static final int HTML
+```
+
+
+Stellt eine html-Datei dar.
+
+### MAPI_MESSAGE {#MAPI-MESSAGE}
+```
+public static final int MAPI_MESSAGE
+```
+
+
+Stellt eine E‑Mail‑Datei dar. Das Dateiformat wird nicht unterstützt, nur zur Erkennung des Dateityps.
+
+### MS_EQUATION {#MS-EQUATION}
+```
+public static final int MS_EQUATION
+```
+
+
+Stellt das MS Equation 3.0‑Objekt dar. Das Dateiformat wird nicht unterstützt, nur zur Erkennung des Dateityps.
+
+### ODS {#ODS}
+```
+public static final int ODS
+```
+
+
+Stellt eine ods-Datei dar. Das Dateiformat wird nicht unterstützt, nur zur Erkennung des Dateityps.
+
+### OLE_10_NATIVE {#OLE-10-NATIVE}
+```
+public static final int OLE_10_NATIVE
+```
+
+
+Stellt das eingebettete native Objekt dar. Das Dateiformat wird nicht unterstützt, nur zur Erkennung des Dateityps.
+
+### OOXML {#OOXML}
+```
+public static final int OOXML
+```
+
+
+Stellt eine Office Open XML‑Datei (wie xlsx, docx, pptx usw.) dar. Das Dateiformat wird nicht unterstützt, nur zur Erkennung des Dateityps. Wenn die Office Open XML‑Datei verschlüsselt ist, kann sie nicht als xlsx, docx, pptx usw. erkannt werden.
+
+### PDF {#PDF}
+```
+public static final int PDF
+```
+
+
+Stellt eine PDF-Datei dar.
+
+### POTM {#POTM}
+```
+public static final int POTM
+```
+
+
+Stellt eine Potm-Datei dar. Das Dateiformat wird nicht unterstützt, nur zur Erkennung des Dateityps.
+
+### POTX {#POTX}
+```
+public static final int POTX
+```
+
+
+Stellt eine Potx-Datei dar. Das Dateiformat wird nicht unterstützt, nur zur Erkennung des Dateityps.
+
+### PPSM {#PPSM}
+```
+public static final int PPSM
+```
+
+
+Stellt eine ppsm-Datei dar. Das Dateiformat wird nicht unterstützt, nur zur Erkennung des Dateityps.
+
+### PPSX {#PPSX}
+```
+public static final int PPSX
+```
+
+
+Stellt eine ppsx-Datei dar. Das Dateiformat wird nicht unterstützt, nur zur Erkennung des Dateityps.
+
+### PPT {#PPT}
+```
+public static final int PPT
+```
+
+
+Stellt eine ppt-Datei dar. Das Dateiformat wird nicht unterstützt, nur zur Erkennung des Dateityps.
+
+### PPTM {#PPTM}
+```
+public static final int PPTM
+```
+
+
+Stellt eine pptm-Datei dar. Das Dateiformat wird nicht unterstützt, nur zur Erkennung des Dateityps.
+
+### PPTX {#PPTX}
+```
+public static final int PPTX
+```
+
+
+Stellt eine pptx-Datei dar. Das Dateiformat wird nicht unterstützt, nur zur Erkennung des Dateityps.
+
+### SLDX {#SLDX}
+```
+public static final int SLDX
+```
+
+
+Stellt eine sldx-Datei dar. Das Dateiformat wird nicht unterstützt, nur zur Erkennung des Dateityps.
+
+### SVG {#SVG}
+```
+public static final int SVG
+```
+
+
+Stellt eine svg-Datei dar.
+
+### TAB_DELIMITED {#TAB-DELIMITED}
+```
+public static final int TAB_DELIMITED
+```
+
+
+Stellt eine tabulatorgetrennte Textdatei dar. Das Dateiformat wird nicht unterstützt, nur zur Erkennung des Dateityps.
+
+### TIFF {#TIFF}
+```
+public static final int TIFF
+```
+
+
+Stellt eine TIFF-Datei dar.
+
+### UNKNOWN {#UNKNOWN}
+```
+public static final int UNKNOWN
+```
+
+
+Stellt ein nicht erkanntes Format dar, das nicht geladen werden kann.
+
+### VDW {#VDW}
+```
+public static final int VDW
+```
+
+
+MS Visio VDW-Webzeichnungsformat.
+
+### VDX {#VDX}
+```
+public static final int VDX
+```
+
+
+MS Visio VDX XML-Format.
+
+### VSD {#VSD}
+```
+public static final int VSD
+```
+
+
+MS Visio VSD-Binärformat.
+
+### VSDM {#VSDM}
+```
+public static final int VSDM
+```
+
+
+MS Visio 2013 VSDM-Dateiformat.
+
+### VSDX {#VSDX}
+```
+public static final int VSDX
+```
+
+
+MS Visio 2013 VSDX-Dateiformat.
+
+### VSS {#VSS}
+```
+public static final int VSS
+```
+
+
+MS Visio VSS Binär-Stencil-Format.
+
+### VSSM {#VSSM}
+```
+public static final int VSSM
+```
+
+
+MS Visio 2013 VSSM-Dateiformat.
+
+### VSSX {#VSSX}
+```
+public static final int VSSX
+```
+
+
+MS Visio 2013 VSSX-Dateiformat.
+
+### VST {#VST}
+```
+public static final int VST
+```
+
+
+MS Visio VST Binär-Template-Format.
+
+### VSTM {#VSTM}
+```
+public static final int VSTM
+```
+
+
+MS Visio 2013 VSTM-Dateiformat.
+
+### VSTX {#VSTX}
+```
+public static final int VSTX
+```
+
+
+MS Visio 2013 VSTX-Template-Dateiformat.
+
+### VSX {#VSX}
+```
+public static final int VSX
+```
+
+
+MS Visio VSX XML-Stencil-Format.
+
+### VTX {#VTX}
+```
+public static final int VTX
+```
+
+
+MS Visio VTX XML-Template-Format.
+
+### XLAM {#XLAM}
+```
+public static final int XLAM
+```
+
+
+Stellt eine addinMacro‑aktivierte Vorlagen‑xltm-Datei dar. Das Dateiformat wird nicht unterstützt, nur zur Erkennung des Dateityps.
+
+### XLSB {#XLSB}
+```
+public static final int XLSB
+```
+
+
+Stellt eine xlsb-Datei dar. Das Dateiformat wird nicht unterstützt, nur zur Erkennung des Dateityps.
+
+### XLSM {#XLSM}
+```
+public static final int XLSM
+```
+
+
+Stellt eine xlsm-Datei dar, die Makros aktiviert. Das Dateiformat wird nicht unterstützt, nur zur Erkennung des Dateityps.
+
+### XLSX {#XLSX}
+```
+public static final int XLSX
+```
+
+
+Stellt eine xlsx-Datei dar. Das Dateiformat wird nicht unterstützt, nur zur Erkennung des Dateityps.
+
+### XLTM {#XLTM}
+```
+public static final int XLTM
+```
+
+
+Stellt eine makroaktivierte Vorlagen‑xltm-Datei dar. Das Dateiformat wird nicht unterstützt, nur zur Erkennung des Dateityps.
+
+### XLTX {#XLTX}
+```
+public static final int XLTX
+```
+
+
+Stellt eine Vorlagen‑xltx-Datei dar. Das Dateiformat wird nicht unterstützt, nur zur Erkennung des Dateityps.
+
+### XML {#XML}
+```
+public static final int XML
+```
+
+
+Stellt eine einfache XML-Datei dar. Das Dateiformat wird nicht unterstützt, nur zur Erkennung des Dateityps.
+
+### XPS {#XPS}
+```
+public static final int XPS
+```
+
+
+Stellt eine XPS-Datei dar.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/fileformatutil/_index.md
+++ b/german/java/com.aspose.diagram/fileformatutil/_index.md
@@ -1,0 +1,168 @@
+---
+title: FileFormatUtil
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt Dienstprogrammmethoden zum Konvertieren von Dateiformat-Enums in Zeichenketten oder Dateierweiterungen und zurück bereit.
+type: docs
+weight: 152
+url: /de/java/com.aspose.diagram/fileformatutil/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class FileFormatUtil
+```
+
+Stellt Dienstprogrammmethoden zum Konvertieren von Dateiformat-Enums in Zeichenketten oder Dateierweiterungen und zurück bereit.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [FileFormatUtil()](#FileFormatUtil--) |  |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [detectFileFormat(InputStream stream)](#detectFileFormat-java.io.InputStream-) | Ermittelt und gibt die Informationen über das Format einer in einem Stream gespeicherten Visio-Datei zurück. |
+| [detectFileFormat(String filePath)](#detectFileFormat-java.lang.String-) | Ermittelt und gibt die Informationen über das Format einer in einer Datei gespeicherten Visio-Datei zurück. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FileFormatUtil() {#FileFormatUtil--}
+```
+public FileFormatUtil()
+```
+
+
+### detectFileFormat(InputStream stream) {#detectFileFormat-java.io.InputStream-}
+```
+public static FileFormatInfo detectFileFormat(InputStream stream)
+```
+
+
+Ermittelt und gibt die Informationen über das Format einer in einem Stream gespeicherten Visio-Datei zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| stream | java.io.InputStream | Der Stream |
+
+**Returns:**
+[FileFormatInfo](../../com.aspose.diagram/fileformatinfo) - A [FileFormatInfo](../../com.aspose.diagram/fileformatinfo) object that contains the detected information.
+### detectFileFormat(String filePath) {#detectFileFormat-java.lang.String-}
+```
+public static FileFormatInfo detectFileFormat(String filePath)
+```
+
+
+Ermittelt und gibt die Informationen über das Format einer in einer Datei gespeicherten Visio-Datei zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| filePath | java.lang.String | Der Dateipfad. |
+
+**Returns:**
+[FileFormatInfo](../../com.aspose.diagram/fileformatinfo) - A [FileFormatInfo](../../com.aspose.diagram/fileformatinfo) object that contains the detected information.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/fill/_index.md
+++ b/german/java/com.aspose.diagram/fill/_index.md
@@ -1,0 +1,597 @@
+---
+title: Füllen
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält die aktuellen Füllformatierungswerte für die Form und den Schatten der Form, einschließlich Vordergrundfarbe und Hintergrundfarbe des Musters.
+type: docs
+weight: 153
+url: /de/java/com.aspose.diagram/fill/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Fill
+```
+
+Enthält die aktuellen Füllformatierungswerte für die Form und den Formschatten, einschließlich Muster, Vordergrundfarbe und Hintergrundfarbe.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getFillBkgnd()](#getFillBkgnd--) | Gibt die für den Hintergrund des Füllmusters der Form verwendete Farbe an. |
+| [getFillBkgndTrans()](#getFillBkgndTrans--) | Gibt den Transparenzgrad für die Hintergrundfarbe (Füllung) des Füllmusters der Form an, von 0 (vollständig undurchsichtig) bis 1 (vollständig transparent). |
+| [getFillForegnd()](#getFillForegnd--) | Gibt die für den Vordergrund (Strich) des Füllmusters der Form verwendete Farbe an. |
+| [getFillForegndTrans()](#getFillForegndTrans--) | Gibt den Transparenzgrad für die Vordergrundfarbe (Füllung) des Füllmusters der Form an, von 0 (vollständig undurchsichtig) bis 1 (vollständig transparent). |
+| [getFillPattern()](#getFillPattern--) | Gibt das Füllmuster für die Form an. |
+| [getGradientFill()](#getGradientFill--) | Enthält die aktuellen Formatierungswerte für den Farbverlauf der Form. |
+| [getShapeShdwBlur()](#getShapeShdwBlur--) | Gibt die Unschärfegröße des Schattens einer Form an. |
+| [getShapeShdwObliqueAngle()](#getShapeShdwObliqueAngle--) | Gibt den Winkel der schrägen Richtung des Schattens einer Form an. |
+| [getShapeShdwOffsetX()](#getShapeShdwOffsetX--) | Bestimmt den Abstand in Seiteneinheiten, um den der Schatten einer Form horizontal von der Form versetzt ist. |
+| [getShapeShdwOffsetY()](#getShapeShdwOffsetY--) | Bestimmt den Abstand in Seiteneinheiten, um den der Schatten einer Form vertikal von der Form versetzt ist. |
+| [getShapeShdwScaleFactor()](#getShapeShdwScaleFactor--) | Gibt den Prozentsatz an, um den der Schatten einer Form vergrößert oder verkleinert werden kann. |
+| [getShapeShdwShow()](#getShapeShdwShow--) | Gibt den Typ des Schattens für eine Form an. |
+| [getShapeShdwType()](#getShapeShdwType--) | Gibt den Typ des Schattens für eine Form an. |
+| [getShdwBkgnd()](#getShdwBkgnd--) | Gibt die für den Hintergrund (Füllung) des Schattens der Form verwendete Farbe an. |
+| [getShdwBkgndTrans()](#getShdwBkgndTrans--) | Gibt den Transparenzgrad für den Hintergrund (Füllung) des Schattens der Form an, von 0,0 (vollständig undurchsichtig) bis 1,0 (vollständig transparent). |
+| [getShdwForegnd()](#getShdwForegnd--) | Gibt die für den Vordergrund (Strich) des Schattens der Form verwendete Farbe an. |
+| [getShdwForegndTrans()](#getShdwForegndTrans--) | Gibt den Transparenzgrad für den Vordergrund (Strich) des Schattens der Form an, von 0,0 (vollständig undurchsichtig) bis 1,0 (vollständig transparent). |
+| [getShdwPattern()](#getShdwPattern--) | Gibt das Füllmuster für den Schatten einer Form an. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/fill\#getDel--) |
+| [setFillBkgnd(ColorValue value)](#setFillBkgnd-com.aspose.diagram.ColorValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getFillBkgnd()](../../com.aspose.diagram/fill\#getFillBkgnd--) |
+| [setFillBkgndTrans(DoubleValue value)](#setFillBkgndTrans-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getFillBkgndTrans()](../../com.aspose.diagram/fill\#getFillBkgndTrans--) |
+| [setFillForegnd(ColorValue value)](#setFillForegnd-com.aspose.diagram.ColorValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getFillForegnd()](../../com.aspose.diagram/fill\#getFillForegnd--) |
+| [setFillForegndTrans(DoubleValue value)](#setFillForegndTrans-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getFillForegndTrans()](../../com.aspose.diagram/fill\#getFillForegndTrans--) |
+| [setFillPattern(IntValue value)](#setFillPattern-com.aspose.diagram.IntValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getFillPattern()](../../com.aspose.diagram/fill\#getFillPattern--) |
+| [setShapeShdwBlur(DoubleValue value)](#setShapeShdwBlur-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getShapeShdwBlur()](../../com.aspose.diagram/fill\#getShapeShdwBlur--) |
+| [setShapeShdwObliqueAngle(DoubleValue value)](#setShapeShdwObliqueAngle-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getShapeShdwObliqueAngle()](../../com.aspose.diagram/fill\#getShapeShdwObliqueAngle--) |
+| [setShapeShdwOffsetX(DoubleValue value)](#setShapeShdwOffsetX-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getShapeShdwOffsetX()](../../com.aspose.diagram/fill\#getShapeShdwOffsetX--) |
+| [setShapeShdwOffsetY(DoubleValue value)](#setShapeShdwOffsetY-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getShapeShdwOffsetY()](../../com.aspose.diagram/fill\#getShapeShdwOffsetY--) |
+| [setShapeShdwScaleFactor(DoubleValue value)](#setShapeShdwScaleFactor-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getShapeShdwScaleFactor()](../../com.aspose.diagram/fill\#getShapeShdwScaleFactor--) |
+| [setShapeShdwShow(ShapeShdwShow value)](#setShapeShdwShow-com.aspose.diagram.ShapeShdwShow-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getShapeShdwShow()](../../com.aspose.diagram/fill\#getShapeShdwShow--) |
+| [setShapeShdwType(ShapeShdwType value)](#setShapeShdwType-com.aspose.diagram.ShapeShdwType-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getShapeShdwType()](../../com.aspose.diagram/fill\#getShapeShdwType--) |
+| [setShdwBkgnd(ColorValue value)](#setShdwBkgnd-com.aspose.diagram.ColorValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getShdwBkgnd()](../../com.aspose.diagram/fill\#getShdwBkgnd--) |
+| [setShdwBkgndTrans(DoubleValue value)](#setShdwBkgndTrans-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getShdwBkgndTrans()](../../com.aspose.diagram/fill\#getShdwBkgndTrans--) |
+| [setShdwForegnd(ColorValue value)](#setShdwForegnd-com.aspose.diagram.ColorValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getShdwForegnd()](../../com.aspose.diagram/fill\#getShdwForegnd--) |
+| [setShdwForegndTrans(DoubleValue value)](#setShdwForegndTrans-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getShdwForegndTrans()](../../com.aspose.diagram/fill\#getShdwForegndTrans--) |
+| [setShdwPattern(IntValue value)](#setShdwPattern-com.aspose.diagram.IntValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getShdwPattern()](../../com.aspose.diagram/fill\#getShdwPattern--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getFillBkgnd() {#getFillBkgnd--}
+```
+public ColorValue getFillBkgnd()
+```
+
+
+Gibt die für den Hintergrund des Füllmusters der Form verwendete Farbe an.
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getFillBkgndTrans() {#getFillBkgndTrans--}
+```
+public DoubleValue getFillBkgndTrans()
+```
+
+
+Gibt den Transparenzgrad für die Hintergrundfarbe (Füllung) des Füllmusters der Form an, von 0 (vollständig undurchsichtig) bis 1 (vollständig transparent).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getFillForegnd() {#getFillForegnd--}
+```
+public ColorValue getFillForegnd()
+```
+
+
+Gibt die für den Vordergrund (Strich) des Füllmusters der Form verwendete Farbe an.
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getFillForegndTrans() {#getFillForegndTrans--}
+```
+public DoubleValue getFillForegndTrans()
+```
+
+
+Gibt den Transparenzgrad für die Vordergrundfarbe (Füllung) des Füllmusters der Form an, von 0 (vollständig undurchsichtig) bis 1 (vollständig transparent).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getFillPattern() {#getFillPattern--}
+```
+public IntValue getFillPattern()
+```
+
+
+Gibt das Füllmuster für die Form an.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getGradientFill() {#getGradientFill--}
+```
+public GradientFill getGradientFill()
+```
+
+
+Enthält die aktuellen Formatierungswerte für den Farbverlauf der Form.
+
+**Returns:**
+[GradientFill](../../com.aspose.diagram/gradientfill)
+### getShapeShdwBlur() {#getShapeShdwBlur--}
+```
+public DoubleValue getShapeShdwBlur()
+```
+
+
+Gibt die Unschärfegröße des Schattens einer Form an. Kann die Unschärfe derzeit nicht zeichnen, kann sie aber jetzt aus VSDX parsen.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShapeShdwObliqueAngle() {#getShapeShdwObliqueAngle--}
+```
+public DoubleValue getShapeShdwObliqueAngle()
+```
+
+
+Gibt den Winkel der schrägen Richtung des Schattens einer Form an.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShapeShdwOffsetX() {#getShapeShdwOffsetX--}
+```
+public DoubleValue getShapeShdwOffsetX()
+```
+
+
+Bestimmt den Abstand in Seiteneinheiten, um den der Schatten einer Form horizontal von der Form versetzt ist.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShapeShdwOffsetY() {#getShapeShdwOffsetY--}
+```
+public DoubleValue getShapeShdwOffsetY()
+```
+
+
+Bestimmt den Abstand in Seiteneinheiten, um den der Schatten einer Form vertikal von der Form versetzt ist.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShapeShdwScaleFactor() {#getShapeShdwScaleFactor--}
+```
+public DoubleValue getShapeShdwScaleFactor()
+```
+
+
+Gibt den Prozentsatz an, um den der Schatten einer Form vergrößert oder verkleinert werden kann.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShapeShdwShow() {#getShapeShdwShow--}
+```
+public ShapeShdwShow getShapeShdwShow()
+```
+
+
+Gibt den Typ des Schattens für eine Form an.
+
+**Returns:**
+[ShapeShdwShow](../../com.aspose.diagram/shapeshdwshow)
+### getShapeShdwType() {#getShapeShdwType--}
+```
+public ShapeShdwType getShapeShdwType()
+```
+
+
+Gibt den Typ des Schattens für eine Form an.
+
+**Returns:**
+[ShapeShdwType](../../com.aspose.diagram/shapeshdwtype)
+### getShdwBkgnd() {#getShdwBkgnd--}
+```
+public ColorValue getShdwBkgnd()
+```
+
+
+Gibt die für den Hintergrund (Füllung) des Schattens der Form verwendete Farbe an.
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getShdwBkgndTrans() {#getShdwBkgndTrans--}
+```
+public DoubleValue getShdwBkgndTrans()
+```
+
+
+Gibt den Transparenzgrad für den Hintergrund (Füllung) des Schattens der Form an, von 0,0 (vollständig undurchsichtig) bis 1,0 (vollständig transparent).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShdwForegnd() {#getShdwForegnd--}
+```
+public ColorValue getShdwForegnd()
+```
+
+
+Gibt die für den Vordergrund (Strich) des Schattens der Form verwendete Farbe an.
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getShdwForegndTrans() {#getShdwForegndTrans--}
+```
+public DoubleValue getShdwForegndTrans()
+```
+
+
+Gibt den Transparenzgrad für den Vordergrund (Strich) des Schattens der Form an, von 0,0 (vollständig undurchsichtig) bis 1,0 (vollständig transparent).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShdwPattern() {#getShdwPattern--}
+```
+public IntValue getShdwPattern()
+```
+
+
+Gibt das Füllmuster für den Schatten einer Form an.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/fill\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setFillBkgnd(ColorValue value) {#setFillBkgnd-com.aspose.diagram.ColorValue-}
+```
+public void setFillBkgnd(ColorValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getFillBkgnd()](../../com.aspose.diagram/fill\#getFillBkgnd--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setFillBkgndTrans(DoubleValue value) {#setFillBkgndTrans-com.aspose.diagram.DoubleValue-}
+```
+public void setFillBkgndTrans(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getFillBkgndTrans()](../../com.aspose.diagram/fill\#getFillBkgndTrans--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setFillForegnd(ColorValue value) {#setFillForegnd-com.aspose.diagram.ColorValue-}
+```
+public void setFillForegnd(ColorValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getFillForegnd()](../../com.aspose.diagram/fill\#getFillForegnd--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setFillForegndTrans(DoubleValue value) {#setFillForegndTrans-com.aspose.diagram.DoubleValue-}
+```
+public void setFillForegndTrans(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getFillForegndTrans()](../../com.aspose.diagram/fill\#getFillForegndTrans--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setFillPattern(IntValue value) {#setFillPattern-com.aspose.diagram.IntValue-}
+```
+public void setFillPattern(IntValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getFillPattern()](../../com.aspose.diagram/fill\#getFillPattern--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setShapeShdwBlur(DoubleValue value) {#setShapeShdwBlur-com.aspose.diagram.DoubleValue-}
+```
+public void setShapeShdwBlur(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getShapeShdwBlur()](../../com.aspose.diagram/fill\#getShapeShdwBlur--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setShapeShdwObliqueAngle(DoubleValue value) {#setShapeShdwObliqueAngle-com.aspose.diagram.DoubleValue-}
+```
+public void setShapeShdwObliqueAngle(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getShapeShdwObliqueAngle()](../../com.aspose.diagram/fill\#getShapeShdwObliqueAngle--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setShapeShdwOffsetX(DoubleValue value) {#setShapeShdwOffsetX-com.aspose.diagram.DoubleValue-}
+```
+public void setShapeShdwOffsetX(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getShapeShdwOffsetX()](../../com.aspose.diagram/fill\#getShapeShdwOffsetX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setShapeShdwOffsetY(DoubleValue value) {#setShapeShdwOffsetY-com.aspose.diagram.DoubleValue-}
+```
+public void setShapeShdwOffsetY(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getShapeShdwOffsetY()](../../com.aspose.diagram/fill\#getShapeShdwOffsetY--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setShapeShdwScaleFactor(DoubleValue value) {#setShapeShdwScaleFactor-com.aspose.diagram.DoubleValue-}
+```
+public void setShapeShdwScaleFactor(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getShapeShdwScaleFactor()](../../com.aspose.diagram/fill\#getShapeShdwScaleFactor--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setShapeShdwShow(ShapeShdwShow value) {#setShapeShdwShow-com.aspose.diagram.ShapeShdwShow-}
+```
+public void setShapeShdwShow(ShapeShdwShow value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getShapeShdwShow()](../../com.aspose.diagram/fill\#getShapeShdwShow--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [ShapeShdwShow](../../com.aspose.diagram/shapeshdwshow) |  |
+
+### setShapeShdwType(ShapeShdwType value) {#setShapeShdwType-com.aspose.diagram.ShapeShdwType-}
+```
+public void setShapeShdwType(ShapeShdwType value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getShapeShdwType()](../../com.aspose.diagram/fill\#getShapeShdwType--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [ShapeShdwType](../../com.aspose.diagram/shapeshdwtype) |  |
+
+### setShdwBkgnd(ColorValue value) {#setShdwBkgnd-com.aspose.diagram.ColorValue-}
+```
+public void setShdwBkgnd(ColorValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getShdwBkgnd()](../../com.aspose.diagram/fill\#getShdwBkgnd--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setShdwBkgndTrans(DoubleValue value) {#setShdwBkgndTrans-com.aspose.diagram.DoubleValue-}
+```
+public void setShdwBkgndTrans(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getShdwBkgndTrans()](../../com.aspose.diagram/fill\#getShdwBkgndTrans--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setShdwForegnd(ColorValue value) {#setShdwForegnd-com.aspose.diagram.ColorValue-}
+```
+public void setShdwForegnd(ColorValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getShdwForegnd()](../../com.aspose.diagram/fill\#getShdwForegnd--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setShdwForegndTrans(DoubleValue value) {#setShdwForegndTrans-com.aspose.diagram.DoubleValue-}
+```
+public void setShdwForegndTrans(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getShdwForegndTrans()](../../com.aspose.diagram/fill\#getShdwForegndTrans--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setShdwPattern(IntValue value) {#setShdwPattern-com.aspose.diagram.IntValue-}
+```
+public void setShdwPattern(IntValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getShdwPattern()](../../com.aspose.diagram/fill\#getShdwPattern--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/filltype/_index.md
+++ b/german/java/com.aspose.diagram/filltype/_index.md
@@ -1,0 +1,183 @@
+---
+title: FillType
+second_title: Aspose.Diagram for Java API-Referenz
+description: Füllformattyp.
+type: docs
+weight: 154
+url: /de/java/com.aspose.diagram/filltype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class FillType
+```
+
+Füllformattyp.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [AUTOMATIC](#AUTOMATIC) | Stellt den automatischen Formatierungstyp dar. |
+| [GRADIENT](#GRADIENT) | Verlaufsfüllformat. |
+| [NONE](#NONE) | Stellt den Formatierungstyp 'none' dar. |
+| [PATTERN](#PATTERN) | Musterfüllformat. |
+| [SOLID](#SOLID) | Einfarbiges Füllformat. |
+| [TEXTURE](#TEXTURE) | Texturfüllformat. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AUTOMATIC {#AUTOMATIC}
+```
+public static final int AUTOMATIC
+```
+
+
+Stellt den automatischen Formatierungstyp dar.
+
+### GRADIENT {#GRADIENT}
+```
+public static final int GRADIENT
+```
+
+
+Verlaufsfüllformat.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Stellt den Formatierungstyp 'none' dar.
+
+### PATTERN {#PATTERN}
+```
+public static final int PATTERN
+```
+
+
+Musterfüllformat.
+
+### SOLID {#SOLID}
+```
+public static final int SOLID
+```
+
+
+Einfarbiges Füllformat.
+
+### TEXTURE {#TEXTURE}
+```
+public static final int TEXTURE
+```
+
+
+Texturfüllformat.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/fld/_index.md
+++ b/german/java/com.aspose.diagram/fld/_index.md
@@ -1,0 +1,155 @@
+---
+title: Fld
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt einen Einfügepunkt für ein Textfeld für das entsprechende Feld-Element an.
+type: docs
+weight: 155
+url: /de/java/com.aspose.diagram/fld/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.FormatTxt](../../com.aspose.diagram/formattxt)
+```
+public class Fld extends FormatTxt
+```
+
+Gibt einen Einfügepunkt für ein Textfeld für das entsprechende Feld-Element an.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [Fld(int IX, Shape shape)](#Fld-int-com.aspose.diagram.Shape-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getValue()](#getValue--) | Value |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Fld(int IX, Shape shape) {#Fld-int-com.aspose.diagram.Shape-}
+```
+public Fld(int IX, Shape shape)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| IX | int | Der nullbasierte Index des Elements Field innerhalb seines übergeordneten Elements Shape. |
+| shape | [Shape](../../com.aspose.diagram/shape) | Form. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+Value
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/floatpointnumcollection/_index.md
+++ b/german/java/com.aspose.diagram/floatpointnumcollection/_index.md
@@ -1,0 +1,231 @@
+---
+title: FloatPointNumCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält eine Sammlung von Verdopplungs-Punktzahlen
+type: docs
+weight: 156
+url: /de/java/com.aspose.diagram/floatpointnumcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class FloatPointNumCollection extends Collection
+```
+
+Enthält eine Sammlung von Verdopplungs-Punktzahlen
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [FloatPointNumCollection()](#FloatPointNumCollection--) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [add(double number)](#add-double-) | Füge die doppelte Punktzahl zur Sammlung hinzu. |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(double number)](#remove-double-) | Entferne die doppelte Punktzahl aus der Sammlung. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FloatPointNumCollection() {#FloatPointNumCollection--}
+```
+public FloatPointNumCollection()
+```
+
+
+Konstruktor.
+
+### add(double number) {#add-double-}
+```
+public int add(double number)
+```
+
+
+Füge die doppelte Punktzahl zur Sammlung hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| number | double |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public double get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+double -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(double number) {#remove-double-}
+```
+public void remove(double number)
+```
+
+
+Entferne die doppelte Punktzahl aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| number | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/folderfontsource/_index.md
+++ b/german/java/com.aspose.diagram/folderfontsource/_index.md
@@ -1,0 +1,177 @@
+---
+title: FolderFontSource
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt den Ordner dar, der TrueType-Schriftdateien enthält.
+type: docs
+weight: 157
+url: /de/java/com.aspose.diagram/folderfontsource/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.FontSourceBase](../../com.aspose.diagram/fontsourcebase)
+```
+public class FolderFontSource extends FontSourceBase
+```
+
+Stellt den Ordner dar, der TrueType-Schriftdateien enthält.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [FolderFontSource(String folderPath, boolean scanSubfolders)](#FolderFontSource-java.lang.String-boolean-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFolderPath()](#getFolderPath--) | Pfad zum Schriftarten‑Ordner. |
+| [getScanSubFolders()](#getScanSubFolders--) | Bestimmt, ob Unterordner durchsucht werden sollen oder nicht. |
+| [getType()](#getType--) | Gibt den Typ der Schriftquellen zurück. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FolderFontSource(String folderPath, boolean scanSubfolders) {#FolderFontSource-java.lang.String-boolean-}
+```
+public FolderFontSource(String folderPath, boolean scanSubfolders)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| folderPath | java.lang.String | Pfad zum Schriftarten‑Ordner |
+| scanSubfolders | boolean | Bestimmt, ob Unterordner durchsucht werden sollen oder nicht. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFolderPath() {#getFolderPath--}
+```
+public String getFolderPath()
+```
+
+
+Pfad zum Schriftarten‑Ordner.
+
+**Returns:**
+java.lang.String
+### getScanSubFolders() {#getScanSubFolders--}
+```
+public boolean getScanSubFolders()
+```
+
+
+Bestimmt, ob Unterordner durchsucht werden sollen oder nicht.
+
+**Returns:**
+boolean
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Gibt den Typ der Schriftquellen zurück.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/font/_index.md
+++ b/german/java/com.aspose.diagram/font/_index.md
@@ -1,0 +1,288 @@
+---
+title: Schriftart
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält Informationen über eine Schrift.
+type: docs
+weight: 158
+url: /de/java/com.aspose.diagram/font/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Font
+```
+
+Enthält Informationen über eine Schrift.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [Font()](#Font--) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCharSets()](#getCharSets--) | Die unterstützten Zeichensätze der Schriftart. |
+| [getClass()](#getClass--) |  |
+| [getFlags()](#getFlags--) | Flags, die Folgendes anzeigen: fehlende Schriftart, Standardschriftart, asiatische Schriftart, komplexe Schriftart, vertikale Schriftart und Schriftarttyp. |
+| [getID()](#getID--) | Die ID des Elements innerhalb seines übergeordneten Elements. |
+| [getName()](#getName--) | Der Name der Schriftart als UTF-16 Unicode-Zeichenkette. |
+| [getPanos()](#getPanos--) | Die Panose-Signatur für die Schriftart. |
+| [getUnicodeRanges()](#getUnicodeRanges--) | Die unterstützten Unicode-Bereiche der Schriftart. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCharSets(String value)](#setCharSets-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getCharSets()](../../com.aspose.diagram/font\#getCharSets--) |
+| [setFlags(int value)](#setFlags-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getFlags()](../../com.aspose.diagram/font\#getFlags--) |
+| [setID(int value)](#setID-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getID()](../../com.aspose.diagram/font\#getID--) |
+| [setName(String value)](#setName-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getName()](../../com.aspose.diagram/font\#getName--) |
+| [setPanos(String value)](#setPanos-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getPanos()](../../com.aspose.diagram/font\#getPanos--) |
+| [setUnicodeRanges(String value)](#setUnicodeRanges-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getUnicodeRanges()](../../com.aspose.diagram/font\#getUnicodeRanges--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Font() {#Font--}
+```
+public Font()
+```
+
+
+Konstruktor.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCharSets() {#getCharSets--}
+```
+public String getCharSets()
+```
+
+
+Die unterstützten Zeichensätze der Schriftart.
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFlags() {#getFlags--}
+```
+public int getFlags()
+```
+
+
+Flags, die Folgendes anzeigen: fehlende Schriftart, Standardschriftart, asiatische Schriftart, komplexe Schriftart, vertikale Schriftart und Schriftarttyp.
+
+**Returns:**
+int
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+Die ID des Elements innerhalb seines übergeordneten Elements.
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Der Name der Schriftart als UTF-16 Unicode-Zeichenkette.
+
+**Returns:**
+java.lang.String
+### getPanos() {#getPanos--}
+```
+public String getPanos()
+```
+
+
+Die Panose-Signatur für die Schriftart. Panose ist ein Klassifizierungssystem für Schriftarten, das sie anhand ihrer visuellen Merkmale kategorisiert.
+
+**Returns:**
+java.lang.String
+### getUnicodeRanges() {#getUnicodeRanges--}
+```
+public String getUnicodeRanges()
+```
+
+
+Die unterstützten Unicode-Bereiche der Schriftart.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCharSets(String value) {#setCharSets-java.lang.String-}
+```
+public void setCharSets(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getCharSets()](../../com.aspose.diagram/font\#getCharSets--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setFlags(int value) {#setFlags-int-}
+```
+public void setFlags(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getFlags()](../../com.aspose.diagram/font\#getFlags--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getID()](../../com.aspose.diagram/font\#getID--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getName()](../../com.aspose.diagram/font\#getName--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setPanos(String value) {#setPanos-java.lang.String-}
+```
+public void setPanos(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getPanos()](../../com.aspose.diagram/font\#getPanos--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setUnicodeRanges(String value) {#setUnicodeRanges-java.lang.String-}
+```
+public void setUnicodeRanges(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getUnicodeRanges()](../../com.aspose.diagram/font\#getUnicodeRanges--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/fontcollection/_index.md
+++ b/german/java/com.aspose.diagram/fontcollection/_index.md
@@ -1,0 +1,247 @@
+---
+title: FontCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält eine Sammlung von Schrift-Elementen.
+type: docs
+weight: 159
+url: /de/java/com.aspose.diagram/fontcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class FontCollection extends Collection
+```
+
+Enthält eine Sammlung von Schrift-Elementen.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [FontCollection()](#FontCollection--) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [add(Font font)](#add-com.aspose.diagram.Font-) | Add the Font object in the collection. |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [getFont(int ID)](#getFont-int-) | Liefert das Element mit der angegebenen ID. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Font font)](#remove-com.aspose.diagram.Font-) | Remove the Font object from the collection. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FontCollection() {#FontCollection--}
+```
+public FontCollection()
+```
+
+
+Konstruktor.
+
+### add(Font font) {#add-com.aspose.diagram.Font-}
+```
+public int add(Font font)
+```
+
+
+Add the Font object in the collection.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| font | [Font](../../com.aspose.diagram/font) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Font get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[Font](../../com.aspose.diagram/font) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### getFont(int ID) {#getFont-int-}
+```
+public Font getFont(int ID)
+```
+
+
+Liefert das Element mit der angegebenen ID.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| ID | int | intDie ID des Elements innerhalb seines übergeordneten Elements. |
+
+**Returns:**
+[Font](../../com.aspose.diagram/font) - [Font](../../com.aspose.diagram/font)Font.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Font font) {#remove-com.aspose.diagram.Font-}
+```
+public void remove(Font font)
+```
+
+
+Remove the Font object from the collection.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| font | [Font](../../com.aspose.diagram/font) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/fontconfigs/_index.md
+++ b/german/java/com.aspose.diagram/fontconfigs/_index.md
@@ -1,0 +1,272 @@
+---
+title: FontConfigs
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt Schrift-Einstellungen an
+type: docs
+weight: 160
+url: /de/java/com.aspose.diagram/fontconfigs/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class FontConfigs
+```
+
+Gibt Schrift-Einstellungen an
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [FontConfigs()](#FontConfigs--) |  |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDefaultFontName()](#getDefaultFontName--) | der Standard-Schriftname. |
+| [getFontSources()](#getFontSources--) | Gibt eine Kopie des Arrays zurück, das die Liste der Quellen enthält. |
+| [getFontSubstitutes(String originalFontName)](#getFontSubstitutes-java.lang.String-) | Gibt ein Array zurück, das Schriftart-Ersatznamen enthält, die verwendet werden, wenn die Originalschriftart nicht vorhanden ist. |
+| [getPreferSystemFontSubstitutes()](#getPreferSystemFontSubstitutes--) | Gibt an, ob System-Schriftart-Ersatz zuerst verwendet werden soll, wenn eine Schriftart nicht vorhanden ist und der Ersatz für diese Schriftart nicht festgelegt ist. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDefaultFontName(String value)](#setDefaultFontName-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe [getDefaultFontName()](../../com.aspose.diagram/fontconfigs\#getDefaultFontName--) |
+| [setFontFolder(String fontFolder, boolean recursive)](#setFontFolder-java.lang.String-boolean-) | Legt den Schriftartenordner fest. |
+| [setFontFolders(String[] fontFolders, boolean recursive)](#setFontFolders-java.lang.String---boolean-) | Legt die Schriftartenordner fest. |
+| [setFontSources(FontSourceBase[] sources)](#setFontSources-com.aspose.diagram.FontSourceBase---) | Legt die Schriftartenquellen fest. |
+| [setFontSubstitutes(String originalFontName, String[] substituteFontNames)](#setFontSubstitutes-java.lang.String-java.lang.String---) | Schriftart-Ersatznamen für den angegebenen Originalschriftartnamen. |
+| [setPreferSystemFontSubstitutes(boolean value)](#setPreferSystemFontSubstitutes-boolean-) | Für die Beschreibung dieser Eigenschaft siehe [getPreferSystemFontSubstitutes()](../../com.aspose.diagram/fontconfigs\#getPreferSystemFontSubstitutes--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FontConfigs() {#FontConfigs--}
+```
+public FontConfigs()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultFontName() {#getDefaultFontName--}
+```
+public static String getDefaultFontName()
+```
+
+
+der Standard-Schriftname.
+
+**Returns:**
+java.lang.String
+### getFontSources() {#getFontSources--}
+```
+public static FontSourceBase[] getFontSources()
+```
+
+
+Gibt eine Kopie des Arrays zurück, das die Liste der Quellen enthält.
+
+**Returns:**
+com.aspose.diagram.FontSourceBase[] -
+### getFontSubstitutes(String originalFontName) {#getFontSubstitutes-java.lang.String-}
+```
+public static String[] getFontSubstitutes(String originalFontName)
+```
+
+
+Gibt ein Array zurück, das Schriftart-Ersatznamen enthält, die verwendet werden, wenn die Originalschriftart nicht vorhanden ist.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| originalFontName | java.lang.String | originalFontName |
+
+**Returns:**
+java.lang.String[] - Ein Array, das Schriftart-Ersatznamen enthält, die verwendet werden, wenn die Originalschriftart nicht vorhanden ist.
+### getPreferSystemFontSubstitutes() {#getPreferSystemFontSubstitutes--}
+```
+public static boolean getPreferSystemFontSubstitutes()
+```
+
+
+Geben Sie an, ob System-Schriftart-Ersatz zuerst verwendet werden soll, wenn eine Schriftart nicht vorhanden ist und der Ersatz dieser Schriftart nicht festgelegt ist. z. B. unter Ubuntu wird die Schriftart "Arial" in der Regel durch "Liberation Sans" ersetzt. Der Standardwert ist false.
+
+**Returns:**
+boolean
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDefaultFontName(String value) {#setDefaultFontName-java.lang.String-}
+```
+public static void setDefaultFontName(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getDefaultFontName()](../../com.aspose.diagram/fontconfigs\#getDefaultFontName--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setFontFolder(String fontFolder, boolean recursive) {#setFontFolder-java.lang.String-boolean-}
+```
+public static void setFontFolder(String fontFolder, boolean recursive)
+```
+
+
+Legt den Schriftartenordner fest.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontFolder | java.lang.String | Der Ordner, der TrueType-Schriftarten enthält. |
+| recursive | boolean | Bestimmt, ob Unterordner durchsucht werden sollen oder nicht. |
+
+### setFontFolders(String[] fontFolders, boolean recursive) {#setFontFolders-java.lang.String---boolean-}
+```
+public static void setFontFolders(String[] fontFolders, boolean recursive)
+```
+
+
+Legt die Schriftartenordner fest.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontFolders | java.lang.String[] | Die Ordner, die TrueType-Schriftarten enthalten. |
+| recursive | boolean | Bestimmt, ob Unterordner durchsucht werden sollen oder nicht. |
+
+### setFontSources(FontSourceBase[] sources) {#setFontSources-com.aspose.diagram.FontSourceBase---}
+```
+public static void setFontSources(FontSourceBase[] sources)
+```
+
+
+Legt die Schriftartenquellen fest.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| sources | [FontSourceBase\[\]](../../com.aspose.diagram/fontsourcebase) | Ein Array von Quellen, die TrueType-Schriftarten enthalten. |
+
+### setFontSubstitutes(String originalFontName, String[] substituteFontNames) {#setFontSubstitutes-java.lang.String-java.lang.String---}
+```
+public static void setFontSubstitutes(String originalFontName, String[] substituteFontNames)
+```
+
+
+Schriftart-Ersatznamen für den angegebenen Originalschriftartnamen.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| originalFontName | java.lang.String | Originaler Schriftartname. |
+| substituteFontNames | java.lang.String[] | Liste von Schriftart-Ersatznamen, die verwendet werden, wenn die Originalschriftart nicht vorhanden ist. |
+
+### setPreferSystemFontSubstitutes(boolean value) {#setPreferSystemFontSubstitutes-boolean-}
+```
+public static void setPreferSystemFontSubstitutes(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getPreferSystemFontSubstitutes()](../../com.aspose.diagram/fontconfigs\#getPreferSystemFontSubstitutes--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/fontsourcebase/_index.md
+++ b/german/java/com.aspose.diagram/fontsourcebase/_index.md
@@ -1,0 +1,147 @@
+---
+title: FontSourceBase
+second_title: Aspose.Diagram for Java API-Referenz
+description: Dies ist eine abstrakte Basisklasse für die Klassen, die dem Benutzer ermöglichen, verschiedene Schriftquellen anzugeben
+type: docs
+weight: 161
+url: /de/java/com.aspose.diagram/fontsourcebase/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public abstract class FontSourceBase
+```
+
+Dies ist eine abstrakte Basisklasse für die Klassen, die dem Benutzer ermöglichen, verschiedene Schriftquellen anzugeben
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [FontSourceBase()](#FontSourceBase--) |  |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getType()](#getType--) | Gibt den Typ der Schriftquellen zurück. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FontSourceBase() {#FontSourceBase--}
+```
+public FontSourceBase()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getType() {#getType--}
+```
+public abstract int getType()
+```
+
+
+Gibt den Typ der Schriftquellen zurück.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/fontsourcetype/_index.md
+++ b/german/java/com.aspose.diagram/fontsourcetype/_index.md
@@ -1,0 +1,156 @@
+---
+title: FontSourceType
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt den Typ einer Schriftquelle an.
+type: docs
+weight: 162
+url: /de/java/com.aspose.diagram/fontsourcetype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class FontSourceType
+```
+
+Gibt den Typ einer Schriftquelle an.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [FONTS_FOLDER](#FONTS-FOLDER) | repräsentiert einen Ordner mit Schriftdateien. |
+| [FONT_FILE](#FONT-FILE) | repräsentiert eine einzelne Schriftdatei. |
+| [MEMORY_FONT](#MEMORY-FONT) | repräsentiert eine einzelne Schrift im Speicher. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FONTS_FOLDER {#FONTS-FOLDER}
+```
+public static final int FONTS_FOLDER
+```
+
+
+repräsentiert einen Ordner mit Schriftdateien.
+
+### FONT_FILE {#FONT-FILE}
+```
+public static final int FONT_FILE
+```
+
+
+repräsentiert eine einzelne Schriftdatei.
+
+### MEMORY_FONT {#MEMORY-FONT}
+```
+public static final int MEMORY_FONT
+```
+
+
+repräsentiert eine einzelne Schrift im Speicher.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/foreign/_index.md
+++ b/german/java/com.aspose.diagram/foreign/_index.md
@@ -1,0 +1,205 @@
+---
+title: Fremd
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält Elemente, die die Breite und Höhe eines Objekts aus einem anderen Programm angeben, das in einem Microsoft Visio-Dokument verwendet wird.
+type: docs
+weight: 163
+url: /de/java/com.aspose.diagram/foreign/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Foreign
+```
+
+Enthält Elemente, die die Breite und Höhe eines aus einem anderen Programm stammenden Objekts in einem Microsoft Visio-Dokument angeben. Außerdem enthält es Elemente, die den Abstand angeben, um den das Bild des Objekts innerhalb seiner Ränder versetzt ist.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getImgHeight()](#getImgHeight--) | Bestimmt die Höhe des Bildes des Objekts innerhalb seiner Grenze. |
+| [getImgOffsetX()](#getImgOffsetX--) | Bestimmt den horizontalen Abstand, um den das Objekt vom Ursprung seiner Grenze versetzt ist. |
+| [getImgOffsetY()](#getImgOffsetY--) | Bestimmt den vertikalen Abstand, um den das Objekt vom Ursprung seiner Grenze versetzt ist. |
+| [getImgWidth()](#getImgWidth--) | Bestimmt die Breite des Bildes des Objekts innerhalb seiner Grenze. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/foreign\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getImgHeight() {#getImgHeight--}
+```
+public DoubleValue getImgHeight()
+```
+
+
+Bestimmt die Höhe des Bildes des Objekts innerhalb seiner Begrenzung. Die Standardformel lautet: F="Height\*1".
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getImgOffsetX() {#getImgOffsetX--}
+```
+public DoubleValue getImgOffsetX()
+```
+
+
+Bestimmt den Abstand, um den das Objekt horizontal vom Ursprung seiner Begrenzung verschoben ist. Der Standardwert ist 0; die Standardformel lautet F="ImgWidth\*0".
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getImgOffsetY() {#getImgOffsetY--}
+```
+public DoubleValue getImgOffsetY()
+```
+
+
+Bestimmt den Abstand, um den das Objekt vertikal vom Ursprung seiner Begrenzung verschoben ist. Der Standardwert ist 0; die Standardformel lautet F="ImgHeight\*0".
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getImgWidth() {#getImgWidth--}
+```
+public DoubleValue getImgWidth()
+```
+
+
+Bestimmt die Breite des Bildes des Objekts innerhalb seiner Begrenzung. Die Standardformel lautet: F="Width\*1".
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/foreign\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/foreigndata/_index.md
+++ b/german/java/com.aspose.diagram/foreigndata/_index.md
@@ -1,0 +1,486 @@
+---
+title: ForeignData
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält einen MIME Multipurpose Internet Mail Extensions codierten BLOB von Bilddaten wie Windows metafile bitmap oder OLE-Daten.
+type: docs
+weight: 164
+url: /de/java/com.aspose.diagram/foreigndata/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ForeignData
+```
+
+Enthält einen MIME (Multipurpose Internet Mail Extensions) codierten BLOB von Bilddaten, wie Windows-Metadatei, Bitmap oder OLE-Daten.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCompressionLevel()](#getCompressionLevel--) | Dieses Attribut ist nur sinnvoll, wenn die Fremddaten ein rasterbasiertes Fremdobjekt sind, wie z. B. eine DIB-, JPG-, PNG-, TIFF- oder GIF-Datei. |
+| [getCompressionType()](#getCompressionType--) | Dieses Attribut ist nur sinnvoll, wenn die Fremddaten ein rasterbasiertes Fremdobjekt sind, wie z. B. eine DIB-, JPG-, PNG-, TIFF- oder GIF-Datei. |
+| [getExtentX()](#getExtentX--) | Dieses Attribut ist nur sinnvoll, wenn die Fremddaten eine Metadatei sind. |
+| [getExtentY()](#getExtentY--) | Dieses Attribut ist nur sinnvoll, wenn die Fremddaten eine Metadatei sind. |
+| [getForeignType()](#getForeignType--) | Datentyp. |
+| [getImageData()](#getImageData--) | Stellt das Bild eines OLE-Objekts als Byte-Array dar. |
+| [getMappingMode()](#getMappingMode--) | Dieses Attribut ist nur sinnvoll, wenn die Fremddaten eine Metadatei sind. |
+| [getObjectData()](#getObjectData--) | Stellt eingebettete OLE-Objektdaten als Byte-Array dar. |
+| [getObjectHeight()](#getObjectHeight--) | Dieses Attribut ist nur sinnvoll, wenn die Fremddaten ein OLE2 eingebettetes Objekt sind. |
+| [getObjectSourceFullName()](#getObjectSourceFullName--) | Gibt den vollständigen Namen der Quelldatei für das verknüpfte OLE-Objekt zurück. |
+| [getObjectType()](#getObjectType--) | Wenn das Attribut ForeignType "Object" ist, muss das Element ForeignData ebenfalls ein Attribut ObjectType besitzen. |
+| [getObjectWidth()](#getObjectWidth--) | Dieses Attribut ist nur sinnvoll, wenn die Fremddaten ein OLE2 eingebettetes Objekt sind. |
+| [getShowAsIcon()](#getShowAsIcon--) | Dieses Attribut ist nur sinnvoll, wenn die Fremddaten ein OLE2 eingebettetes Objekt sind. |
+| [getValue()](#getValue--) | Enthält einen MIME (Multipurpose Internet Mail Extensions) codierten BLOB von Bilddaten, wie Windows-Metadatei, Bitmap oder OLE-Daten. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCompressionLevel(double value)](#setCompressionLevel-double-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getCompressionLevel()](../../com.aspose.diagram/foreigndata\#getCompressionLevel--) |
+| [setCompressionType(int value)](#setCompressionType-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getCompressionType()](../../com.aspose.diagram/foreigndata\#getCompressionType--) |
+| [setExtentX(double value)](#setExtentX-double-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getExtentX()](../../com.aspose.diagram/foreigndata\#getExtentX--) |
+| [setExtentY(double value)](#setExtentY-double-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getExtentY()](../../com.aspose.diagram/foreigndata\#getExtentY--) |
+| [setForeignType(int value)](#setForeignType-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getForeignType()](../../com.aspose.diagram/foreigndata\#getForeignType--) |
+| [setImageData(byte[] value)](#setImageData-byte---) | Für die Beschreibung dieser Eigenschaft siehe bitte [getImageData()](../../com.aspose.diagram/foreigndata\#getImageData--) |
+| [setMappingMode(int value)](#setMappingMode-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getMappingMode()](../../com.aspose.diagram/foreigndata\#getMappingMode--) |
+| [setObjectData(byte[] value)](#setObjectData-byte---) | Für die Beschreibung dieser Eigenschaft siehe bitte [getObjectData()](../../com.aspose.diagram/foreigndata\#getObjectData--) |
+| [setObjectHeight(double value)](#setObjectHeight-double-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getObjectHeight()](../../com.aspose.diagram/foreigndata\#getObjectHeight--) |
+| [setObjectSourceFullName(String value)](#setObjectSourceFullName-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getObjectSourceFullName()](../../com.aspose.diagram/foreigndata\#getObjectSourceFullName--) |
+| [setObjectType(int value)](#setObjectType-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getObjectType()](../../com.aspose.diagram/foreigndata\#getObjectType--) |
+| [setObjectWidth(double value)](#setObjectWidth-double-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getObjectWidth()](../../com.aspose.diagram/foreigndata\#getObjectWidth--) |
+| [setShowAsIcon(int value)](#setShowAsIcon-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getShowAsIcon()](../../com.aspose.diagram/foreigndata\#getShowAsIcon--) |
+| [setValue(byte[] value)](#setValue-byte---) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/foreigndata\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCompressionLevel() {#getCompressionLevel--}
+```
+public double getCompressionLevel()
+```
+
+
+Dieses Attribut ist nur sinnvoll, wenn die Fremddaten ein rasterbasiertes Fremdobjekt sind, wie z. B. eine DIB-, JPG-, PNG-, TIFF- oder GIF-Datei. Der Wert gibt das Kompressionsniveau an, das auf die Datei angewendet wird. Das Kompressionsniveau wird in Hundertstel Prozent gemessen.
+
+**Returns:**
+double
+### getCompressionType() {#getCompressionType--}
+```
+public int getCompressionType()
+```
+
+
+Dieses Attribut ist nur sinnvoll, wenn die Fremddaten ein rasterbasiertes Fremdobjekt sind, wie z. B. eine DIB-, JPG-, PNG-, TIFF- oder GIF-Datei. Der Wert gibt den Typ der auf die Datei angewendeten Kompression an.
+
+**Returns:**
+int
+### getExtentX() {#getExtentX--}
+```
+public double getExtentX()
+```
+
+
+Dieses Attribut ist nur sinnvoll, wenn die Fremddaten eine Metadatei sind. Der Wert gibt die horizontale Ausdehnung der Metadatei an.
+
+**Returns:**
+double
+### getExtentY() {#getExtentY--}
+```
+public double getExtentY()
+```
+
+
+Dieses Attribut ist nur sinnvoll, wenn die Fremddaten eine Metadatei sind. Der Wert gibt die vertikale Ausdehnung der Metadatei an.
+
+**Returns:**
+double
+### getForeignType() {#getForeignType--}
+```
+public int getForeignType()
+```
+
+
+Datentyp.
+
+**Returns:**
+int
+### getImageData() {#getImageData--}
+```
+public byte[] getImageData()
+```
+
+
+Stellt das Bild eines OLE-Objekts als Byte-Array dar.
+
+**Returns:**
+byte[]
+### getMappingMode() {#getMappingMode--}
+```
+public int getMappingMode()
+```
+
+
+Dieses Attribut ist nur sinnvoll, wenn die Fremddaten eine Metadatei sind. Der Wert gibt den Mapping‑Modus der Metadatei an.
+
+**Returns:**
+int
+### getObjectData() {#getObjectData--}
+```
+public byte[] getObjectData()
+```
+
+
+Stellt eingebettete OLE-Objektdaten als Byte-Array dar.
+
+**Returns:**
+byte[]
+### getObjectHeight() {#getObjectHeight--}
+```
+public double getObjectHeight()
+```
+
+
+Dieses Attribut ist nur sinnvoll, wenn die Fremddaten ein OLE2 eingebettetes Objekt sind. Der Wert gibt die Höhe des Objekts in Seiteneinheiten an.
+
+**Returns:**
+double
+### getObjectSourceFullName() {#getObjectSourceFullName--}
+```
+public String getObjectSourceFullName()
+```
+
+
+Gibt den vollständigen Namen der Quelldatei für das verknüpfte OLE-Objekt zurück. Das Festlegen des vollständigen Namens wird nur unterstützt, wenn der Dateityp OleFileType.Unknown ist, z. B. wav‑Datei, avi‑Datei usw.
+
+**Returns:**
+java.lang.String
+### getObjectType() {#getObjectType--}
+```
+public int getObjectType()
+```
+
+
+Wenn das Attribut ForeignType "Object" ist, muss das Element ForeignData ebenfalls ein Attribut ObjectType besitzen.
+
+**Returns:**
+int
+### getObjectWidth() {#getObjectWidth--}
+```
+public double getObjectWidth()
+```
+
+
+Dieses Attribut ist nur sinnvoll, wenn die Fremddaten ein OLE2 eingebettetes Objekt sind. Der Wert gibt die Breite des Objekts in Seiteneinheiten an.
+
+**Returns:**
+double
+### getShowAsIcon() {#getShowAsIcon--}
+```
+public int getShowAsIcon()
+```
+
+
+Dieses Attribut ist nur sinnvoll, wenn die Fremddaten ein OLE2 eingebettetes Objekt sind.
+
+**Returns:**
+int
+### getValue() {#getValue--}
+```
+public byte[] getValue()
+```
+
+
+Enthält einen MIME (Multipurpose Internet Mail Extensions) codierten BLOB von Bilddaten, wie Windows-Metadatei, Bitmap oder OLE-Daten.
+
+**Returns:**
+byte[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCompressionLevel(double value) {#setCompressionLevel-double-}
+```
+public void setCompressionLevel(double value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getCompressionLevel()](../../com.aspose.diagram/foreigndata\#getCompressionLevel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double |  |
+
+### setCompressionType(int value) {#setCompressionType-int-}
+```
+public void setCompressionType(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getCompressionType()](../../com.aspose.diagram/foreigndata\#getCompressionType--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setExtentX(double value) {#setExtentX-double-}
+```
+public void setExtentX(double value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getExtentX()](../../com.aspose.diagram/foreigndata\#getExtentX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double |  |
+
+### setExtentY(double value) {#setExtentY-double-}
+```
+public void setExtentY(double value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getExtentY()](../../com.aspose.diagram/foreigndata\#getExtentY--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double |  |
+
+### setForeignType(int value) {#setForeignType-int-}
+```
+public void setForeignType(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getForeignType()](../../com.aspose.diagram/foreigndata\#getForeignType--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setImageData(byte[] value) {#setImageData-byte---}
+```
+public void setImageData(byte[] value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getImageData()](../../com.aspose.diagram/foreigndata\#getImageData--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | byte[] |  |
+
+### setMappingMode(int value) {#setMappingMode-int-}
+```
+public void setMappingMode(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getMappingMode()](../../com.aspose.diagram/foreigndata\#getMappingMode--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setObjectData(byte[] value) {#setObjectData-byte---}
+```
+public void setObjectData(byte[] value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getObjectData()](../../com.aspose.diagram/foreigndata\#getObjectData--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | byte[] |  |
+
+### setObjectHeight(double value) {#setObjectHeight-double-}
+```
+public void setObjectHeight(double value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getObjectHeight()](../../com.aspose.diagram/foreigndata\#getObjectHeight--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double |  |
+
+### setObjectSourceFullName(String value) {#setObjectSourceFullName-java.lang.String-}
+```
+public void setObjectSourceFullName(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getObjectSourceFullName()](../../com.aspose.diagram/foreigndata\#getObjectSourceFullName--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setObjectType(int value) {#setObjectType-int-}
+```
+public void setObjectType(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getObjectType()](../../com.aspose.diagram/foreigndata\#getObjectType--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setObjectWidth(double value) {#setObjectWidth-double-}
+```
+public void setObjectWidth(double value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getObjectWidth()](../../com.aspose.diagram/foreigndata\#getObjectWidth--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double |  |
+
+### setShowAsIcon(int value) {#setShowAsIcon-int-}
+```
+public void setShowAsIcon(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getShowAsIcon()](../../com.aspose.diagram/foreigndata\#getShowAsIcon--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setValue(byte[] value) {#setValue-byte---}
+```
+public void setValue(byte[] value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/foreigndata\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | byte[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/foreigntype/_index.md
+++ b/german/java/com.aspose.diagram/foreigntype/_index.md
@@ -1,0 +1,183 @@
+---
+title: ForeignType
+second_title: Aspose.Diagram for Java API-Referenz
+description: Datentyp.
+type: docs
+weight: 165
+url: /de/java/com.aspose.diagram/foreigntype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ForeignType
+```
+
+Datentyp.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [BITMAP](#BITMAP) | Bitmap. |
+| [ENH_METAFILE](#ENH-METAFILE) | Erweiterte Metadatei. |
+| [INK](#INK) | Tinte. |
+| [METAFILE](#METAFILE) | Metadatei. |
+| [OBJECT](#OBJECT) | Objekt. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BITMAP {#BITMAP}
+```
+public static final int BITMAP
+```
+
+
+Bitmap.
+
+### ENH_METAFILE {#ENH-METAFILE}
+```
+public static final int ENH_METAFILE
+```
+
+
+Erweiterte Metadatei.
+
+### INK {#INK}
+```
+public static final int INK
+```
+
+
+Tinte.
+
+### METAFILE {#METAFILE}
+```
+public static final int METAFILE
+```
+
+
+Metadatei.
+
+### OBJECT {#OBJECT}
+```
+public static final int OBJECT
+```
+
+
+Objekt.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/formattxt/_index.md
+++ b/german/java/com.aspose.diagram/formattxt/_index.md
@@ -1,0 +1,147 @@
+---
+title: FormatTxt
+second_title: Aspose.Diagram for Java API-Referenz
+description: Abstrakte Klasse für die Textformatierung
+type: docs
+weight: 166
+url: /de/java/com.aspose.diagram/formattxt/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public abstract class FormatTxt
+```
+
+Abstrakte Klasse für die Textformatierung
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [FormatTxt()](#FormatTxt--) |  |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getValue()](#getValue--) | Value |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FormatTxt() {#FormatTxt--}
+```
+public FormatTxt()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getValue() {#getValue--}
+```
+public abstract String getValue()
+```
+
+
+Value
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/formattxtcollection/_index.md
+++ b/german/java/com.aspose.diagram/formattxtcollection/_index.md
@@ -1,0 +1,243 @@
+---
+title: FormatTxtCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: FormatTxt-Sammlung, die den Text einer Form enthält.
+type: docs
+weight: 167
+url: /de/java/com.aspose.diagram/formattxtcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class FormatTxtCollection extends Collection
+```
+
+FormatTxt-Sammlung, die den Text einer Form enthält.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [add(FormatTxt item)](#add-com.aspose.diagram.FormatTxt-) | Fügen Sie das FormatTxt-Objekt zur Sammlung hinzu. |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [getText()](#getText--) | Enthält den Text einer Form mit Formatierung. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(FormatTxt item)](#remove-com.aspose.diagram.FormatTxt-) | Entfernen Sie das FormatTxt-Objekt aus der Sammlung. |
+| [setWholeText(String text)](#setWholeText-java.lang.String-) | Setzen Sie den Text einer Form ohne Formatierung. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(FormatTxt item) {#add-com.aspose.diagram.FormatTxt-}
+```
+public int add(FormatTxt item)
+```
+
+
+Fügen Sie das FormatTxt-Objekt zur Sammlung hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [FormatTxt](../../com.aspose.diagram/formattxt) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public FormatTxt get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[FormatTxt](../../com.aspose.diagram/formattxt) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### getText() {#getText--}
+```
+public String getText()
+```
+
+
+Enthält den Text einer Form mit Formatierung.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(FormatTxt item) {#remove-com.aspose.diagram.FormatTxt-}
+```
+public void remove(FormatTxt item)
+```
+
+
+Entfernen Sie das FormatTxt-Objekt aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [FormatTxt](../../com.aspose.diagram/formattxt) |  |
+
+### setWholeText(String text) {#setWholeText-java.lang.String-}
+```
+public void setWholeText(String text)
+```
+
+
+Setzen Sie den Text einer Form ohne Formatierung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| text | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/frompartvalue/_index.md
+++ b/german/java/com.aspose.diagram/frompartvalue/_index.md
@@ -1,0 +1,264 @@
+---
+title: FromPartValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Der Teil einer Form, von dem eine Verbindung ausgeht.
+type: docs
+weight: 168
+url: /de/java/com.aspose.diagram/frompartvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class FromPartValue
+```
+
+Der Teil einer Form, von dem eine Verbindung ausgeht.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [BEGIN_X_CELL](#BEGIN-X-CELL) | BeginX‑Zelle. |
+| [BEGIN_X_OR_BEGIN_Y_POINT](#BEGIN-X-OR-BEGIN-Y-POINT) | BeginX/BeginY‑Punkt. |
+| [BEGIN_Y_CELL](#BEGIN-Y-CELL) | BeginY‑Zelle. |
+| [BOTTOM_EDGE](#BOTTOM-EDGE) | Untere Kante. |
+| [CENTER_EDGE](#CENTER-EDGE) | Mittlere Kante. |
+| [CONTROL_POINT](#CONTROL-POINT) | Steuerpunkt. |
+| [END_X_CELL](#END-X-CELL) | EndX‑Zelle. |
+| [END_X_OR_END_Y_POINT](#END-X-OR-END-Y-POINT) | EndX/EndY‑Punkt. |
+| [END_Y_CELL](#END-Y-CELL) | EndY-Zelle. |
+| [LEFT_EDGE](#LEFT-EDGE) | Linke Kante. |
+| [MIDDLE_EDGE](#MIDDLE-EDGE) | Mittlere Kante. |
+| [NONE](#NONE) | Keine. |
+| [RIGHT_EDGE](#RIGHT-EDGE) | Rechte Kante. |
+| [TOP_EDGE](#TOP-EDGE) | Obere Kante. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BEGIN_X_CELL {#BEGIN-X-CELL}
+```
+public static final int BEGIN_X_CELL
+```
+
+
+BeginX‑Zelle.
+
+### BEGIN_X_OR_BEGIN_Y_POINT {#BEGIN-X-OR-BEGIN-Y-POINT}
+```
+public static final int BEGIN_X_OR_BEGIN_Y_POINT
+```
+
+
+BeginX/BeginY‑Punkt.
+
+### BEGIN_Y_CELL {#BEGIN-Y-CELL}
+```
+public static final int BEGIN_Y_CELL
+```
+
+
+BeginY‑Zelle.
+
+### BOTTOM_EDGE {#BOTTOM-EDGE}
+```
+public static final int BOTTOM_EDGE
+```
+
+
+Untere Kante.
+
+### CENTER_EDGE {#CENTER-EDGE}
+```
+public static final int CENTER_EDGE
+```
+
+
+Mittlere Kante.
+
+### CONTROL_POINT {#CONTROL-POINT}
+```
+public static final int CONTROL_POINT
+```
+
+
+Steuerpunkt.
+
+### END_X_CELL {#END-X-CELL}
+```
+public static final int END_X_CELL
+```
+
+
+EndX‑Zelle.
+
+### END_X_OR_END_Y_POINT {#END-X-OR-END-Y-POINT}
+```
+public static final int END_X_OR_END_Y_POINT
+```
+
+
+EndX/EndY‑Punkt.
+
+### END_Y_CELL {#END-Y-CELL}
+```
+public static final int END_Y_CELL
+```
+
+
+EndY-Zelle.
+
+### LEFT_EDGE {#LEFT-EDGE}
+```
+public static final int LEFT_EDGE
+```
+
+
+Linke Kante.
+
+### MIDDLE_EDGE {#MIDDLE-EDGE}
+```
+public static final int MIDDLE_EDGE
+```
+
+
+Mittlere Kante.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Keine.
+
+### RIGHT_EDGE {#RIGHT-EDGE}
+```
+public static final int RIGHT_EDGE
+```
+
+
+Rechte Kante.
+
+### TOP_EDGE {#TOP-EDGE}
+```
+public static final int TOP_EDGE
+```
+
+
+Obere Kante.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/geom/_index.md
+++ b/german/java/com.aspose.diagram/geom/_index.md
@@ -1,0 +1,346 @@
+---
+title: Geom
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält Elemente, die die Koordinaten der Scheitelpunkte für die Linien und Bögen angeben, aus denen die Form besteht.
+type: docs
+weight: 169
+url: /de/java/com.aspose.diagram/geom/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Geom
+```
+
+Enthält Elemente, die die Koordinaten der Scheitelpunkte für die Linien und Bögen, aus denen die Form besteht, angeben. Hat die Form mehr als einen Pfad, gibt es für jeden Pfad ein Geom-Element.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [Geom()](#Geom--) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCoordinateCol()](#getCoordinateCol--) | Sammlung von Koordinaten. |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getIX()](#getIX--) | Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements. |
+| [getNextCoordinateIX()](#getNextCoordinateIX--) | Gibt den IX-Wert für das nächste Koordinatensammlungsmitglied der Form zurück. |
+| [getNoFill()](#getNoFill--) | Gibt an, ob ein Pfad gefüllt werden kann. |
+| [getNoLine()](#getNoLine--) | Gibt an, ob eine Linie um die Begrenzung des Pfades gezeichnet wird. |
+| [getNoQuickDrag()](#getNoQuickDrag--) | Bestimmt, ob eine Form ausgewählt oder gezogen werden kann, wenn der Benutzer den durch den Geometry-Abschnitt definierten gefüllten Bereich anklickt. |
+| [getNoShow()](#getNoShow--) | Gibt an, ob ein Pfad auf der Zeichenfläche angezeigt wird. |
+| [getNoSnap()](#getNoSnap--) | Gibt an, ob andere Formen an einem Pfad einrasten. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft siehe [getDel()](../../com.aspose.diagram/geom\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Für die Beschreibung dieser Eigenschaft siehe [getIX()](../../com.aspose.diagram/geom\#getIX--) |
+| [setNoFill(BoolValue value)](#setNoFill-com.aspose.diagram.BoolValue-) | Für die Beschreibung dieser Eigenschaft siehe [getNoFill()](../../com.aspose.diagram/geom\#getNoFill--) |
+| [setNoLine(BoolValue value)](#setNoLine-com.aspose.diagram.BoolValue-) | Für die Beschreibung dieser Eigenschaft siehe [getNoLine()](../../com.aspose.diagram/geom\#getNoLine--) |
+| [setNoQuickDrag(BoolValue value)](#setNoQuickDrag-com.aspose.diagram.BoolValue-) | Für die Beschreibung dieser Eigenschaft siehe [getNoQuickDrag()](../../com.aspose.diagram/geom\#getNoQuickDrag--) |
+| [setNoShow(BoolValue value)](#setNoShow-com.aspose.diagram.BoolValue-) | Für die Beschreibung dieser Eigenschaft siehe [getNoShow()](../../com.aspose.diagram/geom\#getNoShow--) |
+| [setNoSnap(BoolValue value)](#setNoSnap-com.aspose.diagram.BoolValue-) | Für die Beschreibung dieser Eigenschaft siehe [getNoSnap()](../../com.aspose.diagram/geom\#getNoSnap--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Geom() {#Geom--}
+```
+public Geom()
+```
+
+
+Konstruktor.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCoordinateCol() {#getCoordinateCol--}
+```
+public CoordinateCollection getCoordinateCol()
+```
+
+
+Sammlung von Koordinaten. Sie zeigt die Reihenfolge der Koordinaten.
+
+**Returns:**
+[CoordinateCollection](../../com.aspose.diagram/coordinatecollection)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements.
+
+**Returns:**
+int
+### getNextCoordinateIX() {#getNextCoordinateIX--}
+```
+public int getNextCoordinateIX()
+```
+
+
+Gibt den IX-Wert für das nächste Koordinatensammlungsmitglied der Form zurück.
+
+**Returns:**
+int
+### getNoFill() {#getNoFill--}
+```
+public BoolValue getNoFill()
+```
+
+
+Gibt an, ob ein Pfad gefüllt werden kann.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getNoLine() {#getNoLine--}
+```
+public BoolValue getNoLine()
+```
+
+
+Gibt an, ob eine Linie um die Begrenzung des Pfades gezeichnet wird.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getNoQuickDrag() {#getNoQuickDrag--}
+```
+public BoolValue getNoQuickDrag()
+```
+
+
+Bestimmt, ob eine Form ausgewählt oder gezogen werden kann, wenn der Benutzer den durch den Geometry-Abschnitt definierten gefüllten Bereich anklickt.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getNoShow() {#getNoShow--}
+```
+public BoolValue getNoShow()
+```
+
+
+Gibt an, ob ein Pfad auf der Zeichenfläche angezeigt wird.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getNoSnap() {#getNoSnap--}
+```
+public BoolValue getNoSnap()
+```
+
+
+Gibt an, ob andere Formen an einem Pfad einrasten.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getDel()](../../com.aspose.diagram/geom\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getIX()](../../com.aspose.diagram/geom\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setNoFill(BoolValue value) {#setNoFill-com.aspose.diagram.BoolValue-}
+```
+public void setNoFill(BoolValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getNoFill()](../../com.aspose.diagram/geom\#getNoFill--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setNoLine(BoolValue value) {#setNoLine-com.aspose.diagram.BoolValue-}
+```
+public void setNoLine(BoolValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getNoLine()](../../com.aspose.diagram/geom\#getNoLine--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setNoQuickDrag(BoolValue value) {#setNoQuickDrag-com.aspose.diagram.BoolValue-}
+```
+public void setNoQuickDrag(BoolValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getNoQuickDrag()](../../com.aspose.diagram/geom\#getNoQuickDrag--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setNoShow(BoolValue value) {#setNoShow-com.aspose.diagram.BoolValue-}
+```
+public void setNoShow(BoolValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getNoShow()](../../com.aspose.diagram/geom\#getNoShow--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setNoSnap(BoolValue value) {#setNoSnap-com.aspose.diagram.BoolValue-}
+```
+public void setNoSnap(BoolValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getNoSnap()](../../com.aspose.diagram/geom\#getNoSnap--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/geomcollection/_index.md
+++ b/german/java/com.aspose.diagram/geomcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: GeomCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: Geom-Sammlung.
+type: docs
+weight: 170
+url: /de/java/com.aspose.diagram/geomcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class GeomCollection extends Collection
+```
+
+Geom-Sammlung.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [add(Geom item)](#add-com.aspose.diagram.Geom-) | Füge das Geom-Objekt zur Sammlung hinzu. |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Geom item)](#remove-com.aspose.diagram.Geom-) | Entferne das Geom-Objekt aus der Sammlung. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Geom item) {#add-com.aspose.diagram.Geom-}
+```
+public int add(Geom item)
+```
+
+
+Füge das Geom-Objekt zur Sammlung hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [Geom](../../com.aspose.diagram/geom) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Geom get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[Geom](../../com.aspose.diagram/geom) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Geom item) {#remove-com.aspose.diagram.Geom-}
+```
+public void remove(Geom item)
+```
+
+
+Entferne das Geom-Objekt aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [Geom](../../com.aspose.diagram/geom) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/gloweffect/_index.md
+++ b/german/java/com.aspose.diagram/gloweffect/_index.md
@@ -1,0 +1,150 @@
+---
+title: GlowEffect
+second_title: Aspose.Diagram for Java API-Referenz
+description: Diese Klasse definiert einen Leuchteffekt, bei dem ein farbiger, unscharfer Umriss außerhalb der Kanten des Objekts hinzugefügt wird.
+type: docs
+weight: 171
+url: /de/java/com.aspose.diagram/gloweffect/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class GlowEffect
+```
+
+Diese Klasse definiert einen Leuchteffekt, bei dem eine farbige, unscharfe Kontur außerhalb der Objektkanten hinzugefügt wird.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getSize()](#getSize--) | Der Radius des Leuchteffekts, in Punkten. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setSize(double value)](#setSize-double-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getSize()](../../com.aspose.diagram/gloweffect\#getSize--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getSize() {#getSize--}
+```
+public double getSize()
+```
+
+
+Der Radius des Leuchteffekts, in Punkten.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setSize(double value) {#setSize-double-}
+```
+public void setSize(double value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getSize()](../../com.aspose.diagram/gloweffect\#getSize--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/gluedshapesflags/_index.md
+++ b/german/java/com.aspose.diagram/gluedshapesflags/_index.md
@@ -1,0 +1,183 @@
+---
+title: GluedShapesFlags
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt Konstanten an, die bestimmen, welche Shapes basierend auf der Dimensionalität und Richtung der Verbindungspunkte zurückgegeben werden, die an ein bestimmtes Shape, das an die Methode Shape.GluedShapes übergeben wird, angeheftet sind.
+type: docs
+weight: 176
+url: /de/java/com.aspose.diagram/gluedshapesflags/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class GluedShapesFlags
+```
+
+Gibt Konstanten an, die bestimmen, welche Formen zurückgegeben werden, basierend auf der Dimensionalität und Richtungsabhängigkeit der Verbindungspunkte, die an einer bestimmten Form geklebt sind; wird an die Methode Shape.GluedShapes übergeben.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [GLUED_SHAPES_ALL_1_D](#GLUED-SHAPES-ALL-1-D) | Gibt IDs aller 1‑D‑Shapes zurück, die an dieses Shape angeheftet sind. |
+| [GLUED_SHAPES_ALL_2_D](#GLUED-SHAPES-ALL-2-D) | Gibt alle 2‑D‑Shapes zurück, die an dieses Shape angeheftet sind, sowie alle 2‑D‑Shapes, an die dieses Shape angeheftet ist. |
+| [GLUED_SHAPES_INCOMING_1_D](#GLUED-SHAPES-INCOMING-1-D) | Gibt IDs von 1‑D‑Shapes zurück, deren Endpunkte an dieses Shape angeheftet sind. |
+| [GLUED_SHAPES_INCOMING_2_D](#GLUED-SHAPES-INCOMING-2-D) | Wenn das Quellobjekt ein 1‑D‑Shape ist, gibt es IDs von 2‑D‑Shapes zurück, an die der Anfangspunkt angeheftet ist. |
+| [GLUED_SHAPES_OUTGOING_1_D](#GLUED-SHAPES-OUTGOING-1-D) | Geben Sie die IDs von 1‑D‑Formen zurück, deren Anfangspunkte an diese Form geklebt sind. |
+| [GLUED_SHAPES_OUTGOING_2_D](#GLUED-SHAPES-OUTGOING-2-D) | Wenn das Quellobjekt eine 1‑D‑Form ist, geben Sie die IDs der 2‑D‑Form zurück, an die der Endpunkt geklebt ist. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GLUED_SHAPES_ALL_1_D {#GLUED-SHAPES-ALL-1-D}
+```
+public static final int GLUED_SHAPES_ALL_1_D
+```
+
+
+Gibt IDs aller 1‑D‑Shapes zurück, die an dieses Shape angeheftet sind.
+
+### GLUED_SHAPES_ALL_2_D {#GLUED-SHAPES-ALL-2-D}
+```
+public static final int GLUED_SHAPES_ALL_2_D
+```
+
+
+Gibt alle 2‑D‑Shapes zurück, die an dieses Shape angeheftet sind, sowie alle 2‑D‑Shapes, an die dieses Shape angeheftet ist.
+
+### GLUED_SHAPES_INCOMING_1_D {#GLUED-SHAPES-INCOMING-1-D}
+```
+public static final int GLUED_SHAPES_INCOMING_1_D
+```
+
+
+Gibt IDs von 1‑D‑Shapes zurück, deren Endpunkte an dieses Shape angeheftet sind.
+
+### GLUED_SHAPES_INCOMING_2_D {#GLUED-SHAPES-INCOMING-2-D}
+```
+public static final int GLUED_SHAPES_INCOMING_2_D
+```
+
+
+Wenn das Quellobjekt eine 1‑D‑Form ist, geben Sie die IDs der 2‑D‑Form zurück, an die der Anfangspunkt geklebt ist. Wenn das Quellobjekt eine 2‑D‑Form ist, geben Sie die IDs der 2‑D‑Formen zurück, die an diese Form geklebt sind.
+
+### GLUED_SHAPES_OUTGOING_1_D {#GLUED-SHAPES-OUTGOING-1-D}
+```
+public static final int GLUED_SHAPES_OUTGOING_1_D
+```
+
+
+Geben Sie die IDs von 1‑D‑Formen zurück, deren Anfangspunkte an diese Form geklebt sind.
+
+### GLUED_SHAPES_OUTGOING_2_D {#GLUED-SHAPES-OUTGOING-2-D}
+```
+public static final int GLUED_SHAPES_OUTGOING_2_D
+```
+
+
+Wenn das Quellobjekt eine 1‑D‑Form ist, geben Sie die IDs der 2‑D‑Form zurück, an die der Endpunkt geklebt ist. Wenn das Quellobjekt eine 2‑D‑Form ist, geben Sie die IDs der 2‑D‑Formen zurück, an die diese Form geklebt ist.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/gluesettings/_index.md
+++ b/german/java/com.aspose.diagram/gluesettings/_index.md
@@ -1,0 +1,201 @@
+---
+title: GlueSettings
+second_title: Aspose.Diagram for Java API-Referenz
+description: Die Bitwerte zeigen an, dass eine bestimmte Klebe-Einstellung ein- oder ausgeschaltet ist.
+type: docs
+weight: 172
+url: /de/java/com.aspose.diagram/gluesettings/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class GlueSettings
+```
+
+Die Bitwerte zeigen an, dass eine bestimmte Klebeinstellung ein- oder ausgeschaltet ist. Der Wert kann die Summe der Werte sein:
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [CONNECTION_POINTS](#CONNECTION-POINTS) | Kleben an Verbindungspunkten. |
+| [DISABLED](#DISABLED) | Klebefunktion ist deaktiviert |
+| [GEOMETRY](#GEOMETRY) | Kleben an Geometrie. |
+| [GUIDES](#GUIDES) | Kleben an Hilfslinien. |
+| [HANDLES](#HANDLES) | Kleben an Griffen. |
+| [NONE](#NONE) | Kleben ist aktiviert, aber keine anderen Klebe‑Einstellungen sind aktiviert. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+| [VERTICES](#VERTICES) | Kleben an Eckpunkten. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CONNECTION_POINTS {#CONNECTION-POINTS}
+```
+public static final int CONNECTION_POINTS
+```
+
+
+Kleben an Verbindungspunkten.
+
+### DISABLED {#DISABLED}
+```
+public static final int DISABLED
+```
+
+
+Klebefunktion ist deaktiviert
+
+### GEOMETRY {#GEOMETRY}
+```
+public static final int GEOMETRY
+```
+
+
+Kleben an Geometrie.
+
+### GUIDES {#GUIDES}
+```
+public static final int GUIDES
+```
+
+
+Kleben an Hilfslinien.
+
+### HANDLES {#HANDLES}
+```
+public static final int HANDLES
+```
+
+
+Kleben an Griffen.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Kleben ist aktiviert, aber keine anderen Klebe‑Einstellungen sind aktiviert.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### VERTICES {#VERTICES}
+```
+public static final int VERTICES
+```
+
+
+Kleben an Eckpunkten.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/gluesettingsvalue/_index.md
+++ b/german/java/com.aspose.diagram/gluesettingsvalue/_index.md
@@ -1,0 +1,201 @@
+---
+title: GlueSettingsValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt die Objekte an, an die Formen geklebt werden, wenn Kleben im Dokument aktiviert ist.
+type: docs
+weight: 173
+url: /de/java/com.aspose.diagram/gluesettingsvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class GlueSettingsValue
+```
+
+Gibt die Objekte an, an die Formen geklebt werden, wenn Kleben im Dokument aktiviert ist.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [GLUE_IS_DISABLED](#GLUE-IS-DISABLED) | Kleben ist deaktiviert. |
+| [GLUE_IS_ENABLED](#GLUE-IS-ENABLED) | Kleben ist aktiviert, aber keine anderen Klebe‑Einstellungen sind aktiviert. |
+| [GLUE_TO_CONNECTION_POINTS](#GLUE-TO-CONNECTION-POINTS) | Kleben an Verbindungspunkten. |
+| [GLUE_TO_GEOMETRY](#GLUE-TO-GEOMETRY) | Kleben an Geometrie. |
+| [GLUE_TO_GUIDES](#GLUE-TO-GUIDES) | Kleben an Hilfslinien. |
+| [GLUE_TO_HANDLES](#GLUE-TO-HANDLES) | Kleben an Griffen. |
+| [GLUE_TO_VERTICES](#GLUE-TO-VERTICES) | Kleben an Eckpunkten. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GLUE_IS_DISABLED {#GLUE-IS-DISABLED}
+```
+public static final int GLUE_IS_DISABLED
+```
+
+
+Kleben ist deaktiviert.
+
+### GLUE_IS_ENABLED {#GLUE-IS-ENABLED}
+```
+public static final int GLUE_IS_ENABLED
+```
+
+
+Kleben ist aktiviert, aber keine anderen Klebe‑Einstellungen sind aktiviert.
+
+### GLUE_TO_CONNECTION_POINTS {#GLUE-TO-CONNECTION-POINTS}
+```
+public static final int GLUE_TO_CONNECTION_POINTS
+```
+
+
+Kleben an Verbindungspunkten.
+
+### GLUE_TO_GEOMETRY {#GLUE-TO-GEOMETRY}
+```
+public static final int GLUE_TO_GEOMETRY
+```
+
+
+Kleben an Geometrie.
+
+### GLUE_TO_GUIDES {#GLUE-TO-GUIDES}
+```
+public static final int GLUE_TO_GUIDES
+```
+
+
+Kleben an Hilfslinien.
+
+### GLUE_TO_HANDLES {#GLUE-TO-HANDLES}
+```
+public static final int GLUE_TO_HANDLES
+```
+
+
+Kleben an Griffen.
+
+### GLUE_TO_VERTICES {#GLUE-TO-VERTICES}
+```
+public static final int GLUE_TO_VERTICES
+```
+
+
+Kleben an Eckpunkten.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/gluetype/_index.md
+++ b/german/java/com.aspose.diagram/gluetype/_index.md
@@ -1,0 +1,179 @@
+---
+title: GlueType
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt an, ob dynamisches Form-zu-Form-Kleben beim Verbinden mit einer Form zulässig ist.
+type: docs
+weight: 174
+url: /de/java/com.aspose.diagram/gluetype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class GlueType
+```
+
+Gibt an, ob dynamisches (Form-zu-Form) Kleben beim Verbinden mit einer Form erlaubt ist.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [GlueType(int value)](#GlueType-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Gibt an, ob dynamisches (Form-zu-Form) Kleben beim Verbinden mit einer Form erlaubt ist. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/gluetype\\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GlueType(int value) {#GlueType-int-}
+```
+public GlueType(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Gibt an, ob dynamisches (Form-zu-Form) Kleben beim Verbinden mit einer Form erlaubt ist.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/gluetype\\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/gluetypevalue/_index.md
+++ b/german/java/com.aspose.diagram/gluetypevalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: GlueTypeValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt an, ob dynamisches Form-zu-Form-Kleben beim Verbinden mit einer Form zulässig ist.
+type: docs
+weight: 175
+url: /de/java/com.aspose.diagram/gluetypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class GlueTypeValue
+```
+
+Gibt an, ob dynamisches (Form-zu-Form) Kleben beim Verbinden mit einer Form erlaubt ist.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [ALLOW_DYNAMIC_GLUE](#ALLOW-DYNAMIC-GLUE) | Dynamisches Kleben zulassen. |
+| [ALLOW_DYNAMIC_GLUE_2002](#ALLOW-DYNAMIC-GLUE-2002) | Dynamisches Kleben zulassen (veraltet in Microsoft Visio 2002). |
+| [ALLOW_DYNAMIC_GLUE_FOR_DYNAMIC_CONNECTOR](#ALLOW-DYNAMIC-GLUE-FOR-DYNAMIC-CONNECTOR) | Standard. |
+| [NO_ALLOW_2_D_SHAPE](#NO-ALLOW-2-D-SHAPE) | Verhindern, dass diese 2-D-Form mit dynamischem Kleben verbunden wird. |
+| [NO_ALLOW_DYNAMIC_GLUE](#NO-ALLOW-DYNAMIC-GLUE) | Dynamisches Kleben nicht zulassen. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALLOW_DYNAMIC_GLUE {#ALLOW-DYNAMIC-GLUE}
+```
+public static final int ALLOW_DYNAMIC_GLUE
+```
+
+
+Dynamisches Kleben zulassen.
+
+### ALLOW_DYNAMIC_GLUE_2002 {#ALLOW-DYNAMIC-GLUE-2002}
+```
+public static final int ALLOW_DYNAMIC_GLUE_2002
+```
+
+
+Dynamisches Kleben zulassen (veraltet in Microsoft Visio 2002).
+
+### ALLOW_DYNAMIC_GLUE_FOR_DYNAMIC_CONNECTOR {#ALLOW-DYNAMIC-GLUE-FOR-DYNAMIC-CONNECTOR}
+```
+public static final int ALLOW_DYNAMIC_GLUE_FOR_DYNAMIC_CONNECTOR
+```
+
+
+Standard. Dynamisches Kleben nur für den dynamischen Verbinder zulassen; andernfalls statisches Kleben verwenden.
+
+### NO_ALLOW_2_D_SHAPE {#NO-ALLOW-2-D-SHAPE}
+```
+public static final int NO_ALLOW_2_D_SHAPE
+```
+
+
+Verhindern, dass diese 2-D-Form mit dynamischem Kleben verbunden wird.
+
+### NO_ALLOW_DYNAMIC_GLUE {#NO-ALLOW-DYNAMIC-GLUE}
+```
+public static final int NO_ALLOW_DYNAMIC_GLUE
+```
+
+
+Dynamisches Kleben nicht zulassen.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/gradientdirectiontype/_index.md
+++ b/german/java/com.aspose.diagram/gradientdirectiontype/_index.md
@@ -1,0 +1,183 @@
+---
+title: GradientDirectionType
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt alle Richtungsarten eines Farbverlaufs dar.
+type: docs
+weight: 177
+url: /de/java/com.aspose.diagram/gradientdirectiontype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class GradientDirectionType
+```
+
+Stellt alle Richtungsarten eines Farbverlaufs dar.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [FROM_CENTER](#FROM-CENTER) | FromCenter |
+| [FROM_LOWER_LEFT_CORNER](#FROM-LOWER-LEFT-CORNER) | FromLowerLeftCorner |
+| [FROM_LOWER_RIGHT_CORNER](#FROM-LOWER-RIGHT-CORNER) | FromLowerRightCorner |
+| [FROM_UPPER_LEFT_CORNER](#FROM-UPPER-LEFT-CORNER) | FromUpperLeftCorner |
+| [FROM_UPPER_RIGHT_CORNER](#FROM-UPPER-RIGHT-CORNER) | FromUpperRightCorner |
+| [UNKNOWN](#UNKNOWN) | Unknown |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FROM_CENTER {#FROM-CENTER}
+```
+public static final int FROM_CENTER
+```
+
+
+FromCenter
+
+### FROM_LOWER_LEFT_CORNER {#FROM-LOWER-LEFT-CORNER}
+```
+public static final int FROM_LOWER_LEFT_CORNER
+```
+
+
+FromLowerLeftCorner
+
+### FROM_LOWER_RIGHT_CORNER {#FROM-LOWER-RIGHT-CORNER}
+```
+public static final int FROM_LOWER_RIGHT_CORNER
+```
+
+
+FromLowerRightCorner
+
+### FROM_UPPER_LEFT_CORNER {#FROM-UPPER-LEFT-CORNER}
+```
+public static final int FROM_UPPER_LEFT_CORNER
+```
+
+
+FromUpperLeftCorner
+
+### FROM_UPPER_RIGHT_CORNER {#FROM-UPPER-RIGHT-CORNER}
+```
+public static final int FROM_UPPER_RIGHT_CORNER
+```
+
+
+FromUpperRightCorner
+
+### UNKNOWN {#UNKNOWN}
+```
+public static final int UNKNOWN
+```
+
+
+Unknown
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/gradientfill/_index.md
+++ b/german/java/com.aspose.diagram/gradientfill/_index.md
@@ -1,0 +1,211 @@
+---
+title: GradientFill
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt die Verlauffüllung dar.
+type: docs
+weight: 178
+url: /de/java/com.aspose.diagram/gradientfill/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class GradientFill
+```
+
+Stellt die Verlauffüllung dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getGradientAngle()](#getGradientAngle--) | Gibt die Ausrichtung des Farbverlaufs der Füllung an |
+| [getGradientDir()](#getGradientDir--) | Gibt den Typ des Farbverlaufs der Füllung an |
+| [getGradientEnabled()](#getGradientEnabled--) | Gibt an, ob der Farbverlauf der Füllung sichtbar ist. |
+| [getGradientStops()](#getGradientStops--) | Stellt die Sammlung von Verlauf-Stops dar. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setGradientAngle(DoubleValue value)](#setGradientAngle-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getGradientAngle()](../../com.aspose.diagram/gradientfill\#getGradientAngle--) |
+| [setGradientDir(IntValue value)](#setGradientDir-com.aspose.diagram.IntValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getGradientDir()](../../com.aspose.diagram/gradientfill\#getGradientDir--) |
+| [setGradientEnabled(BoolValue value)](#setGradientEnabled-com.aspose.diagram.BoolValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getGradientEnabled()](../../com.aspose.diagram/gradientfill\#getGradientEnabled--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getGradientAngle() {#getGradientAngle--}
+```
+public DoubleValue getGradientAngle()
+```
+
+
+Gibt die Ausrichtung des Farbverlaufs der Füllung an
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getGradientDir() {#getGradientDir--}
+```
+public IntValue getGradientDir()
+```
+
+
+Gibt den Typ des Farbverlaufs der Füllung an
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getGradientEnabled() {#getGradientEnabled--}
+```
+public BoolValue getGradientEnabled()
+```
+
+
+Gibt an, ob der Farbverlauf der Füllung sichtbar ist.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getGradientStops() {#getGradientStops--}
+```
+public GradientStopCollection getGradientStops()
+```
+
+
+Stellt die Sammlung von Verlauf-Stops dar.
+
+**Returns:**
+[GradientStopCollection](../../com.aspose.diagram/gradientstopcollection)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setGradientAngle(DoubleValue value) {#setGradientAngle-com.aspose.diagram.DoubleValue-}
+```
+public void setGradientAngle(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getGradientAngle()](../../com.aspose.diagram/gradientfill\#getGradientAngle--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setGradientDir(IntValue value) {#setGradientDir-com.aspose.diagram.IntValue-}
+```
+public void setGradientDir(IntValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getGradientDir()](../../com.aspose.diagram/gradientfill\#getGradientDir--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setGradientEnabled(BoolValue value) {#setGradientEnabled-com.aspose.diagram.BoolValue-}
+```
+public void setGradientEnabled(BoolValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getGradientEnabled()](../../com.aspose.diagram/gradientfill\#getGradientEnabled--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/gradientfilldir/_index.md
+++ b/german/java/com.aspose.diagram/gradientfilldir/_index.md
@@ -1,0 +1,255 @@
+---
+title: GradientFillDir
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt den Typ des Farbverlaufs der Füllung einer Form an
+type: docs
+weight: 179
+url: /de/java/com.aspose.diagram/gradientfilldir/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class GradientFillDir
+```
+
+Gibt den Typ des Farbverlaufs der Füllung einer Form an
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [LINEAR](#LINEAR) | Gibt einen linearen Farbfüllungsgradienten an. |
+| [PATH](#PATH) | Gibt an, dass der Farbverlauf der Füllfarbe der Form im Pfadmodus ist |
+| [RADIAL_FROM_BOTTOM_LEFT](#RADIAL-FROM-BOTTOM-LEFT) | Gibt an, dass der Farbverlauf der Füllfarbe der Form im radialen Modus von der unteren linken Ecke der Form ausgeht |
+| [RADIAL_FROM_BOTTOM_RIGHT](#RADIAL-FROM-BOTTOM-RIGHT) | Gibt an, dass der Farbverlauf der Füllfarbe der Form im radialen Modus von der unteren rechten Ecke der Form ausgeht |
+| [RADIAL_FROM_CENTER](#RADIAL-FROM-CENTER) | Gibt an, dass der Farbverlauf der Füllfarbe der Form im radialen Modus vom Zentrum der Form ausgeht. |
+| [RADIAL_FROM_CENTER_BOTTOM](#RADIAL-FROM-CENTER-BOTTOM) | Gibt an, dass der Farbverlauf der Füllfarbe der Form im radialen Modus vom Mittelpunkt der unteren Kante der Form ausgeht. |
+| [RADIAL_FROM_CENTER_TOP](#RADIAL-FROM-CENTER-TOP) | Gibt an, dass der Farbverlauf der Füllfarbe der Form im radialen Modus vom Mittelpunkt der oberen Kante der Form ausgeht |
+| [RADIAL_FROM_TOP_LEFT](#RADIAL-FROM-TOP-LEFT) | Gibt an, dass der Farbverlauf der Füllfarbe der Form im radialen Modus von der oberen linken Ecke der Form ausgeht |
+| [RADIAL_FROM_TOP_RIGHT](#RADIAL-FROM-TOP-RIGHT) | Gibt an, dass der Farbverlauf der Füllfarbe der Form im radialen Modus von der oberen rechten Ecke der Form ausgeht |
+| [RECTANGLE_FROM_BOTTOM_LEFT](#RECTANGLE-FROM-BOTTOM-LEFT) | Gibt an, dass der Farbverlauf der Füllfarbe der Form im Rechteckmodus von der unteren linken Ecke der Form ausgeht |
+| [RECTANGLE_FROM_BOTTOM_RIGHT](#RECTANGLE-FROM-BOTTOM-RIGHT) | Gibt an, dass der Farbverlauf der Füllfarbe der Form im Rechteckmodus von der unteren rechten Ecke der Form ausgeht |
+| [RECTANGLE_FROM_CENTER](#RECTANGLE-FROM-CENTER) | Gibt an, dass der Farbverlauf der Füllfarbe der Form im Rechteckmodus vom Zentrum der Form ausgeht. |
+| [RECTANGLE_FROM_TOP_LEFT](#RECTANGLE-FROM-TOP-LEFT) | Gibt an, dass der Farbverlauf der Füllfarbe der Form im Rechteckmodus von der oberen linken Ecke der Form ausgeht |
+| [RECTANGLE_FROM_TOP_RIGHT](#RECTANGLE-FROM-TOP-RIGHT) | Gibt an, dass der Farbverlauf der Füllfarbe der Form im Rechteckmodus von der oberen rechten Ecke der Form ausgeht |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LINEAR {#LINEAR}
+```
+public static final int LINEAR
+```
+
+
+Gibt einen linearen Farbfüllungsgradienten an.
+
+### PATH {#PATH}
+```
+public static final int PATH
+```
+
+
+Gibt an, dass der Farbverlauf der Füllfarbe der Form im Pfadmodus ist
+
+### RADIAL_FROM_BOTTOM_LEFT {#RADIAL-FROM-BOTTOM-LEFT}
+```
+public static final int RADIAL_FROM_BOTTOM_LEFT
+```
+
+
+Gibt an, dass der Farbverlauf der Füllfarbe der Form im radialen Modus von der unteren linken Ecke der Form ausgeht
+
+### RADIAL_FROM_BOTTOM_RIGHT {#RADIAL-FROM-BOTTOM-RIGHT}
+```
+public static final int RADIAL_FROM_BOTTOM_RIGHT
+```
+
+
+Gibt an, dass der Farbverlauf der Füllfarbe der Form im radialen Modus von der unteren rechten Ecke der Form ausgeht
+
+### RADIAL_FROM_CENTER {#RADIAL-FROM-CENTER}
+```
+public static final int RADIAL_FROM_CENTER
+```
+
+
+Gibt an, dass der Farbverlauf der Füllfarbe der Form im radialen Modus vom Zentrum der Form ausgeht.
+
+### RADIAL_FROM_CENTER_BOTTOM {#RADIAL-FROM-CENTER-BOTTOM}
+```
+public static final int RADIAL_FROM_CENTER_BOTTOM
+```
+
+
+Gibt an, dass der Farbverlauf der Füllfarbe der Form im radialen Modus vom Mittelpunkt der unteren Kante der Form ausgeht.
+
+### RADIAL_FROM_CENTER_TOP {#RADIAL-FROM-CENTER-TOP}
+```
+public static final int RADIAL_FROM_CENTER_TOP
+```
+
+
+Gibt an, dass der Farbverlauf der Füllfarbe der Form im radialen Modus vom Mittelpunkt der oberen Kante der Form ausgeht
+
+### RADIAL_FROM_TOP_LEFT {#RADIAL-FROM-TOP-LEFT}
+```
+public static final int RADIAL_FROM_TOP_LEFT
+```
+
+
+Gibt an, dass der Farbverlauf der Füllfarbe der Form im radialen Modus von der oberen linken Ecke der Form ausgeht
+
+### RADIAL_FROM_TOP_RIGHT {#RADIAL-FROM-TOP-RIGHT}
+```
+public static final int RADIAL_FROM_TOP_RIGHT
+```
+
+
+Gibt an, dass der Farbverlauf der Füllfarbe der Form im radialen Modus von der oberen rechten Ecke der Form ausgeht
+
+### RECTANGLE_FROM_BOTTOM_LEFT {#RECTANGLE-FROM-BOTTOM-LEFT}
+```
+public static final int RECTANGLE_FROM_BOTTOM_LEFT
+```
+
+
+Gibt an, dass der Farbverlauf der Füllfarbe der Form im Rechteckmodus von der unteren linken Ecke der Form ausgeht
+
+### RECTANGLE_FROM_BOTTOM_RIGHT {#RECTANGLE-FROM-BOTTOM-RIGHT}
+```
+public static final int RECTANGLE_FROM_BOTTOM_RIGHT
+```
+
+
+Gibt an, dass der Farbverlauf der Füllfarbe der Form im Rechteckmodus von der unteren rechten Ecke der Form ausgeht
+
+### RECTANGLE_FROM_CENTER {#RECTANGLE-FROM-CENTER}
+```
+public static final int RECTANGLE_FROM_CENTER
+```
+
+
+Gibt an, dass der Farbverlauf der Füllfarbe der Form im Rechteckmodus vom Zentrum der Form ausgeht.
+
+### RECTANGLE_FROM_TOP_LEFT {#RECTANGLE-FROM-TOP-LEFT}
+```
+public static final int RECTANGLE_FROM_TOP_LEFT
+```
+
+
+Gibt an, dass der Farbverlauf der Füllfarbe der Form im Rechteckmodus von der oberen linken Ecke der Form ausgeht
+
+### RECTANGLE_FROM_TOP_RIGHT {#RECTANGLE-FROM-TOP-RIGHT}
+```
+public static final int RECTANGLE_FROM_TOP_RIGHT
+```
+
+
+Gibt an, dass der Farbverlauf der Füllfarbe der Form im Rechteckmodus von der oberen rechten Ecke der Form ausgeht
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/gradientfilltype/_index.md
+++ b/german/java/com.aspose.diagram/gradientfilltype/_index.md
@@ -1,0 +1,165 @@
+---
+title: GradientFillType
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt alle Typen der Verlauffüllung dar.
+type: docs
+weight: 180
+url: /de/java/com.aspose.diagram/gradientfilltype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class GradientFillType
+```
+
+Stellt alle Typen der Verlauffüllung dar.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [LINEAR](#LINEAR) | Linear |
+| [PATH](#PATH) | Pfad |
+| [RADIAL](#RADIAL) | Radial |
+| [RECTANGLE](#RECTANGLE) | Rechteck |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LINEAR {#LINEAR}
+```
+public static final int LINEAR
+```
+
+
+Linear
+
+### PATH {#PATH}
+```
+public static final int PATH
+```
+
+
+Pfad
+
+### RADIAL {#RADIAL}
+```
+public static final int RADIAL
+```
+
+
+Radial
+
+### RECTANGLE {#RECTANGLE}
+```
+public static final int RECTANGLE
+```
+
+
+Rechteck
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/gradientstop/_index.md
+++ b/german/java/com.aspose.diagram/gradientstop/_index.md
@@ -1,0 +1,222 @@
+---
+title: GradientStop
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt den Verlauf-Stopp dar.
+type: docs
+weight: 181
+url: /de/java/com.aspose.diagram/gradientstop/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class GradientStop
+```
+
+Stellt den Verlauf-Stopp dar.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [GradientStop()](#GradientStop--) |  |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getColor()](#getColor--) | Liest die Farbe dieses Farbverlaufsstopps. |
+| [getPosition()](#getPosition--) | Die Position des Stopps. |
+| [getTransparency()](#getTransparency--) | Liefert oder setzt den Transparenzgrad des Bereichs als Wert von 0,0 (undurchsichtig) bis 1,0 (transparent). |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setColor(ColorValue value)](#setColor-com.aspose.diagram.ColorValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getColor()](../../com.aspose.diagram/gradientstop\#getColor--) |
+| [setPosition(DoubleValue value)](#setPosition-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getPosition()](../../com.aspose.diagram/gradientstop\#getPosition--) |
+| [setTransparency(DoubleValue value)](#setTransparency-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getTransparency()](../../com.aspose.diagram/gradientstop\#getTransparency--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GradientStop() {#GradientStop--}
+```
+public GradientStop()
+```
+
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColor() {#getColor--}
+```
+public ColorValue getColor()
+```
+
+
+Liest die Farbe dieses Farbverlaufsstopps.
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getPosition() {#getPosition--}
+```
+public DoubleValue getPosition()
+```
+
+
+Die Position des Stopps.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTransparency() {#getTransparency--}
+```
+public DoubleValue getTransparency()
+```
+
+
+Liefert oder setzt den Transparenzgrad des Bereichs als Wert von 0,0 (undurchsichtig) bis 1,0 (transparent).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setColor(ColorValue value) {#setColor-com.aspose.diagram.ColorValue-}
+```
+public void setColor(ColorValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getColor()](../../com.aspose.diagram/gradientstop\#getColor--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setPosition(DoubleValue value) {#setPosition-com.aspose.diagram.DoubleValue-}
+```
+public void setPosition(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getPosition()](../../com.aspose.diagram/gradientstop\#getPosition--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTransparency(DoubleValue value) {#setTransparency-com.aspose.diagram.DoubleValue-}
+```
+public void setTransparency(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getTransparency()](../../com.aspose.diagram/gradientstop\#getTransparency--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/gradientstopcollection/_index.md
+++ b/german/java/com.aspose.diagram/gradientstopcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: GradientStopCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt die Sammlung von Verlauf-Stops dar.
+type: docs
+weight: 182
+url: /de/java/com.aspose.diagram/gradientstopcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class GradientStopCollection extends Collection
+```
+
+Stellt die Sammlung von Verlauf-Stops dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [add(DoubleValue position, ColorValue color)](#add-com.aspose.diagram.DoubleValue-com.aspose.diagram.ColorValue-) | Einen Farbverlaufspunkt hinzufügen. |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ruft den Farbverlaufspunkt nach Index ab. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [set(int index, GradientStop value)](#set-int-com.aspose.diagram.GradientStop-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(DoubleValue position, ColorValue color) {#add-com.aspose.diagram.DoubleValue-com.aspose.diagram.ColorValue-}
+```
+public void add(DoubleValue position, ColorValue color)
+```
+
+
+Einen Farbverlaufspunkt hinzufügen.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| position | [DoubleValue](../../com.aspose.diagram/doublevalue) | Die Position des Stopps,in Prozent. |
+| color | [ColorValue](../../com.aspose.diagram/colorvalue) | Die Farbe des Stopps. |
+
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public GradientStop get(int index)
+```
+
+
+Ruft den Farbverlaufspunkt nach Index ab.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Der Index. |
+
+**Returns:**
+[GradientStop](../../com.aspose.diagram/gradientstop) - The gradient stop.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### set(int index, GradientStop value) {#set-int-com.aspose.diagram.GradientStop-}
+```
+public void set(int index, GradientStop value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+| value | [GradientStop](../../com.aspose.diagram/gradientstop) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/gradientstyletype/_index.md
+++ b/german/java/com.aspose.diagram/gradientstyletype/_index.md
@@ -1,0 +1,192 @@
+---
+title: GradientStyleType
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt den Schattierungsstil des Farbverlaufs dar.
+type: docs
+weight: 183
+url: /de/java/com.aspose.diagram/gradientstyletype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class GradientStyleType
+```
+
+Stellt den Schattierungsstil des Farbverlaufs dar.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [DIAGONAL_DOWN](#DIAGONAL-DOWN) | Diagonal nach unten Schattierungsstil |
+| [DIAGONAL_UP](#DIAGONAL-UP) | Diagonal nach oben Schattierungsstil |
+| [FROM_CENTER](#FROM-CENTER) | Schattierungsstil von der Mitte |
+| [FROM_CORNER](#FROM-CORNER) | Schattierungsstil von der Ecke |
+| [HORIZONTAL](#HORIZONTAL) | Horizontaler Schattierungsstil |
+| [UNKNOWN](#UNKNOWN) | Unbekannter Schattierungsstil. Nur für den Schattierungsstil (der nicht für ein Mitglied des GradientStyleType ist) in der Vorlagendatei. |
+| [VERTICAL](#VERTICAL) | Vertikaler Schattierungsstil |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DIAGONAL_DOWN {#DIAGONAL-DOWN}
+```
+public static final int DIAGONAL_DOWN
+```
+
+
+Diagonal nach unten Schattierungsstil
+
+### DIAGONAL_UP {#DIAGONAL-UP}
+```
+public static final int DIAGONAL_UP
+```
+
+
+Diagonal nach oben Schattierungsstil
+
+### FROM_CENTER {#FROM-CENTER}
+```
+public static final int FROM_CENTER
+```
+
+
+Schattierungsstil von der Mitte
+
+### FROM_CORNER {#FROM-CORNER}
+```
+public static final int FROM_CORNER
+```
+
+
+Schattierungsstil von der Ecke
+
+### HORIZONTAL {#HORIZONTAL}
+```
+public static final int HORIZONTAL
+```
+
+
+Horizontaler Schattierungsstil
+
+### UNKNOWN {#UNKNOWN}
+```
+public static final int UNKNOWN
+```
+
+
+Unbekannter Schattierungsstil. Nur für den Schattierungsstil (der nicht für ein Mitglied des GradientStyleType ist) in der Vorlagendatei.
+
+### VERTICAL {#VERTICAL}
+```
+public static final int VERTICAL
+```
+
+
+Vertikaler Schattierungsstil
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/griddensity/_index.md
+++ b/german/java/com.aspose.diagram/griddensity/_index.md
@@ -1,0 +1,179 @@
+---
+title: GridDensity
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt den Typ des horizontalen/vertikalen Rasters an, der für eine Seite verwendet werden soll.
+type: docs
+weight: 184
+url: /de/java/com.aspose.diagram/griddensity/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class GridDensity
+```
+
+Gibt den Typ des horizontalen/vertikalen Rasters an, der für eine Seite verwendet werden soll.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [GridDensity(int value)](#GridDensity-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Gibt den Typ des horizontalen/vertikalen Rasters an, der für eine Seite verwendet werden soll. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/griddensity\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GridDensity(int value) {#GridDensity-int-}
+```
+public GridDensity(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Gibt den Typ des horizontalen/vertikalen Rasters an, der für eine Seite verwendet werden soll.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/griddensity\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/griddensityvalue/_index.md
+++ b/german/java/com.aspose.diagram/griddensityvalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: GridDensityValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt den Typ des horizontalen/vertikalen Rasters an, der für eine Seite verwendet werden soll.
+type: docs
+weight: 185
+url: /de/java/com.aspose.diagram/griddensityvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class GridDensityValue
+```
+
+Gibt den Typ des horizontalen/vertikalen Rasters an, der für eine Seite verwendet werden soll.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [COARSE](#COARSE) | Grob. |
+| [FINE](#FINE) | Fein |
+| [FIXED](#FIXED) | Fest. |
+| [NORMAL](#NORMAL) | Normal. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### COARSE {#COARSE}
+```
+public static final int COARSE
+```
+
+
+Grob.
+
+### FINE {#FINE}
+```
+public static final int FINE
+```
+
+
+Fein
+
+### FIXED {#FIXED}
+```
+public static final int FIXED
+```
+
+
+Fest.
+
+### NORMAL {#NORMAL}
+```
+public static final int NORMAL
+```
+
+
+Normal. Standard.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/group/_index.md
+++ b/german/java/com.aspose.diagram/group/_index.md
@@ -1,0 +1,216 @@
+---
+title: Gruppe
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält Elemente, die steuern, wie Sie Formen zu einer Gruppe hinzufügen, Mitglieder einer Gruppe verschieben und Gruppen auswählen.
+type: docs
+weight: 186
+url: /de/java/com.aspose.diagram/group/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Group
+```
+
+Enthält Elemente, die steuern, wie Sie Formen zu einer Gruppe hinzufügen, Gruppenmitglieder verschieben und Gruppen auswählen.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getDisplayMode()](#getDisplayMode--) | Wenn es in einem Group-Element enthalten ist, gibt das DisplayMode-Element an, wie eine Gruppierung und ihre Mitglieder angezeigt werden. |
+| [getDontMoveChildren()](#getDontMoveChildren--) | Gibt an, ob Sie Formen in einer Gruppe mit der Maus ziehen können. |
+| [getSelectMode()](#getSelectMode--) | Gibt an, wie der Benutzer eine Gruppenform und deren Mitglieder auswählt. |
+| [hashCode()](#hashCode--) |  |
+| [isDropTarget()](#isDropTarget--) | Gibt an, ob die Gruppe das Hinzufügen einer Form erlaubt, wenn die Form auf die Gruppe gezogen wird. |
+| [isSnapTarget()](#isSnapTarget--) | Gibt an, ob das Einrasten an einer Gruppe oder an Formen innerhalb der Gruppe aktiviert ist. |
+| [isTextEditTarget()](#isTextEditTarget--) | Gibt an, wie Text einer Gruppe zugewiesen wird. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft, siehe bitte [getDel()](../../com.aspose.diagram/group\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getDisplayMode() {#getDisplayMode--}
+```
+public DisplayMode getDisplayMode()
+```
+
+
+Wenn es in einem Group-Element enthalten ist, gibt das DisplayMode-Element an, wie eine Gruppierung und ihre Mitglieder angezeigt werden.
+
+**Returns:**
+[DisplayMode](../../com.aspose.diagram/displaymode)
+### getDontMoveChildren() {#getDontMoveChildren--}
+```
+public BoolValue getDontMoveChildren()
+```
+
+
+Gibt an, ob Sie Formen in einer Gruppe mit der Maus ziehen können.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getSelectMode() {#getSelectMode--}
+```
+public SelectMode getSelectMode()
+```
+
+
+Gibt an, wie der Benutzer eine Gruppenform und deren Mitglieder auswählt.
+
+**Returns:**
+[SelectMode](../../com.aspose.diagram/selectmode)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isDropTarget() {#isDropTarget--}
+```
+public BoolValue isDropTarget()
+```
+
+
+Gibt an, ob die Gruppe das Hinzufügen einer Form erlaubt, wenn die Form auf die Gruppe gezogen wird.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### isSnapTarget() {#isSnapTarget--}
+```
+public BoolValue isSnapTarget()
+```
+
+
+Gibt an, ob das Einrasten an einer Gruppe oder an Formen innerhalb der Gruppe aktiviert ist.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### isTextEditTarget() {#isTextEditTarget--}
+```
+public BoolValue isTextEditTarget()
+```
+
+
+Gibt an, wie Text einer Gruppe zugewiesen wird.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft, siehe bitte [getDel()](../../com.aspose.diagram/group\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/headerfooter/_index.md
+++ b/german/java/com.aspose.diagram/headerfooter/_index.md
@@ -1,0 +1,361 @@
+---
+title: HeaderFooter
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält Elemente für die Kopf- und Fußzeile eines Dokuments.
+type: docs
+weight: 188
+url: /de/java/com.aspose.diagram/headerfooter/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class HeaderFooter
+```
+
+Enthält Elemente für die Kopf- und Fußzeile eines Dokuments.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFooterCenter()](#getFooterCenter--) | Enthält die Textzeichenfolge, die im mittleren Teil der Fußzeile eines Dokuments erscheint. |
+| [getFooterLeft()](#getFooterLeft--) | Enthält die Textzeichenfolge, die im linken Teil der Fußzeile eines Dokuments erscheint. |
+| [getFooterMargin()](#getFooterMargin--) | Gibt den Rand der Fußzeile eines Dokuments an. |
+| [getFooterRight()](#getFooterRight--) | Enthält die Textzeichenfolge, die im rechten Teil der Fußzeile eines Dokuments erscheint. |
+| [getHeaderCenter()](#getHeaderCenter--) | Enthält die Textzeichenfolge, die im mittleren Teil der Kopfzeile eines Dokuments erscheint. |
+| [getHeaderFooterColor()](#getHeaderFooterColor--) | Der RGB-Wert der Textfarbe für die Kopf- und Fußzeile. |
+| [getHeaderFooterFont()](#getHeaderFooterFont--) | Gibt die für den Kopf- und Fußzeilentext verwendete Schriftart an. |
+| [getHeaderLeft()](#getHeaderLeft--) | Enthält die Textzeichenfolge, die im linken Teil der Kopfzeile eines Dokuments erscheint. |
+| [getHeaderMargin()](#getHeaderMargin--) | Gibt den Rand der Fußzeile eines Dokuments an. |
+| [getHeaderRight()](#getHeaderRight--) | Enthält die Textzeichenfolge, die im rechten Teil der Kopfzeile eines Dokuments erscheint. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setFooterCenter(String value)](#setFooterCenter-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getFooterCenter()](../../com.aspose.diagram/headerfooter\#getFooterCenter--) |
+| [setFooterLeft(String value)](#setFooterLeft-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getFooterLeft()](../../com.aspose.diagram/headerfooter\#getFooterLeft--) |
+| [setFooterMargin(Margin value)](#setFooterMargin-com.aspose.diagram.Margin-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getFooterMargin()](../../com.aspose.diagram/headerfooter\#getFooterMargin--) |
+| [setFooterRight(String value)](#setFooterRight-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getFooterRight()](../../com.aspose.diagram/headerfooter\#getFooterRight--) |
+| [setHeaderCenter(String value)](#setHeaderCenter-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getHeaderCenter()](../../com.aspose.diagram/headerfooter\#getHeaderCenter--) |
+| [setHeaderFooterColor(Color value)](#setHeaderFooterColor-com.aspose.diagram.Color-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getHeaderFooterColor()](../../com.aspose.diagram/headerfooter\#getHeaderFooterColor--) |
+| [setHeaderLeft(String value)](#setHeaderLeft-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getHeaderLeft()](../../com.aspose.diagram/headerfooter\#getHeaderLeft--) |
+| [setHeaderMargin(Margin value)](#setHeaderMargin-com.aspose.diagram.Margin-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getHeaderMargin()](../../com.aspose.diagram/headerfooter\#getHeaderMargin--) |
+| [setHeaderRight(String value)](#setHeaderRight-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getHeaderRight()](../../com.aspose.diagram/headerfooter\#getHeaderRight--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFooterCenter() {#getFooterCenter--}
+```
+public String getFooterCenter()
+```
+
+
+Enthält die Textzeichenfolge, die im mittleren Teil der Fußzeile eines Dokuments erscheint.
+
+**Returns:**
+java.lang.String
+### getFooterLeft() {#getFooterLeft--}
+```
+public String getFooterLeft()
+```
+
+
+Enthält die Textzeichenfolge, die im linken Teil der Fußzeile eines Dokuments erscheint.
+
+**Returns:**
+java.lang.String
+### getFooterMargin() {#getFooterMargin--}
+```
+public Margin getFooterMargin()
+```
+
+
+Gibt den Rand der Fußzeile eines Dokuments an.
+
+**Returns:**
+[Margin](../../com.aspose.diagram/margin)
+### getFooterRight() {#getFooterRight--}
+```
+public String getFooterRight()
+```
+
+
+Enthält die Textzeichenfolge, die im rechten Teil der Fußzeile eines Dokuments erscheint.
+
+**Returns:**
+java.lang.String
+### getHeaderCenter() {#getHeaderCenter--}
+```
+public String getHeaderCenter()
+```
+
+
+Enthält die Textzeichenfolge, die im mittleren Teil der Kopfzeile eines Dokuments erscheint.
+
+**Returns:**
+java.lang.String
+### getHeaderFooterColor() {#getHeaderFooterColor--}
+```
+public Color getHeaderFooterColor()
+```
+
+
+Der RGB-Wert der Textfarbe für die Kopf- und Fußzeile.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color)
+### getHeaderFooterFont() {#getHeaderFooterFont--}
+```
+public HeaderFooterFont getHeaderFooterFont()
+```
+
+
+Gibt die für den Kopf- und Fußzeilentext verwendete Schriftart an.
+
+**Returns:**
+[HeaderFooterFont](../../com.aspose.diagram/headerfooterfont)
+### getHeaderLeft() {#getHeaderLeft--}
+```
+public String getHeaderLeft()
+```
+
+
+Enthält die Textzeichenfolge, die im linken Teil der Kopfzeile eines Dokuments erscheint.
+
+**Returns:**
+java.lang.String
+### getHeaderMargin() {#getHeaderMargin--}
+```
+public Margin getHeaderMargin()
+```
+
+
+Gibt den Rand der Fußzeile eines Dokuments an.
+
+**Returns:**
+[Margin](../../com.aspose.diagram/margin)
+### getHeaderRight() {#getHeaderRight--}
+```
+public String getHeaderRight()
+```
+
+
+Enthält die Textzeichenfolge, die im rechten Teil der Kopfzeile eines Dokuments erscheint.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setFooterCenter(String value) {#setFooterCenter-java.lang.String-}
+```
+public void setFooterCenter(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getFooterCenter()](../../com.aspose.diagram/headerfooter\#getFooterCenter--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setFooterLeft(String value) {#setFooterLeft-java.lang.String-}
+```
+public void setFooterLeft(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getFooterLeft()](../../com.aspose.diagram/headerfooter\#getFooterLeft--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setFooterMargin(Margin value) {#setFooterMargin-com.aspose.diagram.Margin-}
+```
+public void setFooterMargin(Margin value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getFooterMargin()](../../com.aspose.diagram/headerfooter\#getFooterMargin--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [Margin](../../com.aspose.diagram/margin) |  |
+
+### setFooterRight(String value) {#setFooterRight-java.lang.String-}
+```
+public void setFooterRight(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getFooterRight()](../../com.aspose.diagram/headerfooter\#getFooterRight--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setHeaderCenter(String value) {#setHeaderCenter-java.lang.String-}
+```
+public void setHeaderCenter(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getHeaderCenter()](../../com.aspose.diagram/headerfooter\#getHeaderCenter--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setHeaderFooterColor(Color value) {#setHeaderFooterColor-com.aspose.diagram.Color-}
+```
+public void setHeaderFooterColor(Color value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getHeaderFooterColor()](../../com.aspose.diagram/headerfooter\#getHeaderFooterColor--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [Color](../../com.aspose.diagram/color) |  |
+
+### setHeaderLeft(String value) {#setHeaderLeft-java.lang.String-}
+```
+public void setHeaderLeft(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getHeaderLeft()](../../com.aspose.diagram/headerfooter\#getHeaderLeft--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setHeaderMargin(Margin value) {#setHeaderMargin-com.aspose.diagram.Margin-}
+```
+public void setHeaderMargin(Margin value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getHeaderMargin()](../../com.aspose.diagram/headerfooter\#getHeaderMargin--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [Margin](../../com.aspose.diagram/margin) |  |
+
+### setHeaderRight(String value) {#setHeaderRight-java.lang.String-}
+```
+public void setHeaderRight(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getHeaderRight()](../../com.aspose.diagram/headerfooter\#getHeaderRight--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/headerfooterfont/_index.md
+++ b/german/java/com.aspose.diagram/headerfooterfont/_index.md
@@ -1,0 +1,475 @@
+---
+title: HeaderFooterFont
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt die für den Kopf- und Fußzeilentext verwendete Schriftart an.
+type: docs
+weight: 189
+url: /de/java/com.aspose.diagram/headerfooterfont/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class HeaderFooterFont
+```
+
+Gibt die für den Kopf- und Fußzeilentext verwendete Schriftart an.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCharSet()](#getCharSet--) | Gibt den Zeichensatz der Schriftart an. |
+| [getClass()](#getClass--) |  |
+| [getClipPrecision()](#getClipPrecision--) | Gibt die Clipping-Genauigkeit der Schriftart an. |
+| [getEscapement()](#getEscapement--) | Gibt das Escapement-Attribut der Schriftart an. |
+| [getFaceName()](#getFaceName--) | Gibt das type face name-Attribut der Schriftart an. |
+| [getHeight()](#getHeight--) | Gibt die Höhe der Schriftart an. |
+| [getItalic()](#getItalic--) | Gibt das Gewicht der Schriftart an. |
+| [getOrientation()](#getOrientation--) | Gibt die Ausrichtung der Schriftart an. |
+| [getOutPrecision()](#getOutPrecision--) | Gibt das Output-Precision-Attribut der Schriftart an. |
+| [getPitchAndFamily()](#getPitchAndFamily--) | Gibt die Pitch- und Familieninformationen der Schriftart an. |
+| [getQuality()](#getQuality--) | Gibt die Ausgabequalität der Schriftart an. |
+| [getStrikeOut()](#getStrikeOut--) | Gibt an, ob die Schriftart durchgestrichen ist. |
+| [getUnderline()](#getUnderline--) | Gibt an, ob die Schriftart unterstrichen ist. |
+| [getWeight()](#getWeight--) | Gibt das Gewicht der Schriftart an. |
+| [getWidth()](#getWidth--) | Gibt die Breite der Schriftart an. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCharSet(long value)](#setCharSet-long-) | Für die Beschreibung dieser Eigenschaft, siehe \{@link HeaderFooterFont\#(getCharSet() & 0xFFFFFFFFL)\} |
+| [setClipPrecision(long value)](#setClipPrecision-long-) | Für die Beschreibung dieser Eigenschaft, siehe \{@link HeaderFooterFont\#(getClipPrecision() & 0xFFFFFFFFL)\} |
+| [setEscapement(int value)](#setEscapement-int-) | Für die Beschreibung dieser Eigenschaft, siehe [getEscapement()](../../com.aspose.diagram/headerfooterfont\#getEscapement--) |
+| [setFaceName(String value)](#setFaceName-java.lang.String-) | Für die Beschreibung dieser Eigenschaft, siehe [getFaceName()](../../com.aspose.diagram/headerfooterfont\#getFaceName--) |
+| [setHeight(int value)](#setHeight-int-) | Für die Beschreibung dieser Eigenschaft, siehe [getHeight()](../../com.aspose.diagram/headerfooterfont\#getHeight--) |
+| [setItalic(int value)](#setItalic-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getItalic()](../../com.aspose.diagram/headerfooterfont\#getItalic--) |
+| [setOrientation(int value)](#setOrientation-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getOrientation()](../../com.aspose.diagram/headerfooterfont\#getOrientation--) |
+| [setOutPrecision(long value)](#setOutPrecision-long-) | Für die Beschreibung dieser Eigenschaft siehe bitte \{@link HeaderFooterFont\#(getOutPrecision() & 0xFFFFFFFFL)\} |
+| [setPitchAndFamily(long value)](#setPitchAndFamily-long-) | Für die Beschreibung dieser Eigenschaft siehe bitte \{@link HeaderFooterFont\#(getPitchAndFamily() & 0xFFFFFFFFL)\} |
+| [setQuality(long value)](#setQuality-long-) | Für die Beschreibung dieser Eigenschaft siehe bitte \{@link HeaderFooterFont\#(getQuality() & 0xFFFFFFFFL)\} |
+| [setStrikeOut(int value)](#setStrikeOut-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getStrikeOut()](../../com.aspose.diagram/headerfooterfont\#getStrikeOut--) |
+| [setUnderline(int value)](#setUnderline-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getUnderline()](../../com.aspose.diagram/headerfooterfont\#getUnderline--) |
+| [setWeight(int value)](#setWeight-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getWeight()](../../com.aspose.diagram/headerfooterfont\#getWeight--) |
+| [setWidth(int value)](#setWidth-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getWidth()](../../com.aspose.diagram/headerfooterfont\#getWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCharSet() {#getCharSet--}
+```
+public long getCharSet()
+```
+
+
+Gibt den Zeichensatz der Schriftart an. Entspricht dem GDI LOGFONT-Feld lfCharSet.
+
+**Returns:**
+long
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getClipPrecision() {#getClipPrecision--}
+```
+public long getClipPrecision()
+```
+
+
+Gibt die Abschneidepräzision der Schriftart an. Entspricht dem GDI LOGFONT-Feld lfClipPrecision.
+
+**Returns:**
+long
+### getEscapement() {#getEscapement--}
+```
+public int getEscapement()
+```
+
+
+Gibt das Eskapement-Attribut der Schriftart an. Entspricht dem GDI LOGFONT-Feld lfEscapement.
+
+**Returns:**
+int
+### getFaceName() {#getFaceName--}
+```
+public String getFaceName()
+```
+
+
+Gibt das Attribut des Schriftartnamens an. Entspricht dem GDI LOGFONT-Feld lfFaceName.
+
+**Returns:**
+java.lang.String
+### getHeight() {#getHeight--}
+```
+public int getHeight()
+```
+
+
+Gibt die Höhe der Schriftart an. Entspricht dem GDI LOGFONT-Feld lfHeight.
+
+**Returns:**
+int
+### getItalic() {#getItalic--}
+```
+public int getItalic()
+```
+
+
+Gibt das Gewicht der Schriftart an. Entspricht dem GDI LOGFONT-Feld lfWeight.
+
+**Returns:**
+int
+### getOrientation() {#getOrientation--}
+```
+public int getOrientation()
+```
+
+
+Gibt die Ausrichtung der Schriftart an. Entspricht dem GDI LOGFONT-Feld lfOrientation.
+
+**Returns:**
+int
+### getOutPrecision() {#getOutPrecision--}
+```
+public long getOutPrecision()
+```
+
+
+Gibt das Ausgabepräzisions-Attribut der Schriftart an. Entspricht dem GDI LOGFONT-Feld lfOutPrecision.
+
+**Returns:**
+long
+### getPitchAndFamily() {#getPitchAndFamily--}
+```
+public long getPitchAndFamily()
+```
+
+
+Gibt Pitch und Familie der Schriftart an. Entspricht dem GDI LOGFONT-Feld lfPitchAndFamily.
+
+**Returns:**
+long
+### getQuality() {#getQuality--}
+```
+public long getQuality()
+```
+
+
+Gibt die Ausgabequalität der Schriftart an. Entspricht dem GDI LOGFONT-Feld lfQuality.
+
+**Returns:**
+long
+### getStrikeOut() {#getStrikeOut--}
+```
+public int getStrikeOut()
+```
+
+
+Gibt an, ob die Schriftart durchgestrichen ist. Entspricht dem GDI LOGFONT-Feld lfStrikeOut.
+
+**Returns:**
+int
+### getUnderline() {#getUnderline--}
+```
+public int getUnderline()
+```
+
+
+Gibt an, ob die Schriftart unterstrichen ist. Entspricht dem GDI LOGFONT-Feld lfUnderline.
+
+**Returns:**
+int
+### getWeight() {#getWeight--}
+```
+public int getWeight()
+```
+
+
+Gibt das Gewicht der Schriftart an. Entspricht dem GDI LOGFONT-Feld lfWeight.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public int getWidth()
+```
+
+
+Gibt die Breite der Schriftart an. Entspricht dem GDI LOGFONT-Feld lfWidth.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCharSet(long value) {#setCharSet-long-}
+```
+public void setCharSet(long value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft, siehe \{@link HeaderFooterFont\#(getCharSet() & 0xFFFFFFFFL)\}
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | long |  |
+
+### setClipPrecision(long value) {#setClipPrecision-long-}
+```
+public void setClipPrecision(long value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft, siehe \{@link HeaderFooterFont\#(getClipPrecision() & 0xFFFFFFFFL)\}
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | long |  |
+
+### setEscapement(int value) {#setEscapement-int-}
+```
+public void setEscapement(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft, siehe [getEscapement()](../../com.aspose.diagram/headerfooterfont\#getEscapement--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setFaceName(String value) {#setFaceName-java.lang.String-}
+```
+public void setFaceName(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft, siehe [getFaceName()](../../com.aspose.diagram/headerfooterfont\#getFaceName--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setHeight(int value) {#setHeight-int-}
+```
+public void setHeight(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft, siehe [getHeight()](../../com.aspose.diagram/headerfooterfont\#getHeight--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setItalic(int value) {#setItalic-int-}
+```
+public void setItalic(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getItalic()](../../com.aspose.diagram/headerfooterfont\#getItalic--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setOrientation(int value) {#setOrientation-int-}
+```
+public void setOrientation(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getOrientation()](../../com.aspose.diagram/headerfooterfont\#getOrientation--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setOutPrecision(long value) {#setOutPrecision-long-}
+```
+public void setOutPrecision(long value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte \{@link HeaderFooterFont\#(getOutPrecision() & 0xFFFFFFFFL)\}
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | long |  |
+
+### setPitchAndFamily(long value) {#setPitchAndFamily-long-}
+```
+public void setPitchAndFamily(long value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte \{@link HeaderFooterFont\#(getPitchAndFamily() & 0xFFFFFFFFL)\}
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | long |  |
+
+### setQuality(long value) {#setQuality-long-}
+```
+public void setQuality(long value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte \{@link HeaderFooterFont\#(getQuality() & 0xFFFFFFFFL)\}
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | long |  |
+
+### setStrikeOut(int value) {#setStrikeOut-int-}
+```
+public void setStrikeOut(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getStrikeOut()](../../com.aspose.diagram/headerfooterfont\#getStrikeOut--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setUnderline(int value) {#setUnderline-int-}
+```
+public void setUnderline(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getUnderline()](../../com.aspose.diagram/headerfooterfont\#getUnderline--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setWeight(int value) {#setWeight-int-}
+```
+public void setWeight(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getWeight()](../../com.aspose.diagram/headerfooterfont\#getWeight--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setWidth(int value) {#setWidth-int-}
+```
+public void setWidth(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getWidth()](../../com.aspose.diagram/headerfooterfont\#getWidth--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/help/_index.md
+++ b/german/java/com.aspose.diagram/help/_index.md
@@ -1,0 +1,172 @@
+---
+title: Hilfe
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält Elemente, die das Hilfedatei‑Thema der Shape‑Elemente und Copyright‑Informationen angeben.
+type: docs
+weight: 190
+url: /de/java/com.aspose.diagram/help/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Help
+```
+
+Enthält Elemente, die das Hilfedatei-Thema und die Copyright-Informationen des Shape-Elements angeben.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCopyright()](#getCopyright--) | Enthält eine Zeichenkette, die eine menschenlesbare Copyright‑Erklärung darstellt. |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getHelpTopic()](#getHelpTopic--) | Gibt die ID des Hilfethemas des Shape‑Elements an. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/help\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCopyright() {#getCopyright--}
+```
+public Str2Value getCopyright()
+```
+
+
+Enthält eine Zeichenkette, die eine menschenlesbare Copyright‑Erklärung darstellt.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getHelpTopic() {#getHelpTopic--}
+```
+public Str2Value getHelpTopic()
+```
+
+
+Gibt die ID des Hilfethemas des Shape‑Elements an.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/help\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/horzalign/_index.md
+++ b/german/java/com.aspose.diagram/horzalign/_index.md
@@ -1,0 +1,179 @@
+---
+title: HorzAlign
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt die horizontale Ausrichtung des Textes im Textblock der Formen an.
+type: docs
+weight: 191
+url: /de/java/com.aspose.diagram/horzalign/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class HorzAlign
+```
+
+Gibt die horizontale Ausrichtung des Textes im Textblock der Form an.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [HorzAlign(int value)](#HorzAlign-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Gibt die horizontale Ausrichtung des Textes im Textblock der Form an. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/horzalign\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### HorzAlign(int value) {#HorzAlign-int-}
+```
+public HorzAlign(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Gibt die horizontale Ausrichtung des Textes im Textblock der Form an.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/horzalign\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/horzalignvalue/_index.md
+++ b/german/java/com.aspose.diagram/horzalignvalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: HorzAlignValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt die horizontale Ausrichtung des Textes im Textblock der Formen an.
+type: docs
+weight: 192
+url: /de/java/com.aspose.diagram/horzalignvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class HorzAlignValue
+```
+
+Gibt die horizontale Ausrichtung des Textes im Textblock der Form an.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [CENTER](#CENTER) | Mitte. |
+| [FORCE_JUSTIFY](#FORCE-JUSTIFY) | Erzwinge Blocksatz. |
+| [JUSTIFY](#JUSTIFY) | Blocksatz. |
+| [LEFT_ALIGN](#LEFT-ALIGN) | Linksbündig. |
+| [RIGHT_ALIGN](#RIGHT-ALIGN) | Rechtsbündig. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CENTER {#CENTER}
+```
+public static final int CENTER
+```
+
+
+Mitte.
+
+### FORCE_JUSTIFY {#FORCE-JUSTIFY}
+```
+public static final int FORCE_JUSTIFY
+```
+
+
+Erzwinge Blocksatz.
+
+### JUSTIFY {#JUSTIFY}
+```
+public static final int JUSTIFY
+```
+
+
+Blocksatz.
+
+### LEFT_ALIGN {#LEFT-ALIGN}
+```
+public static final int LEFT_ALIGN
+```
+
+
+Linksbündig.
+
+### RIGHT_ALIGN {#RIGHT-ALIGN}
+```
+public static final int RIGHT_ALIGN
+```
+
+
+Rechtsbündig.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/htmlsaveoptions/_index.md
+++ b/german/java/com.aspose.diagram/htmlsaveoptions/_index.md
@@ -1,0 +1,629 @@
+---
+title: HTMLSaveOptions
+second_title: Aspose.Diagram for Java API-Referenz
+description: Ermöglicht das Angeben zusätzlicher Optionen beim Rendern von Diagrammseiten zu HTML.
+type: docs
+weight: 187
+url: /de/java/com.aspose.diagram/htmlsaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.SaveOptions](../../com.aspose.diagram/saveoptions), [com.aspose.diagram.RenderingSaveOptions](../../com.aspose.diagram/renderingsaveoptions)
+```
+public class HTMLSaveOptions extends RenderingSaveOptions
+```
+
+Ermöglicht das Angeben zusätzlicher Optionen beim Rendern von Diagrammseiten zu HTML.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [HTMLSaveOptions()](#HTMLSaveOptions--) | Initialisiert eine neue Instanz dieser Klasse, die verwendet werden kann, um ein Dokument im Format Aspose.Diagram.SaveFileFormat zu speichern. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | Erstellt ein Speicheroptionen-Objekt einer Klasse, die für das angegebene Speicherformat geeignet ist. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDefaultFont()](#getDefaultFont--) | Wenn Zeichen im Diagramm Unicode sind und nicht mit dem korrekten Schriftwert gesetzt werden oder die Schriftart nicht lokal installiert ist, können sie in PDF, Bild oder XPS als Block erscheinen. |
+| [getEmfRenderSetting()](#getEmfRenderSetting--) | Einstellung zum Rendern von Emf-Metadateien. |
+| [getEnlargePage()](#getEnlargePage--) | Gibt an, ob die Seite vergrößert werden soll. |
+| [getExportGuideShapes()](#getExportGuideShapes--) | Definiert, ob die Leitlinienformen exportiert werden sollen oder nicht. |
+| [getExportHiddenPage()](#getExportHiddenPage--) | Definiert, ob die versteckte Seite exportiert werden soll oder nicht. |
+| [getPageCount()](#getPageCount--) | die Anzahl der Seiten, die in HTML gerendert werden sollen. |
+| [getPageIndex()](#getPageIndex--) | der nullbasierte Index der ersten zu rendernden Seite. |
+| [getPageSize()](#getPageSize--) | die Seitengröße für die erzeugten Bilder. |
+| [getResolution()](#getResolution--) | die Auflösung für das erzeugte HTML, in Punkten pro Zoll. |
+| [getSaveAsSingleFile()](#getSaveAsSingleFile--) | Gibt an, ob das HTML als einzelne Datei gespeichert werden soll. |
+| [getSaveForegroundPagesOnly()](#getSaveForegroundPagesOnly--) | Gibt an, ob alle Seiten als Bild gespeichert werden oder nur der Vordergrund. |
+| [getSaveFormat()](#getSaveFormat--) | Gibt das Format an, in dem die gerenderten Diagrammseiten gespeichert werden, wenn dieses Speicheroptionen-Objekt verwendet wird. |
+| [getSaveTitle()](#getSaveTitle--) | Definiert, ob der Titel exportiert werden soll oder nicht. |
+| [getSaveToolBar()](#getSaveToolBar--) | Gibt an, ob die Symbolleiste gespeichert wird. Der Standardwert ist true. |
+| [getShapes()](#getShapes--) | Formen zum Rendern. |
+| [getStreamProvider()](#getStreamProvider--) | der IStreamProvider zum Exportieren von Objekten. |
+| [getTitle()](#getTitle--) | der Titel des Diagramms, das in HTML gerendert werden soll. |
+| [getWarningCallback()](#getWarningCallback--) | Warnungs-Callback. |
+| [hashCode()](#hashCode--) |  |
+| [isExportComments()](#isExportComments--) | Definiert, ob Kommentare exportiert werden sollen oder nicht. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDefaultFont()](../../com.aspose.diagram/saveoptions\\#getDefaultFont--) |
+| [setEmfRenderSetting(int value)](#setEmfRenderSetting-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\\#getEmfRenderSetting--) |
+| [setEnlargePage(boolean value)](#setEnlargePage-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--) |
+| [setExportComments(boolean value)](#setExportComments-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--) |
+| [setExportGuideShapes(boolean value)](#setExportGuideShapes-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--) |
+| [setExportHiddenPage(boolean value)](#setExportHiddenPage-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getExportHiddenPage()](../../com.aspose.diagram/htmlsaveoptions\#getExportHiddenPage--) |
+| [setPageCount(int value)](#setPageCount-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getPageCount()](../../com.aspose.diagram/htmlsaveoptions\#getPageCount--) |
+| [setPageIndex(int value)](#setPageIndex-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getPageIndex()](../../com.aspose.diagram/htmlsaveoptions\#getPageIndex--) |
+| [setPageSize(PageSize value)](#setPageSize-com.aspose.diagram.PageSize-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--) |
+| [setResolution(int value)](#setResolution-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getResolution()](../../com.aspose.diagram/htmlsaveoptions\#getResolution--) |
+| [setSaveAsSingleFile(boolean value)](#setSaveAsSingleFile-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getSaveAsSingleFile()](../../com.aspose.diagram/htmlsaveoptions\#getSaveAsSingleFile--) |
+| [setSaveForegroundPagesOnly(boolean value)](#setSaveForegroundPagesOnly-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getSaveForegroundPagesOnly()](../../com.aspose.diagram/htmlsaveoptions\#getSaveForegroundPagesOnly--) |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getSaveFormat()](../../com.aspose.diagram/htmlsaveoptions\#getSaveFormat--) |
+| [setSaveTitle(boolean value)](#setSaveTitle-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getSaveTitle()](../../com.aspose.diagram/htmlsaveoptions\#getSaveTitle--) |
+| [setSaveToolBar(boolean value)](#setSaveToolBar-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getSaveToolBar()](../../com.aspose.diagram/htmlsaveoptions\#getSaveToolBar--) |
+| [setShapes(ShapeCollection value)](#setShapes-com.aspose.diagram.ShapeCollection-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--) |
+| [setStreamProvider(IStreamProvider value)](#setStreamProvider-com.aspose.diagram.IStreamProvider-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getStreamProvider()](../../com.aspose.diagram/htmlsaveoptions\#getStreamProvider--) |
+| [setTitle(String value)](#setTitle-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getTitle()](../../com.aspose.diagram/htmlsaveoptions\#getTitle--) |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### HTMLSaveOptions() {#HTMLSaveOptions--}
+```
+public HTMLSaveOptions()
+```
+
+
+Initialisiert eine neue Instanz dieser Klasse, die verwendet werden kann, um ein Dokument im Format Aspose.Diagram.SaveFileFormat zu speichern.
+
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+Erstellt ein Speicheroptionen-Objekt einer Klasse, die für das angegebene Speicherformat geeignet ist.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| saveFormat | int | Das Aspose.Diagram.SaveFileFormat, für das ein Save-Optionen-Objekt erstellt werden soll. |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+Wenn Zeichen im Diagramm Unicode sind und nicht mit dem korrekten Schriftwert gesetzt werden oder die Schriftart nicht lokal installiert ist, können sie im PDF, Bild oder XPS als Block erscheinen. Setzen Sie die DefaultFont, z. B. MingLiu oder MS Gothic, um diese Zeichen anzuzeigen.
+
+**Returns:**
+java.lang.String
+### getEmfRenderSetting() {#getEmfRenderSetting--}
+```
+public int getEmfRenderSetting()
+```
+
+
+Einstellung für das Rendern von EMF-Metadateien. EMF-Metadateien, die als "EMF+ Dual" identifiziert werden, können sowohl EMF+-Datensätze als auch EMF-Datensätze enthalten. Jeder Datensatztyp kann zum Rendern des Bildes verwendet werden, nur EMF+-Datensätze oder nur EMF-Datensätze. Wenn EmfPlusPrefer gesetzt ist, werden EMF+-Datensätze geparst, andernfalls werden nur EMF-Datensätze geparst. Der Standardwert ist EmfOnly"/>.
+
+**Returns:**
+int
+### getEnlargePage() {#getEnlargePage--}
+```
+public boolean getEnlargePage()
+```
+
+
+Gibt an, ob die Seite vergrößert werden soll. Wenn true – Seite vergrößern. Wenn false – Seite nicht vergrößern. Der Standardwert ist true.
+
+**Returns:**
+boolean
+### getExportGuideShapes() {#getExportGuideShapes--}
+```
+public boolean getExportGuideShapes()
+```
+
+
+Definiert, ob Leitlinienformen exportiert werden sollen oder nicht. Standardwert ist true.
+
+**Returns:**
+boolean
+### getExportHiddenPage() {#getExportHiddenPage--}
+```
+public boolean getExportHiddenPage()
+```
+
+
+Definiert, ob versteckte Seiten exportiert werden sollen oder nicht. Standardwert ist true.
+
+**Returns:**
+boolean
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+Die Anzahl der Seiten, die in HTML gerendert werden sollen. Standard ist MaxValue, was bedeutet, dass alle Seiten des Diagramms gerendert werden.
+
+**Returns:**
+int
+### getPageIndex() {#getPageIndex--}
+```
+public int getPageIndex()
+```
+
+
+Der nullbasierte Index der ersten zu rendernden Seite. Standard ist 0.
+
+**Returns:**
+int
+### getPageSize() {#getPageSize--}
+```
+public PageSize getPageSize()
+```
+
+
+die Seitengröße für die erzeugten Bilder. Kann [PageSize](../../com.aspose.diagram/pagesize) oder null sein. Der Standardwert ist null. Wenn PageSize null ist, wird die Seitengröße für das erzeugte Bild aus dem Quell‑Diagramm übernommen.
+
+**Returns:**
+[PageSize](../../com.aspose.diagram/pagesize)
+### getResolution() {#getResolution--}
+```
+public int getResolution()
+```
+
+
+die Auflösung für das erzeugte HTML, in Punkten pro Zoll. Diese Eigenschaft wirkt nur beim Speichern als HTML. Der Standardwert ist 96.
+
+**Returns:**
+int
+### getSaveAsSingleFile() {#getSaveAsSingleFile--}
+```
+public boolean getSaveAsSingleFile()
+```
+
+
+Gibt an, ob das HTML als einzelne Datei gespeichert werden soll. Der Standardwert ist false. Wenn mehrere Seiten vorhanden sind, müssen diese Seiten und andere Ressourcen in separaten Dateien gespeichert werden. Für einige Szenarien benötigt der Benutzer möglicherweise nur eine Ergebnisdatei, z. B. zum einfachen Übertragen. In diesem Fall kann der Benutzer diese Eigenschaft auf true setzen.
+
+**Returns:**
+boolean
+### getSaveForegroundPagesOnly() {#getSaveForegroundPagesOnly--}
+```
+public boolean getSaveForegroundPagesOnly()
+```
+
+
+Legt fest, ob alle Seiten im Bild gespeichert werden oder nur der Vordergrund. Wenn true – werden nur Vordergrundseiten gerendert (mit Hintergrund, falls vorhanden). Wenn false – werden Vordergrundseiten gerendert (mit Hintergrund, falls vorhanden) und danach leere Hintergrundseiten. Kann nur true zurückgeben, wenn PageCount > 1. Der Standardwert ist false.
+
+**Returns:**
+boolean
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+Gibt das Format an, in dem die gerenderten Diagrammseiten gespeichert werden, wenn dieses Speicheroptionsobjekt verwendet wird. Kann nur Aspose.Diagram.SaveFileFormat sein.
+
+**Returns:**
+int
+### getSaveTitle() {#getSaveTitle--}
+```
+public boolean getSaveTitle()
+```
+
+
+Legt fest, ob der Titel exportiert werden soll oder nicht. Der Standardwert ist true.
+
+**Returns:**
+boolean
+### getSaveToolBar() {#getSaveToolBar--}
+```
+public boolean getSaveToolBar()
+```
+
+
+Gibt an, ob die Symbolleiste gespeichert wird. Der Standardwert ist true.
+
+**Returns:**
+boolean
+### getShapes() {#getShapes--}
+```
+public ShapeCollection getShapes()
+```
+
+
+Zu rendernde Shapes. Standardanzahl ist 0.
+
+**Returns:**
+[ShapeCollection](../../com.aspose.diagram/shapecollection)
+### getStreamProvider() {#getStreamProvider--}
+```
+public IStreamProvider getStreamProvider()
+```
+
+
+der IStreamProvider zum Exportieren von Objekten.
+
+**Returns:**
+[IStreamProvider](../../com.aspose.diagram/istreamprovider)
+### getTitle() {#getTitle--}
+```
+public String getTitle()
+```
+
+
+Der Titel des Diagramms, das in HTML gerendert werden soll. Wenn Title null ist, wird Diagram.DocumentProperties.Title [DocumentProperties](../../com.aspose.diagram/documentproperties) als Titel verwendet. Wenn Diagram.DocumentProperties.Title null oder leer ist, wird der Dateiname des Diagramms als Titel verwendet.
+
+**Returns:**
+java.lang.String
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+Warnungs-Callback.
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExportComments() {#isExportComments--}
+```
+public boolean isExportComments()
+```
+
+
+Legt fest, ob Kommentare exportiert werden sollen oder nicht. Der Standardwert ist false.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDefaultFont()](../../com.aspose.diagram/saveoptions\\#getDefaultFont--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setEmfRenderSetting(int value) {#setEmfRenderSetting-int-}
+```
+public void setEmfRenderSetting(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\\#getEmfRenderSetting--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setEnlargePage(boolean value) {#setEnlargePage-boolean-}
+```
+public void setEnlargePage(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setExportComments(boolean value) {#setExportComments-boolean-}
+```
+public void setExportComments(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setExportGuideShapes(boolean value) {#setExportGuideShapes-boolean-}
+```
+public void setExportGuideShapes(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setExportHiddenPage(boolean value) {#setExportHiddenPage-boolean-}
+```
+public void setExportHiddenPage(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getExportHiddenPage()](../../com.aspose.diagram/htmlsaveoptions\#getExportHiddenPage--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setPageCount(int value) {#setPageCount-int-}
+```
+public void setPageCount(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getPageCount()](../../com.aspose.diagram/htmlsaveoptions\#getPageCount--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setPageIndex(int value) {#setPageIndex-int-}
+```
+public void setPageIndex(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getPageIndex()](../../com.aspose.diagram/htmlsaveoptions\#getPageIndex--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setPageSize(PageSize value) {#setPageSize-com.aspose.diagram.PageSize-}
+```
+public void setPageSize(PageSize value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [PageSize](../../com.aspose.diagram/pagesize) |  |
+
+### setResolution(int value) {#setResolution-int-}
+```
+public void setResolution(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getResolution()](../../com.aspose.diagram/htmlsaveoptions\#getResolution--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setSaveAsSingleFile(boolean value) {#setSaveAsSingleFile-boolean-}
+```
+public void setSaveAsSingleFile(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getSaveAsSingleFile()](../../com.aspose.diagram/htmlsaveoptions\#getSaveAsSingleFile--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setSaveForegroundPagesOnly(boolean value) {#setSaveForegroundPagesOnly-boolean-}
+```
+public void setSaveForegroundPagesOnly(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getSaveForegroundPagesOnly()](../../com.aspose.diagram/htmlsaveoptions\#getSaveForegroundPagesOnly--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getSaveFormat()](../../com.aspose.diagram/htmlsaveoptions\#getSaveFormat--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setSaveTitle(boolean value) {#setSaveTitle-boolean-}
+```
+public void setSaveTitle(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getSaveTitle()](../../com.aspose.diagram/htmlsaveoptions\#getSaveTitle--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setSaveToolBar(boolean value) {#setSaveToolBar-boolean-}
+```
+public void setSaveToolBar(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getSaveToolBar()](../../com.aspose.diagram/htmlsaveoptions\#getSaveToolBar--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setShapes(ShapeCollection value) {#setShapes-com.aspose.diagram.ShapeCollection-}
+```
+public void setShapes(ShapeCollection value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [ShapeCollection](../../com.aspose.diagram/shapecollection) |  |
+
+### setStreamProvider(IStreamProvider value) {#setStreamProvider-com.aspose.diagram.IStreamProvider-}
+```
+public void setStreamProvider(IStreamProvider value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getStreamProvider()](../../com.aspose.diagram/htmlsaveoptions\#getStreamProvider--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [IStreamProvider](../../com.aspose.diagram/istreamprovider) |  |
+
+### setTitle(String value) {#setTitle-java.lang.String-}
+```
+public void setTitle(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getTitle()](../../com.aspose.diagram/htmlsaveoptions\#getTitle--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/hyperlink/_index.md
+++ b/german/java/com.aspose.diagram/hyperlink/_index.md
@@ -1,0 +1,348 @@
+---
+title: Hyperlink
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält Elemente zum Erstellen mehrerer Sprünge zwischen einer Form oder Zeichenfläche und einer anderen Zeichenfläche, einer anderen Datei oder einer Website.
+type: docs
+weight: 193
+url: /de/java/com.aspose.diagram/hyperlink/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Hyperlink
+```
+
+Enthält Elemente zum Erstellen mehrerer Sprünge zwischen einer Form oder Zeichenfläche und einer anderen Zeichenfläche, einer anderen Datei oder einer Website.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [Hyperlink()](#Hyperlink--) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAddress()](#getAddress--) | Gibt eine URL-Adresse, einen DOS-Dateinamen oder einen UNC-Pfad an, zu dem gesprungen werden soll. |
+| [getClass()](#getClass--) |  |
+| [getDefault()](#getDefault--) | Gibt den Standard-Hyperlink für eine Form oder Seite an. |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getDescription()](#getDescription--) | Das Beschreibungselement enthält eine Textzeichenfolge, die den Hyperlink beschreibt. |
+| [getExtraInfo()](#getExtraInfo--) | Enthält Informationen, die zur Auflösung einer URL verwendet werden, wie z. B. die Koordinaten einer Image-Map. |
+| [getFrame()](#getFrame--) | Enthält den Namen eines Frames, auf den zugegriffen werden soll, wenn Microsoft Visio als aktives Dokument in einer Container-Anwendung geöffnet ist. |
+| [getID()](#getID--) | Die eindeutige ID des Elements innerhalb seines übergeordneten Elements. |
+| [getInvisible()](#getInvisible--) | Unsichtbares Element gibt an, ob ein Hyperlink im Kontextmenü für eine Form oder Seite angezeigt wird. |
+| [getName()](#getName--) | Der Name des Elements. |
+| [getNameU()](#getNameU--) | Der universelle Name des Elements. |
+| [getNewWindow()](#getNewWindow--) | Gibt an, ob Microsoft Visio ein Fenster an einem neuen Ort öffnet, wenn es einem Hyperlink folgt, um eine Webseite oder ein anderes Visio-Dokument zu öffnen. |
+| [getSortKey()](#getSortKey--) | Unsichtbares Element gibt an, ob ein Hyperlink im Kontextmenü für eine Form oder Seite angezeigt wird. |
+| [getSubAddress()](#getSubAddress--) | Gibt einen Ort im Zieldokument an, zu dem verlinkt werden soll. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/hyperlink\#getDel--) |
+| [setID(int value)](#setID-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getID()](../../com.aspose.diagram/hyperlink\#getID--) |
+| [setName(String value)](#setName-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getName()](../../com.aspose.diagram/hyperlink\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getNameU()](../../com.aspose.diagram/hyperlink\#getNameU--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Hyperlink() {#Hyperlink--}
+```
+public Hyperlink()
+```
+
+
+Konstruktor.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAddress() {#getAddress--}
+```
+public Str2Value getAddress()
+```
+
+
+Gibt eine URL-Adresse, einen DOS-Dateinamen oder einen UNC-Pfad an, zu dem gesprungen werden soll.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefault() {#getDefault--}
+```
+public BoolValue getDefault()
+```
+
+
+Gibt den Standard-Hyperlink für eine Form oder Seite an.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getDescription() {#getDescription--}
+```
+public Str2Value getDescription()
+```
+
+
+Das Beschreibungselement enthält eine Textzeichenfolge, die den Hyperlink beschreibt.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getExtraInfo() {#getExtraInfo--}
+```
+public Str2Value getExtraInfo()
+```
+
+
+Enthält Informationen, die zur Auflösung einer URL verwendet werden, wie z. B. die Koordinaten einer Image-Map. Zum Beispiel würde x=41 y=7 die Koordinaten einer Image-Map angeben.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getFrame() {#getFrame--}
+```
+public Str2Value getFrame()
+```
+
+
+Enthält den Namen eines Frames, auf den zugegriffen werden soll, wenn Microsoft Visio als aktives Dokument in einer Container-Anwendung geöffnet ist. Der Standardwert ist eine leere Zeichenfolge.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+Die eindeutige ID des Elements innerhalb seines übergeordneten Elements.
+
+**Returns:**
+int
+### getInvisible() {#getInvisible--}
+```
+public BoolValue getInvisible()
+```
+
+
+Unsichtbares Element gibt an, ob ein Hyperlink im Kontextmenü für eine Form oder Seite angezeigt wird.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Der Name des Elements.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+Der universelle Name des Elements.
+
+**Returns:**
+java.lang.String
+### getNewWindow() {#getNewWindow--}
+```
+public BoolValue getNewWindow()
+```
+
+
+Gibt an, ob Microsoft Visio ein Fenster an einem neuen Ort öffnet, wenn es einem Hyperlink folgt, um eine Webseite oder ein anderes Visio-Dokument zu öffnen.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getSortKey() {#getSortKey--}
+```
+public Str2Value getSortKey()
+```
+
+
+Unsichtbares Element gibt an, ob ein Hyperlink im Kontextmenü für eine Form oder Seite angezeigt wird.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getSubAddress() {#getSubAddress--}
+```
+public Str2Value getSubAddress()
+```
+
+
+Gibt einen Ort im Zieldokument an, zu dem verlinkt werden soll.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/hyperlink\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getID()](../../com.aspose.diagram/hyperlink\#getID--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getName()](../../com.aspose.diagram/hyperlink\#getName--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getNameU()](../../com.aspose.diagram/hyperlink\#getNameU--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/hyperlinkcollection/_index.md
+++ b/german/java/com.aspose.diagram/hyperlinkcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: HyperlinkCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: Hyperlink-Sammlung.
+type: docs
+weight: 194
+url: /de/java/com.aspose.diagram/hyperlinkcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class HyperlinkCollection extends Collection
+```
+
+Hyperlink-Sammlung.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [add(Hyperlink item)](#add-com.aspose.diagram.Hyperlink-) | Füge das Hyperlink-Objekt zur Sammlung hinzu. |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Hyperlink item)](#remove-com.aspose.diagram.Hyperlink-) | Entferne das Hyperlink-Objekt aus der Sammlung. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Hyperlink item) {#add-com.aspose.diagram.Hyperlink-}
+```
+public int add(Hyperlink item)
+```
+
+
+Füge das Hyperlink-Objekt zur Sammlung hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [Hyperlink](../../com.aspose.diagram/hyperlink) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Hyperlink get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[Hyperlink](../../com.aspose.diagram/hyperlink) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Hyperlink item) {#remove-com.aspose.diagram.Hyperlink-}
+```
+public void remove(Hyperlink item)
+```
+
+
+Entferne das Hyperlink-Objekt aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [Hyperlink](../../com.aspose.diagram/hyperlink) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/iconsizevalue/_index.md
+++ b/german/java/com.aspose.diagram/iconsizevalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: IconSizeValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Optionaler int.
+type: docs
+weight: 195
+url: /de/java/com.aspose.diagram/iconsizevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class IconSizeValue
+```
+
+Optionaler int. Die Größe des Symbols des Elements.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [DOUBLE](#DOUBLE) | Double. |
+| [NORMAL](#NORMAL) | Normal. |
+| [TALL](#TALL) | Hoch. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+| [WIDE](#WIDE) | Breit. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DOUBLE {#DOUBLE}
+```
+public static final int DOUBLE
+```
+
+
+Double.
+
+### NORMAL {#NORMAL}
+```
+public static final int NORMAL
+```
+
+
+Normal.
+
+### TALL {#TALL}
+```
+public static final int TALL
+```
+
+
+Hoch.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### WIDE {#WIDE}
+```
+public static final int WIDE
+```
+
+
+Breit.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/image/_index.md
+++ b/german/java/com.aspose.diagram/image/_index.md
@@ -1,0 +1,227 @@
+---
+title: Bild
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält die Gamma-, Helligkeits-, Kontrast-, Weichzeichnungs-, Schärfungs-, Rauschunterdrückungs- und Transparenzwerte für ein Bitmap.
+type: docs
+weight: 196
+url: /de/java/com.aspose.diagram/image/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Image
+```
+
+Enthält die Gamma-, Helligkeits-, Kontrast-, Unschärfe-, Schärfungs-, Rauschunterdrückungs- und Transparenzwerte für ein Bitmap.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBlur()](#getBlur--) | Weichzeichnet oder glättet ein Bitmap-Bild. |
+| [getBrightness()](#getBrightness--) | Passt die Helligkeit eines Bitmap-Bildes an. |
+| [getClass()](#getClass--) |  |
+| [getContrast()](#getContrast--) | Gibt den Kontrast eines Bitmap-Bildes an. |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getDenoise()](#getDenoise--) | Entfernt Rauschen (Pixel, die zufällig verteilte Farbwerte haben) aus einem Bitmap-Bild. |
+| [getGamma()](#getGamma--) | Passt die Intensität eines Bildes für ein bestimmtes Ausgabegerät an oder korrigiert sie, z. B. einen Monitor oder Scanner. |
+| [getSharpen()](#getSharpen--) | Gibt den Betrag an, um ein Bitmap-Bild zu schärfen. |
+| [getTransparency()](#getTransparency--) | Gibt den Transparenzgrad für eine Ebenenfarbe an, von 0 (undurchsichtig) bis 1 (vollständig transparent). |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/image\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBlur() {#getBlur--}
+```
+public DoubleValue getBlur()
+```
+
+
+Weichzeichnet oder glättet ein Bitmap-Bild. Das Blur-Element enthält einen Wert zwischen 0 und 1; der Standardwert ist 0.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBrightness() {#getBrightness--}
+```
+public DoubleValue getBrightness()
+```
+
+
+Passt die Helligkeit eines Bitmap-Bildes an. Das Brightness-Element enthält einen Wert zwischen 0 und 1; der Standardwert ist 0,5.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getContrast() {#getContrast--}
+```
+public DoubleValue getContrast()
+```
+
+
+Gibt den Kontrast eines Bitmap-Bildes an. Das Contrast-Element enthält einen Wert zwischen 0 und 1.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getDenoise() {#getDenoise--}
+```
+public DoubleValue getDenoise()
+```
+
+
+Entfernt Rauschen (Pixel, die zufällig verteilte Farbwerte haben) aus einem Bitmap-Bild.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getGamma() {#getGamma--}
+```
+public DoubleValue getGamma()
+```
+
+
+Passt die Intensität eines Bildes für ein bestimmtes Ausgabegerät an oder korrigiert sie, z. B. einen Monitor oder Scanner. Der Standardwert ist 1 (keine Korrektur).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getSharpen() {#getSharpen--}
+```
+public DoubleValue getSharpen()
+```
+
+
+Gibt den Betrag an, um ein Bitmap-Bild zu schärfen. Das Schärfen eines Bildes fokussiert es, indem der Kontrast benachbarter Pixel erhöht wird.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTransparency() {#getTransparency--}
+```
+public DoubleValue getTransparency()
+```
+
+
+Gibt den Transparenzgrad für eine Ebenenfarbe an, von 0 (undurchsichtig) bis 1 (vollständig transparent).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/image\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/imageactivexcontrol/_index.md
+++ b/german/java/com.aspose.diagram/imageactivexcontrol/_index.md
@@ -1,0 +1,597 @@
+---
+title: ImageActiveXControl
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt die Bildsteuerung dar.
+type: docs
+weight: 197
+url: /de/java/com.aspose.diagram/imageactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class ImageActiveXControl extends ActiveXControl
+```
+
+Stellt die Bildsteuerung dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBackOleColor()](#getBackOleColor--) | die OLE‑Farbe des Hintergrunds. |
+| [getBorderOleColor()](#getBorderOleColor--) | die OLE‑Farbe des Hintergrunds. |
+| [getBorderStyle()](#getBorderStyle--) | der von dem Steuerelement verwendete Randtyp. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | die Binärdaten des Steuerelements. |
+| [getForeOleColor()](#getForeOleColor--) | die OLE‑Farbe des Vordergrunds. |
+| [getHeight()](#getHeight--) | die Höhe des Steuerelements in Punkt‑Einheiten. |
+| [getIMEMode()](#getIMEMode--) | der Standard‑Laufzeitmodus des Input Method Editors für das Steuerelement, wenn es den Fokus erhält. |
+| [getMouseIcon()](#getMouseIcon--) | ein benutzerdefiniertes Symbol, das als Mauszeiger für das Steuerelement angezeigt wird. |
+| [getMousePointer()](#getMousePointer--) | der Typ des als Mauszeiger für das Steuerelement angezeigten Symbols. |
+| [getPicture()](#getPicture--) | Die Daten des Bildes. |
+| [getPictureAlignment()](#getPictureAlignment--) | die Ausrichtung des Bildes innerhalb des Formulars oder Bildes. |
+| [getPictureSizeMode()](#getPictureSizeMode--) | wie das Bild angezeigt wird. |
+| [getSpecialEffect()](#getSpecialEffect--) | der Spezialeffekt des Steuerelements. |
+| [getType()](#getType--) | Ermittelt den Typ des ActiveX-Steuerelements. |
+| [getWidth()](#getWidth--) | die Breite des Steuerelements in Punkt-Einheiten. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | Gibt an, ob das Steuerelement automatisch die Größe ändert, um seinen gesamten Inhalt anzuzeigen. |
+| [isEnabled()](#isEnabled--) | Gibt an, ob das Steuerelement den Fokus erhalten und auf benutzergenerierte Ereignisse reagieren kann. |
+| [isLocked()](#isLocked--) | Gibt an, ob Daten im Steuerelement für die Bearbeitung gesperrt sind. |
+| [isTiled()](#isTiled--) | Gibt an, ob das Bild über den Hintergrund gekachelt wird. |
+| [isTransparent()](#isTransparent--) | Gibt an, ob das Steuerelement transparent ist. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isAutoSize()](../../com.aspose.diagram/imageactivexcontrol\\#isAutoSize--) |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setBorderOleColor(int value)](#setBorderOleColor-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getBorderOleColor()](../../com.aspose.diagram/imageactivexcontrol\\#getBorderOleColor--) |
+| [setBorderStyle(int value)](#setBorderStyle-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getBorderStyle()](../../com.aspose.diagram/imageactivexcontrol\\#getBorderStyle--) |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setHeight(double value)](#setHeight-double-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setIMEMode(int value)](#setIMEMode-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) |
+| [setLocked(boolean value)](#setLocked-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | Für die Beschreibung dieser Eigenschaft siehe bitte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setPicture(byte[] value)](#setPicture-byte---) | Für die Beschreibung dieser Eigenschaft siehe bitte [getPicture()](../../com.aspose.diagram/imageactivexcontrol\\#getPicture--) |
+| [setPictureAlignment(int value)](#setPictureAlignment-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getPictureAlignment()](../../com.aspose.diagram/imageactivexcontrol\#getPictureAlignment--) |
+| [setPictureSizeMode(int value)](#setPictureSizeMode-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getPictureSizeMode()](../../com.aspose.diagram/imageactivexcontrol\#getPictureSizeMode--) |
+| [setSpecialEffect(int value)](#setSpecialEffect-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getSpecialEffect()](../../com.aspose.diagram/imageactivexcontrol\#getSpecialEffect--) |
+| [setTiled(boolean value)](#setTiled-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isTiled()](../../com.aspose.diagram/imageactivexcontrol\#isTiled--) |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) |
+| [setWidth(double value)](#setWidth-double-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+die OLE‑Farbe des Hintergrunds.
+
+**Returns:**
+int
+### getBorderOleColor() {#getBorderOleColor--}
+```
+public int getBorderOleColor()
+```
+
+
+die OLE‑Farbe des Hintergrunds.
+
+**Returns:**
+int
+### getBorderStyle() {#getBorderStyle--}
+```
+public int getBorderStyle()
+```
+
+
+der von dem Steuerelement verwendete Randtyp.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+die Binärdaten des Steuerelements.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+Die OLE-Farbe des Vordergrunds. Gilt nicht für das Image-Steuerelement.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+die Höhe des Steuerelements in Punkt‑Einheiten.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+der Standard‑Laufzeitmodus des Input Method Editors für das Steuerelement, wenn es den Fokus erhält.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+ein benutzerdefiniertes Symbol, das als Mauszeiger für das Steuerelement angezeigt wird.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+der Typ des als Mauszeiger für das Steuerelement angezeigten Symbols.
+
+**Returns:**
+int
+### getPicture() {#getPicture--}
+```
+public byte[] getPicture()
+```
+
+
+Die Daten des Bildes.
+
+**Returns:**
+byte[]
+### getPictureAlignment() {#getPictureAlignment--}
+```
+public int getPictureAlignment()
+```
+
+
+die Ausrichtung des Bildes innerhalb des Formulars oder Bildes.
+
+**Returns:**
+int
+### getPictureSizeMode() {#getPictureSizeMode--}
+```
+public int getPictureSizeMode()
+```
+
+
+wie das Bild angezeigt wird.
+
+**Returns:**
+int
+### getSpecialEffect() {#getSpecialEffect--}
+```
+public int getSpecialEffect()
+```
+
+
+der Spezialeffekt des Steuerelements.
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Ermittelt den Typ des ActiveX-Steuerelements.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+die Breite des Steuerelements in Punkt-Einheiten.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+Gibt an, ob das Steuerelement automatisch die Größe ändert, um seinen gesamten Inhalt anzuzeigen.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+Gibt an, ob das Steuerelement den Fokus erhalten und auf benutzergenerierte Ereignisse reagieren kann.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+Gibt an, ob Daten im Steuerelement für die Bearbeitung gesperrt sind.
+
+**Returns:**
+boolean
+### isTiled() {#isTiled--}
+```
+public boolean isTiled()
+```
+
+
+Gibt an, ob das Bild über den Hintergrund gekachelt wird.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+Gibt an, ob das Steuerelement transparent ist.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isAutoSize()](../../com.aspose.diagram/imageactivexcontrol\\#isAutoSize--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setBorderOleColor(int value) {#setBorderOleColor-int-}
+```
+public void setBorderOleColor(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getBorderOleColor()](../../com.aspose.diagram/imageactivexcontrol\\#getBorderOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setBorderStyle(int value) {#setBorderStyle-int-}
+```
+public void setBorderStyle(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getBorderStyle()](../../com.aspose.diagram/imageactivexcontrol\\#getBorderStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setPicture(byte[] value) {#setPicture-byte---}
+```
+public void setPicture(byte[] value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getPicture()](../../com.aspose.diagram/imageactivexcontrol\\#getPicture--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | byte[] |  |
+
+### setPictureAlignment(int value) {#setPictureAlignment-int-}
+```
+public void setPictureAlignment(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getPictureAlignment()](../../com.aspose.diagram/imageactivexcontrol\#getPictureAlignment--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setPictureSizeMode(int value) {#setPictureSizeMode-int-}
+```
+public void setPictureSizeMode(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getPictureSizeMode()](../../com.aspose.diagram/imageactivexcontrol\#getPictureSizeMode--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setSpecialEffect(int value) {#setSpecialEffect-int-}
+```
+public void setSpecialEffect(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getSpecialEffect()](../../com.aspose.diagram/imageactivexcontrol\#getSpecialEffect--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setTiled(boolean value) {#setTiled-boolean-}
+```
+public void setTiled(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isTiled()](../../com.aspose.diagram/imageactivexcontrol\#isTiled--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/imagecolormode/_index.md
+++ b/german/java/com.aspose.diagram/imagecolormode/_index.md
@@ -1,0 +1,156 @@
+---
+title: ImageColorMode
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt den Farbmodus für die erzeugten Bilder von Dokumentseiten an.
+type: docs
+weight: 198
+url: /de/java/com.aspose.diagram/imagecolormode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ImageColorMode
+```
+
+Gibt den Farbmodus für die erzeugten Bilder von Dokumentseiten an.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [BLACK_AND_WHITE](#BLACK-AND-WHITE) | Die Seiten des Dokuments werden als Schwarz-weiß-Bilder gerendert. |
+| [GRAYSCALE](#GRAYSCALE) | Die Seiten des Dokuments werden als Graustufen-Bilder gerendert. |
+| [NONE](#NONE) | Die Seiten des Dokuments werden als Farbbilder gerendert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BLACK_AND_WHITE {#BLACK-AND-WHITE}
+```
+public static final int BLACK_AND_WHITE
+```
+
+
+Die Seiten des Dokuments werden als Schwarz-weiß-Bilder gerendert.
+
+### GRAYSCALE {#GRAYSCALE}
+```
+public static final int GRAYSCALE
+```
+
+
+Die Seiten des Dokuments werden als Graustufen-Bilder gerendert.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Die Seiten des Dokuments werden als Farbbilder gerendert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/imageformat/_index.md
+++ b/german/java/com.aspose.diagram/imageformat/_index.md
@@ -1,0 +1,273 @@
+---
+title: ImageFormat
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt das Dateiformat des Bildes an.
+type: docs
+weight: 199
+url: /de/java/com.aspose.diagram/imageformat/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ImageFormat
+```
+
+Gibt das Dateiformat des Bildes an.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [ImageFormat()](#ImageFormat--) |  |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object obj)](#equals-java.lang.Object-) | Gibt einen Wert zurück, der angibt, ob das angegebene Objekt ein ImageFormat-Objekt ist, das diesem ImageFormat-Objekt entspricht. |
+| [getBmp()](#getBmp--) | Ruft das Bitmap (BMP)-Bildformat ab. |
+| [getClass()](#getClass--) |  |
+| [getEmf()](#getEmf--) | Ruft das Enhanced Metafile (EMF)-Bildformat ab. |
+| [getExif()](#getExif--) | Ruft das Exchangeable Image File (Exif)-Format ab. |
+| [getGif()](#getGif--) | Ruft das Graphics Interchange Format (GIF)-Bildformat ab. |
+| [getIcon()](#getIcon--) | Ruft das Windows-Icon-Bildformat ab. |
+| [getImageFormatFromSuffixName(String name)](#getImageFormatFromSuffixName-java.lang.String-) | Ermittelt das Bildformat anhand des Suffixnamens |
+| [getJpeg()](#getJpeg--) | Ruft das Joint Photographic Experts Group (JPEG)-Bildformat ab. |
+| [getMemoryBmp()](#getMemoryBmp--) | Ruft ein Speicher-Bitmap-Bildformat ab. |
+| [getName()](#getName--) | Ermittelt den Zeichenkettennamen dieser ImageFormat-Instanz |
+| [getPng()](#getPng--) | Ruft das W3C Portable Network Graphics (PNG)-Bildformat ab. |
+| [getTiff()](#getTiff--) | Liefert das Tagged Image File Format (TIFF) Bildformat. |
+| [getWmf()](#getWmf--) | Liefert das Windows Metafile (WMF) Bildformat. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ImageFormat() {#ImageFormat--}
+```
+public ImageFormat()
+```
+
+
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+Gibt einen Wert zurück, der angibt, ob das angegebene Objekt ein ImageFormat-Objekt ist, das diesem ImageFormat-Objekt entspricht.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| obj | java.lang.Object | Das zu testende Objekt. |
+
+**Returns:**
+boolean – true, wenn o ein ImageFormat-Objekt ist, das diesem ImageFormat-Objekt entspricht; andernfalls false.
+### getBmp() {#getBmp--}
+```
+public static ImageFormat getBmp()
+```
+
+
+Ruft das Bitmap (BMP)-Bildformat ab.
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the bitmap image format.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getEmf() {#getEmf--}
+```
+public static ImageFormat getEmf()
+```
+
+
+Ruft das Enhanced Metafile (EMF)-Bildformat ab.
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the enhanced metafile image format.
+### getExif() {#getExif--}
+```
+public static ImageFormat getExif()
+```
+
+
+Ruft das Exchangeable Image File (Exif)-Format ab.
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the Exif format.
+### getGif() {#getGif--}
+```
+public static ImageFormat getGif()
+```
+
+
+Ruft das Graphics Interchange Format (GIF)-Bildformat ab.
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the GIF image format.
+### getIcon() {#getIcon--}
+```
+public static ImageFormat getIcon()
+```
+
+
+Ruft das Windows-Icon-Bildformat ab.
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the Windows icon image format.
+### getImageFormatFromSuffixName(String name) {#getImageFormatFromSuffixName-java.lang.String-}
+```
+public static ImageFormat getImageFormatFromSuffixName(String name)
+```
+
+
+Ermittelt das Bildformat anhand des Suffixnamens
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Name | java.lang.String | Suffixname |
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - >An ImageFormat object according to the suffix name.
+### getJpeg() {#getJpeg--}
+```
+public static ImageFormat getJpeg()
+```
+
+
+Ruft das Joint Photographic Experts Group (JPEG)-Bildformat ab.
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the JPEG image format.
+### getMemoryBmp() {#getMemoryBmp--}
+```
+public static ImageFormat getMemoryBmp()
+```
+
+
+Ruft ein Speicher-Bitmap-Bildformat ab.
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the memory bitmap image format.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Ermittelt den Zeichenkettennamen dieser ImageFormat-Instanz
+
+**Returns:**
+java.lang.String – der Zeichenkettenname dieser ImageFormat-Instanz
+### getPng() {#getPng--}
+```
+public static ImageFormat getPng()
+```
+
+
+Ruft das W3C Portable Network Graphics (PNG)-Bildformat ab.
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the PNG image format.
+### getTiff() {#getTiff--}
+```
+public static ImageFormat getTiff()
+```
+
+
+Liefert das Tagged Image File Format (TIFF) Bildformat.
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the TIFF image format.
+### getWmf() {#getWmf--}
+```
+public static ImageFormat getWmf()
+```
+
+
+Liefert das Windows Metafile (WMF) Bildformat.
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the Windows metafile image format.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/imagesaveoptions/_index.md
+++ b/german/java/com.aspose.diagram/imagesaveoptions/_index.md
@@ -1,0 +1,809 @@
+---
+title: ImageSaveOptions
+second_title: Aspose.Diagram for Java API-Referenz
+description: Ermöglicht das Angeben zusätzlicher Optionen beim Rendern von Diagrammseiten zu Bildern.
+type: docs
+weight: 200
+url: /de/java/com.aspose.diagram/imagesaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.SaveOptions](../../com.aspose.diagram/saveoptions), [com.aspose.diagram.RenderingSaveOptions](../../com.aspose.diagram/renderingsaveoptions)
+```
+public class ImageSaveOptions extends RenderingSaveOptions
+```
+
+Ermöglicht das Angeben zusätzlicher Optionen beim Rendern von Diagrammseiten zu Bildern.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [ImageSaveOptions(int saveFormat)](#ImageSaveOptions-int-) | Initialisiert eine neue Instanz dieser Klasse, die zum Speichern gerenderter Bilder im Format Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat oder Aspose.Diagram.SaveFileFormat verwendet werden kann. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | Erstellt ein Speicheroptionen-Objekt einer Klasse, die für das angegebene Speicherformat geeignet ist. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCompositingQuality()](#getCompositingQuality--) | Gibt die Qualitätsstufe an, die beim Compositing verwendet werden soll. |
+| [getContentZoom()](#getContentZoom--) | Dieser Parameter ist ähnlich wie scale, wirkt sich jedoch nicht auf die Größe des erzeugten Bildes aus. |
+| [getDefaultFont()](#getDefaultFont--) | Wenn Zeichen im Diagramm Unicode sind und nicht mit dem korrekten Schriftwert gesetzt werden oder die Schriftart nicht lokal installiert ist, können sie in PDF, Bild oder XPS als Block erscheinen. |
+| [getEmfRenderSetting()](#getEmfRenderSetting--) | Einstellung zum Rendern von Emf-Metadateien. |
+| [getEnlargePage()](#getEnlargePage--) | Gibt an, ob die Seite vergrößert werden soll. |
+| [getExportGuideShapes()](#getExportGuideShapes--) | Definiert, ob die Leitlinienformen exportiert werden sollen oder nicht. |
+| [getExportHiddenPage()](#getExportHiddenPage--) | Definiert, ob die versteckte Seite exportiert werden soll oder nicht. |
+| [getImageBrightness()](#getImageBrightness--) | die Helligkeit für die erzeugten Bilder. |
+| [getImageColorMode()](#getImageColorMode--) | der Farbmodus für die erzeugten Bilder. |
+| [getImageContrast()](#getImageContrast--) | der Kontrast für die erzeugten Bilder. |
+| [getInterpolationMode()](#getInterpolationMode--) | Gibt den Algorithmus an, der verwendet wird, wenn Bilder skaliert oder rotiert werden. |
+| [getJpegQuality()](#getJpegQuality--) | ein Wert, der die Qualität der erzeugten JPEG-Bilder bestimmt. |
+| [getPageCount()](#getPageCount--) | die Anzahl der Seiten, die beim Speichern in einer mehrseitigen TIFF-Datei gerendert werden. |
+| [getPageIndex()](#getPageIndex--) | der nullbasierte Index der ersten zu rendernden Seite. |
+| [getPageSize()](#getPageSize--) | die Seitengröße für die erzeugten Bilder. |
+| [getPixelOffsetMode()](#getPixelOffsetMode--) | ein Wert, der angibt, wie Pixel beim Rendern versetzt werden. |
+| [getResolution()](#getResolution--) | die Auflösung der erzeugten Bilder, in Punkten pro Zoll. |
+| [getSameAsPdfConversionArea()](#getSameAsPdfConversionArea--) | Gibt an, ob der Speicherbereich derselbe wie PDF ist. |
+| [getSaveForegroundPagesOnly()](#getSaveForegroundPagesOnly--) | Gibt an, ob alle Seiten als Bild gespeichert werden oder nur der Vordergrund. |
+| [getSaveFormat()](#getSaveFormat--) | Gibt das Format an, in dem die gerenderten Diagrammseiten gespeichert werden, wenn dieses Speicheroptionen-Objekt verwendet wird. |
+| [getScale()](#getScale--) | der Zoomfaktor für die erzeugten Bilder. |
+| [getShapes()](#getShapes--) | Formen zum Rendern. |
+| [getSmoothingMode()](#getSmoothingMode--) | Gibt an, ob Glättung (Antialiasing) auf Linien und Kurven sowie die Kanten von gefüllten Bereichen angewendet wird. |
+| [getTiffCompression()](#getTiffCompression--) | der Kompressionstyp, der beim Speichern der erzeugten Bilder im TIFF-Format angewendet wird. |
+| [getWarningCallback()](#getWarningCallback--) | Warnungs-Callback. |
+| [hashCode()](#hashCode--) |  |
+| [isExportComments()](#isExportComments--) | Definiert, ob Kommentare exportiert werden sollen oder nicht. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCompositingQuality(int value)](#setCompositingQuality-int-) | Für die Beschreibung dieser Eigenschaft siehe [getCompositingQuality()](../../com.aspose.diagram/imagesaveoptions\#getCompositingQuality--) |
+| [setContentZoom(float value)](#setContentZoom-float-) | Für die Beschreibung dieser Eigenschaft siehe [getContentZoom()](../../com.aspose.diagram/imagesaveoptions\#getContentZoom--) |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDefaultFont()](../../com.aspose.diagram/saveoptions\\#getDefaultFont--) |
+| [setEmfRenderSetting(int value)](#setEmfRenderSetting-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\\#getEmfRenderSetting--) |
+| [setEnlargePage(boolean value)](#setEnlargePage-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--) |
+| [setExportComments(boolean value)](#setExportComments-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--) |
+| [setExportGuideShapes(boolean value)](#setExportGuideShapes-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--) |
+| [setExportHiddenPage(boolean value)](#setExportHiddenPage-boolean-) | Für die Beschreibung dieser Eigenschaft siehe [getExportHiddenPage()](../../com.aspose.diagram/imagesaveoptions\#getExportHiddenPage--) |
+| [setImageBrightness(float value)](#setImageBrightness-float-) | Für die Beschreibung dieser Eigenschaft siehe [getImageBrightness()](../../com.aspose.diagram/imagesaveoptions\#getImageBrightness--) |
+| [setImageColorMode(int value)](#setImageColorMode-int-) | Für die Beschreibung dieser Eigenschaft siehe [getImageColorMode()](../../com.aspose.diagram/imagesaveoptions\#getImageColorMode--) |
+| [setImageContrast(float value)](#setImageContrast-float-) | Für die Beschreibung dieser Eigenschaft siehe [getImageContrast()](../../com.aspose.diagram/imagesaveoptions\#getImageContrast--) |
+| [setInterpolationMode(int value)](#setInterpolationMode-int-) | Für die Beschreibung dieser Eigenschaft siehe [getInterpolationMode()](../../com.aspose.diagram/imagesaveoptions\#getInterpolationMode--) |
+| [setJpegQuality(int value)](#setJpegQuality-int-) | Für die Beschreibung dieser Eigenschaft siehe [getJpegQuality()](../../com.aspose.diagram/imagesaveoptions\#getJpegQuality--) |
+| [setPageCount(int value)](#setPageCount-int-) | Für die Beschreibung dieser Eigenschaft siehe [getPageCount()](../../com.aspose.diagram/imagesaveoptions\#getPageCount--) |
+| [setPageIndex(int value)](#setPageIndex-int-) | Für die Beschreibung dieser Eigenschaft siehe [getPageIndex()](../../com.aspose.diagram/imagesaveoptions\#getPageIndex--) |
+| [setPageSize(PageSize value)](#setPageSize-com.aspose.diagram.PageSize-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--) |
+| [setPixelOffsetMode(int value)](#setPixelOffsetMode-int-) | Für die Beschreibung dieser Eigenschaft siehe [getPixelOffsetMode()](../../com.aspose.diagram/imagesaveoptions\#getPixelOffsetMode--) |
+| [setResolution(float value)](#setResolution-float-) | Für die Beschreibung dieser Eigenschaft siehe [getResolution()](../../com.aspose.diagram/imagesaveoptions\#getResolution--) |
+| [setSameAsPdfConversionArea(boolean value)](#setSameAsPdfConversionArea-boolean-) | Für die Beschreibung dieser Eigenschaft siehe [getSameAsPdfConversionArea()](../../com.aspose.diagram/imagesaveoptions\#getSameAsPdfConversionArea--) |
+| [setSaveForegroundPagesOnly(boolean value)](#setSaveForegroundPagesOnly-boolean-) | Für die Beschreibung dieser Eigenschaft siehe [getSaveForegroundPagesOnly()](../../com.aspose.diagram/imagesaveoptions\#getSaveForegroundPagesOnly--) |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | Für die Beschreibung dieser Eigenschaft siehe [getSaveFormat()](../../com.aspose.diagram/imagesaveoptions\#getSaveFormat--) |
+| [setScale(float value)](#setScale-float-) | Für die Beschreibung dieser Eigenschaft siehe [getScale()](../../com.aspose.diagram/imagesaveoptions\#getScale--) |
+| [setShapes(ShapeCollection value)](#setShapes-com.aspose.diagram.ShapeCollection-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--) |
+| [setSmoothingMode(int value)](#setSmoothingMode-int-) | Für die Beschreibung dieser Eigenschaft siehe [getSmoothingMode()](../../com.aspose.diagram/imagesaveoptions\#getSmoothingMode--) |
+| [setTiffCompression(int value)](#setTiffCompression-int-) | Für die Beschreibung dieser Eigenschaft siehe [getTiffCompression()](../../com.aspose.diagram/imagesaveoptions\#getTiffCompression--) |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ImageSaveOptions(int saveFormat) {#ImageSaveOptions-int-}
+```
+public ImageSaveOptions(int saveFormat)
+```
+
+
+Initialisiert eine neue Instanz dieser Klasse, die zum Speichern gerenderter Bilder im Format Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat oder Aspose.Diagram.SaveFileFormat verwendet werden kann.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| saveFormat | int | Kann sein Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat oder Aspose.Diagram.SaveFileFormat. |
+
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+Erstellt ein Speicheroptionen-Objekt einer Klasse, die für das angegebene Speicherformat geeignet ist.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| saveFormat | int | Das Aspose.Diagram.SaveFileFormat, für das ein Save-Optionen-Objekt erstellt werden soll. |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCompositingQuality() {#getCompositingQuality--}
+```
+public int getCompositingQuality()
+```
+
+
+Gibt die Qualitätsstufe an, die beim Compositing verwendet werden soll. Diese Eigenschaft wirkt nur beim Speichern in Rasterbildformate. Der Standardwert ist Aspose.Diagram.Saving.CompositingQuality.
+
+**Returns:**
+int
+### getContentZoom() {#getContentZoom--}
+```
+public float getContentZoom()
+```
+
+
+Dieser Parameter ist ähnlich wie scale, beeinflusst jedoch nicht die Größe des erzeugten Bildes. Der Standardwert ist 1,0. Der Wert muss größer als 0 sein.
+
+**Returns:**
+float
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+Wenn Zeichen im Diagramm Unicode sind und nicht mit dem korrekten Schriftwert gesetzt werden oder die Schriftart nicht lokal installiert ist, können sie im PDF, Bild oder XPS als Block erscheinen. Setzen Sie die DefaultFont, z. B. MingLiu oder MS Gothic, um diese Zeichen anzuzeigen.
+
+**Returns:**
+java.lang.String
+### getEmfRenderSetting() {#getEmfRenderSetting--}
+```
+public int getEmfRenderSetting()
+```
+
+
+Einstellung für das Rendern von EMF-Metadateien. EMF-Metadateien, die als "EMF+ Dual" identifiziert werden, können sowohl EMF+-Datensätze als auch EMF-Datensätze enthalten. Jeder Datensatztyp kann zum Rendern des Bildes verwendet werden, nur EMF+-Datensätze oder nur EMF-Datensätze. Wenn EmfPlusPrefer gesetzt ist, werden EMF+-Datensätze geparst, andernfalls werden nur EMF-Datensätze geparst. Der Standardwert ist EmfOnly"/>.
+
+**Returns:**
+int
+### getEnlargePage() {#getEnlargePage--}
+```
+public boolean getEnlargePage()
+```
+
+
+Gibt an, ob die Seite vergrößert werden soll. Wenn true – Seite vergrößern. Wenn false – Seite nicht vergrößern. Der Standardwert ist true.
+
+**Returns:**
+boolean
+### getExportGuideShapes() {#getExportGuideShapes--}
+```
+public boolean getExportGuideShapes()
+```
+
+
+Definiert, ob Leitlinienformen exportiert werden sollen oder nicht. Standardwert ist true.
+
+**Returns:**
+boolean
+### getExportHiddenPage() {#getExportHiddenPage--}
+```
+public boolean getExportHiddenPage()
+```
+
+
+Definiert, ob versteckte Seiten exportiert werden sollen oder nicht. Standardwert ist true.
+
+**Returns:**
+boolean
+### getImageBrightness() {#getImageBrightness--}
+```
+public float getImageBrightness()
+```
+
+
+Die Helligkeit für die erzeugten Bilder. Diese Eigenschaft wirkt nur beim Speichern in Rasterbildformate. Der Standardwert ist 0,5. Der Wert muss im Bereich zwischen 0 und 1 liegen.
+
+**Returns:**
+float
+### getImageColorMode() {#getImageColorMode--}
+```
+public int getImageColorMode()
+```
+
+
+Der Farbmodus für die erzeugten Bilder. Diese Eigenschaft wirkt nur beim Speichern in Rasterbildformate. Der Standardwert ist Aspose.Diagram.Saving.ImageColorMode.
+
+**Returns:**
+int
+### getImageContrast() {#getImageContrast--}
+```
+public float getImageContrast()
+```
+
+
+Der Kontrast für die erzeugten Bilder. Diese Eigenschaft wirkt nur beim Speichern in Rasterbildformate. Der Standardwert ist 0,5. Der Wert muss im Bereich zwischen 0 und 1 liegen.
+
+**Returns:**
+float
+### getInterpolationMode() {#getInterpolationMode--}
+```
+public int getInterpolationMode()
+```
+
+
+Gibt den Algorithmus an, der verwendet wird, wenn Bilder skaliert oder rotiert werden. Diese Eigenschaft wirkt nur beim Speichern in Rasterbildformate. Der Standardwert ist Aspose.Diagram.Saving.InterpolationMode.
+
+**Returns:**
+int
+### getJpegQuality() {#getJpegQuality--}
+```
+public int getJpegQuality()
+```
+
+
+Ein Wert, der die Qualität der erzeugten JPEG‑Bilder bestimmt. Wirkt nur beim Speichern als JPEG. Verwenden Sie diese Eigenschaft, um die Qualität der erzeugten Bilder beim Speichern im JPEG‑Format zu erhalten oder festzulegen. Der Wert kann von 0 bis 100 variieren, wobei 0 die schlechteste Qualität aber maximale Kompression bedeutet und 100 die beste Qualität aber minimale Kompression. Der Standardwert ist 95.
+
+**Returns:**
+int
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+Die Anzahl der Seiten, die beim Speichern in einer mehrseitigen TIFF‑Datei gerendert werden sollen. Standard ist MaxValue, was bedeutet, dass alle Seiten des Diagramms gerendert werden.
+
+**Returns:**
+int
+### getPageIndex() {#getPageIndex--}
+```
+public int getPageIndex()
+```
+
+
+Der nullbasierte Index der ersten zu rendernden Seite. Standard ist 0.
+
+**Returns:**
+int
+### getPageSize() {#getPageSize--}
+```
+public PageSize getPageSize()
+```
+
+
+die Seitengröße für die erzeugten Bilder. Kann [PageSize](../../com.aspose.diagram/pagesize) oder null sein. Der Standardwert ist null. Wenn PageSize null ist, wird die Seitengröße für das erzeugte Bild aus dem Quell‑Diagramm übernommen.
+
+**Returns:**
+[PageSize](../../com.aspose.diagram/pagesize)
+### getPixelOffsetMode() {#getPixelOffsetMode--}
+```
+public int getPixelOffsetMode()
+```
+
+
+Ein Wert, der angibt, wie Pixel beim Rendern versetzt werden. Diese Eigenschaft wirkt nur beim Speichern in Rasterbildformate. Der Standardwert ist Aspose.Diagram.Saving.PixelOffsetMode.
+
+**Returns:**
+int
+### getResolution() {#getResolution--}
+```
+public float getResolution()
+```
+
+
+Die Auflösung für die erzeugten Bilder, in Punkten pro Zoll. Diese Eigenschaft wirkt nur beim Speichern in Rasterbildformate. Der Standardwert ist 96.
+
+**Returns:**
+float
+### getSameAsPdfConversionArea() {#getSameAsPdfConversionArea--}
+```
+public boolean getSameAsPdfConversionArea()
+```
+
+
+Gibt an, ob der zu speichernde Bereich dem PDF entspricht. Wenn true – ist der gerenderte Bereich gleich dem PDF. Wenn false – ist der gerenderte Bereich der Standard. Der Standardwert ist false.
+
+**Returns:**
+boolean
+### getSaveForegroundPagesOnly() {#getSaveForegroundPagesOnly--}
+```
+public boolean getSaveForegroundPagesOnly()
+```
+
+
+Legt fest, ob alle Seiten im Bild gespeichert werden oder nur der Vordergrund. Wenn true – werden nur Vordergrundseiten gerendert (mit Hintergrund, falls vorhanden). Wenn false – werden Vordergrundseiten gerendert (mit Hintergrund, falls vorhanden) und danach leere Hintergrundseiten. Kann nur true zurückgeben, wenn PageCount > 1. Der Standardwert ist false.
+
+**Returns:**
+boolean
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+Gibt das Format an, in dem die gerenderten Diagrammseiten gespeichert werden, wenn dieses Save‑Options‑Objekt verwendet wird. Kann Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat oder Aspose.Diagram.SaveFileFormat sein.
+
+**Returns:**
+int
+### getScale() {#getScale--}
+```
+public float getScale()
+```
+
+
+Der Zoom‑Faktor für die erzeugten Bilder. Der Standardwert ist 1,0. Der Wert muss größer als 0 sein.
+
+**Returns:**
+float
+### getShapes() {#getShapes--}
+```
+public ShapeCollection getShapes()
+```
+
+
+Zu rendernde Shapes. Standardanzahl ist 0.
+
+**Returns:**
+[ShapeCollection](../../com.aspose.diagram/shapecollection)
+### getSmoothingMode() {#getSmoothingMode--}
+```
+public int getSmoothingMode()
+```
+
+
+Gibt an, ob Glättung (Antialiasing) auf Linien und Kurven sowie die Kanten gefüllter Flächen angewendet wird. Diese Eigenschaft wirkt nur beim Speichern in Rasterbildformate. Der Standardwert ist Aspose.Diagram.Saving.SmoothingMode.
+
+**Returns:**
+int
+### getTiffCompression() {#getTiffCompression--}
+```
+public int getTiffCompression()
+```
+
+
+Der Kompressionstyp, der beim Speichern erzeugter Bilder im TIFF‑Format angewendet wird. Wirkt nur beim Speichern als TIFF. Der Standardwert ist Aspose.Diagram.Saving.TiffCompression.
+
+**Returns:**
+int
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+Warnungs-Callback.
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExportComments() {#isExportComments--}
+```
+public boolean isExportComments()
+```
+
+
+Legt fest, ob Kommentare exportiert werden sollen oder nicht. Der Standardwert ist false.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCompositingQuality(int value) {#setCompositingQuality-int-}
+```
+public void setCompositingQuality(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getCompositingQuality()](../../com.aspose.diagram/imagesaveoptions\#getCompositingQuality--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setContentZoom(float value) {#setContentZoom-float-}
+```
+public void setContentZoom(float value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getContentZoom()](../../com.aspose.diagram/imagesaveoptions\#getContentZoom--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | float |  |
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDefaultFont()](../../com.aspose.diagram/saveoptions\\#getDefaultFont--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setEmfRenderSetting(int value) {#setEmfRenderSetting-int-}
+```
+public void setEmfRenderSetting(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\\#getEmfRenderSetting--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setEnlargePage(boolean value) {#setEnlargePage-boolean-}
+```
+public void setEnlargePage(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setExportComments(boolean value) {#setExportComments-boolean-}
+```
+public void setExportComments(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setExportGuideShapes(boolean value) {#setExportGuideShapes-boolean-}
+```
+public void setExportGuideShapes(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setExportHiddenPage(boolean value) {#setExportHiddenPage-boolean-}
+```
+public void setExportHiddenPage(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getExportHiddenPage()](../../com.aspose.diagram/imagesaveoptions\#getExportHiddenPage--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setImageBrightness(float value) {#setImageBrightness-float-}
+```
+public void setImageBrightness(float value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getImageBrightness()](../../com.aspose.diagram/imagesaveoptions\#getImageBrightness--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | float |  |
+
+### setImageColorMode(int value) {#setImageColorMode-int-}
+```
+public void setImageColorMode(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getImageColorMode()](../../com.aspose.diagram/imagesaveoptions\#getImageColorMode--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setImageContrast(float value) {#setImageContrast-float-}
+```
+public void setImageContrast(float value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getImageContrast()](../../com.aspose.diagram/imagesaveoptions\#getImageContrast--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | float |  |
+
+### setInterpolationMode(int value) {#setInterpolationMode-int-}
+```
+public void setInterpolationMode(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getInterpolationMode()](../../com.aspose.diagram/imagesaveoptions\#getInterpolationMode--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setJpegQuality(int value) {#setJpegQuality-int-}
+```
+public void setJpegQuality(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getJpegQuality()](../../com.aspose.diagram/imagesaveoptions\#getJpegQuality--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setPageCount(int value) {#setPageCount-int-}
+```
+public void setPageCount(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getPageCount()](../../com.aspose.diagram/imagesaveoptions\#getPageCount--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setPageIndex(int value) {#setPageIndex-int-}
+```
+public void setPageIndex(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getPageIndex()](../../com.aspose.diagram/imagesaveoptions\#getPageIndex--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setPageSize(PageSize value) {#setPageSize-com.aspose.diagram.PageSize-}
+```
+public void setPageSize(PageSize value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [PageSize](../../com.aspose.diagram/pagesize) |  |
+
+### setPixelOffsetMode(int value) {#setPixelOffsetMode-int-}
+```
+public void setPixelOffsetMode(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getPixelOffsetMode()](../../com.aspose.diagram/imagesaveoptions\#getPixelOffsetMode--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setResolution(float value) {#setResolution-float-}
+```
+public void setResolution(float value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getResolution()](../../com.aspose.diagram/imagesaveoptions\#getResolution--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | float |  |
+
+### setSameAsPdfConversionArea(boolean value) {#setSameAsPdfConversionArea-boolean-}
+```
+public void setSameAsPdfConversionArea(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getSameAsPdfConversionArea()](../../com.aspose.diagram/imagesaveoptions\#getSameAsPdfConversionArea--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setSaveForegroundPagesOnly(boolean value) {#setSaveForegroundPagesOnly-boolean-}
+```
+public void setSaveForegroundPagesOnly(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getSaveForegroundPagesOnly()](../../com.aspose.diagram/imagesaveoptions\#getSaveForegroundPagesOnly--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getSaveFormat()](../../com.aspose.diagram/imagesaveoptions\#getSaveFormat--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setScale(float value) {#setScale-float-}
+```
+public void setScale(float value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getScale()](../../com.aspose.diagram/imagesaveoptions\#getScale--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | float |  |
+
+### setShapes(ShapeCollection value) {#setShapes-com.aspose.diagram.ShapeCollection-}
+```
+public void setShapes(ShapeCollection value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [ShapeCollection](../../com.aspose.diagram/shapecollection) |  |
+
+### setSmoothingMode(int value) {#setSmoothingMode-int-}
+```
+public void setSmoothingMode(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getSmoothingMode()](../../com.aspose.diagram/imagesaveoptions\#getSmoothingMode--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setTiffCompression(int value) {#setTiffCompression-int-}
+```
+public void setTiffCompression(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getTiffCompression()](../../com.aspose.diagram/imagesaveoptions\#getTiffCompression--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/individualfontconfigs/_index.md
+++ b/german/java/com.aspose.diagram/individualfontconfigs/_index.md
@@ -1,0 +1,193 @@
+---
+title: IndividualFontConfigs
+second_title: Aspose.Diagram for Java API-Referenz
+description: Schriftkonfigurationen für jedes Objekt.
+type: docs
+weight: 201
+url: /de/java/com.aspose.diagram/individualfontconfigs/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class IndividualFontConfigs
+```
+
+Schriftkonfigurationen für jedes [Diagram](../../com.aspose.diagram/diagram)-Objekt.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [IndividualFontConfigs()](#IndividualFontConfigs--) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFontSources()](#getFontSources--) | Gibt eine Kopie des Arrays zurück, das die Liste der Quellen enthält. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setFontFolder(String fontFolder, boolean recursive)](#setFontFolder-java.lang.String-boolean-) | Legt den Schriftartenordner fest. |
+| [setFontFolders(String[] fontFolders, boolean recursive)](#setFontFolders-java.lang.String---boolean-) | Legt die Schriftartenordner fest. |
+| [setFontSources(FontSourceBase[] sources)](#setFontSources-com.aspose.diagram.FontSourceBase---) | Legt die Schriftartenquellen fest. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### IndividualFontConfigs() {#IndividualFontConfigs--}
+```
+public IndividualFontConfigs()
+```
+
+
+Konstruktor.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFontSources() {#getFontSources--}
+```
+public FontSourceBase[] getFontSources()
+```
+
+
+Gibt eine Kopie des Arrays zurück, das die Liste der Quellen enthält.
+
+**Returns:**
+com.aspose.diagram.FontSourceBase[] -
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setFontFolder(String fontFolder, boolean recursive) {#setFontFolder-java.lang.String-boolean-}
+```
+public void setFontFolder(String fontFolder, boolean recursive)
+```
+
+
+Legt den Schriftartenordner fest.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontFolder | java.lang.String | Der Ordner, der TrueType-Schriftarten enthält. |
+| recursive | boolean | Bestimmt, ob Unterordner durchsucht werden sollen oder nicht. |
+
+### setFontFolders(String[] fontFolders, boolean recursive) {#setFontFolders-java.lang.String---boolean-}
+```
+public void setFontFolders(String[] fontFolders, boolean recursive)
+```
+
+
+Legt die Schriftartenordner fest.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontFolders | java.lang.String[] | Die Ordner, die TrueType-Schriftarten enthalten. |
+| recursive | boolean | Bestimmt, ob Unterordner durchsucht werden sollen oder nicht. |
+
+### setFontSources(FontSourceBase[] sources) {#setFontSources-com.aspose.diagram.FontSourceBase---}
+```
+public void setFontSources(FontSourceBase[] sources)
+```
+
+
+Legt die Schriftartenquellen fest.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| sources | [FontSourceBase\[\]](../../com.aspose.diagram/fontsourcebase) | Ein Array von Quellen, die TrueType-Schriftarten enthalten. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/infiniteline/_index.md
+++ b/german/java/com.aspose.diagram/infiniteline/_index.md
@@ -1,0 +1,299 @@
+---
+title: InfiniteLine
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält Elemente, die die x- und y-Koordinaten von zwei Punkten auf einer unendlichen Linie angeben.
+type: docs
+weight: 202
+url: /de/java/com.aspose.diagram/infiniteline/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class InfiniteLine extends Coordinate
+```
+
+Enthält Elemente, die die x- und y-Koordinaten von zwei Punkten auf einer unendlichen Linie angeben. Die X- und Y-Elemente geben die x- und y-Koordinaten des ersten Punktes an, und die A- und B-Elemente geben die x- und y-Koordinaten des zweiten Punktes an.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [InfiniteLine()](#InfiniteLine--) | Erstellt eine Instanz der Klasse [InfiniteLine](../../com.aspose.diagram/infiniteline). |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | Eine x‑Koordinate eines Punktes auf der unendlichen Linie, gekoppelt mit der y‑Koordinate, die durch das B‑Element dargestellt wird. |
+| [getB()](#getB--) | Eine y‑Koordinate eines Punktes auf einer unendlichen Linie, gekoppelt mit der x‑Koordinate, die durch das A‑Element dargestellt wird. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getIX()](#getIX--) | Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements. |
+| [getX()](#getX--) | Eine x‑Koordinate eines Punktes auf der unendlichen Linie. |
+| [getY()](#getY--) | Eine y‑Koordinate eines Punktes auf der unendlichen Linie. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getA()](../../com.aspose.diagram/infiniteline\#getA--) |
+| [setB(DoubleValue value)](#setB-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getB()](../../com.aspose.diagram/infiniteline\#getB--) |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/infiniteline\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getIX()](../../com.aspose.diagram/infiniteline\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getX()](../../com.aspose.diagram/infiniteline\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getY()](../../com.aspose.diagram/infiniteline\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### InfiniteLine() {#InfiniteLine--}
+```
+public InfiniteLine()
+```
+
+
+Erstellt eine Instanz der Klasse [InfiniteLine](../../com.aspose.diagram/infiniteline).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+Eine x‑Koordinate eines Punktes auf der unendlichen Linie, gekoppelt mit der y‑Koordinate, die durch das B‑Element dargestellt wird.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getB() {#getB--}
+```
+public DoubleValue getB()
+```
+
+
+Eine y‑Koordinate eines Punktes auf einer unendlichen Linie, gekoppelt mit der x‑Koordinate, die durch das A‑Element dargestellt wird.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+Eine x‑Koordinate eines Punktes auf der unendlichen Linie.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+Eine y‑Koordinate eines Punktes auf der unendlichen Linie.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getA()](../../com.aspose.diagram/infiniteline\#getA--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setB(DoubleValue value) {#setB-com.aspose.diagram.DoubleValue-}
+```
+public void setB(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getB()](../../com.aspose.diagram/infiniteline\#getB--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/infiniteline\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getIX()](../../com.aspose.diagram/infiniteline\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getX()](../../com.aspose.diagram/infiniteline\#getX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getY()](../../com.aspose.diagram/infiniteline\#getY--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/infinitelinecollection/_index.md
+++ b/german/java/com.aspose.diagram/infinitelinecollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: InfiniteLineCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: InfiniteLine‑Sammlung.
+type: docs
+weight: 203
+url: /de/java/com.aspose.diagram/infinitelinecollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class InfiniteLineCollection extends Collection
+```
+
+InfiniteLine‑Sammlung.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public InfiniteLine get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[InfiniteLine](../../com.aspose.diagram/infiniteline) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/inputmethodeditormode/_index.md
+++ b/german/java/com.aspose.diagram/inputmethodeditormode/_index.md
@@ -1,0 +1,246 @@
+---
+title: InputMethodEditorMode
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt den Standard‑Laufzeitmodus des Input Method Editors dar.
+type: docs
+weight: 204
+url: /de/java/com.aspose.diagram/inputmethodeditormode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class InputMethodEditorMode
+```
+
+Stellt den Standard‑Laufzeitmodus des Input Method Editors dar.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [ALPHA](#ALPHA) | IME aktiviert im Halbbreiten-Alphanumerikmodus. |
+| [ALPHA_FULL](#ALPHA-FULL) | IME aktiviert im Vollbreiten-Alphanumerikmodus. |
+| [DISABLE](#DISABLE) | IME deaktiviert. Der Benutzer kann IME nicht über die Tastatur aktivieren. |
+| [HANGUL](#HANGUL) | IME aktiviert im Halbbreiten-Hangul-Modus. |
+| [HANGUL_FULL](#HANGUL-FULL) | IME aktiviert im Vollbreiten-Hangul-Modus. |
+| [HANZI](#HANZI) | IME aktiviert im Halbbreiten-Hanzi-Modus. |
+| [HANZI_FULL](#HANZI-FULL) | IME aktiviert im Vollbreiten-Hanzi-Modus. |
+| [HIRAGANA](#HIRAGANA) | IME aktiviert im Vollbreiten-Hiragana-Modus. |
+| [KATAKANA](#KATAKANA) | IME aktiviert im Vollbreiten-Katakana-Modus. |
+| [KATAKANA_HALF](#KATAKANA-HALF) | IME aktiviert im Halbbreiten-Katakana-Modus. |
+| [NO_CONTROL](#NO-CONTROL) | Steuert IME nicht. |
+| [OFF](#OFF) | IME deaktiviert. |
+| [ON](#ON) | IME aktiviert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALPHA {#ALPHA}
+```
+public static final int ALPHA
+```
+
+
+IME aktiviert im Halbbreiten-Alphanumerikmodus.
+
+### ALPHA_FULL {#ALPHA-FULL}
+```
+public static final int ALPHA_FULL
+```
+
+
+IME aktiviert im Vollbreiten-Alphanumerikmodus.
+
+### DISABLE {#DISABLE}
+```
+public static final int DISABLE
+```
+
+
+IME deaktiviert. Der Benutzer kann IME nicht über die Tastatur aktivieren.
+
+### HANGUL {#HANGUL}
+```
+public static final int HANGUL
+```
+
+
+IME aktiviert im Halbbreiten-Hangul-Modus.
+
+### HANGUL_FULL {#HANGUL-FULL}
+```
+public static final int HANGUL_FULL
+```
+
+
+IME aktiviert im Vollbreiten-Hangul-Modus.
+
+### HANZI {#HANZI}
+```
+public static final int HANZI
+```
+
+
+IME aktiviert im Halbbreiten-Hanzi-Modus.
+
+### HANZI_FULL {#HANZI-FULL}
+```
+public static final int HANZI_FULL
+```
+
+
+IME aktiviert im Vollbreiten-Hanzi-Modus.
+
+### HIRAGANA {#HIRAGANA}
+```
+public static final int HIRAGANA
+```
+
+
+IME aktiviert im Vollbreiten-Hiragana-Modus.
+
+### KATAKANA {#KATAKANA}
+```
+public static final int KATAKANA
+```
+
+
+IME aktiviert im Vollbreiten-Katakana-Modus.
+
+### KATAKANA_HALF {#KATAKANA-HALF}
+```
+public static final int KATAKANA_HALF
+```
+
+
+IME aktiviert im Halbbreiten-Katakana-Modus.
+
+### NO_CONTROL {#NO-CONTROL}
+```
+public static final int NO_CONTROL
+```
+
+
+Steuert IME nicht.
+
+### OFF {#OFF}
+```
+public static final int OFF
+```
+
+
+IME deaktiviert. Englischer Modus.
+
+### ON {#ON}
+```
+public static final int ON
+```
+
+
+IME aktiviert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/interpolationmode/_index.md
+++ b/german/java/com.aspose.diagram/interpolationmode/_index.md
@@ -1,0 +1,210 @@
+---
+title: InterpolationMode
+second_title: Aspose.Diagram for Java API-Referenz
+description: Die Aufzählung InterpolationMode gibt den Algorithmus an, der verwendet wird, wenn Bilder skaliert oder rotiert werden.
+type: docs
+weight: 206
+url: /de/java/com.aspose.diagram/interpolationmode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class InterpolationMode
+```
+
+Die Aufzählung InterpolationMode gibt den Algorithmus an, der verwendet wird, wenn Bilder skaliert oder rotiert werden.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [BICUBIC](#BICUBIC) | Gibt bikubische Interpolation an. |
+| [BILINEAR](#BILINEAR) | Gibt bilineare Interpolation an. |
+| [DEFAULT](#DEFAULT) | Gibt den Standardmodus an. |
+| [HIGH](#HIGH) | Gibt hochqualitative Interpolation an. |
+| [HIGH_QUALITY_BICUBIC](#HIGH-QUALITY-BICUBIC) | Gibt hochqualitative, bikubische Interpolation an. |
+| [HIGH_QUALITY_BILINEAR](#HIGH-QUALITY-BILINEAR) | Gibt hochqualitative, bilineare Interpolation an. |
+| [INVALID](#INVALID) | Entspricht dem Invalid-Element der QualityMode-Aufzählung. |
+| [LOW](#LOW) | Gibt niedrige Qualitätsinterpolation an. |
+| [NEAREST_NEIGHBOR](#NEAREST-NEIGHBOR) | Gibt nächstnachbar-Interpolation an. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BICUBIC {#BICUBIC}
+```
+public static final int BICUBIC
+```
+
+
+Gibt bikubische Interpolation an. Es wird keine Vorfilterung durchgeführt. Dieser Modus ist nicht geeignet, ein Bild unter 25 % seiner Originalgröße zu verkleinern.
+
+### BILINEAR {#BILINEAR}
+```
+public static final int BILINEAR
+```
+
+
+Gibt bilineare Interpolation an. Es wird keine Vorfilterung durchgeführt. Dieser Modus ist nicht geeignet, ein Bild unter 50 % seiner Originalgröße zu verkleinern.
+
+### DEFAULT {#DEFAULT}
+```
+public static final int DEFAULT
+```
+
+
+Gibt den Standardmodus an.
+
+### HIGH {#HIGH}
+```
+public static final int HIGH
+```
+
+
+Gibt hochqualitative Interpolation an.
+
+### HIGH_QUALITY_BICUBIC {#HIGH-QUALITY-BICUBIC}
+```
+public static final int HIGH_QUALITY_BICUBIC
+```
+
+
+Gibt hochqualitative, bikubische Interpolation an. Vorfilterung wird durchgeführt, um ein hochwertiges Verkleinern zu gewährleisten. Dieser Modus erzeugt die qualitativ hochwertigsten transformierten Bilder.
+
+### HIGH_QUALITY_BILINEAR {#HIGH-QUALITY-BILINEAR}
+```
+public static final int HIGH_QUALITY_BILINEAR
+```
+
+
+Gibt hochqualitative, bilineare Interpolation an. Vorfilterung wird durchgeführt, um ein hochwertiges Verkleinern zu gewährleisten.
+
+### INVALID {#INVALID}
+```
+public static final int INVALID
+```
+
+
+Entspricht dem Invalid-Element der QualityMode-Aufzählung.
+
+### LOW {#LOW}
+```
+public static final int LOW
+```
+
+
+Gibt niedrige Qualitätsinterpolation an.
+
+### NEAREST_NEIGHBOR {#NEAREST-NEIGHBOR}
+```
+public static final int NEAREST_NEIGHBOR
+```
+
+
+Gibt nächstnachbar-Interpolation an.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/interruptmonitor/_index.md
+++ b/german/java/com.aspose.diagram/interruptmonitor/_index.md
@@ -1,0 +1,156 @@
+---
+title: InterruptMonitor
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt alle Operatoren bezüglich des Interrupts dar.
+type: docs
+weight: 207
+url: /de/java/com.aspose.diagram/interruptmonitor/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.AbstractInterruptMonitor](../../com.aspose.diagram/abstractinterruptmonitor)
+```
+public class InterruptMonitor extends AbstractInterruptMonitor
+```
+
+Stellt alle Operatoren bezüglich des Interrupts dar.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [InterruptMonitor()](#InterruptMonitor--) |  |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [interrupt()](#interrupt--) | Unterbrechen Sie den aktuellen Operator. |
+| [isInterruptionRequested()](#isInterruptionRequested--) | Markieren Sie den Monitor als anfordernde Unterbrechung |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### InterruptMonitor() {#InterruptMonitor--}
+```
+public InterruptMonitor()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### interrupt() {#interrupt--}
+```
+public void interrupt()
+```
+
+
+Unterbrechen Sie den aktuellen Operator.
+
+### isInterruptionRequested() {#isInterruptionRequested--}
+```
+public boolean isInterruptionRequested()
+```
+
+
+Markieren Sie den Monitor als anfordernde Unterbrechung
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/intvalue/_index.md
+++ b/german/java/com.aspose.diagram/intvalue/_index.md
@@ -1,0 +1,230 @@
+---
+title: IntValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Ganzzahlwert
+type: docs
+weight: 205
+url: /de/java/com.aspose.diagram/intvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class IntValue
+```
+
+Ganzzahlwert
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [IntValue(int value, int unit)](#IntValue-int-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Attribute eines Elements. |
+| [getValue()](#getValue--) | Ganzzahlwert. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [isThemed()](#isThemed--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setThemed(boolean value)](#setThemed-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isThemed()](../../com.aspose.diagram/intvalue\#isThemed--) |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getUfe()](../../com.aspose.diagram/intvalue\#getUfe--) |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/intvalue\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### IntValue(int value, int unit) {#IntValue-int-int-}
+```
+public IntValue(int value, int unit)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+| Einheit | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Attribute eines Elements.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Ganzzahlwert.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### isThemed() {#isThemed--}
+```
+public boolean isThemed()
+```
+
+
+
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setThemed(boolean value) {#setThemed-boolean-}
+```
+public void setThemed(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isThemed()](../../com.aspose.diagram/intvalue\#isThemed--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getUfe()](../../com.aspose.diagram/intvalue\#getUfe--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/intvalue\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/ipagesavingcallback/_index.md
+++ b/german/java/com.aspose.diagram/ipagesavingcallback/_index.md
@@ -1,0 +1,45 @@
+---
+title: IPageSavingCallback
+second_title: Aspose.Diagram for Java API-Referenz
+description: Steuert/zeigt den Fortschritt des Seiten‑Speichervorgangs an.
+type: docs
+weight: 456
+url: /de/java/com.aspose.diagram/ipagesavingcallback/
+---
+```
+public interface IPageSavingCallback
+```
+
+Steuert/zeigt den Fortschritt des Seiten‑Speichervorgangs an.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [pageEndSaving(PageEndSavingArgs args)](#pageEndSaving-com.aspose.diagram.PageEndSavingArgs-) | Control/Indicate a page ends to be output. |
+| [pageStartSaving(PageStartSavingArgs args)](#pageStartSaving-com.aspose.diagram.PageStartSavingArgs-) | Control/Indicate a page starts to be output. |
+### pageEndSaving(PageEndSavingArgs args) {#pageEndSaving-com.aspose.diagram.PageEndSavingArgs-}
+```
+public abstract void pageEndSaving(PageEndSavingArgs args)
+```
+
+
+Control/Indicate a page ends to be output.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| args | [PageEndSavingArgs](../../com.aspose.diagram/pageendsavingargs) | Informationen für eine Seite beenden den Speicherungsprozess. |
+
+### pageStartSaving(PageStartSavingArgs args) {#pageStartSaving-com.aspose.diagram.PageStartSavingArgs-}
+```
+public abstract void pageStartSaving(PageStartSavingArgs args)
+```
+
+
+Control/Indicate a page starts to be output.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| args | [PageStartSavingArgs](../../com.aspose.diagram/pagestartsavingargs) | Informationen für eine Seite starten den Speicherungsprozess. |
+

--- a/german/java/com.aspose.diagram/issue/_index.md
+++ b/german/java/com.aspose.diagram/issue/_index.md
@@ -1,0 +1,210 @@
+---
+title: Issue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt ein einzelnes Validierungsproblem im Dokument dar.
+type: docs
+weight: 208
+url: /de/java/com.aspose.diagram/issue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Issue
+```
+
+Stellt ein einzelnes Validierungsproblem im Dokument dar.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [Issue()](#Issue--) | Konstruktor |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getID()](#getID--) | Gibt die eindeutige Kennung des Validierungsproblems an. |
+| [getIgnored()](#getIgnored--) | Gibt an, ob das Validierungsproblem derzeit ignoriert wird. |
+| [getIssueTarget()](#getIssueTarget--) | Abhängig vom Ziel des übergeordneten Validierungsproblems gibt es entweder die Seite oder sowohl die Seite als auch die Form an, mit denen das übergeordnete Validierungsproblem verknüpft ist. |
+| [getRuleInfo()](#getRuleInfo--) | Gibt Informationen über die Validierungsregel an, auf die sich das übergeordnete Validierungsproblem bezieht. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setID(long value)](#setID-long-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getID()](../../com.aspose.diagram/issue\#getID--) |
+| [setIgnored(int value)](#setIgnored-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getIgnored()](../../com.aspose.diagram/issue\#getIgnored--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Issue() {#Issue--}
+```
+public Issue()
+```
+
+
+Konstruktor
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getID() {#getID--}
+```
+public long getID()
+```
+
+
+Gibt die eindeutige Kennung des Validierungsproblems an.
+
+**Returns:**
+long
+### getIgnored() {#getIgnored--}
+```
+public int getIgnored()
+```
+
+
+Gibt an, ob das Validierungsproblem derzeit ignoriert wird. Der Standardwert ist False.
+
+**Returns:**
+int
+### getIssueTarget() {#getIssueTarget--}
+```
+public IssueTarget getIssueTarget()
+```
+
+
+Abhängig vom Ziel des übergeordneten Validierungsproblems gibt es entweder die Seite oder sowohl die Seite als auch die Form an, mit der das übergeordnete Validierungsproblem verknüpft ist. Wenn das Ziel des übergeordneten Validierungsproblems ein Dokument ist, gibt IssueTarget weder eine Seite noch eine Form an.
+
+**Returns:**
+[IssueTarget](../../com.aspose.diagram/issuetarget)
+### getRuleInfo() {#getRuleInfo--}
+```
+public RuleInfo getRuleInfo()
+```
+
+
+Gibt Informationen über die Validierungsregel an, auf die sich das übergeordnete Validierungsproblem bezieht.
+
+**Returns:**
+[RuleInfo](../../com.aspose.diagram/ruleinfo)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setID(long value) {#setID-long-}
+```
+public void setID(long value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getID()](../../com.aspose.diagram/issue\#getID--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | long |  |
+
+### setIgnored(int value) {#setIgnored-int-}
+```
+public void setIgnored(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getIgnored()](../../com.aspose.diagram/issue\#getIgnored--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/issuecollection/_index.md
+++ b/german/java/com.aspose.diagram/issuecollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: IssueCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: Issue‑Sammlung.
+type: docs
+weight: 209
+url: /de/java/com.aspose.diagram/issuecollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class IssueCollection extends Collection
+```
+
+Issue‑Sammlung.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [add(Issue issue)](#add-com.aspose.diagram.Issue-) | Füge das Problem zur Sammlung hinzu. |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Issue issue)](#remove-com.aspose.diagram.Issue-) | Entferne das Problem aus der Sammlung. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Issue issue) {#add-com.aspose.diagram.Issue-}
+```
+public int add(Issue issue)
+```
+
+
+Füge das Problem zur Sammlung hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| issue | [Issue](../../com.aspose.diagram/issue) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Issue get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[Issue](../../com.aspose.diagram/issue) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Issue issue) {#remove-com.aspose.diagram.Issue-}
+```
+public void remove(Issue issue)
+```
+
+
+Entferne das Problem aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| issue | [Issue](../../com.aspose.diagram/issue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/issuetarget/_index.md
+++ b/german/java/com.aspose.diagram/issuetarget/_index.md
@@ -1,0 +1,194 @@
+---
+title: IssueTarget
+second_title: Aspose.Diagram for Java API-Referenz
+description: Abhängig vom Ziel des übergeordneten Validierungsproblems gibt es entweder die Seite oder sowohl die Seite als auch die Form an, mit der das übergeordnete Validierungsproblem verknüpft ist.
+type: docs
+weight: 210
+url: /de/java/com.aspose.diagram/issuetarget/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class IssueTarget
+```
+
+Abhängig vom Ziel des übergeordneten Validierungsproblems gibt es entweder die Seite oder sowohl die Seite als auch die Form an, mit der das übergeordnete Validierungsproblem verknüpft ist. Wenn das Ziel des übergeordneten Validierungsproblems ein Dokument ist, gibt IssueTarget weder eine Seite noch eine Form an.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [IssueTarget(long pageID, long shapeID)](#IssueTarget-long-long-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getPageId()](#getPageId--) | Gibt die eindeutige Kennung der Seite an, die dem übergeordneten Validierungsproblem zugeordnet ist. |
+| [getShapeId()](#getShapeId--) | Gibt die eindeutige Kennung der Form an, die dem übergeordneten Validierungsproblem zugeordnet ist. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setPageId(long value)](#setPageId-long-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getPageId()](../../com.aspose.diagram/issuetarget\#getPageId--) |
+| [setShapeId(long value)](#setShapeId-long-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getShapeId()](../../com.aspose.diagram/issuetarget\#getShapeId--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### IssueTarget(long pageID, long shapeID) {#IssueTarget-long-long-}
+```
+public IssueTarget(long pageID, long shapeID)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| pageID | long |  |
+| shapeID | long |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getPageId() {#getPageId--}
+```
+public long getPageId()
+```
+
+
+Gibt die eindeutige Kennung der Seite an, die dem übergeordneten Validierungsproblem zugeordnet ist. Wenn das Ziel das Dokument ist, kann der PageID-Wert 0xFFFFFFFF sein.
+
+**Returns:**
+long
+### getShapeId() {#getShapeId--}
+```
+public long getShapeId()
+```
+
+
+Gibt die eindeutige Kennung der Form an, die dem übergeordneten Validierungsproblem zugeordnet ist. Wenn das Ziel das Dokument oder eine Seite ist, kann der ShapeID-Wert 0xFFFFFFFF sein.
+
+**Returns:**
+long
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setPageId(long value) {#setPageId-long-}
+```
+public void setPageId(long value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getPageId()](../../com.aspose.diagram/issuetarget\#getPageId--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | long |  |
+
+### setShapeId(long value) {#setShapeId-long-}
+```
+public void setShapeId(long value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getShapeId()](../../com.aspose.diagram/issuetarget\#getShapeId--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | long |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/istreamprovider/_index.md
+++ b/german/java/com.aspose.diagram/istreamprovider/_index.md
@@ -1,0 +1,45 @@
+---
+title: IStreamProvider
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt den exportierten Stream‑Provider dar.
+type: docs
+weight: 457
+url: /de/java/com.aspose.diagram/istreamprovider/
+---
+```
+public interface IStreamProvider
+```
+
+Stellt den exportierten Stream‑Provider dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [closeStream(StreamProviderOptions options)](#closeStream-com.aspose.diagram.StreamProviderOptions-) | Schließt den Stream. |
+| [initStream(StreamProviderOptions options)](#initStream-com.aspose.diagram.StreamProviderOptions-) | Ruft den Stream ab. |
+### closeStream(StreamProviderOptions options) {#closeStream-com.aspose.diagram.StreamProviderOptions-}
+```
+public abstract void closeStream(StreamProviderOptions options)
+```
+
+
+Schließt den Stream.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| options | [StreamProviderOptions](../../com.aspose.diagram/streamprovideroptions) |  |
+
+### initStream(StreamProviderOptions options) {#initStream-com.aspose.diagram.StreamProviderOptions-}
+```
+public abstract void initStream(StreamProviderOptions options)
+```
+
+
+Ruft den Stream ab.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| options | [StreamProviderOptions](../../com.aspose.diagram/streamprovideroptions) |  |
+

--- a/german/java/com.aspose.diagram/iwarningcallback/_index.md
+++ b/german/java/com.aspose.diagram/iwarningcallback/_index.md
@@ -1,0 +1,31 @@
+---
+title: IWarningCallback
+second_title: Aspose.Diagram for Java API-Referenz
+description: Rückruf‑Schnittstelle für Warnungen.
+type: docs
+weight: 458
+url: /de/java/com.aspose.diagram/iwarningcallback/
+---
+```
+public interface IWarningCallback
+```
+
+Rückruf‑Schnittstelle für Warnungen.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [warning(WarningInfo warningInfo)](#warning-com.aspose.diagram.WarningInfo-) | Unser Callback muss nur die Methode "Warning" implementieren. |
+### warning(WarningInfo warningInfo) {#warning-com.aspose.diagram.WarningInfo-}
+```
+public abstract void warning(WarningInfo warningInfo)
+```
+
+
+Unser Callback muss nur die Methode "Warning" implementieren.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| warningInfo | [WarningInfo](../../com.aspose.diagram/warninginfo) | Warnungsinfo |
+

--- a/german/java/com.aspose.diagram/labelactivexcontrol/_index.md
+++ b/german/java/com.aspose.diagram/labelactivexcontrol/_index.md
@@ -1,0 +1,622 @@
+---
+title: LabelActiveXControl
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt das Label‑ActiveX‑Steuerelement dar.
+type: docs
+weight: 211
+url: /de/java/com.aspose.diagram/labelactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class LabelActiveXControl extends ActiveXControl
+```
+
+Stellt das Label‑ActiveX‑Steuerelement dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAccelerator()](#getAccelerator--) | Die Beschleunigungstaste für das Steuerelement. |
+| [getBackOleColor()](#getBackOleColor--) | die OLE‑Farbe des Hintergrunds. |
+| [getBorderOleColor()](#getBorderOleColor--) | die OLE‑Farbe des Hintergrunds. |
+| [getBorderStyle()](#getBorderStyle--) | der von dem Steuerelement verwendete Randtyp. |
+| [getCaption()](#getCaption--) | Der beschreibende Text, der auf einem Steuerelement erscheint. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | die Binärdaten des Steuerelements. |
+| [getForeOleColor()](#getForeOleColor--) | die OLE‑Farbe des Vordergrunds. |
+| [getHeight()](#getHeight--) | die Höhe des Steuerelements in Punkt‑Einheiten. |
+| [getIMEMode()](#getIMEMode--) | der Standard‑Laufzeitmodus des Input Method Editors für das Steuerelement, wenn es den Fokus erhält. |
+| [getMouseIcon()](#getMouseIcon--) | ein benutzerdefiniertes Symbol, das als Mauszeiger für das Steuerelement angezeigt wird. |
+| [getMousePointer()](#getMousePointer--) | der Typ des als Mauszeiger für das Steuerelement angezeigten Symbols. |
+| [getPicture()](#getPicture--) | Die Daten des Bildes. |
+| [getPicturePosition()](#getPicturePosition--) | Der Ort des Bildes des Steuerelements relativ zu seiner Beschriftung. |
+| [getSpecialEffect()](#getSpecialEffect--) | der Spezialeffekt des Steuerelements. |
+| [getType()](#getType--) | Ermittelt den Typ des ActiveX-Steuerelements. |
+| [getWidth()](#getWidth--) | die Breite des Steuerelements in Punkt-Einheiten. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | Gibt an, ob das Steuerelement automatisch die Größe ändert, um seinen gesamten Inhalt anzuzeigen. |
+| [isEnabled()](#isEnabled--) | Gibt an, ob das Steuerelement den Fokus erhalten und auf benutzergenerierte Ereignisse reagieren kann. |
+| [isLocked()](#isLocked--) | Gibt an, ob Daten im Steuerelement für die Bearbeitung gesperrt sind. |
+| [isTransparent()](#isTransparent--) | Gibt an, ob das Steuerelement transparent ist. |
+| [isWordWrapped()](#isWordWrapped--) | Gibt an, ob der Inhalt des Steuerelements am Zeilenende automatisch umbrochen wird. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAccelerator(char value)](#setAccelerator-char-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getAccelerator()](../../com.aspose.diagram/labelactivexcontrol\#getAccelerator--) |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setBorderOleColor(int value)](#setBorderOleColor-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getBorderOleColor()](../../com.aspose.diagram/labelactivexcontrol\#getBorderOleColor--) |
+| [setBorderStyle(int value)](#setBorderStyle-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getBorderStyle()](../../com.aspose.diagram/labelactivexcontrol\#getBorderStyle--) |
+| [setCaption(String value)](#setCaption-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getCaption()](../../com.aspose.diagram/labelactivexcontrol\#getCaption--) |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setHeight(double value)](#setHeight-double-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setIMEMode(int value)](#setIMEMode-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) |
+| [setLocked(boolean value)](#setLocked-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | Für die Beschreibung dieser Eigenschaft siehe bitte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setPicture(byte[] value)](#setPicture-byte---) | Für die Beschreibung dieser Eigenschaft siehe bitte [getPicture()](../../com.aspose.diagram/labelactivexcontrol\#getPicture--) |
+| [setPicturePosition(int value)](#setPicturePosition-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getPicturePosition()](../../com.aspose.diagram/labelactivexcontrol\#getPicturePosition--) |
+| [setSpecialEffect(int value)](#setSpecialEffect-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getSpecialEffect()](../../com.aspose.diagram/labelactivexcontrol\#getSpecialEffect--) |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) |
+| [setWidth(double value)](#setWidth-double-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [setWordWrapped(boolean value)](#setWordWrapped-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isWordWrapped()](../../com.aspose.diagram/labelactivexcontrol\#isWordWrapped--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAccelerator() {#getAccelerator--}
+```
+public char getAccelerator()
+```
+
+
+Die Beschleunigungstaste für das Steuerelement.
+
+**Returns:**
+char
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+die OLE‑Farbe des Hintergrunds.
+
+**Returns:**
+int
+### getBorderOleColor() {#getBorderOleColor--}
+```
+public int getBorderOleColor()
+```
+
+
+die OLE‑Farbe des Hintergrunds.
+
+**Returns:**
+int
+### getBorderStyle() {#getBorderStyle--}
+```
+public int getBorderStyle()
+```
+
+
+der von dem Steuerelement verwendete Randtyp.
+
+**Returns:**
+int
+### getCaption() {#getCaption--}
+```
+public String getCaption()
+```
+
+
+Der beschreibende Text, der auf einem Steuerelement erscheint.
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+die Binärdaten des Steuerelements.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+Die OLE-Farbe des Vordergrunds. Gilt nicht für das Image-Steuerelement.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+die Höhe des Steuerelements in Punkt‑Einheiten.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+der Standard‑Laufzeitmodus des Input Method Editors für das Steuerelement, wenn es den Fokus erhält.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+ein benutzerdefiniertes Symbol, das als Mauszeiger für das Steuerelement angezeigt wird.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+der Typ des als Mauszeiger für das Steuerelement angezeigten Symbols.
+
+**Returns:**
+int
+### getPicture() {#getPicture--}
+```
+public byte[] getPicture()
+```
+
+
+Die Daten des Bildes.
+
+**Returns:**
+byte[]
+### getPicturePosition() {#getPicturePosition--}
+```
+public int getPicturePosition()
+```
+
+
+Der Ort des Bildes des Steuerelements relativ zu seiner Beschriftung.
+
+**Returns:**
+int
+### getSpecialEffect() {#getSpecialEffect--}
+```
+public int getSpecialEffect()
+```
+
+
+der Spezialeffekt des Steuerelements.
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Ermittelt den Typ des ActiveX-Steuerelements.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+die Breite des Steuerelements in Punkt-Einheiten.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+Gibt an, ob das Steuerelement automatisch die Größe ändert, um seinen gesamten Inhalt anzuzeigen.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+Gibt an, ob das Steuerelement den Fokus erhalten und auf benutzergenerierte Ereignisse reagieren kann.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+Gibt an, ob Daten im Steuerelement für die Bearbeitung gesperrt sind.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+Gibt an, ob das Steuerelement transparent ist.
+
+**Returns:**
+boolean
+### isWordWrapped() {#isWordWrapped--}
+```
+public boolean isWordWrapped()
+```
+
+
+Gibt an, ob der Inhalt des Steuerelements am Zeilenende automatisch umbrochen wird.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAccelerator(char value) {#setAccelerator-char-}
+```
+public void setAccelerator(char value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getAccelerator()](../../com.aspose.diagram/labelactivexcontrol\#getAccelerator--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | char |  |
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setBorderOleColor(int value) {#setBorderOleColor-int-}
+```
+public void setBorderOleColor(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getBorderOleColor()](../../com.aspose.diagram/labelactivexcontrol\#getBorderOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setBorderStyle(int value) {#setBorderStyle-int-}
+```
+public void setBorderStyle(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getBorderStyle()](../../com.aspose.diagram/labelactivexcontrol\#getBorderStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setCaption(String value) {#setCaption-java.lang.String-}
+```
+public void setCaption(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getCaption()](../../com.aspose.diagram/labelactivexcontrol\#getCaption--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setPicture(byte[] value) {#setPicture-byte---}
+```
+public void setPicture(byte[] value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getPicture()](../../com.aspose.diagram/labelactivexcontrol\#getPicture--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | byte[] |  |
+
+### setPicturePosition(int value) {#setPicturePosition-int-}
+```
+public void setPicturePosition(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getPicturePosition()](../../com.aspose.diagram/labelactivexcontrol\#getPicturePosition--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setSpecialEffect(int value) {#setSpecialEffect-int-}
+```
+public void setSpecialEffect(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getSpecialEffect()](../../com.aspose.diagram/labelactivexcontrol\#getSpecialEffect--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double |  |
+
+### setWordWrapped(boolean value) {#setWordWrapped-boolean-}
+```
+public void setWordWrapped(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isWordWrapped()](../../com.aspose.diagram/labelactivexcontrol\#isWordWrapped--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/layer/_index.md
+++ b/german/java/com.aspose.diagram/layer/_index.md
@@ -1,0 +1,334 @@
+---
+title: Ebene
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält Elemente, die eine einzelne Ebene und deren Eigenschaften für eine Seite definieren.
+type: docs
+weight: 212
+url: /de/java/com.aspose.diagram/layer/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Layer
+```
+
+Enthält Elemente, die eine einzelne Ebene und deren Eigenschaften für eine Seite definieren.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [Layer()](#Layer--) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getActive()](#getActive--) | Gibt an, ob eine Ebene aktiv ist. |
+| [getClass()](#getClass--) |  |
+| [getColor()](#getColor--) | Der Index der Farbe in der Farbpalette, die zur Anzeige der Ebene verwendet wird, oder ein RGB-Wert, der eine benutzerdefinierte Farbe außerhalb der Farbpalette angibt (zum Beispiel \#ff9900). |
+| [getColorTrans()](#getColorTrans--) | Bestimmt den Transparenzgrad für die Textfarbe einer Ebene oder Form, von 0 (vollständig undurchsichtig) bis 1 (vollständig transparent). |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getGlue()](#getGlue--) | Gibt an, ob Formen, die zur Ebene gehören, angeheftet werden können. |
+| [getIX()](#getIX--) | Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements. |
+| [getLock()](#getLock--) | Gibt an, ob Formen, die zur Ebene gehören, gegen Auswahl oder Bearbeitung gesperrt sind. |
+| [getName()](#getName--) | Das Name-Element gibt den Namen einer Ebene an. |
+| [getNameUniv()](#getNameUniv--) | Gibt den universellen Namen einer Ebene an. |
+| [getPrint()](#getPrint--) | Gibt an, ob Formen, die zur Ebene gehören, beim Drucken der Zeichnung gedruckt werden. |
+| [getSnap()](#getSnap--) | Gibt an, ob andere Formen an Formen, die der Ebene zugewiesen sind, einrasten können. |
+| [getStatus()](#getStatus--) | Gibt an, ob die Ebene eine gültige Ebene für ein Dokument ist. |
+| [getVisible()](#getVisible--) | Gibt an, ob Formen, die zur Ebene gehören, auf der Zeichenfläche sichtbar sind. |
+| [hashCode()](#hashCode--) |  |
+| [isColorChecked()](#isColorChecked--) | Ein Flag, das angibt, ob das Element lokal geprüft wurde. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setColorChecked(int value)](#setColorChecked-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isColorChecked()](../../com.aspose.diagram/layer\#isColorChecked--) |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/layer\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getIX()](../../com.aspose.diagram/layer\#getIX--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Layer() {#Layer--}
+```
+public Layer()
+```
+
+
+Konstruktor.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getActive() {#getActive--}
+```
+public BoolValue getActive()
+```
+
+
+Gibt an, ob eine Ebene aktiv ist. Formen, die nicht vorher einer Ebene zugewiesen wurden, werden beim Ablegen auf der Zeichenfläche den aktiven Ebene(n) zugewiesen.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColor() {#getColor--}
+```
+public ColorValue getColor()
+```
+
+
+Der Index der Farbe in der Farbpalette, die zur Anzeige der Ebene verwendet wird, oder ein RGB-Wert, der eine benutzerdefinierte Farbe außerhalb der Farbpalette angibt (zum Beispiel \#ff9900).
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getColorTrans() {#getColorTrans--}
+```
+public DoubleValue getColorTrans()
+```
+
+
+Bestimmt den Transparenzgrad für die Textfarbe einer Ebene oder Form, von 0 (vollständig undurchsichtig) bis 1 (vollständig transparent).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getGlue() {#getGlue--}
+```
+public BoolValue getGlue()
+```
+
+
+Gibt an, ob Formen, die zur Ebene gehören, angeheftet werden können.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements.
+
+**Returns:**
+int
+### getLock() {#getLock--}
+```
+public BoolValue getLock()
+```
+
+
+Gibt an, ob Formen, die zur Ebene gehören, gegen Auswahl oder Bearbeitung gesperrt sind.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getName() {#getName--}
+```
+public Str2Value getName()
+```
+
+
+Das Name-Element gibt den Namen einer Ebene an.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getNameUniv() {#getNameUniv--}
+```
+public Str2Value getNameUniv()
+```
+
+
+Gibt den universellen Namen einer Ebene an.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getPrint() {#getPrint--}
+```
+public BoolValue getPrint()
+```
+
+
+Gibt an, ob Formen, die zur Ebene gehören, beim Drucken der Zeichnung gedruckt werden.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getSnap() {#getSnap--}
+```
+public BoolValue getSnap()
+```
+
+
+Gibt an, ob andere Formen an Formen, die der Ebene zugewiesen sind, einrasten können. Formen, die der Ebene zugewiesen sind, können an andere Formen einrasten, aber andere Formen können nicht an ihnen einrasten.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getStatus() {#getStatus--}
+```
+public BoolValue getStatus()
+```
+
+
+Gibt an, ob die Ebene eine gültige Ebene für ein Dokument ist.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getVisible() {#getVisible--}
+```
+public BoolValue getVisible()
+```
+
+
+Gibt an, ob Formen, die zur Ebene gehören, auf der Zeichenfläche sichtbar sind.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isColorChecked() {#isColorChecked--}
+```
+public int isColorChecked()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal geprüft wurde. Ein Wert von 1 bedeutet, dass das Element lokal geprüft wurde.
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setColorChecked(int value) {#setColorChecked-int-}
+```
+public void setColorChecked(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isColorChecked()](../../com.aspose.diagram/layer\#isColorChecked--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/layer\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getIX()](../../com.aspose.diagram/layer\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/layercollection/_index.md
+++ b/german/java/com.aspose.diagram/layercollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: LayerCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: Ebenen‑Sammlung.
+type: docs
+weight: 213
+url: /de/java/com.aspose.diagram/layercollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class LayerCollection extends Collection
+```
+
+Ebenen‑Sammlung.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [add(Layer item)](#add-com.aspose.diagram.Layer-) | Füge das Layer-Objekt zur Sammlung hinzu. |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Layer item)](#remove-com.aspose.diagram.Layer-) | Entferne das Layer-Objekt aus der Sammlung. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Layer item) {#add-com.aspose.diagram.Layer-}
+```
+public int add(Layer item)
+```
+
+
+Füge das Layer-Objekt zur Sammlung hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [Layer](../../com.aspose.diagram/layer) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Layer get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[Layer](../../com.aspose.diagram/layer) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Layer item) {#remove-com.aspose.diagram.Layer-}
+```
+public void remove(Layer item)
+```
+
+
+Entferne das Layer-Objekt aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [Layer](../../com.aspose.diagram/layer) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/layermem/_index.md
+++ b/german/java/com.aspose.diagram/layermem/_index.md
@@ -1,0 +1,161 @@
+---
+title: LayerMem
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält das LayerMember-Element, das jede Ebene angibt, der die Form zugewiesen ist.
+type: docs
+weight: 214
+url: /de/java/com.aspose.diagram/layermem/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LayerMem
+```
+
+Enthält das Element LayerMember, das jede Ebene angibt, der die Form zugewiesen ist.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getLayerMember()](#getLayerMember--) | Gibt die Ebene oder Ebenen an, der die Form zugewiesen ist. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/layermem\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getLayerMember() {#getLayerMember--}
+```
+public Str2Value getLayerMember()
+```
+
+
+Gibt die Ebene oder Ebenen an, der die Form zugewiesen ist. Die Ebenenzuweisung wird basierend auf dem nullbasierten Index der Ebenen für die Seite angegeben. Wenn einer Form mehr als eine Ebene zugewiesen ist, wird jeder Ebenenindex durch ein Semikolon getrennt angezeigt.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/layermem\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/layout/_index.md
+++ b/german/java/com.aspose.diagram/layout/_index.md
@@ -1,0 +1,362 @@
+---
+title: Layout
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält Elemente, die die Platzierung von Formen und die Routing‑Einstellungen von Verbindern steuern.
+type: docs
+weight: 215
+url: /de/java/com.aspose.diagram/layout/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Layout
+```
+
+Enthält Elemente, die die Platzierung von Formen und die Routing‑Einstellungen von Verbindern steuern.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getConFixedCode()](#getConFixedCode--) | Bestimmt, wann ein Connector umgeleitet wird. |
+| [getConLineJumpCode()](#getConLineJumpCode--) | Bestimmt, ob ein Verbinder springt, wenn zwei Verbinder sich kreuzen, |
+| [getConLineJumpDirX()](#getConLineJumpDirX--) | Bestimmt die Sprungrichtung für Linien, die auf einem horizontalen Segment eines dynamischen Connectors auftreten. |
+| [getConLineJumpDirY()](#getConLineJumpDirY--) | Bestimmt die Sprungrichtung für Linien, die auf einem vertikalen Segment eines dynamischen Connectors auftreten. |
+| [getConLineJumpStyle()](#getConLineJumpStyle--) | Bestimmt den Sprungstil für Linien auf einem dynamischen Connector. |
+| [getConLineRouteExt()](#getConLineRouteExt--) | Bestimmt das Erscheinungsbild eines Connectors. |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getDisplayLevel()](#getDisplayLevel--) | Bestimmt das Anzeigeebenenband (den relativen Bereich der Z-Order-Gruppierung) für das Shape. |
+| [getRelationships()](#getRelationships--) | Speichert die Beziehungen zwischen Containern, Listen, Callouts und Shapes. |
+| [getShapeFixedCode()](#getShapeFixedCode--) | Gibt das Platzierungsverhalten für eine platzierbare Form an. |
+| [getShapePermeablePlace()](#getShapePermeablePlace--) | Gibt an, ob platzierbare Shapes über einem Shape platziert werden können, wenn ein Benutzer „Lay Out Shapes“ (Shapes‑Menü) auswählt. |
+| [getShapePermeableX()](#getShapePermeableX--) | Gibt an, ob ein Verbinder horizontal durch ein Shape führen kann. |
+| [getShapePermeableY()](#getShapePermeableY--) | Gibt an, ob ein Verbinder vertikal durch ein Shape führen kann. |
+| [getShapePlaceFlip()](#getShapePlaceFlip--) | Gibt an, wie eine platzierbare Form auf der Seite gedreht und/oder gespiegelt wird, wenn ein Benutzer Lay Out Shapes (Shapes‑Menü) auswählt. |
+| [getShapePlaceStyle()](#getShapePlaceStyle--) | Bestimmt den Platzierungsstil für untergeordnete Elemente. |
+| [getShapePlowCode()](#getShapePlowCode--) | Gibt an, ob sich eine platzierbare Form entfernt, wenn Sie eine andere platzierbare Form in die Nähe der Form auf der Zeichenfläche ziehen. |
+| [getShapeRouteStyle()](#getShapeRouteStyle--) | Gibt den Routing‑Stil und die Richtung für einen Verbinder auf der Zeichenfläche an. |
+| [getShapeSplit()](#getShapeSplit--) | Bestimmt, ob dieses Shape teilbare Shapes teilen kann. |
+| [getShapeSplittable()](#getShapeSplittable--) | Bestimmt, ob dieses 1‑D‑Shape geteilt werden kann. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft, bitte siehe [getDel()](../../com.aspose.diagram/layout\#getDel--) |
+| [setShapePlaceStyle(ShapePlaceStyle value)](#setShapePlaceStyle-com.aspose.diagram.ShapePlaceStyle-) | Für die Beschreibung dieser Eigenschaft, bitte siehe [getShapePlaceStyle()](../../com.aspose.diagram/layout\#getShapePlaceStyle--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConFixedCode() {#getConFixedCode--}
+```
+public ConFixedCode getConFixedCode()
+```
+
+
+Bestimmt, wann ein Connector umgeleitet wird.
+
+**Returns:**
+[ConFixedCode](../../com.aspose.diagram/confixedcode)
+### getConLineJumpCode() {#getConLineJumpCode--}
+```
+public ConLineJumpCode getConLineJumpCode()
+```
+
+
+Bestimmt, ob ein Verbinder springt, wenn zwei Verbinder sich kreuzen,
+
+**Returns:**
+[ConLineJumpCode](../../com.aspose.diagram/conlinejumpcode)
+### getConLineJumpDirX() {#getConLineJumpDirX--}
+```
+public ConLineJumpDirX getConLineJumpDirX()
+```
+
+
+Bestimmt die Sprungrichtung für Linien, die auf einem horizontalen Segment eines dynamischen Connectors auftreten.
+
+**Returns:**
+[ConLineJumpDirX](../../com.aspose.diagram/conlinejumpdirx)
+### getConLineJumpDirY() {#getConLineJumpDirY--}
+```
+public ConLineJumpDirY getConLineJumpDirY()
+```
+
+
+Bestimmt die Sprungrichtung für Linien, die auf einem vertikalen Segment eines dynamischen Connectors auftreten.
+
+**Returns:**
+[ConLineJumpDirY](../../com.aspose.diagram/conlinejumpdiry)
+### getConLineJumpStyle() {#getConLineJumpStyle--}
+```
+public ConLineJumpStyle getConLineJumpStyle()
+```
+
+
+Bestimmt den Sprungstil für Linien auf einem dynamischen Connector.
+
+**Returns:**
+[ConLineJumpStyle](../../com.aspose.diagram/conlinejumpstyle)
+### getConLineRouteExt() {#getConLineRouteExt--}
+```
+public ConLineRouteExt getConLineRouteExt()
+```
+
+
+Bestimmt das Erscheinungsbild eines Connectors.
+
+**Returns:**
+[ConLineRouteExt](../../com.aspose.diagram/conlinerouteext)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getDisplayLevel() {#getDisplayLevel--}
+```
+public IntValue getDisplayLevel()
+```
+
+
+Bestimmt das Anzeigeebenenband (den relativen Bereich der Z-Order-Gruppierung) für das Shape.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getRelationships() {#getRelationships--}
+```
+public BoolValue getRelationships()
+```
+
+
+Speichert die Beziehungen zwischen Containern, Listen, Callouts und Shapes.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getShapeFixedCode() {#getShapeFixedCode--}
+```
+public ShapeFixedCode getShapeFixedCode()
+```
+
+
+Gibt das Platzierungsverhalten für eine platzierbare Form an.
+
+**Returns:**
+[ShapeFixedCode](../../com.aspose.diagram/shapefixedcode)
+### getShapePermeablePlace() {#getShapePermeablePlace--}
+```
+public BoolValue getShapePermeablePlace()
+```
+
+
+Gibt an, ob platzierbare Shapes über einem Shape platziert werden können, wenn ein Benutzer „Lay Out Shapes“ (Shapes‑Menü) auswählt.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getShapePermeableX() {#getShapePermeableX--}
+```
+public BoolValue getShapePermeableX()
+```
+
+
+Gibt an, ob ein Verbinder horizontal durch ein Shape führen kann.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getShapePermeableY() {#getShapePermeableY--}
+```
+public BoolValue getShapePermeableY()
+```
+
+
+Gibt an, ob ein Verbinder vertikal durch ein Shape führen kann.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getShapePlaceFlip() {#getShapePlaceFlip--}
+```
+public ShapePlaceFlip getShapePlaceFlip()
+```
+
+
+Gibt an, wie eine platzierbare Form auf der Seite gedreht und/oder gespiegelt wird, wenn ein Benutzer Lay Out Shapes (Shapes‑Menü) auswählt.
+
+**Returns:**
+[ShapePlaceFlip](../../com.aspose.diagram/shapeplaceflip)
+### getShapePlaceStyle() {#getShapePlaceStyle--}
+```
+public ShapePlaceStyle getShapePlaceStyle()
+```
+
+
+Bestimmt den Platzierungsstil für untergeordnete Elemente.
+
+**Returns:**
+[ShapePlaceStyle](../../com.aspose.diagram/shapeplacestyle)
+### getShapePlowCode() {#getShapePlowCode--}
+```
+public ShapePlowCode getShapePlowCode()
+```
+
+
+Gibt an, ob sich eine platzierbare Form entfernt, wenn Sie eine andere platzierbare Form in die Nähe der Form auf der Zeichenfläche ziehen.
+
+**Returns:**
+[ShapePlowCode](../../com.aspose.diagram/shapeplowcode)
+### getShapeRouteStyle() {#getShapeRouteStyle--}
+```
+public ShapeRouteStyle getShapeRouteStyle()
+```
+
+
+Gibt den Routing‑Stil und die Richtung für einen Verbinder auf der Zeichenfläche an.
+
+**Returns:**
+[ShapeRouteStyle](../../com.aspose.diagram/shaperoutestyle)
+### getShapeSplit() {#getShapeSplit--}
+```
+public BoolValue getShapeSplit()
+```
+
+
+Bestimmt, ob dieses Shape teilbare Shapes teilen kann.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getShapeSplittable() {#getShapeSplittable--}
+```
+public BoolValue getShapeSplittable()
+```
+
+
+Bestimmt, ob dieses 1‑D‑Shape geteilt werden kann.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft, bitte siehe [getDel()](../../com.aspose.diagram/layout\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setShapePlaceStyle(ShapePlaceStyle value) {#setShapePlaceStyle-com.aspose.diagram.ShapePlaceStyle-}
+```
+public void setShapePlaceStyle(ShapePlaceStyle value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft, bitte siehe [getShapePlaceStyle()](../../com.aspose.diagram/layout\#getShapePlaceStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [ShapePlaceStyle](../../com.aspose.diagram/shapeplacestyle) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/layoutdirection/_index.md
+++ b/german/java/com.aspose.diagram/layoutdirection/_index.md
@@ -1,0 +1,201 @@
+---
+title: LayoutDirection
+second_title: Aspose.Diagram for Java API-Referenz
+description: Wird verwendet, um die Richtung des Layouts festzulegen.
+type: docs
+weight: 216
+url: /de/java/com.aspose.diagram/layoutdirection/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LayoutDirection
+```
+
+Wird verwendet, um die Richtung des Layouts festzulegen.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [BOTTOM_TO_TOP](#BOTTOM-TO-TOP) | Platziert die Form von unten nach oben. |
+| [DOWN_THEN_LEFT](#DOWN-THEN-LEFT) | Platziert Formen zuerst nach unten und dann nach links. |
+| [DOWN_THEN_RIGHT](#DOWN-THEN-RIGHT) | Platziert Formen zuerst nach unten und dann nach rechts. |
+| [LEFT_THEN_DOWN](#LEFT-THEN-DOWN) | Platziert Formen zuerst nach links und dann nach unten. |
+| [LEFT_TO_RIGHT](#LEFT-TO-RIGHT) | Platziert die Form von links nach rechts. |
+| [RIGHT_THEN_DOWN](#RIGHT-THEN-DOWN) | Platziert Formen zuerst nach rechts und dann nach unten. |
+| [RIGHT_TO_LEFT](#RIGHT-TO-LEFT) | Platziert die Form von rechts nach links. |
+| [TOP_TO_BOTTOM](#TOP-TO-BOTTOM) | Platziert die Form von oben nach unten. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOTTOM_TO_TOP {#BOTTOM-TO-TOP}
+```
+public static final int BOTTOM_TO_TOP
+```
+
+
+Platziert die Form von unten nach oben. Sinnvoll nur, wenn der Flowchart-Stil gewählt ist.
+
+### DOWN_THEN_LEFT {#DOWN-THEN-LEFT}
+```
+public static final int DOWN_THEN_LEFT
+```
+
+
+Platziert Formen zuerst nach unten und dann nach links. Sinnvoll nur, wenn der CompactTree-Stil gewählt ist.
+
+### DOWN_THEN_RIGHT {#DOWN-THEN-RIGHT}
+```
+public static final int DOWN_THEN_RIGHT
+```
+
+
+Platziert Formen zuerst nach unten und dann nach rechts. Sinnvoll nur, wenn der CompactTree-Stil gewählt ist.
+
+### LEFT_THEN_DOWN {#LEFT-THEN-DOWN}
+```
+public static final int LEFT_THEN_DOWN
+```
+
+
+Platziert Formen zuerst nach links und dann nach unten. Sinnvoll nur, wenn der CompactTree-Stil gewählt ist.
+
+### LEFT_TO_RIGHT {#LEFT-TO-RIGHT}
+```
+public static final int LEFT_TO_RIGHT
+```
+
+
+Platziert die Form von links nach rechts. Das ergibt nur Sinn, wenn der Flowchart‑Stil gewählt ist.
+
+### RIGHT_THEN_DOWN {#RIGHT-THEN-DOWN}
+```
+public static final int RIGHT_THEN_DOWN
+```
+
+
+Platziert Formen zuerst nach rechts und dann nach unten. Das ergibt nur Sinn, wenn der CompactTree‑Stil gewählt ist.
+
+### RIGHT_TO_LEFT {#RIGHT-TO-LEFT}
+```
+public static final int RIGHT_TO_LEFT
+```
+
+
+Platziert die Form von rechts nach links. Das ergibt nur Sinn, wenn der Flowchart‑Stil gewählt ist.
+
+### TOP_TO_BOTTOM {#TOP-TO-BOTTOM}
+```
+public static final int TOP_TO_BOTTOM
+```
+
+
+Platziert die Form von oben nach unten. Das ergibt nur Sinn, wenn der Flowchart‑Stil gewählt ist.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/layoutoptions/_index.md
+++ b/german/java/com.aspose.diagram/layoutoptions/_index.md
@@ -1,0 +1,238 @@
+---
+title: LayoutOptions
+second_title: Aspose.Diagram for Java API-Referenz
+description: Wird verwendet, um Stil und zusätzliche Optionen des Layouts von Formen festzulegen, um ein Re-Layout von Seiten durchzuführen.
+type: docs
+weight: 217
+url: /de/java/com.aspose.diagram/layoutoptions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LayoutOptions
+```
+
+Wird verwendet, um Stil und zusätzliche Optionen des Layouts von Formen anzugeben, um ein Neu‑Layout von Seite(n) durchzuführen.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [LayoutOptions()](#LayoutOptions--) | Initialisiert eine neue Instanz von LayoutOptions. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDirection()](#getDirection--) | Wird verwendet, um die Richtung des Form-Layouts festzulegen. |
+| [getEnlargePage()](#getEnlargePage--) | Definiert, ob die Seite vergrößert werden muss, um die Zeichnung aufzunehmen, oder nicht. |
+| [getLayoutStyle()](#getLayoutStyle--) | Wird verwendet, um den Stil des Layouts anzugeben. |
+| [getSpaceShapes()](#getSpaceShapes--) | Definiert den Abstand zwischen den Formen in Zoll. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDirection(int value)](#setDirection-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDirection()](../../com.aspose.diagram/layoutoptions\#getDirection--) |
+| [setEnlargePage(boolean value)](#setEnlargePage-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getEnlargePage()](../../com.aspose.diagram/layoutoptions\#getEnlargePage--) |
+| [setLayoutStyle(int value)](#setLayoutStyle-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getLayoutStyle()](../../com.aspose.diagram/layoutoptions\#getLayoutStyle--) |
+| [setSpaceShapes(float value)](#setSpaceShapes-float-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getSpaceShapes()](../../com.aspose.diagram/layoutoptions\#getSpaceShapes--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LayoutOptions() {#LayoutOptions--}
+```
+public LayoutOptions()
+```
+
+
+Initialisiert eine neue Instanz von LayoutOptions.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDirection() {#getDirection--}
+```
+public int getDirection()
+```
+
+
+Wird verwendet, um die Richtung des Form-Layouts festzulegen. Standardwert ist TopToBottom.
+
+**Returns:**
+int
+### getEnlargePage() {#getEnlargePage--}
+```
+public boolean getEnlargePage()
+```
+
+
+Definiert, ob die Seite vergrößert werden muss, um die Zeichnung aufzunehmen, oder nicht. Standardwert ist false.
+
+**Returns:**
+boolean
+### getLayoutStyle() {#getLayoutStyle--}
+```
+public int getLayoutStyle()
+```
+
+
+Wird verwendet, um den Stil des Layouts anzugeben. Standardwert ist FlowChart.
+
+**Returns:**
+int
+### getSpaceShapes() {#getSpaceShapes--}
+```
+public float getSpaceShapes()
+```
+
+
+Definiert den Abstand zwischen den Formen in Zoll. Standardwert 0,3 Zoll ~ 7,5 mm.
+
+**Returns:**
+float
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDirection(int value) {#setDirection-int-}
+```
+public void setDirection(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDirection()](../../com.aspose.diagram/layoutoptions\#getDirection--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setEnlargePage(boolean value) {#setEnlargePage-boolean-}
+```
+public void setEnlargePage(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getEnlargePage()](../../com.aspose.diagram/layoutoptions\#getEnlargePage--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setLayoutStyle(int value) {#setLayoutStyle-int-}
+```
+public void setLayoutStyle(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getLayoutStyle()](../../com.aspose.diagram/layoutoptions\#getLayoutStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setSpaceShapes(float value) {#setSpaceShapes-float-}
+```
+public void setSpaceShapes(float value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getSpaceShapes()](../../com.aspose.diagram/layoutoptions\#getSpaceShapes--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | float |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/layoutstyle/_index.md
+++ b/german/java/com.aspose.diagram/layoutstyle/_index.md
@@ -1,0 +1,165 @@
+---
+title: LayoutStyle
+second_title: Aspose.Diagram for Java API-Referenz
+description: Wird verwendet, um den Stil des Layouts anzugeben.
+type: docs
+weight: 218
+url: /de/java/com.aspose.diagram/layoutstyle/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LayoutStyle
+```
+
+Wird verwendet, um den Stil des Layouts anzugeben.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [CIRCULAR](#CIRCULAR) | Kreisförmiger Stil. |
+| [COMPACT_TREE](#COMPACT-TREE) | Baumstil. |
+| [FLOW_CHART](#FLOW-CHART) | Flussdiagrammstil. |
+| [RADIAL](#RADIAL) | Radialer Stil. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CIRCULAR {#CIRCULAR}
+```
+public static final int CIRCULAR
+```
+
+
+Kreisförmiger Stil.
+
+### COMPACT_TREE {#COMPACT-TREE}
+```
+public static final int COMPACT_TREE
+```
+
+
+Baumstil.
+
+### FLOW_CHART {#FLOW-CHART}
+```
+public static final int FLOW_CHART
+```
+
+
+Flussdiagrammstil.
+
+### RADIAL {#RADIAL}
+```
+public static final int RADIAL
+```
+
+
+Radialer Stil.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/license/_index.md
+++ b/german/java/com.aspose.diagram/license/_index.md
@@ -1,0 +1,188 @@
+---
+title: Lizenz
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt Methoden zum Lizenzieren der Komponente bereit.
+type: docs
+weight: 219
+url: /de/java/com.aspose.diagram/license/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class License
+```
+
+Stellt Methoden zum Lizenzieren der Komponente bereit.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [License()](#License--) | Initialisiert eine neue Instanz dieser Klasse. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setLicense(InputStream stream)](#setLicense-java.io.InputStream-) | Lizenziert die Komponente. |
+| [setLicense(String licenseName)](#setLicense-java.lang.String-) | Lizenziert die Komponente. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### License() {#License--}
+```
+public License()
+```
+
+
+Initialisiert eine neue Instanz dieser Klasse.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setLicense(InputStream stream) {#setLicense-java.io.InputStream-}
+```
+public void setLicense(InputStream stream)
+```
+
+
+Lizenziert die Komponente.
+
+Verwenden Sie diese Methode, um eine Lizenz aus einem Stream zu laden.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| stream | java.io.InputStream | Ein Stream, der die Lizenz enthält. |
+
+### setLicense(String licenseName) {#setLicense-java.lang.String-}
+```
+public void setLicense(String licenseName)
+```
+
+
+Lizenziert die Komponente.
+
+Versucht, die Lizenz an den folgenden Orten zu finden:
+
+1. Expliziter Pfad.
+
+2. Der Ordner der Komponenten‑Assembly.
+
+3. Der Ordner der aufrufenden Assembly des Clients.
+
+4. Der Ordner der Einstieg‑Assembly.
+
+5. Eine eingebettete Ressource in der aufrufenden Assembly des Clients.
+
+**Note:**On the .NET Compact Framework, tries to find the license only in these locations:
+
+1. Expliziter Pfad.
+
+2. Eine eingebettete Ressource in der aufrufenden Assembly des Clients.
+
+2. Der Ordner der Komponenten‑JAR‑Datei.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| licenseName | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/lightrigdirectiontype/_index.md
+++ b/german/java/com.aspose.diagram/lightrigdirectiontype/_index.md
@@ -1,0 +1,201 @@
+---
+title: LightRigDirectionType
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt den Lichtgestell‑Richtungstyp dar.
+type: docs
+weight: 220
+url: /de/java/com.aspose.diagram/lightrigdirectiontype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LightRigDirectionType
+```
+
+Stellt den Lichtgestell‑Richtungstyp dar.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [BOTTOM](#BOTTOM) | Unten |
+| [BOTTOM_LEFT](#BOTTOM-LEFT) | Unten links. |
+| [BOTTOM_RIGHT](#BOTTOM-RIGHT) | Unten rechts. |
+| [LEFT](#LEFT) | Links. |
+| [RIGHT](#RIGHT) | Rechts. |
+| [TOP](#TOP) | Oben. |
+| [TOP_LEFT](#TOP-LEFT) | Oben links. |
+| [TOP_RIGHT](#TOP-RIGHT) | Oben rechts. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOTTOM {#BOTTOM}
+```
+public static final int BOTTOM
+```
+
+
+Unten
+
+### BOTTOM_LEFT {#BOTTOM-LEFT}
+```
+public static final int BOTTOM_LEFT
+```
+
+
+Unten links.
+
+### BOTTOM_RIGHT {#BOTTOM-RIGHT}
+```
+public static final int BOTTOM_RIGHT
+```
+
+
+Unten rechts.
+
+### LEFT {#LEFT}
+```
+public static final int LEFT
+```
+
+
+Links.
+
+### RIGHT {#RIGHT}
+```
+public static final int RIGHT
+```
+
+
+Rechts.
+
+### TOP {#TOP}
+```
+public static final int TOP
+```
+
+
+Oben.
+
+### TOP_LEFT {#TOP-LEFT}
+```
+public static final int TOP_LEFT
+```
+
+
+Oben links.
+
+### TOP_RIGHT {#TOP-RIGHT}
+```
+public static final int TOP_RIGHT
+```
+
+
+Oben rechts.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/line/_index.md
+++ b/german/java/com.aspose.diagram/line/_index.md
@@ -1,0 +1,447 @@
+---
+title: Line
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält Elemente, die allgemeine Positionsinformationen zu einer Form angeben.
+type: docs
+weight: 221
+url: /de/java/com.aspose.diagram/line/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Line
+```
+
+Enthält Elemente, die allgemeine Positionsinformationen zu einer Form angeben.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBeginArrow()](#getBeginArrow--) | Gibt an, ob eine Linie an ihrem ersten Scheitelpunkt einen Pfeilkopf oder ein anderes Linienende-Format hat. |
+| [getBeginArrowSize()](#getBeginArrowSize--) | Bestimmt die Größe des Pfeilkopfes am Anfang der Linie. |
+| [getClass()](#getClass--) |  |
+| [getCompoundType()](#getCompoundType--) | Gibt den Linien-CompoundType der Form an. |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getEndArrow()](#getEndArrow--) | Gibt an, ob eine Linie an ihrem letzten Scheitelpunkt einen Pfeilkopf oder ein anderes Linienende-Format hat. |
+| [getEndArrowSize()](#getEndArrowSize--) | Gibt die Größe des Pfeilkopfes am Ende der Linie an. |
+| [getGradientLine()](#getGradientLine--) | Enthält die aktuellen Farbverlaufs-Linienformatierungswerte für die Form |
+| [getLineCap()](#getLineCap--) | Gibt an, ob eine Linie abgerundete oder eckige Linienenden hat. |
+| [getLineColor()](#getLineColor--) | Gibt die Linienfarbe der Form an. |
+| [getLineColorTrans()](#getLineColorTrans--) | Gibt den Transparenzgrad der Linienfarbe einer Form an, von 0 (undurchsichtig) bis 1 (vollständig transparent). |
+| [getLinePattern()](#getLinePattern--) | Gibt das Linienmuster der Form an |
+| [getLineWeight()](#getLineWeight--) | Gibt die Linienstärke einer Form an. |
+| [getRounding()](#getRounding--) | Gibt den Radius des Abrundungsbogens an, der dort angewendet wird, wo zwei zusammenhängende Segmente eines Pfades aufeinandertreffen. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setBeginArrow(IntValue value)](#setBeginArrow-com.aspose.diagram.IntValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getBeginArrow()](../../com.aspose.diagram/line\#getBeginArrow--) |
+| [setBeginArrowSize(ArrowSize value)](#setBeginArrowSize-com.aspose.diagram.ArrowSize-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getBeginArrowSize()](../../com.aspose.diagram/line\#getBeginArrowSize--) |
+| [setCompoundType(CompoundType value)](#setCompoundType-com.aspose.diagram.CompoundType-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getCompoundType()](../../com.aspose.diagram/line\#getCompoundType--) |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/line\#getDel--) |
+| [setEndArrow(IntValue value)](#setEndArrow-com.aspose.diagram.IntValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getEndArrow()](../../com.aspose.diagram/line\#getEndArrow--) |
+| [setEndArrowSize(ArrowSize value)](#setEndArrowSize-com.aspose.diagram.ArrowSize-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getEndArrowSize()](../../com.aspose.diagram/line\#getEndArrowSize--) |
+| [setLineCap(BoolValue value)](#setLineCap-com.aspose.diagram.BoolValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getLineCap()](../../com.aspose.diagram/line\#getLineCap--) |
+| [setLineColor(ColorValue value)](#setLineColor-com.aspose.diagram.ColorValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getLineColor()](../../com.aspose.diagram/line\#getLineColor--) |
+| [setLineColorTrans(DoubleValue value)](#setLineColorTrans-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getLineColorTrans()](../../com.aspose.diagram/line\#getLineColorTrans--) |
+| [setLinePattern(IntValue value)](#setLinePattern-com.aspose.diagram.IntValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getLinePattern()](../../com.aspose.diagram/line\#getLinePattern--) |
+| [setLineWeight(DoubleValue value)](#setLineWeight-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getLineWeight()](../../com.aspose.diagram/line\#getLineWeight--) |
+| [setRounding(DoubleValue value)](#setRounding-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getRounding()](../../com.aspose.diagram/line\#getRounding--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBeginArrow() {#getBeginArrow--}
+```
+public IntValue getBeginArrow()
+```
+
+
+Gibt an, ob eine Linie an ihrem ersten Scheitelpunkt einen Pfeilkopf oder ein anderes Linienende-Format hat. Geben Sie eine Zahl von 0 bis 45 ein oder die USE‑Funktion mit dem Namen eines benutzerdefinierten Linienendes.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getBeginArrowSize() {#getBeginArrowSize--}
+```
+public ArrowSize getBeginArrowSize()
+```
+
+
+Bestimmt die Größe der Pfeilspitze am Anfang der Linie. Geben Sie eine Zahl von 0 bis 6 ein.
+
+**Returns:**
+[ArrowSize](../../com.aspose.diagram/arrowsize)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCompoundType() {#getCompoundType--}
+```
+public CompoundType getCompoundType()
+```
+
+
+Gibt den Linien-CompoundType der Form an.
+
+**Returns:**
+[CompoundType](../../com.aspose.diagram/compoundtype)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getEndArrow() {#getEndArrow--}
+```
+public IntValue getEndArrow()
+```
+
+
+Gibt an, ob eine Linie an ihrem letzten Scheitelpunkt einen Pfeilkopf oder ein anderes Linienende-Format hat.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getEndArrowSize() {#getEndArrowSize--}
+```
+public ArrowSize getEndArrowSize()
+```
+
+
+Gibt die Größe des Pfeilkopfes am Ende der Linie an.
+
+**Returns:**
+[ArrowSize](../../com.aspose.diagram/arrowsize)
+### getGradientLine() {#getGradientLine--}
+```
+public GradientFill getGradientLine()
+```
+
+
+Enthält die aktuellen Farbverlaufs-Linienformatierungswerte für die Form
+
+**Returns:**
+[GradientFill](../../com.aspose.diagram/gradientfill)
+### getLineCap() {#getLineCap--}
+```
+public BoolValue getLineCap()
+```
+
+
+Gibt an, ob eine Linie abgerundete oder eckige Linienenden hat.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLineColor() {#getLineColor--}
+```
+public ColorValue getLineColor()
+```
+
+
+Gibt die Linienfarbe der Form an.
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getLineColorTrans() {#getLineColorTrans--}
+```
+public DoubleValue getLineColorTrans()
+```
+
+
+Gibt den Transparenzgrad der Linienfarbe einer Form an, von 0 (undurchsichtig) bis 1 (vollständig transparent). Der Standardwert ist 0.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLinePattern() {#getLinePattern--}
+```
+public IntValue getLinePattern()
+```
+
+
+Gibt das Linienmuster der Form an
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getLineWeight() {#getLineWeight--}
+```
+public DoubleValue getLineWeight()
+```
+
+
+Gibt die Linienstärke einer Form an. Die Linienstärke ist unabhängig vom Maßstab der Zeichnung. Wird die Zeichnung skaliert, bleibt die Linienstärke unverändert.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getRounding() {#getRounding--}
+```
+public DoubleValue getRounding()
+```
+
+
+Gibt den Radius des Abrundungsbogens an, der dort angewendet wird, wo zwei zusammenhängende Segmente eines Pfades aufeinandertreffen. Beispielsweise kann die Abrundung verwendet werden, um einem Rechteck abgerundete Ecken zu geben.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setBeginArrow(IntValue value) {#setBeginArrow-com.aspose.diagram.IntValue-}
+```
+public void setBeginArrow(IntValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getBeginArrow()](../../com.aspose.diagram/line\#getBeginArrow--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setBeginArrowSize(ArrowSize value) {#setBeginArrowSize-com.aspose.diagram.ArrowSize-}
+```
+public void setBeginArrowSize(ArrowSize value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getBeginArrowSize()](../../com.aspose.diagram/line\#getBeginArrowSize--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [ArrowSize](../../com.aspose.diagram/arrowsize) |  |
+
+### setCompoundType(CompoundType value) {#setCompoundType-com.aspose.diagram.CompoundType-}
+```
+public void setCompoundType(CompoundType value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getCompoundType()](../../com.aspose.diagram/line\#getCompoundType--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [CompoundType](../../com.aspose.diagram/compoundtype) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/line\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setEndArrow(IntValue value) {#setEndArrow-com.aspose.diagram.IntValue-}
+```
+public void setEndArrow(IntValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getEndArrow()](../../com.aspose.diagram/line\#getEndArrow--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setEndArrowSize(ArrowSize value) {#setEndArrowSize-com.aspose.diagram.ArrowSize-}
+```
+public void setEndArrowSize(ArrowSize value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getEndArrowSize()](../../com.aspose.diagram/line\#getEndArrowSize--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [ArrowSize](../../com.aspose.diagram/arrowsize) |  |
+
+### setLineCap(BoolValue value) {#setLineCap-com.aspose.diagram.BoolValue-}
+```
+public void setLineCap(BoolValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getLineCap()](../../com.aspose.diagram/line\#getLineCap--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setLineColor(ColorValue value) {#setLineColor-com.aspose.diagram.ColorValue-}
+```
+public void setLineColor(ColorValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getLineColor()](../../com.aspose.diagram/line\#getLineColor--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setLineColorTrans(DoubleValue value) {#setLineColorTrans-com.aspose.diagram.DoubleValue-}
+```
+public void setLineColorTrans(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getLineColorTrans()](../../com.aspose.diagram/line\#getLineColorTrans--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setLinePattern(IntValue value) {#setLinePattern-com.aspose.diagram.IntValue-}
+```
+public void setLinePattern(IntValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getLinePattern()](../../com.aspose.diagram/line\#getLinePattern--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setLineWeight(DoubleValue value) {#setLineWeight-com.aspose.diagram.DoubleValue-}
+```
+public void setLineWeight(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getLineWeight()](../../com.aspose.diagram/line\#getLineWeight--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setRounding(DoubleValue value) {#setRounding-com.aspose.diagram.DoubleValue-}
+```
+public void setRounding(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getRounding()](../../com.aspose.diagram/line\#getRounding--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/lineadjustfrom/_index.md
+++ b/german/java/com.aspose.diagram/lineadjustfrom/_index.md
@@ -1,0 +1,179 @@
+---
+title: LineAdjustFrom
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt an, welche dynamischen Verbinder auseinandergezogen werden sollen, wenn sie übereinander geroutet werden.
+type: docs
+weight: 222
+url: /de/java/com.aspose.diagram/lineadjustfrom/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LineAdjustFrom
+```
+
+Gibt an, welche dynamischen Verbinder auseinandergezogen werden sollen, wenn sie übereinander geroutet werden.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [LineAdjustFrom(int value)](#LineAdjustFrom-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Gibt an, welche dynamischen Verbinder auseinandergezogen werden sollen, wenn sie übereinander geroutet werden. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/lineadjustfrom\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LineAdjustFrom(int value) {#LineAdjustFrom-int-}
+```
+public LineAdjustFrom(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Gibt an, welche dynamischen Verbinder auseinandergezogen werden sollen, wenn sie übereinander geroutet werden.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/lineadjustfrom\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/lineadjustfromvalue/_index.md
+++ b/german/java/com.aspose.diagram/lineadjustfromvalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: LineAdjustFromValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt an, welche dynamischen Verbinder auseinandergezogen werden sollen, wenn sie übereinander geroutet werden.
+type: docs
+weight: 223
+url: /de/java/com.aspose.diagram/lineadjustfromvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LineAdjustFromValue
+```
+
+Gibt an, welche dynamischen Verbinder auseinandergezogen werden sollen, wenn sie übereinander geroutet werden.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [ALL_LINES](#ALL-LINES) | Alle Linien. |
+| [NO_LINES](#NO-LINES) | Keine Linien. |
+| [ROUTING_STYLE_DEFAULT](#ROUTING-STYLE-DEFAULT) | Standard-Routing-Stil. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+| [UNRELATED_LINES](#UNRELATED-LINES) | Unzusammenhängende Zeilen. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALL_LINES {#ALL-LINES}
+```
+public static final int ALL_LINES
+```
+
+
+Alle Linien.
+
+### NO_LINES {#NO-LINES}
+```
+public static final int NO_LINES
+```
+
+
+Keine Linien.
+
+### ROUTING_STYLE_DEFAULT {#ROUTING-STYLE-DEFAULT}
+```
+public static final int ROUTING_STYLE_DEFAULT
+```
+
+
+Standard-Routing-Stil.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### UNRELATED_LINES {#UNRELATED-LINES}
+```
+public static final int UNRELATED_LINES
+```
+
+
+Unzusammenhängende Zeilen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/lineadjustto/_index.md
+++ b/german/java/com.aspose.diagram/lineadjustto/_index.md
@@ -1,0 +1,179 @@
+---
+title: LineAdjustTo
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt an, welche dynamischen Verbinder übereinander ausgerichtet werden sollen, wenn sie übereinander geroutet werden.
+type: docs
+weight: 224
+url: /de/java/com.aspose.diagram/lineadjustto/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LineAdjustTo
+```
+
+Gibt an, welche dynamischen Verbinder übereinander ausgerichtet werden sollen, wenn sie übereinander geroutet werden.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [LineAdjustTo(int value)](#LineAdjustTo-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Gibt an, welche dynamischen Verbinder übereinander ausgerichtet werden sollen, wenn sie übereinander geroutet werden. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/lineadjustto\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LineAdjustTo(int value) {#LineAdjustTo-int-}
+```
+public LineAdjustTo(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Gibt an, welche dynamischen Verbinder übereinander ausgerichtet werden sollen, wenn sie übereinander geroutet werden.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/lineadjustto\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/lineadjusttovalue/_index.md
+++ b/german/java/com.aspose.diagram/lineadjusttovalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: LineAdjustToValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt an, welche dynamischen Verbinder übereinander ausgerichtet werden sollen, wenn sie übereinander geroutet werden.
+type: docs
+weight: 225
+url: /de/java/com.aspose.diagram/lineadjusttovalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LineAdjustToValue
+```
+
+Gibt an, welche dynamischen Verbinder übereinander ausgerichtet werden sollen, wenn sie übereinander geroutet werden.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [ALL_LINES_CLOSE](#ALL-LINES-CLOSE) | Alle Linien, die nahe beieinander liegen. |
+| [NO_LINES](#NO-LINES) | Keine Linien. |
+| [RELATEDLINES](#RELATEDLINES) | Verwandte Linien. |
+| [ROUTING_STYLE_DEFAULT](#ROUTING-STYLE-DEFAULT) | Standard-Routing-Stil. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALL_LINES_CLOSE {#ALL-LINES-CLOSE}
+```
+public static final int ALL_LINES_CLOSE
+```
+
+
+Alle Linien, die nahe beieinander liegen.
+
+### NO_LINES {#NO-LINES}
+```
+public static final int NO_LINES
+```
+
+
+Keine Linien.
+
+### RELATEDLINES {#RELATEDLINES}
+```
+public static final int RELATEDLINES
+```
+
+
+Verwandte Linien.
+
+### ROUTING_STYLE_DEFAULT {#ROUTING-STYLE-DEFAULT}
+```
+public static final int ROUTING_STYLE_DEFAULT
+```
+
+
+Standard-Routing-Stil.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/linejumpcode/_index.md
+++ b/german/java/com.aspose.diagram/linejumpcode/_index.md
@@ -1,0 +1,179 @@
+---
+title: LineJumpCode
+second_title: Aspose.Diagram for Java API-Referenz
+description: Bestimmt die dynamischen Verbinder, zu denen Sprünge hinzugefügt werden sollen.
+type: docs
+weight: 226
+url: /de/java/com.aspose.diagram/linejumpcode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LineJumpCode
+```
+
+Bestimmt die dynamischen Verbinder, zu denen Sprünge hinzugefügt werden sollen.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [LineJumpCode(int value)](#LineJumpCode-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Bestimmt die dynamischen Verbinder, zu denen Sprünge hinzugefügt werden sollen. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/linejumpcode\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LineJumpCode(int value) {#LineJumpCode-int-}
+```
+public LineJumpCode(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Bestimmt die dynamischen Verbinder, zu denen Sprünge hinzugefügt werden sollen.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/linejumpcode\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/linejumpcodevalue/_index.md
+++ b/german/java/com.aspose.diagram/linejumpcodevalue/_index.md
@@ -1,0 +1,192 @@
+---
+title: LineJumpCodeValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Bestimmt die dynamischen Verbinder, zu denen Sprünge hinzugefügt werden sollen.
+type: docs
+weight: 227
+url: /de/java/com.aspose.diagram/linejumpcodevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LineJumpCodeValue
+```
+
+Bestimmt die dynamischen Verbinder, zu denen Sprünge hinzugefügt werden sollen.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [FIRST_DISPLAYED_LINE](#FIRST-DISPLAYED-LINE) | Erste angezeigte Linie (untere Form in der Anzeigereihenfolge). |
+| [HORIZONTAL_LINES](#HORIZONTAL-LINES) | Horizontale Linien. |
+| [LAST_DISPLAYED_LINE](#LAST-DISPLAYED-LINE) | Letzte angezeigte Linie (obere Form in der Anzeigereihenfolge). |
+| [LAST_ROUTED_LINE](#LAST-ROUTED-LINE) | Letzte geroutete Linie. |
+| [NONE](#NONE) | Keine. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+| [VERTICAL_LINES](#VERTICAL-LINES) | Vertikale Linien. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FIRST_DISPLAYED_LINE {#FIRST-DISPLAYED-LINE}
+```
+public static final int FIRST_DISPLAYED_LINE
+```
+
+
+Erste angezeigte Linie (untere Form in der Anzeigereihenfolge).
+
+### HORIZONTAL_LINES {#HORIZONTAL-LINES}
+```
+public static final int HORIZONTAL_LINES
+```
+
+
+Horizontale Linien.
+
+### LAST_DISPLAYED_LINE {#LAST-DISPLAYED-LINE}
+```
+public static final int LAST_DISPLAYED_LINE
+```
+
+
+Letzte angezeigte Linie (obere Form in der Anzeigereihenfolge).
+
+### LAST_ROUTED_LINE {#LAST-ROUTED-LINE}
+```
+public static final int LAST_ROUTED_LINE
+```
+
+
+Letzte geroutete Linie.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Keine.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### VERTICAL_LINES {#VERTICAL-LINES}
+```
+public static final int VERTICAL_LINES
+```
+
+
+Vertikale Linien.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/linejumpstyle/_index.md
+++ b/german/java/com.aspose.diagram/linejumpstyle/_index.md
@@ -1,0 +1,179 @@
+---
+title: LineJumpStyle
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt den Zeilensprungstil für alle Verbinder auf der Zeichenfläche an, die keinen lokalen Zeilensprungstil haben.
+type: docs
+weight: 228
+url: /de/java/com.aspose.diagram/linejumpstyle/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LineJumpStyle
+```
+
+Gibt den Linien‑Sprungstil für alle Verbinder auf der Zeichen‑Seite an, die keinen lokalen Linien‑Sprungstil haben.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [LineJumpStyle(int value)](#LineJumpStyle-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Gibt den Linien‑Sprungstil für alle Verbinder auf der Zeichen‑Seite an, die keinen lokalen Linien‑Sprungstil haben. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/linejumpstyle\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LineJumpStyle(int value) {#LineJumpStyle-int-}
+```
+public LineJumpStyle(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Gibt den Linien‑Sprungstil für alle Verbinder auf der Zeichen‑Seite an, die keinen lokalen Linien‑Sprungstil haben.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/linejumpstyle\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/linejumpstylevalue/_index.md
+++ b/german/java/com.aspose.diagram/linejumpstylevalue/_index.md
@@ -1,0 +1,228 @@
+---
+title: LineJumpStyleValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt den Zeilensprungstil für alle Verbinder auf der Zeichenfläche an, die keinen lokalen Zeilensprungstil haben.
+type: docs
+weight: 229
+url: /de/java/com.aspose.diagram/linejumpstylevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LineJumpStyleValue
+```
+
+Gibt den Linien‑Sprungstil für alle Verbinder auf der Zeichen‑Seite an, die keinen lokalen Linien‑Sprungstil haben.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [ARC](#ARC) | Bogen. |
+| [DEFAULT](#DEFAULT) | Standard. |
+| [GAP](#GAP) | Lücke. |
+| [SIDES_2](#SIDES-2) | 2 Seiten. |
+| [SIDES_3](#SIDES-3) | 3 Seiten. |
+| [SIDES_4](#SIDES-4) | 4 Seiten. |
+| [SIDES_5](#SIDES-5) | 5 Seiten. |
+| [SIDES_6](#SIDES-6) | 6 Seiten. |
+| [SIDES_7](#SIDES-7) | 7 Seiten. |
+| [SQUARE](#SQUARE) | Quadrat. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ARC {#ARC}
+```
+public static final int ARC
+```
+
+
+Bogen.
+
+### DEFAULT {#DEFAULT}
+```
+public static final int DEFAULT
+```
+
+
+Standard.
+
+### GAP {#GAP}
+```
+public static final int GAP
+```
+
+
+Lücke.
+
+### SIDES_2 {#SIDES-2}
+```
+public static final int SIDES_2
+```
+
+
+2 Seiten.
+
+### SIDES_3 {#SIDES-3}
+```
+public static final int SIDES_3
+```
+
+
+3 Seiten.
+
+### SIDES_4 {#SIDES-4}
+```
+public static final int SIDES_4
+```
+
+
+4 Seiten.
+
+### SIDES_5 {#SIDES-5}
+```
+public static final int SIDES_5
+```
+
+
+5 Seiten.
+
+### SIDES_6 {#SIDES-6}
+```
+public static final int SIDES_6
+```
+
+
+6 Seiten.
+
+### SIDES_7 {#SIDES-7}
+```
+public static final int SIDES_7
+```
+
+
+7 Seiten.
+
+### SQUARE {#SQUARE}
+```
+public static final int SQUARE
+```
+
+
+Quadrat.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/linerouteext/_index.md
+++ b/german/java/com.aspose.diagram/linerouteext/_index.md
@@ -1,0 +1,179 @@
+---
+title: LineRouteExt
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt das Standard‑Aussehen für alle Verbinder auf einer Seite an.
+type: docs
+weight: 230
+url: /de/java/com.aspose.diagram/linerouteext/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LineRouteExt
+```
+
+Gibt das Standard‑Aussehen für alle Verbinder auf einer Seite an.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [LineRouteExt(int value)](#LineRouteExt-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Gibt das Standard‑Aussehen für alle Verbinder auf einer Seite an. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/linerouteext\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LineRouteExt(int value) {#LineRouteExt-int-}
+```
+public LineRouteExt(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Gibt das Standard‑Aussehen für alle Verbinder auf einer Seite an.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/linerouteext\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/linerouteextvalue/_index.md
+++ b/german/java/com.aspose.diagram/linerouteextvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: LineRouteExtValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt das Standard‑Aussehen für alle Verbinder auf einer Seite an.
+type: docs
+weight: 231
+url: /de/java/com.aspose.diagram/linerouteextvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LineRouteExtValue
+```
+
+Gibt das Standard‑Aussehen für alle Verbinder auf einer Seite an.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [CURVED](#CURVED) | Gekrümmt. |
+| [DEFAULT](#DEFAULT) | Standard. |
+| [STRAIGHT](#STRAIGHT) | Gerade. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CURVED {#CURVED}
+```
+public static final int CURVED
+```
+
+
+Gekrümmt.
+
+### DEFAULT {#DEFAULT}
+```
+public static final int DEFAULT
+```
+
+
+Standard.
+
+### STRAIGHT {#STRAIGHT}
+```
+public static final int STRAIGHT
+```
+
+
+Gerade.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/lineto/_index.md
+++ b/german/java/com.aspose.diagram/lineto/_index.md
@@ -1,0 +1,249 @@
+---
+title: LineTo
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält die x- und y-Koordinaten des Endknotens eines geraden Liniensegments.
+type: docs
+weight: 232
+url: /de/java/com.aspose.diagram/lineto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class LineTo extends Coordinate
+```
+
+Enthält x- und y-Koordinaten des Endknotens eines geraden Liniensegments. Diese Koordinaten sind jeweils in den X- und Y-Elementen enthalten.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [LineTo()](#LineTo--) | Creates an instance of the [LineTo](../../com.aspose.diagram/lineto) class. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getIX()](#getIX--) | Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements. |
+| [getX()](#getX--) | The x-coordinate of the ending vertex of a straight line segment. |
+| [getY()](#getY--) | The y-coordinate of the ending vertex of a straight line segment. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/lineto\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getIX()](../../com.aspose.diagram/lineto\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getX()](../../com.aspose.diagram/lineto\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getY()](../../com.aspose.diagram/lineto\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LineTo() {#LineTo--}
+```
+public LineTo()
+```
+
+
+Creates an instance of the [LineTo](../../com.aspose.diagram/lineto) class.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+The x-coordinate of the ending vertex of a straight line segment.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+The y-coordinate of the ending vertex of a straight line segment.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/lineto\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getIX()](../../com.aspose.diagram/lineto\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getX()](../../com.aspose.diagram/lineto\#getX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getY()](../../com.aspose.diagram/lineto\#getY--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/linetocollection/_index.md
+++ b/german/java/com.aspose.diagram/linetocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: LineToCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: LineTo-Sammlung.
+type: docs
+weight: 233
+url: /de/java/com.aspose.diagram/linetocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class LineToCollection extends Collection
+```
+
+LineTo-Sammlung.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public LineTo get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[LineTo](../../com.aspose.diagram/lineto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/listboxactivexcontrol/_index.md
+++ b/german/java/com.aspose.diagram/listboxactivexcontrol/_index.md
@@ -1,0 +1,772 @@
+---
+title: ListBoxActiveXControl
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt ein ListBox ActiveX-Steuerelement dar.
+type: docs
+weight: 234
+url: /de/java/com.aspose.diagram/listboxactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class ListBoxActiveXControl extends ActiveXControl
+```
+
+Stellt ein ListBox ActiveX-Steuerelement dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBackOleColor()](#getBackOleColor--) | die OLE‑Farbe des Hintergrunds. |
+| [getBorderOleColor()](#getBorderOleColor--) | die OLE‑Farbe des Hintergrunds. |
+| [getBorderStyle()](#getBorderStyle--) | der von dem Steuerelement verwendete Randtyp. |
+| [getBoundColumn()](#getBoundColumn--) | Gibt an, wie die Value‑Eigenschaft für ein ComboBox‑ oder ListBox‑Steuerelement bestimmt wird, wenn der Wert der MultiSelect‑Eigenschaft (fmMultiSelectSingle) ist. |
+| [getClass()](#getClass--) |  |
+| [getColumnCount()](#getColumnCount--) | Gibt die Anzahl der Spalten an, die in einem ComboBox‑ oder ListBox‑Steuerelement angezeigt werden. |
+| [getColumnWidths()](#getColumnWidths--) | die Breite der Spalte. |
+| [getData()](#getData--) | die Binärdaten des Steuerelements. |
+| [getForeOleColor()](#getForeOleColor--) | die OLE‑Farbe des Vordergrunds. |
+| [getHeight()](#getHeight--) | die Höhe des Steuerelements in Punkt‑Einheiten. |
+| [getIMEMode()](#getIMEMode--) | der Standard‑Laufzeitmodus des Input Method Editors für das Steuerelement, wenn es den Fokus erhält. |
+| [getIntegralHeight()](#getIntegralHeight--) | Gibt an, ob das Steuerelement nur vollständige Textzeilen anzeigt, ohne Teilzeilen anzuzeigen. |
+| [getListStyle()](#getListStyle--) | das visuelle Erscheinungsbild. |
+| [getListWidth()](#getListWidth--) | die Breite in Punkt-Einheiten. |
+| [getMatchEntry()](#getMatchEntry--) | Gibt an, wie eine ListBox oder ComboBox ihre Liste durchsucht, während der Benutzer tippt. |
+| [getMouseIcon()](#getMouseIcon--) | ein benutzerdefiniertes Symbol, das als Mauszeiger für das Steuerelement angezeigt wird. |
+| [getMousePointer()](#getMousePointer--) | der Typ des als Mauszeiger für das Steuerelement angezeigten Symbols. |
+| [getScrollBars()](#getScrollBars--) | Gibt an, ob das Steuerelement vertikale Bildlaufleisten, horizontale Bildlaufleisten, beides oder keine hat. |
+| [getShowColumnHeads()](#getShowColumnHeads--) | Gibt an, ob Spaltenüberschriften angezeigt werden. |
+| [getSpecialEffect()](#getSpecialEffect--) | der Spezialeffekt des Steuerelements. |
+| [getTextColumn()](#getTextColumn--) | Stellt die Spalte in einer ComboBox oder ListBox dar, die dem Benutzer angezeigt wird. |
+| [getType()](#getType--) | Ermittelt den Typ des ActiveX-Steuerelements. |
+| [getValue()](#getValue--) | der Wert des Steuerelements. |
+| [getWidth()](#getWidth--) | die Breite des Steuerelements in Punkt-Einheiten. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | Gibt an, ob das Steuerelement automatisch die Größe ändert, um seinen gesamten Inhalt anzuzeigen. |
+| [isEnabled()](#isEnabled--) | Gibt an, ob das Steuerelement den Fokus erhalten und auf benutzergenerierte Ereignisse reagieren kann. |
+| [isLocked()](#isLocked--) | Gibt an, ob Daten im Steuerelement für die Bearbeitung gesperrt sind. |
+| [isTransparent()](#isTransparent--) | Gibt an, ob das Steuerelement transparent ist. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setBorderOleColor(int value)](#setBorderOleColor-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getBorderOleColor()](../../com.aspose.diagram/listboxactivexcontrol\#getBorderOleColor--) |
+| [setBorderStyle(int value)](#setBorderStyle-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getBorderStyle()](../../com.aspose.diagram/listboxactivexcontrol\#getBorderStyle--) |
+| [setBoundColumn(int value)](#setBoundColumn-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getBoundColumn()](../../com.aspose.diagram/listboxactivexcontrol\#getBoundColumn--) |
+| [setColumnCount(int value)](#setColumnCount-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getColumnCount()](../../com.aspose.diagram/listboxactivexcontrol\#getColumnCount--) |
+| [setColumnWidths(double value)](#setColumnWidths-double-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getColumnWidths()](../../com.aspose.diagram/listboxactivexcontrol\#getColumnWidths--) |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setHeight(double value)](#setHeight-double-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setIMEMode(int value)](#setIMEMode-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) |
+| [setIntegralHeight(boolean value)](#setIntegralHeight-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getIntegralHeight()](../../com.aspose.diagram/listboxactivexcontrol\#getIntegralHeight--) |
+| [setListStyle(int value)](#setListStyle-int-) | Für die Beschreibung dieser Eigenschaft, bitte siehe [getListStyle()](../../com.aspose.diagram/listboxactivexcontrol\#getListStyle--) |
+| [setListWidth(double value)](#setListWidth-double-) | Für die Beschreibung dieser Eigenschaft, bitte siehe [getListWidth()](../../com.aspose.diagram/listboxactivexcontrol\#getListWidth--) |
+| [setLocked(boolean value)](#setLocked-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) |
+| [setMatchEntry(int value)](#setMatchEntry-int-) | Für die Beschreibung dieser Eigenschaft, bitte siehe [getMatchEntry()](../../com.aspose.diagram/listboxactivexcontrol\#getMatchEntry--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | Für die Beschreibung dieser Eigenschaft siehe bitte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setScrollBars(int value)](#setScrollBars-int-) | Für die Beschreibung dieser Eigenschaft, bitte siehe [getScrollBars()](../../com.aspose.diagram/listboxactivexcontrol\#getScrollBars--) |
+| [setShowColumnHeads(boolean value)](#setShowColumnHeads-boolean-) | Für die Beschreibung dieser Eigenschaft, bitte siehe [getShowColumnHeads()](../../com.aspose.diagram/listboxactivexcontrol\#getShowColumnHeads--) |
+| [setSpecialEffect(int value)](#setSpecialEffect-int-) | Für die Beschreibung dieser Eigenschaft, bitte siehe [getSpecialEffect()](../../com.aspose.diagram/listboxactivexcontrol\#getSpecialEffect--) |
+| [setTextColumn(int value)](#setTextColumn-int-) | Für die Beschreibung dieser Eigenschaft, bitte siehe [getTextColumn()](../../com.aspose.diagram/listboxactivexcontrol\#getTextColumn--) |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) |
+| [setValue(String value)](#setValue-java.lang.String-) | Für die Beschreibung dieser Eigenschaft, bitte siehe [getValue()](../../com.aspose.diagram/listboxactivexcontrol\#getValue--) |
+| [setWidth(double value)](#setWidth-double-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+die OLE‑Farbe des Hintergrunds.
+
+**Returns:**
+int
+### getBorderOleColor() {#getBorderOleColor--}
+```
+public int getBorderOleColor()
+```
+
+
+die OLE‑Farbe des Hintergrunds.
+
+**Returns:**
+int
+### getBorderStyle() {#getBorderStyle--}
+```
+public int getBorderStyle()
+```
+
+
+der von dem Steuerelement verwendete Randtyp.
+
+**Returns:**
+int
+### getBoundColumn() {#getBoundColumn--}
+```
+public int getBoundColumn()
+```
+
+
+Gibt an, wie die Value‑Eigenschaft für ein ComboBox‑ oder ListBox‑Steuerelement bestimmt wird, wenn der Wert der MultiSelect‑Eigenschaft (fmMultiSelectSingle) ist.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColumnCount() {#getColumnCount--}
+```
+public int getColumnCount()
+```
+
+
+Gibt die Anzahl der Spalten an, die in einem ComboBox‑ oder ListBox‑Steuerelement angezeigt werden.
+
+**Returns:**
+int
+### getColumnWidths() {#getColumnWidths--}
+```
+public double getColumnWidths()
+```
+
+
+die Breite der Spalte.
+
+**Returns:**
+double
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+die Binärdaten des Steuerelements.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+Die OLE-Farbe des Vordergrunds. Gilt nicht für das Image-Steuerelement.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+die Höhe des Steuerelements in Punkt‑Einheiten.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+der Standard‑Laufzeitmodus des Input Method Editors für das Steuerelement, wenn es den Fokus erhält.
+
+**Returns:**
+int
+### getIntegralHeight() {#getIntegralHeight--}
+```
+public boolean getIntegralHeight()
+```
+
+
+Gibt an, ob das Steuerelement nur vollständige Textzeilen anzeigt, ohne Teilzeilen anzuzeigen.
+
+**Returns:**
+boolean
+### getListStyle() {#getListStyle--}
+```
+public int getListStyle()
+```
+
+
+das visuelle Erscheinungsbild.
+
+**Returns:**
+int
+### getListWidth() {#getListWidth--}
+```
+public double getListWidth()
+```
+
+
+die Breite in Punkt-Einheiten.
+
+**Returns:**
+double
+### getMatchEntry() {#getMatchEntry--}
+```
+public int getMatchEntry()
+```
+
+
+Gibt an, wie eine ListBox oder ComboBox ihre Liste durchsucht, während der Benutzer tippt.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+ein benutzerdefiniertes Symbol, das als Mauszeiger für das Steuerelement angezeigt wird.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+der Typ des als Mauszeiger für das Steuerelement angezeigten Symbols.
+
+**Returns:**
+int
+### getScrollBars() {#getScrollBars--}
+```
+public int getScrollBars()
+```
+
+
+Gibt an, ob das Steuerelement vertikale Bildlaufleisten, horizontale Bildlaufleisten, beides oder keine hat.
+
+**Returns:**
+int
+### getShowColumnHeads() {#getShowColumnHeads--}
+```
+public boolean getShowColumnHeads()
+```
+
+
+Gibt an, ob Spaltenüberschriften angezeigt werden.
+
+**Returns:**
+boolean
+### getSpecialEffect() {#getSpecialEffect--}
+```
+public int getSpecialEffect()
+```
+
+
+der Spezialeffekt des Steuerelements.
+
+**Returns:**
+int
+### getTextColumn() {#getTextColumn--}
+```
+public int getTextColumn()
+```
+
+
+Stellt die Spalte in einer ComboBox oder ListBox dar, die dem Benutzer angezeigt wird.
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Ermittelt den Typ des ActiveX-Steuerelements.
+
+**Returns:**
+int
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+der Wert des Steuerelements.
+
+**Returns:**
+java.lang.String
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+die Breite des Steuerelements in Punkt-Einheiten.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+Gibt an, ob das Steuerelement automatisch die Größe ändert, um seinen gesamten Inhalt anzuzeigen.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+Gibt an, ob das Steuerelement den Fokus erhalten und auf benutzergenerierte Ereignisse reagieren kann.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+Gibt an, ob Daten im Steuerelement für die Bearbeitung gesperrt sind.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+Gibt an, ob das Steuerelement transparent ist.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setBorderOleColor(int value) {#setBorderOleColor-int-}
+```
+public void setBorderOleColor(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getBorderOleColor()](../../com.aspose.diagram/listboxactivexcontrol\#getBorderOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setBorderStyle(int value) {#setBorderStyle-int-}
+```
+public void setBorderStyle(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getBorderStyle()](../../com.aspose.diagram/listboxactivexcontrol\#getBorderStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setBoundColumn(int value) {#setBoundColumn-int-}
+```
+public void setBoundColumn(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getBoundColumn()](../../com.aspose.diagram/listboxactivexcontrol\#getBoundColumn--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setColumnCount(int value) {#setColumnCount-int-}
+```
+public void setColumnCount(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getColumnCount()](../../com.aspose.diagram/listboxactivexcontrol\#getColumnCount--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setColumnWidths(double value) {#setColumnWidths-double-}
+```
+public void setColumnWidths(double value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getColumnWidths()](../../com.aspose.diagram/listboxactivexcontrol\#getColumnWidths--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setIntegralHeight(boolean value) {#setIntegralHeight-boolean-}
+```
+public void setIntegralHeight(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getIntegralHeight()](../../com.aspose.diagram/listboxactivexcontrol\#getIntegralHeight--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setListStyle(int value) {#setListStyle-int-}
+```
+public void setListStyle(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft, bitte siehe [getListStyle()](../../com.aspose.diagram/listboxactivexcontrol\#getListStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setListWidth(double value) {#setListWidth-double-}
+```
+public void setListWidth(double value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft, bitte siehe [getListWidth()](../../com.aspose.diagram/listboxactivexcontrol\#getListWidth--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setMatchEntry(int value) {#setMatchEntry-int-}
+```
+public void setMatchEntry(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft, bitte siehe [getMatchEntry()](../../com.aspose.diagram/listboxactivexcontrol\#getMatchEntry--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setScrollBars(int value) {#setScrollBars-int-}
+```
+public void setScrollBars(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft, bitte siehe [getScrollBars()](../../com.aspose.diagram/listboxactivexcontrol\#getScrollBars--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setShowColumnHeads(boolean value) {#setShowColumnHeads-boolean-}
+```
+public void setShowColumnHeads(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft, bitte siehe [getShowColumnHeads()](../../com.aspose.diagram/listboxactivexcontrol\#getShowColumnHeads--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setSpecialEffect(int value) {#setSpecialEffect-int-}
+```
+public void setSpecialEffect(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft, bitte siehe [getSpecialEffect()](../../com.aspose.diagram/listboxactivexcontrol\#getSpecialEffect--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setTextColumn(int value) {#setTextColumn-int-}
+```
+public void setTextColumn(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft, bitte siehe [getTextColumn()](../../com.aspose.diagram/listboxactivexcontrol\#getTextColumn--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setValue(String value) {#setValue-java.lang.String-}
+```
+public void setValue(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft, bitte siehe [getValue()](../../com.aspose.diagram/listboxactivexcontrol\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/loadfileformat/_index.md
+++ b/german/java/com.aspose.diagram/loadfileformat/_index.md
@@ -1,0 +1,246 @@
+---
+title: LoadFileFormat
+second_title: Aspose.Diagram for Java API-Referenz
+description: Aufzählung für die Auswahl des Diagrammformat-Ladevorgangs.
+type: docs
+weight: 235
+url: /de/java/com.aspose.diagram/loadfileformat/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LoadFileFormat
+```
+
+Aufzählung für die Auswahl des Diagrammformat-Ladevorgangs.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [VDW](#VDW) | MS Visio Vdw Web-Zeichnungsformat. |
+| [VDX](#VDX) | MS Visio VDX XML-Format. |
+| [VSD](#VSD) | MS Visio Vsd Binärformat. |
+| [VSDM](#VSDM) | MS Visio Vsdm-Dateiformat, das Makros ermöglicht. |
+| [VSDX](#VSDX) | MS Visio 2013 Vsdx-Dateiformat. |
+| [VSS](#VSS) | MS Visio Vss Binär-Stencil-Format. |
+| [VSSM](#VSSM) | MS Visio Vssm-Dateiformat, das Makros ermöglicht. |
+| [VSSX](#VSSX) | MS Visio 2013 Vssx-Dateiformat. |
+| [VST](#VST) | MS Visio Vst Binärvorlagenformat. |
+| [VSTM](#VSTM) | MS Visio Vstm-Dateiformat, das Makros ermöglicht. |
+| [VSTX](#VSTX) | MS Visio 2013 Vstx Vorlagendateiformat. |
+| [VSX](#VSX) | MS Visio Vsx XML-Stencil-Format. |
+| [VTX](#VTX) | MS Visio Vtx XML-Vorlagenformat. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### VDW {#VDW}
+```
+public static final int VDW
+```
+
+
+MS Visio Vdw Web-Zeichnungsformat.
+
+### VDX {#VDX}
+```
+public static final int VDX
+```
+
+
+MS Visio VDX XML-Format.
+
+### VSD {#VSD}
+```
+public static final int VSD
+```
+
+
+MS Visio Vsd Binärformat.
+
+### VSDM {#VSDM}
+```
+public static final int VSDM
+```
+
+
+MS Visio Vsdm-Dateiformat, das Makros ermöglicht.
+
+### VSDX {#VSDX}
+```
+public static final int VSDX
+```
+
+
+MS Visio 2013 Vsdx-Dateiformat.
+
+### VSS {#VSS}
+```
+public static final int VSS
+```
+
+
+MS Visio Vss Binär-Stencil-Format.
+
+### VSSM {#VSSM}
+```
+public static final int VSSM
+```
+
+
+MS Visio Vssm-Dateiformat, das Makros ermöglicht.
+
+### VSSX {#VSSX}
+```
+public static final int VSSX
+```
+
+
+MS Visio 2013 Vssx-Dateiformat.
+
+### VST {#VST}
+```
+public static final int VST
+```
+
+
+MS Visio Vst Binärvorlagenformat.
+
+### VSTM {#VSTM}
+```
+public static final int VSTM
+```
+
+
+MS Visio Vstm-Dateiformat, das Makros ermöglicht.
+
+### VSTX {#VSTX}
+```
+public static final int VSTX
+```
+
+
+MS Visio 2013 Vstx Vorlagendateiformat.
+
+### VSX {#VSX}
+```
+public static final int VSX
+```
+
+
+MS Visio Vsx XML-Stencil-Format.
+
+### VTX {#VTX}
+```
+public static final int VTX
+```
+
+
+MS Visio Vtx XML-Vorlagenformat.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/loadoptions/_index.md
+++ b/german/java/com.aspose.diagram/loadoptions/_index.md
@@ -1,0 +1,252 @@
+---
+title: LoadOptions
+second_title: Aspose.Diagram for Java API-Referenz
+description: Ermöglicht das Angeben zusätzlicher Optionen beim Laden eines Diagramms in ein Diagramm-Objekt.
+type: docs
+weight: 236
+url: /de/java/com.aspose.diagram/loadoptions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LoadOptions
+```
+
+Ermöglicht das Angeben zusätzlicher Optionen beim Laden eines Diagramms in ein Diagramm-Objekt.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [LoadOptions()](#LoadOptions--) | Initialisiert eine neue Instanz dieser Klasse mit Standardwerten. |
+| [LoadOptions(int format)](#LoadOptions-int-) | Initialisiert eine neue Instanz dieser Klasse mit dem angegebenen Format. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getInterruptMonitor()](#getInterruptMonitor--) | der Interrupt-Monitor. |
+| [getLoadFormat()](#getLoadFormat--) | Gibt das Format des zu ladenden Diagramms an. |
+| [getLocale()](#getLocale--) | das beim Laden der Datei für das Diagramm verwendete Locale. |
+| [getPages()](#getPages--) | Gibt den Index der zu ladenden Seiten an. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setInterruptMonitor(AbstractInterruptMonitor value)](#setInterruptMonitor-com.aspose.diagram.AbstractInterruptMonitor-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getInterruptMonitor()](../../com.aspose.diagram/loadoptions\#getInterruptMonitor--) |
+| [setLoadFormat(int value)](#setLoadFormat-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getLoadFormat()](../../com.aspose.diagram/loadoptions\#getLoadFormat--) |
+| [setLocale(Locale value)](#setLocale-java.util.Locale-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getLocale()](../../com.aspose.diagram/loadoptions\#getLocale--) |
+| [setPages(ArrayList value)](#setPages-java.util.ArrayList-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getPages()](../../com.aspose.diagram/loadoptions\#getPages--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LoadOptions() {#LoadOptions--}
+```
+public LoadOptions()
+```
+
+
+Initialisiert eine neue Instanz dieser Klasse mit Standardwerten. Das Standarddateiformat ist als Aspose.Diagram.LoadFileFormat festgelegt.
+
+### LoadOptions(int format) {#LoadOptions-int-}
+```
+public LoadOptions(int format)
+```
+
+
+Initialisiert eine neue Instanz dieser Klasse mit dem angegebenen Format.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Format | int | Aspose.Diagram.LoadFileFormat Ladeformat. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getInterruptMonitor() {#getInterruptMonitor--}
+```
+public AbstractInterruptMonitor getInterruptMonitor()
+```
+
+
+der Interrupt-Monitor.
+
+**Returns:**
+[AbstractInterruptMonitor](../../com.aspose.diagram/abstractinterruptmonitor)
+### getLoadFormat() {#getLoadFormat--}
+```
+public int getLoadFormat()
+```
+
+
+Gibt das Format des zu ladenden Diagramms an. Standard ist Aspose.Diagram.LoadFileFormat. Lesen/Schreiben Aspose.Diagram.LoadFileFormat.
+
+**Returns:**
+int
+### getLocale() {#getLocale--}
+```
+public Locale getLocale()
+```
+
+
+das beim Laden der Datei für das Diagramm verwendete Locale.
+
+**Returns:**
+java.util.Locale
+### getPages() {#getPages--}
+```
+public ArrayList getPages()
+```
+
+
+Gibt den Index der zu ladenden Seiten an.
+
+**Returns:**
+java.util.ArrayList
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setInterruptMonitor(AbstractInterruptMonitor value) {#setInterruptMonitor-com.aspose.diagram.AbstractInterruptMonitor-}
+```
+public void setInterruptMonitor(AbstractInterruptMonitor value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getInterruptMonitor()](../../com.aspose.diagram/loadoptions\#getInterruptMonitor--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [AbstractInterruptMonitor](../../com.aspose.diagram/abstractinterruptmonitor) |  |
+
+### setLoadFormat(int value) {#setLoadFormat-int-}
+```
+public void setLoadFormat(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getLoadFormat()](../../com.aspose.diagram/loadoptions\#getLoadFormat--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setLocale(Locale value) {#setLocale-java.util.Locale-}
+```
+public void setLocale(Locale value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getLocale()](../../com.aspose.diagram/loadoptions\#getLocale--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.util.Locale |  |
+
+### setPages(ArrayList value) {#setPages-java.util.ArrayList-}
+```
+public void setPages(ArrayList value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getPages()](../../com.aspose.diagram/loadoptions\#getPages--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.util.ArrayList |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/localizefont/_index.md
+++ b/german/java/com.aspose.diagram/localizefont/_index.md
@@ -1,0 +1,204 @@
+---
+title: LocalizeFont
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt an, ob der Formtext in eine andere Sprache lokalisiert werden soll.
+type: docs
+weight: 237
+url: /de/java/com.aspose.diagram/localizefont/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LocalizeFont
+```
+
+Gibt an, ob der Formtext lokalisiert (in eine andere Sprache übersetzt) werden soll.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [LocalizeFont(int value)](#LocalizeFont-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Gibt an, ob der Formtext lokalisiert (in eine andere Sprache übersetzt) werden soll. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | For the description of this property, please see [getUfe()](../../com.aspose.diagram/localizefont\#getUfe--) |
+| [setValue(int value)](#setValue-int-) | For the description of this property, please see [getValue()](../../com.aspose.diagram/localizefont\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LocalizeFont(int value) {#LocalizeFont-int-}
+```
+public LocalizeFont(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Gibt an, ob der Formtext lokalisiert (in eine andere Sprache übersetzt) werden soll.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+For the description of this property, please see [getUfe()](../../com.aspose.diagram/localizefont\#getUfe--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+For the description of this property, please see [getValue()](../../com.aspose.diagram/localizefont\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/localizefontvalue/_index.md
+++ b/german/java/com.aspose.diagram/localizefontvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: LocalizeFontValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt an, ob der Formtext in eine andere Sprache lokalisiert werden soll.
+type: docs
+weight: 238
+url: /de/java/com.aspose.diagram/localizefontvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LocalizeFontValue
+```
+
+Gibt an, ob der Formtext lokalisiert (in eine andere Sprache übersetzt) werden soll.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [ALWAYS_LOCALIZE_FONT](#ALWAYS-LOCALIZE-FONT) | Schriftart immer lokalisieren. |
+| [LOCALIZE_FONT_ONLY_ARIAL_SYMBOL](#LOCALIZE-FONT-ONLY-ARIAL-SYMBOL) | Schriftart nur lokalisieren, wenn sie Arial oder Symbol ist (Standard). |
+| [NEVER_LOCALIZE_FONT](#NEVER-LOCALIZE-FONT) | Schriftart niemals lokalisieren. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALWAYS_LOCALIZE_FONT {#ALWAYS-LOCALIZE-FONT}
+```
+public static final int ALWAYS_LOCALIZE_FONT
+```
+
+
+Schriftart immer lokalisieren.
+
+### LOCALIZE_FONT_ONLY_ARIAL_SYMBOL {#LOCALIZE-FONT-ONLY-ARIAL-SYMBOL}
+```
+public static final int LOCALIZE_FONT_ONLY_ARIAL_SYMBOL
+```
+
+
+Schriftart nur lokalisieren, wenn sie Arial oder Symbol ist (Standard).
+
+### NEVER_LOCALIZE_FONT {#NEVER-LOCALIZE-FONT}
+```
+public static final int NEVER_LOCALIZE_FONT
+```
+
+
+Schriftart niemals lokalisieren.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/margin/_index.md
+++ b/german/java/com.aspose.diagram/margin/_index.md
@@ -1,0 +1,194 @@
+---
+title: Margin
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt den Rand an.
+type: docs
+weight: 239
+url: /de/java/com.aspose.diagram/margin/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Margin
+```
+
+Gibt den Rand an.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [Margin(double value, int unit)](#Margin-double-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUnit()](#getUnit--) | Stellt eine Maßeinheit dar. |
+| [getValue()](#getValue--) | Gibt den Rand an. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUnit(int value)](#setUnit-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getUnit()](../../com.aspose.diagram/margin\#getUnit--) |
+| [setValue(double value)](#setValue-double-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/margin\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Margin(double value, int unit) {#Margin-double-int-}
+```
+public Margin(double value, int unit)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double |  |
+| Einheit | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUnit() {#getUnit--}
+```
+public int getUnit()
+```
+
+
+Stellt eine Maßeinheit dar. Der Standardwert ist DP.
+
+**Returns:**
+int
+### getValue() {#getValue--}
+```
+public double getValue()
+```
+
+
+Gibt den Rand an.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUnit(int value) {#setUnit-int-}
+```
+public void setUnit(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getUnit()](../../com.aspose.diagram/margin\#getUnit--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setValue(double value) {#setValue-double-}
+```
+public void setValue(double value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/margin\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/master/_index.md
+++ b/german/java/com.aspose.diagram/master/_index.md
@@ -1,0 +1,516 @@
+---
+title: Master
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält Elemente, die einen Master für das Dokument definieren.
+type: docs
+weight: 240
+url: /de/java/com.aspose.diagram/master/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Master
+```
+
+Enthält Elemente, die einen Master für das Dokument definieren. Ein Master ist eine Form auf einer Schablone, die Sie wiederholt zum Erstellen von Zeichnungen verwenden. Wenn Sie eine Form von einer Schablone auf die Zeichenfläche ziehen, wird die Form zu einer Instanz dieses Masters, und eine lokale Kopie des Masters wird in das Dokument aufgenommen.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [Master()](#Master--) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [dispose()](#dispose--) | Führt anwendungsspezifische Aufgaben aus, die mit dem Freigeben, Freisetzen oder Zurücksetzen nicht verwalteter Ressourcen verbunden sind. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAlignName()](#getAlignName--) | Gibt an, ob der Text des Masters im Schablonenfenster linksbündig, rechtsbündig oder zentriert ausgerichtet ist. |
+| [getBaseID()](#getBaseID--) | Eine GUID (global eindeutiger Bezeichner), die den Master über Dokumente hinweg identifiziert. |
+| [getClass()](#getClass--) |  |
+| [getConnects()](#getConnects--) | Enthält ein Connect-Element für jede Verbindung zwischen zwei Formen in einer Zeichnung. |
+| [getHidden()](#getHidden--) | Gibt an, ob der Master in der Benutzeroberfläche ausgeblendet ist. |
+| [getID()](#getID--) | Die eindeutige ID des Elements innerhalb seines übergeordneten Elements. |
+| [getIcon()](#getIcon--) | Gibt ein MIME (Multipurpose Internet Mail Extensions) codiertes Binär-Icon (im .ico-Format) für ein Master- oder MasterShortcut-Element in einem Dokument an. |
+| [getIconSize()](#getIconSize--) | Die Größe des Icons des Elements. |
+| [getIconUpdate()](#getIconUpdate--) | Gibt an, ob das Icon automatisch aus dem Master selbst generiert wird. |
+| [getMatchByName()](#getMatchByName--) | Das MatchByName-Attribut bestimmt, wie Microsoft Visio entscheidet, ob ein Dokument-Master bereits vorhanden ist, wenn eine Instanz eines Masters auf die Zeichenfläche gezogen wird. |
+| [getName()](#getName--) | Der Name des Elements. |
+| [getNameU()](#getNameU--) | Der universelle Name des Elements. |
+| [getPageSheet()](#getPageSheet--) | Enthält Elemente, die das Seitenblatt für ein Seiten‑ oder Master‑Element definieren. |
+| [getPatternFlags()](#getPatternFlags--) | Das PatternFlags-Attribut bestimmt, ob ein Master sich wie ein benutzerdefiniertes Muster verhält. |
+| [getPrompt()](#getPrompt--) | Die Statusleiste und der Tooltip geben Hinweise für das Element. |
+| [getShapes()](#getShapes--) | Sammlung von Shape-Objekten. |
+| [getUniqueID()](#getUniqueID--) | Eine GUID, die den Master im Dokument identifiziert. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAlignName(int value)](#setAlignName-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getAlignName()](../../com.aspose.diagram/master\#getAlignName--) |
+| [setBaseID(UUID value)](#setBaseID-java.util.UUID-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getBaseID()](../../com.aspose.diagram/master\#getBaseID--) |
+| [setHidden(int value)](#setHidden-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getHidden()](../../com.aspose.diagram/master\#getHidden--) |
+| [setID(int value)](#setID-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getID()](../../com.aspose.diagram/master\#getID--) |
+| [setIcon(byte[] value)](#setIcon-byte---) | Für die Beschreibung dieser Eigenschaft siehe bitte [getIcon()](../../com.aspose.diagram/master\#getIcon--) |
+| [setIconSize(int value)](#setIconSize-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getIconSize()](../../com.aspose.diagram/master\#getIconSize--) |
+| [setIconUpdate(int value)](#setIconUpdate-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getIconUpdate()](../../com.aspose.diagram/master\#getIconUpdate--) |
+| [setMatchByName(int value)](#setMatchByName-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getMatchByName()](../../com.aspose.diagram/master\#getMatchByName--) |
+| [setName(String value)](#setName-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getName()](../../com.aspose.diagram/master\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getNameU()](../../com.aspose.diagram/master\#getNameU--) |
+| [setPatternFlags(int value)](#setPatternFlags-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getPatternFlags()](../../com.aspose.diagram/master\#getPatternFlags--) |
+| [setPrompt(String value)](#setPrompt-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getPrompt()](../../com.aspose.diagram/master\#getPrompt--) |
+| [setUniqueID(UUID value)](#setUniqueID-java.util.UUID-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getUniqueID()](../../com.aspose.diagram/master\#getUniqueID--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Master() {#Master--}
+```
+public Master()
+```
+
+
+Konstruktor.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### dispose() {#dispose--}
+```
+public void dispose()
+```
+
+
+Führt anwendungsspezifische Aufgaben aus, die mit dem Freigeben, Freisetzen oder Zurücksetzen nicht verwalteter Ressourcen verbunden sind.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAlignName() {#getAlignName--}
+```
+public int getAlignName()
+```
+
+
+Gibt an, ob der Text des Masters im Schablonenfenster linksbündig, rechtsbündig oder zentriert ausgerichtet ist.
+
+**Returns:**
+int
+### getBaseID() {#getBaseID--}
+```
+public UUID getBaseID()
+```
+
+
+Eine GUID (global eindeutiger Bezeichner), die den Master über Dokumente hinweg identifiziert.
+
+**Returns:**
+java.util.UUID
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConnects() {#getConnects--}
+```
+public ConnectCollection getConnects()
+```
+
+
+Enthält ein Connect-Element für jede Verbindung zwischen zwei Formen in einer Zeichnung.
+
+**Returns:**
+[ConnectCollection](../../com.aspose.diagram/connectcollection)
+### getHidden() {#getHidden--}
+```
+public int getHidden()
+```
+
+
+Gibt an, ob der Master in der Benutzeroberfläche ausgeblendet ist.
+
+**Returns:**
+int
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+Die eindeutige ID des Elements innerhalb seines übergeordneten Elements.
+
+**Returns:**
+int
+### getIcon() {#getIcon--}
+```
+public byte[] getIcon()
+```
+
+
+Gibt ein MIME (Multipurpose Internet Mail Extensions) codiertes Binär-Icon (im .ico-Format) für ein Master- oder MasterShortcut-Element in einem Dokument an.
+
+**Returns:**
+byte[]
+### getIconSize() {#getIconSize--}
+```
+public int getIconSize()
+```
+
+
+Die Größe des Icons des Elements.
+
+**Returns:**
+int
+### getIconUpdate() {#getIconUpdate--}
+```
+public int getIconUpdate()
+```
+
+
+Gibt an, ob das Icon automatisch aus dem Master selbst generiert wird.
+
+**Returns:**
+int
+### getMatchByName() {#getMatchByName--}
+```
+public int getMatchByName()
+```
+
+
+Das MatchByName-Attribut bestimmt, wie Microsoft Visio entscheidet, ob ein Dokument-Master bereits vorhanden ist, wenn eine Instanz eines Masters auf die Zeichenfläche gezogen wird. Es ermöglicht, dass Änderungen an einem Dokument-Master auf neue Instanzen des Masters angewendet werden, selbst wenn die Instanzen aus einer eigenständigen Stencil-Datei gezogen werden.
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Der Name des Elements.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+Der universelle Name des Elements.
+
+**Returns:**
+java.lang.String
+### getPageSheet() {#getPageSheet--}
+```
+public PageSheet getPageSheet()
+```
+
+
+Enthält Elemente, die das Seitenblatt für ein Seiten‑ oder Master‑Element definieren.
+
+**Returns:**
+[PageSheet](../../com.aspose.diagram/pagesheet)
+### getPatternFlags() {#getPatternFlags--}
+```
+public int getPatternFlags()
+```
+
+
+Das PatternFlags-Attribut bestimmt, ob ein Master sich wie ein benutzerdefiniertes Muster verhält.
+
+**Returns:**
+int
+### getPrompt() {#getPrompt--}
+```
+public String getPrompt()
+```
+
+
+Die Statusleiste und der Tooltip geben Hinweise für das Element.
+
+**Returns:**
+java.lang.String
+### getShapes() {#getShapes--}
+```
+public ShapeCollection getShapes()
+```
+
+
+Sammlung von Shape-Objekten.
+
+**Returns:**
+[ShapeCollection](../../com.aspose.diagram/shapecollection)
+### getUniqueID() {#getUniqueID--}
+```
+public UUID getUniqueID()
+```
+
+
+Eine GUID, die den Master im Dokument identifiziert.
+
+**Returns:**
+java.util.UUID
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAlignName(int value) {#setAlignName-int-}
+```
+public void setAlignName(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getAlignName()](../../com.aspose.diagram/master\#getAlignName--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setBaseID(UUID value) {#setBaseID-java.util.UUID-}
+```
+public void setBaseID(UUID value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getBaseID()](../../com.aspose.diagram/master\#getBaseID--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.util.UUID |  |
+
+### setHidden(int value) {#setHidden-int-}
+```
+public void setHidden(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getHidden()](../../com.aspose.diagram/master\#getHidden--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getID()](../../com.aspose.diagram/master\#getID--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setIcon(byte[] value) {#setIcon-byte---}
+```
+public void setIcon(byte[] value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getIcon()](../../com.aspose.diagram/master\#getIcon--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | byte[] |  |
+
+### setIconSize(int value) {#setIconSize-int-}
+```
+public void setIconSize(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getIconSize()](../../com.aspose.diagram/master\#getIconSize--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setIconUpdate(int value) {#setIconUpdate-int-}
+```
+public void setIconUpdate(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getIconUpdate()](../../com.aspose.diagram/master\#getIconUpdate--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setMatchByName(int value) {#setMatchByName-int-}
+```
+public void setMatchByName(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getMatchByName()](../../com.aspose.diagram/master\#getMatchByName--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getName()](../../com.aspose.diagram/master\#getName--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getNameU()](../../com.aspose.diagram/master\#getNameU--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setPatternFlags(int value) {#setPatternFlags-int-}
+```
+public void setPatternFlags(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getPatternFlags()](../../com.aspose.diagram/master\#getPatternFlags--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setPrompt(String value) {#setPrompt-java.lang.String-}
+```
+public void setPrompt(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getPrompt()](../../com.aspose.diagram/master\#getPrompt--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setUniqueID(UUID value) {#setUniqueID-java.util.UUID-}
+```
+public void setUniqueID(UUID value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getUniqueID()](../../com.aspose.diagram/master\#getUniqueID--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.util.UUID |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/mastercollection/_index.md
+++ b/german/java/com.aspose.diagram/mastercollection/_index.md
@@ -1,0 +1,304 @@
+---
+title: MasterCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: Master-Sammlung.
+type: docs
+weight: 241
+url: /de/java/com.aspose.diagram/mastercollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class MasterCollection extends Collection
+```
+
+Master-Sammlung.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [add(Master master)](#add-com.aspose.diagram.Master-) | Füge das Master-Objekt zur Sammlung hinzu. |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [getMaster(int ID)](#getMaster-int-) | Liefert das Element mit der angegebenen ID. |
+| [getMasterByName(String name)](#getMasterByName-java.lang.String-) | Hole Master nach Namen. |
+| [getMasterShortcuts()](#getMasterShortcuts--) | MasterShortcut-Sammlung. |
+| [getMaxRelID()](#getMaxRelID--) | Erhalte die maximale rel-ID in der Sammlung. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [isExist(String name)](#isExist-java.lang.String-) | Existiert ein Master in der Sammlung. |
+| [isExistRelId(String relID)](#isExistRelId-java.lang.String-) | Existiert die Master-rel-ID in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Master master)](#remove-com.aspose.diagram.Master-) | Entferne das Master-Objekt aus der Sammlung. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Master master) {#add-com.aspose.diagram.Master-}
+```
+public int add(Master master)
+```
+
+
+Füge das Master-Objekt zur Sammlung hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| master | [Master](../../com.aspose.diagram/master) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Master get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[Master](../../com.aspose.diagram/master) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### getMaster(int ID) {#getMaster-int-}
+```
+public Master getMaster(int ID)
+```
+
+
+Liefert das Element mit der angegebenen ID.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| ID | int |  |
+
+**Returns:**
+[Master](../../com.aspose.diagram/master) - 
+### getMasterByName(String name) {#getMasterByName-java.lang.String-}
+```
+public Master getMasterByName(String name)
+```
+
+
+Hole Master nach Namen.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Name | java.lang.String |  |
+
+**Returns:**
+[Master](../../com.aspose.diagram/master) - 
+### getMasterShortcuts() {#getMasterShortcuts--}
+```
+public MasterShortcutCollection getMasterShortcuts()
+```
+
+
+MasterShortcut-Sammlung.
+
+**Returns:**
+[MasterShortcutCollection](../../com.aspose.diagram/mastershortcutcollection)
+### getMaxRelID() {#getMaxRelID--}
+```
+public int getMaxRelID()
+```
+
+
+Erhalte die maximale rel-ID in der Sammlung.
+
+**Returns:**
+int -
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### isExist(String name) {#isExist-java.lang.String-}
+```
+public boolean isExist(String name)
+```
+
+
+Existiert ein Master in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Name | java.lang.String |  |
+
+**Returns:**
+boolean -
+### isExistRelId(String relID) {#isExistRelId-java.lang.String-}
+```
+public boolean isExistRelId(String relID)
+```
+
+
+Existiert die Master-rel-ID in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| relID | java.lang.String |  |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Master master) {#remove-com.aspose.diagram.Master-}
+```
+public void remove(Master master)
+```
+
+
+Entferne das Master-Objekt aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| master | [Master](../../com.aspose.diagram/master) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/mastershortcut/_index.md
+++ b/german/java/com.aspose.diagram/mastershortcut/_index.md
@@ -1,0 +1,388 @@
+---
+title: MasterShortcut
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt eine im Dokument definierte Master-Verknüpfung an.
+type: docs
+weight: 242
+url: /de/java/com.aspose.diagram/mastershortcut/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class MasterShortcut
+```
+
+Gibt eine im Dokument definierte Master-Verknüpfung an.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [MasterShortcut()](#MasterShortcut--) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAlignName()](#getAlignName--) | Gibt an, ob der Text des Elements im Stencil‑Fenster linksbündig, rechtsbündig oder zentriert ausgerichtet ist. |
+| [getClass()](#getClass--) |  |
+| [getID()](#getID--) | Die eindeutige ID des Elements innerhalb seines übergeordneten Elements. |
+| [getIcon()](#getIcon--) | Gibt ein MIME (Multipurpose Internet Mail Extensions) codiertes Binär-Icon (im .ico-Format) für ein Master- oder MasterShortcut-Element in einem Dokument an. |
+| [getIconSize()](#getIconSize--) | Die Größe des Icons des Elements. |
+| [getName()](#getName--) | Der Name des Elements. |
+| [getNameU()](#getNameU--) | Der universelle Name des Elements. |
+| [getPatternFlags()](#getPatternFlags--) | Bestimmt, ob ein Master sich als benutzerdefiniertes Muster verhält. |
+| [getPrompt()](#getPrompt--) | Die Statusleiste und der Tooltip geben Hinweise für das Element. |
+| [getShortcutHelp()](#getShortcutHelp--) | Ein Hilfetext für das Element. |
+| [getShortcutURL()](#getShortcutURL--) | Eine URL zu einem MasterShortcut‑Element. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAlignName(int value)](#setAlignName-int-) | Für die Beschreibung dieser Eigenschaft siehe [getAlignName()](../../com.aspose.diagram/mastershortcut\#getAlignName--) |
+| [setID(int value)](#setID-int-) | Für die Beschreibung dieser Eigenschaft siehe [getID()](../../com.aspose.diagram/mastershortcut\#getID--) |
+| [setIcon(byte[] value)](#setIcon-byte---) | Für die Beschreibung dieser Eigenschaft siehe [getIcon()](../../com.aspose.diagram/mastershortcut\#getIcon--) |
+| [setIconSize(int value)](#setIconSize-int-) | Für die Beschreibung dieser Eigenschaft siehe [getIconSize()](../../com.aspose.diagram/mastershortcut\#getIconSize--) |
+| [setName(String value)](#setName-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe [getName()](../../com.aspose.diagram/mastershortcut\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe [getNameU()](../../com.aspose.diagram/mastershortcut\#getNameU--) |
+| [setPatternFlags(int value)](#setPatternFlags-int-) | Für die Beschreibung dieser Eigenschaft siehe [getPatternFlags()](../../com.aspose.diagram/mastershortcut\#getPatternFlags--) |
+| [setPrompt(String value)](#setPrompt-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe [getPrompt()](../../com.aspose.diagram/mastershortcut\#getPrompt--) |
+| [setShortcutHelp(String value)](#setShortcutHelp-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe [getShortcutHelp()](../../com.aspose.diagram/mastershortcut\#getShortcutHelp--) |
+| [setShortcutURL(String value)](#setShortcutURL-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe [getShortcutURL()](../../com.aspose.diagram/mastershortcut\#getShortcutURL--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### MasterShortcut() {#MasterShortcut--}
+```
+public MasterShortcut()
+```
+
+
+Konstruktor.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAlignName() {#getAlignName--}
+```
+public int getAlignName()
+```
+
+
+Gibt an, ob der Text des Elements im Stencil‑Fenster linksbündig, rechtsbündig oder zentriert ausgerichtet ist.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+Die eindeutige ID des Elements innerhalb seines übergeordneten Elements.
+
+**Returns:**
+int
+### getIcon() {#getIcon--}
+```
+public byte[] getIcon()
+```
+
+
+Gibt ein MIME (Multipurpose Internet Mail Extensions) codiertes Binär-Icon (im .ico-Format) für ein Master- oder MasterShortcut-Element in einem Dokument an.
+
+**Returns:**
+byte[]
+### getIconSize() {#getIconSize--}
+```
+public int getIconSize()
+```
+
+
+Die Größe des Icons des Elements.
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Der Name des Elements.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+Der universelle Name des Elements.
+
+**Returns:**
+java.lang.String
+### getPatternFlags() {#getPatternFlags--}
+```
+public int getPatternFlags()
+```
+
+
+Bestimmt, ob ein Master sich als benutzerdefiniertes Muster verhält.
+
+**Returns:**
+int
+### getPrompt() {#getPrompt--}
+```
+public String getPrompt()
+```
+
+
+Die Statusleiste und der Tooltip geben Hinweise für das Element.
+
+**Returns:**
+java.lang.String
+### getShortcutHelp() {#getShortcutHelp--}
+```
+public String getShortcutHelp()
+```
+
+
+Ein Hilfetext für das Element.
+
+**Returns:**
+java.lang.String
+### getShortcutURL() {#getShortcutURL--}
+```
+public String getShortcutURL()
+```
+
+
+Eine URL zu einem MasterShortcut‑Element. Wenn dieses Attribut vorhanden ist, ist dieses MasterShortcut‑Element ein Shortcut.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAlignName(int value) {#setAlignName-int-}
+```
+public void setAlignName(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getAlignName()](../../com.aspose.diagram/mastershortcut\#getAlignName--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getID()](../../com.aspose.diagram/mastershortcut\#getID--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setIcon(byte[] value) {#setIcon-byte---}
+```
+public void setIcon(byte[] value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getIcon()](../../com.aspose.diagram/mastershortcut\#getIcon--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | byte[] |  |
+
+### setIconSize(int value) {#setIconSize-int-}
+```
+public void setIconSize(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getIconSize()](../../com.aspose.diagram/mastershortcut\#getIconSize--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getName()](../../com.aspose.diagram/mastershortcut\#getName--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getNameU()](../../com.aspose.diagram/mastershortcut\#getNameU--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setPatternFlags(int value) {#setPatternFlags-int-}
+```
+public void setPatternFlags(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getPatternFlags()](../../com.aspose.diagram/mastershortcut\#getPatternFlags--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setPrompt(String value) {#setPrompt-java.lang.String-}
+```
+public void setPrompt(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getPrompt()](../../com.aspose.diagram/mastershortcut\#getPrompt--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setShortcutHelp(String value) {#setShortcutHelp-java.lang.String-}
+```
+public void setShortcutHelp(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getShortcutHelp()](../../com.aspose.diagram/mastershortcut\#getShortcutHelp--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setShortcutURL(String value) {#setShortcutURL-java.lang.String-}
+```
+public void setShortcutURL(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getShortcutURL()](../../com.aspose.diagram/mastershortcut\#getShortcutURL--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/mastershortcutcollection/_index.md
+++ b/german/java/com.aspose.diagram/mastershortcutcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: MasterShortcutCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: MasterShortcut-Sammlung.
+type: docs
+weight: 243
+url: /de/java/com.aspose.diagram/mastershortcutcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class MasterShortcutCollection extends Collection
+```
+
+MasterShortcut-Sammlung.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [add(MasterShortcut masterShortcut)](#add-com.aspose.diagram.MasterShortcut-) | Füge das Master-Objekt zur Sammlung hinzu. |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(MasterShortcut masterShortcut)](#remove-com.aspose.diagram.MasterShortcut-) | Entfernt das MasterShortcut-Objekt aus der Sammlung. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(MasterShortcut masterShortcut) {#add-com.aspose.diagram.MasterShortcut-}
+```
+public int add(MasterShortcut masterShortcut)
+```
+
+
+Füge das Master-Objekt zur Sammlung hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| masterShortcut | [MasterShortcut](../../com.aspose.diagram/mastershortcut) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public MasterShortcut get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[MasterShortcut](../../com.aspose.diagram/mastershortcut) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(MasterShortcut masterShortcut) {#remove-com.aspose.diagram.MasterShortcut-}
+```
+public void remove(MasterShortcut masterShortcut)
+```
+
+
+Entfernt das MasterShortcut-Objekt aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| masterShortcut | [MasterShortcut](../../com.aspose.diagram/mastershortcut) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/measureconst/_index.md
+++ b/german/java/com.aspose.diagram/measureconst/_index.md
@@ -1,0 +1,561 @@
+---
+title: MeasureConst
+second_title: Aspose.Diagram for Java API-Referenz
+description: Maßeinheiten.
+type: docs
+weight: 244
+url: /de/java/com.aspose.diagram/measureconst/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class MeasureConst
+```
+
+Einheiten von\\ Maß.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [AC](#AC) | Acre. |
+| [AD](#AD) | Grad. |
+| [AM](#AM) | Minuten. |
+| [AS](#AS) | Sekunden. |
+| [BOOL](#BOOL) | Boolesch. |
+| [C](#C) | Ciceros. |
+| [CM](#CM) | Zentimeter. |
+| [COLOR](#COLOR) | Ein Farbwert. |
+| [CY](#CY) | Währung. |
+| [C_D](#C-D) | Ciceros/Didits. |
+| [D](#D) | Didots. |
+| [DA](#DA) | Standard-Winkeleinheiten. |
+| [DATE](#DATE) | Datum und Uhrzeit. |
+| [DE](#DE) | Standard-Dauereinheiten. |
+| [DEG](#DEG) | Bruchgrad. |
+| [DL](#DL) | Standard-Längeneinheiten. |
+| [DP](#DP) | Standard-Seiteneinheiten. |
+| [DT](#DT) | Standard-Typeneinheiten. |
+| [ED](#ED) | Verstrichene Tage. |
+| [EH](#EH) | Verstrichene Stunden. |
+| [EM](#EM) | Verstrichene Minuten. |
+| [ES](#ES) | Verstrichene Sekunden. |
+| [EW](#EW) | Verstrichene Wochen. |
+| [FT](#FT) | Feet. |
+| [F_I](#F-I) | Feet/inch. |
+| [GUID](#GUID) | A global unique identifier. |
+| [HA](#HA) | Hectare. |
+| [IN](#IN) | Inches. |
+| [IN_F](#IN-F) | Inches fractional. |
+| [KM](#KM) | Kilometres. |
+| [M](#M) | Metres. |
+| [MI](#MI) | Miles. |
+| [MI_F](#MI-F) | Milest fractional. |
+| [MM](#MM) | Milimetres. |
+| [MULTIDIM](#MULTIDIM) | Multidimential value. |
+| [NM](#NM) | Nautical miles. |
+| [NUM](#NUM) | Zahl. |
+| [NURBS](#NURBS) | Nurbs curve data. |
+| [P](#P) | Picas. |
+| [PER](#PER) | Percent. |
+| [PNT](#PNT) | 2-D coordinate. |
+| [POLYLINE](#POLYLINE) | Polyline point data. |
+| [PT](#PT) | Points. |
+| [P_PT](#P-PT) | Picas/points. |
+| [RAD](#RAD) | Radians. |
+| [STR](#STR) | Zeichenkette. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+| [YD](#YD) | Yards. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AC {#AC}
+```
+public static final int AC
+```
+
+
+Acre.
+
+### AD {#AD}
+```
+public static final int AD
+```
+
+
+Grad.
+
+### AM {#AM}
+```
+public static final int AM
+```
+
+
+Minuten.
+
+### AS {#AS}
+```
+public static final int AS
+```
+
+
+Sekunden.
+
+### BOOL {#BOOL}
+```
+public static final int BOOL
+```
+
+
+Boolesch.
+
+### C {#C}
+```
+public static final int C
+```
+
+
+Ciceros.
+
+### CM {#CM}
+```
+public static final int CM
+```
+
+
+Zentimeter.
+
+### COLOR {#COLOR}
+```
+public static final int COLOR
+```
+
+
+Ein Farbwert.
+
+### CY {#CY}
+```
+public static final int CY
+```
+
+
+Währung.
+
+### C_D {#C-D}
+```
+public static final int C_D
+```
+
+
+Ciceros/Didits.
+
+### D {#D}
+```
+public static final int D
+```
+
+
+Didots.
+
+### DA {#DA}
+```
+public static final int DA
+```
+
+
+Standard-Winkeleinheiten.
+
+### DATE {#DATE}
+```
+public static final int DATE
+```
+
+
+Datum und Uhrzeit.
+
+### DE {#DE}
+```
+public static final int DE
+```
+
+
+Standard-Dauereinheiten.
+
+### DEG {#DEG}
+```
+public static final int DEG
+```
+
+
+Bruchgrad.
+
+### DL {#DL}
+```
+public static final int DL
+```
+
+
+Standard-Längeneinheiten.
+
+### DP {#DP}
+```
+public static final int DP
+```
+
+
+Standard-Seiteneinheiten.
+
+### DT {#DT}
+```
+public static final int DT
+```
+
+
+Standard-Typeneinheiten.
+
+### ED {#ED}
+```
+public static final int ED
+```
+
+
+Verstrichene Tage.
+
+### EH {#EH}
+```
+public static final int EH
+```
+
+
+Verstrichene Stunden.
+
+### EM {#EM}
+```
+public static final int EM
+```
+
+
+Verstrichene Minuten.
+
+### ES {#ES}
+```
+public static final int ES
+```
+
+
+Verstrichene Sekunden.
+
+### EW {#EW}
+```
+public static final int EW
+```
+
+
+Verstrichene Wochen.
+
+### FT {#FT}
+```
+public static final int FT
+```
+
+
+Feet.
+
+### F_I {#F-I}
+```
+public static final int F_I
+```
+
+
+Feet/inch.
+
+### GUID {#GUID}
+```
+public static final int GUID
+```
+
+
+A global unique identifier.
+
+### HA {#HA}
+```
+public static final int HA
+```
+
+
+Hectare.
+
+### IN {#IN}
+```
+public static final int IN
+```
+
+
+Inches.
+
+### IN_F {#IN-F}
+```
+public static final int IN_F
+```
+
+
+Inches fractional.
+
+### KM {#KM}
+```
+public static final int KM
+```
+
+
+Kilometres.
+
+### M {#M}
+```
+public static final int M
+```
+
+
+Metres.
+
+### MI {#MI}
+```
+public static final int MI
+```
+
+
+Miles.
+
+### MI_F {#MI-F}
+```
+public static final int MI_F
+```
+
+
+Milest fractional.
+
+### MM {#MM}
+```
+public static final int MM
+```
+
+
+Milimetres.
+
+### MULTIDIM {#MULTIDIM}
+```
+public static final int MULTIDIM
+```
+
+
+Multidimential value.
+
+### NM {#NM}
+```
+public static final int NM
+```
+
+
+Nautical miles.
+
+### NUM {#NUM}
+```
+public static final int NUM
+```
+
+
+Zahl.
+
+### NURBS {#NURBS}
+```
+public static final int NURBS
+```
+
+
+Nurbs curve data.
+
+### P {#P}
+```
+public static final int P
+```
+
+
+Picas.
+
+### PER {#PER}
+```
+public static final int PER
+```
+
+
+Percent.
+
+### PNT {#PNT}
+```
+public static final int PNT
+```
+
+
+2-D coordinate.
+
+### POLYLINE {#POLYLINE}
+```
+public static final int POLYLINE
+```
+
+
+Polyline point data.
+
+### PT {#PT}
+```
+public static final int PT
+```
+
+
+Points.
+
+### P_PT {#P-PT}
+```
+public static final int P_PT
+```
+
+
+Picas/points.
+
+### RAD {#RAD}
+```
+public static final int RAD
+```
+
+
+Radians.
+
+### STR {#STR}
+```
+public static final int STR
+```
+
+
+Zeichenkette.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### YD {#YD}
+```
+public static final int YD
+```
+
+
+Yards.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/memoryfontsource/_index.md
+++ b/german/java/com.aspose.diagram/memoryfontsource/_index.md
@@ -1,0 +1,165 @@
+---
+title: MemoryFontSource
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt die einzelne TrueType-Schriftdatei dar, die im Speicher abgelegt ist.
+type: docs
+weight: 245
+url: /de/java/com.aspose.diagram/memoryfontsource/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.FontSourceBase](../../com.aspose.diagram/fontsourcebase)
+```
+public class MemoryFontSource extends FontSourceBase
+```
+
+Stellt die einzelne TrueType-Schriftdatei dar, die im Speicher abgelegt ist.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [MemoryFontSource(byte[] fontData)](#MemoryFontSource-byte---) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFontData()](#getFontData--) | Binäre Schriftartdaten. |
+| [getType()](#getType--) | Gibt den Typ der Schriftquellen zurück. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### MemoryFontSource(byte[] fontData) {#MemoryFontSource-byte---}
+```
+public MemoryFontSource(byte[] fontData)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fontData | byte[] | Binäre Schriftartdaten. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFontData() {#getFontData--}
+```
+public byte[] getFontData()
+```
+
+
+Binäre Schriftartdaten.
+
+**Returns:**
+byte[]
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Gibt den Typ der Schriftquellen zurück.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/milestonehelper/_index.md
+++ b/german/java/com.aspose.diagram/milestonehelper/_index.md
@@ -1,0 +1,278 @@
+---
+title: MilestoneHelper
+second_title: Aspose.Diagram for Java API-Referenz
+description: MilestoneHelper zum Festlegen der Eigenschaft einer Meilenstein-Form.
+type: docs
+weight: 246
+url: /de/java/com.aspose.diagram/milestonehelper/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class MilestoneHelper
+```
+
+MilestoneHelper zum Festlegen der Eigenschaft einer Meilenstein-Form.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [MilestoneHelper(Shape shape)](#MilestoneHelper-com.aspose.diagram.Shape-) |  |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMilestoneDate()](#getMilestoneDate--) | Meilenstein‑Datum |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [refreshMilestone(Shape timeline)](#refreshMilestone-com.aspose.diagram.Shape-) | Meilenstein aktualisieren |
+| [setAutoUpdate(boolean value)](#setAutoUpdate-boolean-) | whether to update data for markers (milestones, intervals) as they are moved on timeline |
+|  | [setDateFormat(int value)](#setDateFormat-int-) | Datumsformat der Form /// |
+
+| ----------------------- | ------------------------------- |
+| **Value**\\u9286\\u20ac | **Format String**\\u9286\\u20ac |
+| 0                       | dddd, yyyy-M-d                  |
+| 1                       | yyyy-MM-dd                      |
+| 2                       | yy-MMM-d                        |
+| 3                       | yyyy/M/d                        |
+| 4                       | yy-MMM.                         | |
+| [setDateFormatString(String value)](#setDateFormatString-java.lang.String-) | Datumsformat‑Zeichenfolge der Form |
+| [setMilestoneDate(DateTime value)](#setMilestoneDate-com.aspose.diagram.DateTime-) |  |
+| [setType(int value)](#setType-int-) | Typ der Form |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### MilestoneHelper(Shape shape) {#MilestoneHelper-com.aspose.diagram.Shape-}
+```
+public MilestoneHelper(Shape shape)
+```
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| shape | [Shape](../../com.aspose.diagram/shape) |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMilestoneDate() {#getMilestoneDate--}
+```
+public DateTime getMilestoneDate()
+```
+
+
+Meilenstein‑Datum
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### refreshMilestone(Shape timeline) {#refreshMilestone-com.aspose.diagram.Shape-}
+```
+public void refreshMilestone(Shape timeline)
+```
+
+
+Meilenstein aktualisieren
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| timeline | [Shape](../../com.aspose.diagram/shape) |  |
+
+### setAutoUpdate(boolean value) {#setAutoUpdate-boolean-}
+```
+public void setAutoUpdate(boolean value)
+```
+
+
+whether to update data for markers (milestones, intervals) as they are moved on timeline
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setDateFormat(int value) {#setDateFormat-int-}
+```
+public void setDateFormat(int value)
+```
+
+
+Datumsformat der Form ///
+
+| ----------------------- | ------------------------------- |
+| **Value**\\u9286\\u20ac | **Format String**\\u9286\\u20ac |
+| 0                       | dddd, yyyy-M-d                  |
+| 1                       | yyyy-MM-dd                      |
+| 2                       | yy-MMM-d                        |
+| 3                       | yyyy/M/d                        |
+| 4                       | yy-MMM.-d                       |
+| 5                       | d MMMM yyyy                     |
+| 6                       | yy-M                            |
+| 7                       | MMM-yy                          |
+| 8                       | MMMM d, yyyy                    |
+| 9                       | MMM d, yyyy                     |
+| 10                      | M-d-yy                          |
+| 11                      | M-d                             |
+| 12                      | d MMMM, yyyy                    |
+| 13                      | d MMM, yyyy                     |
+| 14                      | d-M-yy                          |
+| 15                      | d-M                             |
+| 16                      | yy-M-d                          |
+| 17                      | yyyy-M-d                        |
+| 18                      | M-yy                            |
+| 19                      | M-yyyy                          |
+| 20                      | MMMM yyyy                       |
+| 21                      | MMMM yy                         |
+| 22                      | MMM yyyy                        |
+| 23                      | MMM yy                          |
+| 24                      | yy                              |
+| 25                      | yyyy                            |
+| 26                      | d                               |
+| 27                      | MMMM                            |
+| 28                      | MMM                             |
+| 29                      | M                               |
+| 30                      | MM/dd/yyyy                      |
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setDateFormatString(String value) {#setDateFormatString-java.lang.String-}
+```
+public void setDateFormatString(String value)
+```
+
+
+Datumsformat‑Zeichenfolge der Form
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setMilestoneDate(DateTime value) {#setMilestoneDate-com.aspose.diagram.DateTime-}
+```
+public void setMilestoneDate(DateTime value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setType(int value) {#setType-int-}
+```
+public void setType(int value)
+```
+
+
+Typ der Form
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/misc/_index.md
+++ b/german/java/com.aspose.diagram/misc/_index.md
@@ -1,0 +1,381 @@
+---
+title: Misc
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält verschiedene Elemente von Formen und Gruppen, wie solche, die die Auswahlhervorhebung und Sichtbarkeit steuern.
+type: docs
+weight: 247
+url: /de/java/com.aspose.diagram/misc/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Misc
+```
+
+Enthält verschiedene Elemente von Formen und Gruppen, wie solche, die die Auswahlhervorhebung und Sichtbarkeit steuern.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBegTrigger()](#getBegTrigger--) | Enthält eine von Microsoft Visio erzeugte Trigger-Formel, die bestimmt, ob der Anfangspunkt einer 1‑D‑Form verschoben werden soll, um ihre Verbindung zu einer anderen Form beizubehalten. |
+| [getCalendar()](#getCalendar--) | Bestimmt den Kalender, der für benutzerdefinierte Eigenschaften, Textfelder und Formeln von Elementen verwendet wird. |
+| [getClass()](#getClass--) |  |
+| [getComment()](#getComment--) | Enthält den Kommentartext im Zeichenkettenformat für eine Form. |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getDropOnPageScale()](#getDropOnPageScale--) | Bestimmt den Prozentsatz, um den eine Form skaliert wird, wenn sie auf die Zeichenfläche gezogen wird. |
+| [getDynFeedback()](#getDynFeedback--) | Gibt den Typ des visuellen Feedbacks an, das Benutzern beim Ziehen eines Connectors bereitgestellt wird. |
+| [getEndTrigger()](#getEndTrigger--) | Enthält eine von Microsoft Visio erzeugte Trigger-Formel. |
+| [getGlueType()](#getGlueType--) | Gibt an, ob dynamisches (Form-zu-Form) Kleben beim Verbinden mit einer Form erlaubt ist. |
+| [getHideText()](#getHideText--) | Blendet den Text einer Form aus. |
+| [getLangID()](#getLangID--) | Gibt die Locale-ID (LCID) der Sprache an, in der die Zellformel, der Text, die benutzerdefinierte Eigenschaft oder der Kommentar eingegeben wurde. |
+| [getLocalizeMerge()](#getLocalizeMerge--) | Bestimmt, ob Formen lokalisiert werden (ob ihr LangID-Element zurückgesetzt wird), wenn sie zwischen Dokumenten kopiert werden. |
+| [getNoAlignBox()](#getNoAlignBox--) | Gibt an, ob das Auswahlrechteck angezeigt wird, wenn die Form ausgewählt ist. |
+| [getNoCtlHandles()](#getNoCtlHandles--) | Gibt an, ob Steuerungsgriffe angezeigt werden, wenn die Form ausgewählt ist. |
+| [getNoLiveDynamics()](#getNoLiveDynamics--) | Gibt an, ob eine Form dynamisch ihre Größe ändert oder rotiert, während der Benutzer sie manipuliert. |
+| [getNoObjHandles()](#getNoObjHandles--) | Gibt an, ob Auswahlgriffe angezeigt werden, wenn die Form ausgewählt ist. |
+| [getNonPrinting()](#getNonPrinting--) | Gibt an, ob eine ausgewählte Form gedruckt werden kann. |
+| [getObjType()](#getObjType--) | Gibt an, ob Objekte in Diagrammen platzierbar oder routbar sind, wenn Sie Microsoft Visio zum Anordnen von Formen auf der Zeichenfläche verwenden. |
+| [getShapeKeywords()](#getShapeKeywords--) | Enthält Suchbegriffe, die benutzerdefinierten Masterformen zugewiesen wurden. |
+| [getUpdateAlignBox()](#getUpdateAlignBox--) | Gibt an, ob das Auswahlrechteck einer Form neu berechnet werden soll, sobald ein Steuerungsgriff verschoben wird. |
+| [getWalkPreference()](#getWalkPreference--) | Gibt an, ob ein Endpunkt einer 1‑D‑Form zu einem horizontalen oder vertikalen Verbindungspunkt der Form, an die sie geklebt ist, mit dynamischem Kleben verschoben wird, wenn die Form in eine mehrdeutige Position bewegt wird. |
+| [hashCode()](#hashCode--) |  |
+| [isDropSource()](#isDropSource--) | Gibt an, ob die Form zu einer Gruppe hinzugefügt werden kann, indem sie auf die Gruppe gezogen wird. |
+| [isReplaceLockShapeData()](#isReplaceLockShapeData--) | Zeigt an, ob die Werte der angegebenen Zellen in einer Masterform die Werte (einschließlich lokaler Werte) einer ersetzten Form während eines Formersetzungs‑Vorgangs überschreiben. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/misc\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBegTrigger() {#getBegTrigger--}
+```
+public DoubleValue getBegTrigger()
+```
+
+
+Enthält eine von Microsoft Visio erzeugte Trigger-Formel, die bestimmt, ob der Anfangspunkt einer 1‑D‑Form verschoben werden soll, um ihre Verbindung zu einer anderen Form beizubehalten.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getCalendar() {#getCalendar--}
+```
+public Calendar getCalendar()
+```
+
+
+Bestimmt den Kalender, der für benutzerdefinierte Eigenschaften, Textfelder und Formeln von Elementen verwendet wird.
+
+**Returns:**
+[Calendar](../../com.aspose.diagram/calendar)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getComment() {#getComment--}
+```
+public Str2Value getComment()
+```
+
+
+Enthält den Kommentartext im Zeichenkettenformat für eine Form.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getDropOnPageScale() {#getDropOnPageScale--}
+```
+public DoubleValue getDropOnPageScale()
+```
+
+
+Bestimmt den Prozentsatz, um den eine Form skaliert wird, wenn sie auf die Zeichenfläche gezogen wird.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDynFeedback() {#getDynFeedback--}
+```
+public DynFeedback getDynFeedback()
+```
+
+
+Gibt den Typ des visuellen Feedbacks an, das Benutzern beim Ziehen eines Connectors bereitgestellt wird.
+
+**Returns:**
+[DynFeedback](../../com.aspose.diagram/dynfeedback)
+### getEndTrigger() {#getEndTrigger--}
+```
+public DoubleValue getEndTrigger()
+```
+
+
+Enthält eine von Microsoft Visio erzeugte Trigger-Formel. Diese Trigger-Formel bestimmt, ob der Endpunkt einer 1‑D‑Form verschoben werden soll, um ihre Verbindung zu einer anderen Form beizubehalten.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getGlueType() {#getGlueType--}
+```
+public GlueType getGlueType()
+```
+
+
+Gibt an, ob dynamisches (Form-zu-Form) Kleben beim Verbinden mit einer Form erlaubt ist.
+
+**Returns:**
+[GlueType](../../com.aspose.diagram/gluetype)
+### getHideText() {#getHideText--}
+```
+public BoolValue getHideText()
+```
+
+
+Blendet den Text für eine Form aus. Sie können den Text anzeigen, Eigenschaften bearbeiten und Stile auf den Text im Textblock anwenden, obwohl die Änderungen erst sichtbar werden, wenn Sie das HideText-Element auf 0 setzen.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLangID() {#getLangID--}
+```
+public IntValue getLangID()
+```
+
+
+Gibt die Locale-ID (LCID) der Sprache an, in der die Zellformel, der Text, die benutzerdefinierte Eigenschaft oder der Kommentar eingegeben wurde.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getLocalizeMerge() {#getLocalizeMerge--}
+```
+public BoolValue getLocalizeMerge()
+```
+
+
+Bestimmt, ob Formen lokalisiert werden (ob ihr LangID-Element zurückgesetzt wird), wenn sie zwischen Dokumenten kopiert werden.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getNoAlignBox() {#getNoAlignBox--}
+```
+public BoolValue getNoAlignBox()
+```
+
+
+Gibt an, ob das Auswahlrechteck angezeigt wird, wenn die Form ausgewählt ist.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getNoCtlHandles() {#getNoCtlHandles--}
+```
+public BoolValue getNoCtlHandles()
+```
+
+
+Gibt an, ob Steuerungsgriffe angezeigt werden, wenn die Form ausgewählt ist.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getNoLiveDynamics() {#getNoLiveDynamics--}
+```
+public BoolValue getNoLiveDynamics()
+```
+
+
+Gibt an, ob eine Form dynamisch ihre Größe ändert oder rotiert, während der Benutzer sie manipuliert.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getNoObjHandles() {#getNoObjHandles--}
+```
+public BoolValue getNoObjHandles()
+```
+
+
+Gibt an, ob Auswahlgriffe angezeigt werden, wenn die Form ausgewählt ist.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getNonPrinting() {#getNonPrinting--}
+```
+public BoolValue getNonPrinting()
+```
+
+
+Gibt an, ob eine ausgewählte Form gedruckt werden kann.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getObjType() {#getObjType--}
+```
+public ObjType getObjType()
+```
+
+
+Gibt an, ob Objekte in Diagrammen platzierbar oder routbar sind, wenn Sie Microsoft Visio zum Anordnen von Formen auf der Zeichenfläche verwenden.
+
+**Returns:**
+[ObjType](../../com.aspose.diagram/objtype)
+### getShapeKeywords() {#getShapeKeywords--}
+```
+public Str2Value getShapeKeywords()
+```
+
+
+Enthält Suchbegriffe, die benutzerdefinierten Masterformen zugewiesen wurden.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getUpdateAlignBox() {#getUpdateAlignBox--}
+```
+public BoolValue getUpdateAlignBox()
+```
+
+
+Gibt an, ob das Auswahlrechteck einer Form neu berechnet werden soll, sobald ein Steuerungsgriff verschoben wird.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getWalkPreference() {#getWalkPreference--}
+```
+public WalkPreference getWalkPreference()
+```
+
+
+Gibt an, ob ein Endpunkt einer 1‑D‑Form zu einem horizontalen oder vertikalen Verbindungspunkt der Form, an die sie geklebt ist, mit dynamischem Kleben verschoben wird, wenn die Form in eine mehrdeutige Position bewegt wird.
+
+**Returns:**
+[WalkPreference](../../com.aspose.diagram/walkpreference)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isDropSource() {#isDropSource--}
+```
+public BoolValue isDropSource()
+```
+
+
+Gibt an, ob die Form zu einer Gruppe hinzugefügt werden kann, indem sie auf die Gruppe gezogen wird.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### isReplaceLockShapeData() {#isReplaceLockShapeData--}
+```
+public BoolValue isReplaceLockShapeData()
+```
+
+
+Zeigt an, ob die Werte der angegebenen Zellen in einer Masterform die Werte (einschließlich lokaler Werte) einer ersetzten Form während eines Formersetzungs‑Vorgangs überschreiben.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/misc\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/moveto/_index.md
+++ b/german/java/com.aspose.diagram/moveto/_index.md
@@ -1,0 +1,249 @@
+---
+title: MoveTo
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält die x- und y-Koordinaten des ersten Scheitelpunkts einer Form oder enthält die x- und y-Koordinaten des ersten Scheitelpunkts nach einer Unterbrechung im Pfad.
+type: docs
+weight: 248
+url: /de/java/com.aspose.diagram/moveto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class MoveTo extends Coordinate
+```
+
+Enthält die x- und y-Koordinaten des ersten Scheitelpunkts einer Form oder die x- und y-Koordinaten des ersten Scheitelpunkts nach einem Pfadunterbruch.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [MoveTo()](#MoveTo--) | Erstellt eine Instanz der Klasse [MoveTo](../../com.aspose.diagram/moveto). |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getIX()](#getIX--) | Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements. |
+| [getX()](#getX--) | Das X-Element stellt die x-Koordinate des ersten Scheitelpunkts eines Pfades dar. |
+| [getY()](#getY--) | Das Y-Element stellt die y-Koordinate des ersten Scheitelpunkts eines Pfades dar. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/moveto\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getIX()](../../com.aspose.diagram/moveto\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getX()](../../com.aspose.diagram/moveto\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getY()](../../com.aspose.diagram/moveto\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### MoveTo() {#MoveTo--}
+```
+public MoveTo()
+```
+
+
+Erstellt eine Instanz der Klasse [MoveTo](../../com.aspose.diagram/moveto).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+Das X-Element stellt die x-Koordinate des ersten Scheitelpunkts eines Pfades dar. Wenn das MoveTo-Element zwischen zwei Elementen erscheint, stellt das X-Element die x-Koordinate des ersten Scheitelpunkts nach der Unterbrechung im Pfad dar.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+Das Y-Element stellt die y-Koordinate des ersten Scheitelpunkts eines Pfades dar. Wenn das MoveTo-Element zwischen zwei Elementen erscheint, stellt das Y-Element die y-Koordinate des ersten Scheitelpunkts nach der Unterbrechung im Pfad dar.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/moveto\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getIX()](../../com.aspose.diagram/moveto\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getX()](../../com.aspose.diagram/moveto\#getX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getY()](../../com.aspose.diagram/moveto\#getY--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/movetocollection/_index.md
+++ b/german/java/com.aspose.diagram/movetocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: MoveToCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: MoveTo-Sammlung.
+type: docs
+weight: 249
+url: /de/java/com.aspose.diagram/movetocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class MoveToCollection extends Collection
+```
+
+MoveTo-Sammlung.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public MoveTo get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[MoveTo](../../com.aspose.diagram/moveto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/nurbsto/_index.md
+++ b/german/java/com.aspose.diagram/nurbsto/_index.md
@@ -1,0 +1,374 @@
+---
+title: NURBSTo
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält die x- und y-Koordinatenposition des vorletzten Knotens, die Position des letzten Gewichts, die Position des ersten Knotens, die Position des ersten Gewichts und die Formel für einen nicht-uniform rationalen B-Spline (NURBS).
+type: docs
+weight: 250
+url: /de/java/com.aspose.diagram/nurbsto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class NURBSTo extends Coordinate
+```
+
+Enthält die x- und y-Koordinaten, die Position des vorletzten Knotens, die Position des letzten Gewichts, die Position des ersten Knotens, die Position des ersten Gewichts und die Formel für einen nicht-uniform rationalen B-Spline (NURBS). Diese Informationen sind jeweils in den Elementen X, Y, A, B, C, D und E angegeben.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [NURBSTo()](#NURBSTo--) | Erstellt eine Instanz der Klasse [NURBSTo](../../com.aspose.diagram/nurbsto). |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | Der vorletzte Knoten des nicht-uniform rationalen B-Spline (NURBS). |
+| [getB()](#getB--) | Das letzte Gewicht des nicht-uniform rationalen B-Spline (NURBS). |
+| [getC()](#getC--) | Der erste Knoten des nicht-uniform rationalen B-Spline (NURBS). |
+| [getClass()](#getClass--) |  |
+| [getD()](#getD--) | Das erste Gewicht des nicht-uniform rationalen B-Spline (NURBS). |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getE()](#getE--) | Enthält eine Formel für einen nicht-uniform rationalen B-Spline (NURBS). |
+| [getIX()](#getIX--) | Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements. |
+| [getX()](#getX--) | Die x-Koordinate des letzten Kontrollpunkts eines nicht-uniform rationalen B-Spline (NURBS). |
+| [getY()](#getY--) | Die y-Koordinate des letzten Kontrollpunkts eines nicht-uniform rationalen B-Spline (NURBS). |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getA()](../../com.aspose.diagram/nurbsto\#getA--) |
+| [setB(DoubleValue value)](#setB-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getB()](../../com.aspose.diagram/nurbsto\#getB--) |
+| [setC(DoubleValue value)](#setC-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getC()](../../com.aspose.diagram/nurbsto\#getC--) |
+| [setD(DoubleValue value)](#setD-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getD()](../../com.aspose.diagram/nurbsto\#getD--) |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/nurbsto\#getDel--) |
+| [setE(StrValue value)](#setE-com.aspose.diagram.StrValue-) | Für die Beschreibung dieser Eigenschaft, bitte siehe [getE()](../../com.aspose.diagram/nurbsto\#getE--) |
+| [setIX(int value)](#setIX-int-) | Für die Beschreibung dieser Eigenschaft, bitte siehe [getIX()](../../com.aspose.diagram/nurbsto\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft, bitte siehe [getX()](../../com.aspose.diagram/nurbsto\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft, bitte siehe [getY()](../../com.aspose.diagram/nurbsto\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### NURBSTo() {#NURBSTo--}
+```
+public NURBSTo()
+```
+
+
+Erstellt eine Instanz der Klasse [NURBSTo](../../com.aspose.diagram/nurbsto).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+Der vorletzte Knoten des nicht-uniform rationalen B-Spline (NURBS).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getB() {#getB--}
+```
+public DoubleValue getB()
+```
+
+
+Das letzte Gewicht des nicht-uniform rationalen B-Spline (NURBS).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getC() {#getC--}
+```
+public DoubleValue getC()
+```
+
+
+Der erste Knoten des nicht-uniform rationalen B-Spline (NURBS).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getD() {#getD--}
+```
+public DoubleValue getD()
+```
+
+
+Das erste Gewicht des nicht-uniform rationalen B-Spline (NURBS).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getE() {#getE--}
+```
+public StrValue getE()
+```
+
+
+Enthält eine Formel für einen nicht-uniform rationalen B-Spline (NURBS).
+
+**Returns:**
+[StrValue](../../com.aspose.diagram/strvalue)
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+Die x-Koordinate des letzten Kontrollpunkts eines nicht-uniform rationalen B-Spline (NURBS).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+Die y-Koordinate des letzten Kontrollpunkts eines nicht-uniform rationalen B-Spline (NURBS).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getA()](../../com.aspose.diagram/nurbsto\#getA--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setB(DoubleValue value) {#setB-com.aspose.diagram.DoubleValue-}
+```
+public void setB(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getB()](../../com.aspose.diagram/nurbsto\#getB--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setC(DoubleValue value) {#setC-com.aspose.diagram.DoubleValue-}
+```
+public void setC(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getC()](../../com.aspose.diagram/nurbsto\#getC--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setD(DoubleValue value) {#setD-com.aspose.diagram.DoubleValue-}
+```
+public void setD(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getD()](../../com.aspose.diagram/nurbsto\#getD--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/nurbsto\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setE(StrValue value) {#setE-com.aspose.diagram.StrValue-}
+```
+public void setE(StrValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft, bitte siehe [getE()](../../com.aspose.diagram/nurbsto\#getE--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [StrValue](../../com.aspose.diagram/strvalue) |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft, bitte siehe [getIX()](../../com.aspose.diagram/nurbsto\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft, bitte siehe [getX()](../../com.aspose.diagram/nurbsto\#getX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft, bitte siehe [getY()](../../com.aspose.diagram/nurbsto\#getY--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/nurbstocollection/_index.md
+++ b/german/java/com.aspose.diagram/nurbstocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: NURBSToCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: NURBSTo-Sammlung.
+type: docs
+weight: 251
+url: /de/java/com.aspose.diagram/nurbstocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class NURBSToCollection extends Collection
+```
+
+NURBSTo-Sammlung.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public NURBSTo get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[NURBSTo](../../com.aspose.diagram/nurbsto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/objectkind/_index.md
+++ b/german/java/com.aspose.diagram/objectkind/_index.md
@@ -1,0 +1,190 @@
+---
+title: ObjectKind
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt den Typ des Textfelds an.
+type: docs
+weight: 254
+url: /de/java/com.aspose.diagram/objectkind/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ObjectKind
+```
+
+Gibt den Typ des Textfelds an.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [ObjectKind(int value)](#ObjectKind-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Gibt den Typ des Textfelds an. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/objectkind\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ObjectKind(int value) {#ObjectKind-int-}
+```
+public ObjectKind(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Gibt den Typ des Textfelds an.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/objectkind\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/objectkindvalue/_index.md
+++ b/german/java/com.aspose.diagram/objectkindvalue/_index.md
@@ -1,0 +1,156 @@
+---
+title: ObjectKindValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt den Typ des Textfelds an.
+type: docs
+weight: 255
+url: /de/java/com.aspose.diagram/objectkindvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ObjectKindValue
+```
+
+Gibt den Typ des Textfelds an.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [HORIZONTAL_IN_VERTICAL](#HORIZONTAL-IN-VERTICAL) | Horizontal in vertikal. |
+| [STANDARD](#STANDARD) | Standard. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### HORIZONTAL_IN_VERTICAL {#HORIZONTAL-IN-VERTICAL}
+```
+public static final int HORIZONTAL_IN_VERTICAL
+```
+
+
+Horizontal in vertikal.
+
+### STANDARD {#STANDARD}
+```
+public static final int STANDARD
+```
+
+
+Standard.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/objecttype/_index.md
+++ b/german/java/com.aspose.diagram/objecttype/_index.md
@@ -1,0 +1,183 @@
+---
+title: ObjectType
+second_title: Aspose.Diagram for Java API-Referenz
+description: Wenn das Attribut ForeignType den Wert Object hat, muss das Element ForeignData ebenfalls ein Attribut ObjectType besitzen.
+type: docs
+weight: 256
+url: /de/java/com.aspose.diagram/objecttype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ObjectType
+```
+
+Wenn das Attribut ForeignType "Object" ist, muss das Element ForeignData ebenfalls ein Attribut ObjectType besitzen.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [CONTROL](#CONTROL) | Steuerung. |
+| [EMBEDDED_OBJECT](#EMBEDDED-OBJECT) | Eingebettetes Objekt. |
+| [LINKED_OBJECT](#LINKED-OBJECT) | Verknüpftes Objekt. |
+| [OLE_2_NAMED](#OLE-2-NAMED) | OLE2 benannt. |
+| [OLE_2_OBJECT](#OLE-2-OBJECT) | OLE2-Objekt. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CONTROL {#CONTROL}
+```
+public static final int CONTROL
+```
+
+
+Steuerung.
+
+### EMBEDDED_OBJECT {#EMBEDDED-OBJECT}
+```
+public static final int EMBEDDED_OBJECT
+```
+
+
+Eingebettetes Objekt.
+
+### LINKED_OBJECT {#LINKED-OBJECT}
+```
+public static final int LINKED_OBJECT
+```
+
+
+Verknüpftes Objekt.
+
+### OLE_2_NAMED {#OLE-2-NAMED}
+```
+public static final int OLE_2_NAMED
+```
+
+
+OLE2 benannt.
+
+### OLE_2_OBJECT {#OLE-2-OBJECT}
+```
+public static final int OLE_2_OBJECT
+```
+
+
+OLE2-Objekt.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/objtype/_index.md
+++ b/german/java/com.aspose.diagram/objtype/_index.md
@@ -1,0 +1,179 @@
+---
+title: ObjType
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt an, ob Objekte in Diagrammen platzierbar oder routbar sind, wenn Sie Microsoft Visio zum Anordnen von Formen auf der Zeichenfläche verwenden.
+type: docs
+weight: 252
+url: /de/java/com.aspose.diagram/objtype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ObjType
+```
+
+Gibt an, ob Objekte in Diagrammen platzierbar oder routbar sind, wenn Sie Microsoft Visio zum Anordnen von Formen auf der Zeichenfläche verwenden.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [ObjType(int value)](#ObjType-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Gibt an, ob Objekte in Diagrammen platzierbar oder routbar sind, wenn Sie Microsoft Visio zum Anordnen von Formen auf der Zeichenfläche verwenden. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | For the description of this property, please see [getValue()](../../com.aspose.diagram/objtype\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ObjType(int value) {#ObjType-int-}
+```
+public ObjType(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Gibt an, ob Objekte in Diagrammen platzierbar oder routbar sind, wenn Sie Microsoft Visio zum Anordnen von Formen auf der Zeichenfläche verwenden.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+For the description of this property, please see [getValue()](../../com.aspose.diagram/objtype\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/objtypevalue/_index.md
+++ b/german/java/com.aspose.diagram/objtypevalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: ObjTypeValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt an, ob Objekte in Diagrammen platzierbar oder routbar sind, wenn Sie Microsoft Visio zum Anordnen von Formen auf der Zeichenfläche verwenden.
+type: docs
+weight: 253
+url: /de/java/com.aspose.diagram/objtypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ObjTypeValue
+```
+
+Gibt an, ob Objekte in Diagrammen platzierbar oder routbar sind, wenn Sie Microsoft Visio zum Anordnen von Formen auf der Zeichenfläche verwenden.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [DRAWING_CONTEXT](#DRAWING-CONTEXT) | Visio entscheidet basierend auf dem Zeichenkontext. |
+| [SHAPE_NOT_PLACEABLE_NOT_ROUTABLE](#SHAPE-NOT-PLACEABLE-NOT-ROUTABLE) | Form ist nicht platzierbar, nicht routbar. |
+| [SHAPE_PLACEABLE](#SHAPE-PLACEABLE) | Form ist platzierbar. |
+| [SHAPE_PLACEABLE_ROUTABLE](#SHAPE-PLACEABLE-ROUTABLE) | Gruppe enthält platzierbare/routbare Formen. |
+| [SHAPE_ROUTABLE](#SHAPE-ROUTABLE) | Shape ist routbar. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DRAWING_CONTEXT {#DRAWING-CONTEXT}
+```
+public static final int DRAWING_CONTEXT
+```
+
+
+Visio entscheidet basierend auf dem Zeichenkontext.
+
+### SHAPE_NOT_PLACEABLE_NOT_ROUTABLE {#SHAPE-NOT-PLACEABLE-NOT-ROUTABLE}
+```
+public static final int SHAPE_NOT_PLACEABLE_NOT_ROUTABLE
+```
+
+
+Form ist nicht platzierbar, nicht routbar.
+
+### SHAPE_PLACEABLE {#SHAPE-PLACEABLE}
+```
+public static final int SHAPE_PLACEABLE
+```
+
+
+Form ist platzierbar.
+
+### SHAPE_PLACEABLE_ROUTABLE {#SHAPE-PLACEABLE-ROUTABLE}
+```
+public static final int SHAPE_PLACEABLE_ROUTABLE
+```
+
+
+Gruppe enthält platzierbare/routbare Formen.
+
+### SHAPE_ROUTABLE {#SHAPE-ROUTABLE}
+```
+public static final int SHAPE_ROUTABLE
+```
+
+
+Shape ist routbar.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/optionsvalue/_index.md
+++ b/german/java/com.aspose.diagram/optionsvalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: OptionsValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Optionaler vorzeichenloser Ganzzahlwert.
+type: docs
+weight: 257
+url: /de/java/com.aspose.diagram/optionsvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class OptionsValue
+```
+
+Optionale vorzeichenlose Ganzzahl. Optionen, die auf das Datenrecordset angewendet werden sollen. Mögliche Werte können jede Kombination aus einem oder mehreren der in der folgenden Tabelle gezeigten Werte sein.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [DELAY_QUERY](#DELAY-QUERY) | Führt die Befehlszeichenfolgenabfrage nicht aus, bis das Datenrecordset das nächste Mal aktualisiert wird. |
+| [NO_ADV_CONFIG](#NO-ADV-CONFIG) | Begrenzt die Kontrolle, die Benutzer über die Aktualisierung des Datenrecordsets im Dialogfeld „Refresh konfigurieren“ haben. |
+| [NO_EXTERNAL_DATA_UI](#NO-EXTERNAL-DATA-UI) | Verhindert, dass Daten im Datenrecordset im Fenster „Externe Daten“ angezeigt werden. |
+| [NO_LINK_ON_PASTE](#NO-LINK-ON-PASTE) | Kopiert Shape‑Datenverknüpfungen nicht in die Zwischenablage, wenn Formen kopiert oder ausgeschnitten werden. |
+| [NO_REFRESH_UI](#NO-REFRESH-UI) | Verhindert, dass das Datenrecordset im Dialogfeld „Daten aktualisieren“ angezeigt wird. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DELAY_QUERY {#DELAY-QUERY}
+```
+public static final int DELAY_QUERY
+```
+
+
+Führt die Befehlszeichenfolgenabfrage nicht aus, bis das Datenrecordset das nächste Mal aktualisiert wird.
+
+### NO_ADV_CONFIG {#NO-ADV-CONFIG}
+```
+public static final int NO_ADV_CONFIG
+```
+
+
+Begrenzt die Kontrolle, die Benutzer über die Aktualisierung des Datenrecordsets im Dialogfeld „Refresh konfigurieren“ haben. Insbesondere können Benutzer den Primärschlüssel nicht ändern oder festlegen, wann Shape‑Daten überschrieben werden sollen; jedoch können sie das Aktualisierungsintervall festlegen und die Datenquelle ändern.
+
+### NO_EXTERNAL_DATA_UI {#NO-EXTERNAL-DATA-UI}
+```
+public static final int NO_EXTERNAL_DATA_UI
+```
+
+
+Verhindert, dass Daten im Datenrecordset im Fenster „Externe Daten“ angezeigt werden.
+
+### NO_LINK_ON_PASTE {#NO-LINK-ON-PASTE}
+```
+public static final int NO_LINK_ON_PASTE
+```
+
+
+Kopiert Shape‑Datenverknüpfungen nicht in die Zwischenablage, wenn Formen kopiert oder ausgeschnitten werden.
+
+### NO_REFRESH_UI {#NO-REFRESH-UI}
+```
+public static final int NO_REFRESH_UI
+```
+
+
+Verhindert, dass das Datenrecordset im Dialogfeld „Daten aktualisieren“ angezeigt wird.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/outputformat/_index.md
+++ b/german/java/com.aspose.diagram/outputformat/_index.md
@@ -1,0 +1,179 @@
+---
+title: OutputFormat
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt das Ausgabeformat für eine Zeichnung an.
+type: docs
+weight: 258
+url: /de/java/com.aspose.diagram/outputformat/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class OutputFormat
+```
+
+Gibt das Ausgabeformat für eine Zeichnung an.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [OutputFormat(int value)](#OutputFormat-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Gibt das Ausgabeformat für eine Zeichnung an. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/outputformat\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### OutputFormat(int value) {#OutputFormat-int-}
+```
+public OutputFormat(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Gibt das Ausgabeformat für eine Zeichnung an.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/outputformat\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/outputformatvalue/_index.md
+++ b/german/java/com.aspose.diagram/outputformatvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: OutputFormatValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt das Ausgabeformat für eine Zeichnung an.
+type: docs
+weight: 259
+url: /de/java/com.aspose.diagram/outputformatvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class OutputFormatValue
+```
+
+Gibt das Ausgabeformat für eine Zeichnung an.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [DEFAULT_PRINT](#DEFAULT-PRINT) | Standard. |
+| [HTML_OR_GIF_OUTPUT](#HTML-OR-GIF-OUTPUT) | HTML- oder GIF-Ausgabe. |
+| [POWER_POINT_SLIDE_SHOW](#POWER-POINT-SLIDE-SHOW) | PowerPoint-Folienpräsentation. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DEFAULT_PRINT {#DEFAULT-PRINT}
+```
+public static final int DEFAULT_PRINT
+```
+
+
+Standard. Drucken.
+
+### HTML_OR_GIF_OUTPUT {#HTML-OR-GIF-OUTPUT}
+```
+public static final int HTML_OR_GIF_OUTPUT
+```
+
+
+HTML- oder GIF-Ausgabe.
+
+### POWER_POINT_SLIDE_SHOW {#POWER-POINT-SLIDE-SHOW}
+```
+public static final int POWER_POINT_SLIDE_SHOW
+```
+
+
+PowerPoint-Folienpräsentation.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/page/_index.md
+++ b/german/java/com.aspose.diagram/page/_index.md
@@ -1,0 +1,1156 @@
+---
+title: Seite
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält Elemente, die eine Seite im Dokument definieren.
+type: docs
+weight: 260
+url: /de/java/com.aspose.diagram/page/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Page
+```
+
+Enthält Elemente, die eine Seite im Dokument definieren.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [Page()](#Page--) | Konstruktor. |
+| [Page(int ID)](#Page-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [addActiveXControl(int type, double pinX, double pinY, double width, double height)](#addActiveXControl-int-double-double-double-double-) | Erstellt ein Activex-Steuerelement. |
+| [addComment(Shape shape, String comment)](#addComment-com.aspose.diagram.Shape-java.lang.String-) | Fügt einem Shape einen Kommentar hinzu. |
+| [addComment(double pinX, double pinY, String comment)](#addComment-double-double-java.lang.String-) | Fügt einen Kommentar mit definierten PinX und PinY hinzu. |
+| [addComment(long shapeID, String comment)](#addComment-long-java.lang.String-) | Fügt einem Shape einen Kommentar mit der Shape-ID hinzu. |
+| [addShape(Shape newShape, String masterName)](#addShape-com.aspose.diagram.Shape-java.lang.String-) | Fügt ein vom Master erstelltes Shape zu einer bestimmten Seite hinzu. |
+| [addShape(double pinX, double pinY, double width, double height, InputStream stream)](#addShape-double-double-double-double-java.io.InputStream-) |  |
+| [addShape(double pinX, double pinY, double width, double height, InputStream imageStream, InputStream objectDataStream)](#addShape-double-double-double-double-java.io.InputStream-java.io.InputStream-) |  |
+| [addShape(double pinX, double pinY, double width, double height, String masterName)](#addShape-double-double-double-double-java.lang.String-) | Fügt ein vom Master erstelltes Shape auf einer Seite mit definierten PinX, PinY, Breite und Höhe hinzu. |
+| [addShape(double pinX, double pinY, String masterName)](#addShape-double-double-java.lang.String-) | Fügt ein vom Master erstelltes Shape auf einer Seite mit definierten PinX und PinY hinzu. |
+| [addText(double pinX, double pinY, double width, double height, String text)](#addText-double-double-double-double-java.lang.String-) | Fügt Text mit definierten PinX und PinY hinzu. |
+| [addText(double pinX, double pinY, double width, double height, String text, String fontName, String fontColor, double size)](#addText-double-double-double-double-java.lang.String-java.lang.String-java.lang.String-double-) | Fügt Text mit definierten PinX und PinY hinzu. |
+| [applyStyle(int textStyle, int lineStyle, int fillStyle)](#applyStyle-int-int-int-) | Wendet Stil für die gesamte Seite an. |
+| [autoSpaceShapes(ShapeCollection shapes, AutoSpaceOptions options)](#autoSpaceShapes-com.aspose.diagram.ShapeCollection-com.aspose.diagram.AutoSpaceOptions-) | Automatischer Abstand zwischen Shapes. |
+| [bringForward(long shapeId)](#bringForward-long-) | Bringt ein Shape, definiert durch ID, eine Position im Z-Order nach vorne. |
+| [bringToFront(long shapeId)](#bringToFront-long-) | Bringt ein Shape, definiert durch ID, an die Spitze des Z-Order. |
+| [centerDrawing()](#centerDrawing--) | Zentriert die Shapes einer Seite relativ zum Umfang der Seite. |
+| [connectShapesViaConnector(Shape shapeFrom, int placeFrom, Shape shapeTo, int placeTo, Shape connector)](#connectShapesViaConnector-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-) | Verbinde Shapes über einen Connector. |
+| [connectShapesViaConnector(long shapeFromId, int placeFrom, long shapeToId, int placeTo, long connectorId)](#connectShapesViaConnector-long-int-long-int-long-) | Verbinde Shapes über einen Connector. |
+| [connectShapesViaConnector(long shapeFromId, String fromConnectionName, long shapeToId, String toConnectionName, long connectorId)](#connectShapesViaConnector-long-java.lang.String-long-java.lang.String-long-) | Verbinde Shapes über einen Connector. |
+| [connectShapesViaConnectorIndex(Shape shapeFrom, int fromIndex, Shape shapeTo, int toIndex, Shape connector)](#connectShapesViaConnectorIndex-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-) | Verbinde Shapes über den Connector-Index. |
+| [connectShapesViaConnectorIndex(long shapeFromId, int fromIndex, long shapeToId, int toIndex, long connectorId)](#connectShapesViaConnectorIndex-long-int-long-int-long-) | Verbinde Shapes über den Connector-Index. |
+| [copy(Page source)](#copy-com.aspose.diagram.Page-) |  |
+| [dispose()](#dispose--) | Führt anwendungsspezifische Aufgaben aus, die mit dem Freigeben, Freisetzen oder Zurücksetzen nicht verwalteter Ressourcen verbunden sind. |
+| [drawEllipse(double pinX, double pinY, double width, double height)](#drawEllipse-double-double-double-double-) | Der Vorgang des Zeichnens einer Ellipse. |
+| [drawLine(double beginX, double beginY, double endX, double endY)](#drawLine-double-double-double-double-) | Der Vorgang des Zeichnens einer einzelnen Linie. |
+| [drawLine(double pinX, double pinY, double width, double height, double[] xyArray)](#drawLine-double-double-double-double-double---) | Der Vorgang des Zeichnens einer Linie. |
+| [drawPolyline(double pinX, double pinY, double width, double height, double[] xyArray)](#drawPolyline-double-double-double-double-double---) | Der Vorgang des Zeichnens einer Polylinie. |
+| [drawRectangle(double pinX, double pinY, double width, double height)](#drawRectangle-double-double-double-double-) | Der Vorgang des Zeichnens eines Rechtecks. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAssociatedPage()](#getAssociatedPage--) | Die ID der ursprünglichen Zeichenblattseite, die von Prüfern der Zeichnung in separaten Markup-Overlays markiert wurde. |
+| [getBackPage()](#getBackPage--) | Die Hintergrundseite der Seite. |
+| [getBackground()](#getBackground--) | Ein Flag, das angibt, ob die Seite eine Hintergrundseite ist. |
+| [getClass()](#getClass--) |  |
+| [getConnects()](#getConnects--) | Enthält ein Connect-Element für jede Verbindung zwischen zwei Formen in einer Zeichnung. |
+| [getID()](#getID--) | Die eindeutige ID des Elements innerhalb seines übergeordneten Elements. |
+| [getName()](#getName--) | Der Name des Elements. |
+| [getNameU()](#getNameU--) | Der universelle Name des Elements. |
+| [getPageSheet()](#getPageSheet--) | Enthält Elemente, die das Seitenblatt für ein Seiten‑ oder Master‑Element definieren. |
+| [getPages()](#getPages--) | Seitensammlung. |
+| [getReviewerID()](#getReviewerID--) | Die ID des Prüfers, der mit dem Markup-Overlay verknüpft ist. |
+| [getShapes()](#getShapes--) | Formensammlung. |
+| [getViewCenterX()](#getViewCenterX--) | ViewCenterX und ViewCenterY geben einen Mittelpunkt auf einer Seite an, den eine neue Ansicht (Fenster) beim ersten Öffnen annimmt. |
+| [getViewCenterY()](#getViewCenterY--) | ViewCenterX und ViewCenterY geben einen Mittelpunkt auf einer Seite an, den eine neue Ansicht (Fenster) beim ersten Öffnen annimmt. |
+| [getViewScale()](#getViewScale--) | Der standardmäßige Vergrößerungsfaktor, der verwendet wird, wenn eine neue Ansicht (Fenster) der Seite geöffnet wird. |
+| [glueShapeToConnectorBeginX(long shapeFromId, String connectionName, long connectorId)](#glueShapeToConnectorBeginX-long-java.lang.String-long-) | Form an Connector's BeginX anheften |
+| [glueShapeToConnectorEndX(long shapeToId, String connectionName, long connectorId)](#glueShapeToConnectorEndX-long-java.lang.String-long-) | Form an Connector's EndX anheften |
+| [glueShapes(Shape shapeFrom, int placeTo, Shape shapeTo)](#glueShapes-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-) | Formen anheften. |
+| [glueShapes(long shapeFromId, int placeTo, long shapeToId)](#glueShapes-long-int-long-) | Formen anheften |
+| [glueShapesInContainer(long shapeFromId, int shapeToBeginConnectionIndex, int shapeToEndConnectionIndex, long shapeToId)](#glueShapesInContainer-long-int-int-long-) | Formen im Container anheften |
+| [glueShapesInContainer(long shapeFromId, String shapeToBeginConnectionName, String shapeToEndConnectionName, long shapeToId)](#glueShapesInContainer-long-java.lang.String-java.lang.String-long-) | Formen im Container mithilfe des Verbindungsnamens anheften |
+| [glueShapesInContainerByID(long shapeFromId, int shapeToBeginConnectionID, int shapeToEndConnectionID, long shapeToId)](#glueShapesInContainerByID-long-int-int-long-) | Formen im Container nach Verbindungs-ID anheften |
+| [hashCode()](#hashCode--) |  |
+| [layout(LayoutOptions options)](#layout-com.aspose.diagram.LayoutOptions-) | Ordnet die Formen an und/oder leitet die Connectoren für die Seite um. |
+| [moveTo(int index)](#moveTo-int-) | Verschiebt die Seite an einen anderen Ort in den Seiten. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [sendBackward(long shapeId)](#sendBackward-long-) | Verschiebt eine Form, definiert durch ID, um eine Position im Z-Order zurück. |
+| [sendToBack(long shapeId)](#sendToBack-long-) | Verschiebt eine Form, definiert durch ID, an das Ende des Z-Order. |
+| [setAssociatedPage(Page value)](#setAssociatedPage-com.aspose.diagram.Page-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getAssociatedPage()](../../com.aspose.diagram/page\#getAssociatedPage--) |
+| [setBackPage(Page value)](#setBackPage-com.aspose.diagram.Page-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getBackPage()](../../com.aspose.diagram/page\#getBackPage--) |
+| [setBackground(int value)](#setBackground-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getBackground()](../../com.aspose.diagram/page\#getBackground--) |
+| [setID(int value)](#setID-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getID()](../../com.aspose.diagram/page\#getID--) |
+| [setName(String value)](#setName-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getName()](../../com.aspose.diagram/page\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getNameU()](../../com.aspose.diagram/page\#getNameU--) |
+| [setPages(PageCollection value)](#setPages-com.aspose.diagram.PageCollection-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getPages()](../../com.aspose.diagram/page\#getPages--) |
+| [setPresetTheme(int value)](#setPresetTheme-int-) | Ein vordefiniertes Design auf dieser Seite anwenden |
+| [setPresetThemeQuickStyle(int value)](#setPresetThemeQuickStyle-int-) | Ein vordefinierter Designvarianten‑Quickstyle auf dieser Seite anwenden |
+| [setPresetThemeVariant(int value)](#setPresetThemeVariant-int-) | Eine vordefinierte Designvariante auf dieser Seite anwenden |
+| [setReviewerID(int value)](#setReviewerID-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getReviewerID()](../../com.aspose.diagram/page\#getReviewerID--) |
+| [setViewCenterX(double value)](#setViewCenterX-double-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getViewCenterX()](../../com.aspose.diagram/page\#getViewCenterX--) |
+| [setViewCenterY(double value)](#setViewCenterY-double-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getViewCenterY()](../../com.aspose.diagram/page\#getViewCenterY--) |
+| [setViewScale(double value)](#setViewScale-double-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getViewScale()](../../com.aspose.diagram/page\#getViewScale--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Page() {#Page--}
+```
+public Page()
+```
+
+
+Konstruktor.
+
+### Page(int ID) {#Page-int-}
+```
+public Page(int ID)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| ID | int |  |
+
+### addActiveXControl(int type, double pinX, double pinY, double width, double height) {#addActiveXControl-int-double-double-double-double-}
+```
+public long addActiveXControl(int type, double pinX, double pinY, double width, double height)
+```
+
+
+Erstellt ein Activex-Steuerelement.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Typ | int | Der Typ des Steuerelements. |
+| pinX | double | Gibt die x‑Koordinate des Pins der Form (Rotationszentrum) in Bezug auf die Seite an. |
+| pinY | double | Gibt die y‑Koordinate des Pins der Form (Rotationszentrum) in Bezug auf die Seite an. |
+| Breite | double | Gibt die Breite der Form in Zoll an. |
+| Höhe | double | Gibt die Höhe der Form in Zoll an. |
+
+**Returns:**
+long -
+### addComment(Shape shape, String comment) {#addComment-com.aspose.diagram.Shape-java.lang.String-}
+```
+public void addComment(Shape shape, String comment)
+```
+
+
+Fügt einem Shape einen Kommentar hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| shape | [Shape](../../com.aspose.diagram/shape) | Gibt die Form an, die den Kommentar hinzufügt. |
+| comment | java.lang.String | Zeichenkette des Kommentars. |
+
+### addComment(double pinX, double pinY, String comment) {#addComment-double-double-java.lang.String-}
+```
+public void addComment(double pinX, double pinY, String comment)
+```
+
+
+Fügt einen Kommentar mit definierten PinX und PinY hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| pinX | double | Gibt die x‑Koordinate des Pins des Kommentars (Rotationszentrum) in Bezug auf die Seite an. |
+| pinY | double | Gibt die y‑Koordinate des Pins des Kommentars (Rotationszentrum) in Bezug auf die Seite an. |
+| comment | java.lang.String | Zeichenkette des Kommentars. |
+
+### addComment(long shapeID, String comment) {#addComment-long-java.lang.String-}
+```
+public void addComment(long shapeID, String comment)
+```
+
+
+Fügt einem Shape einen Kommentar mit der Shape-ID hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| shapeID | long |  |
+| comment | java.lang.String | Zeichenkette des Kommentars. |
+
+### addShape(Shape newShape, String masterName) {#addShape-com.aspose.diagram.Shape-java.lang.String-}
+```
+public long addShape(Shape newShape, String masterName)
+```
+
+
+Fügt ein vom Master erstelltes Shape zu einer bestimmten Seite hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| newShape | [Shape](../../com.aspose.diagram/shape) | Neues Formobjekt[Shape](../../com.aspose.diagram/shape). |
+| masterName | java.lang.String | Name des Masters. |
+
+**Returns:**
+long - Die eindeutige ID der Form innerhalb der Formensammlung auf der angegebenen Seite.
+### addShape(double pinX, double pinY, double width, double height, InputStream stream) {#addShape-double-double-double-double-java.io.InputStream-}
+```
+public long addShape(double pinX, double pinY, double width, double height, InputStream stream)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| pinX | double |  |
+| pinY | double |  |
+| Breite | double |  |
+| Höhe | double |  |
+| stream | java.io.InputStream |  |
+
+**Returns:**
+long
+### addShape(double pinX, double pinY, double width, double height, InputStream imageStream, InputStream objectDataStream) {#addShape-double-double-double-double-java.io.InputStream-java.io.InputStream-}
+```
+public long addShape(double pinX, double pinY, double width, double height, InputStream imageStream, InputStream objectDataStream)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| pinX | double |  |
+| pinY | double |  |
+| Breite | double |  |
+| Höhe | double |  |
+| imageStream | java.io.InputStream |  |
+| objectDataStream | java.io.InputStream |  |
+
+**Returns:**
+long
+### addShape(double pinX, double pinY, double width, double height, String masterName) {#addShape-double-double-double-double-java.lang.String-}
+```
+public long addShape(double pinX, double pinY, double width, double height, String masterName)
+```
+
+
+Fügt ein vom Master erstelltes Shape auf einer Seite mit definierten PinX, PinY, Breite und Höhe hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| pinX | double | Gibt die x‑Koordinate des Pins der Form (Rotationszentrum) in Bezug auf die Seite an. |
+| pinY | double | Gibt die y‑Koordinate des Pins der Form (Rotationszentrum) in Bezug auf die Seite an. |
+| Breite | double | Gibt die Breite der Form in Zoll an. |
+| Höhe | double | Gibt die Höhe der Form in Zoll an. |
+| masterName | java.lang.String | Name des Masters. |
+
+**Returns:**
+long - Die eindeutige ID der Form innerhalb der Formensammlung auf der angegebenen Seite.
+### addShape(double pinX, double pinY, String masterName) {#addShape-double-double-java.lang.String-}
+```
+public long addShape(double pinX, double pinY, String masterName)
+```
+
+
+Fügt ein vom Master erstelltes Shape auf einer Seite mit definierten PinX und PinY hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| pinX | double | Gibt die x‑Koordinate des Pins der Form (Rotationszentrum) in Bezug auf die Seite an. |
+| pinY | double | Gibt die y‑Koordinate des Pins der Form (Rotationszentrum) in Bezug auf die Seite an. |
+| masterName | java.lang.String | Name des Masters. |
+
+**Returns:**
+long - Die eindeutige ID der Form innerhalb der Formensammlung auf der angegebenen Seite.
+### addText(double pinX, double pinY, double width, double height, String text) {#addText-double-double-double-double-java.lang.String-}
+```
+public Shape addText(double pinX, double pinY, double width, double height, String text)
+```
+
+
+Fügt Text mit definierten PinX und PinY hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| pinX | double | Specifies the x-coordinate of the text's pin (center of rotation) in relation to the page. |
+| pinY | double | Specifies the y-coordinate of the text's pin (center of rotation) in relation to the page. |
+| Breite | double |  |
+| Höhe | double |  |
+| text | java.lang.String | text string. |
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape) - Returns a shape object that represents the new text object.
+### addText(double pinX, double pinY, double width, double height, String text, String fontName, String fontColor, double size) {#addText-double-double-double-double-java.lang.String-java.lang.String-java.lang.String-double-}
+```
+public Shape addText(double pinX, double pinY, double width, double height, String text, String fontName, String fontColor, double size)
+```
+
+
+Fügt Text mit definierten PinX und PinY hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| pinX | double | Specifies the x-coordinate of the text's pin (center of rotation) in relation to the page. |
+| pinY | double | Specifies the y-coordinate of the text's pin (center of rotation) in relation to the page. |
+| Breite | double | Specifies the width of the text. |
+| Höhe | double | Specifies the height of the text. |
+| text | java.lang.String | text string. |
+| fontName | java.lang.String | text font name. |
+| fontColor | java.lang.String | text font color. |
+| size | double | text font size. |
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape) - Returns a shape object that represents the new text object.
+### applyStyle(int textStyle, int lineStyle, int fillStyle) {#applyStyle-int-int-int-}
+```
+public void applyStyle(int textStyle, int lineStyle, int fillStyle)
+```
+
+
+Applies style for full page. Default value is -1.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| textStyle | int | text Style id. |
+| lineStyle | int | line Style id. |
+| fillStyle | int | fill Style id. |
+
+### autoSpaceShapes(ShapeCollection shapes, AutoSpaceOptions options) {#autoSpaceShapes-com.aspose.diagram.ShapeCollection-com.aspose.diagram.AutoSpaceOptions-}
+```
+public void autoSpaceShapes(ShapeCollection shapes, AutoSpaceOptions options)
+```
+
+
+Automatischer Abstand zwischen Shapes.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| shapes | [ShapeCollection](../../com.aspose.diagram/shapecollection) | Specifies the shapes be auto spaced. |
+| options | [AutoSpaceOptions](../../com.aspose.diagram/autospaceoptions) |  |
+
+### bringForward(long shapeId) {#bringForward-long-}
+```
+public void bringForward(long shapeId)
+```
+
+
+Bringt ein Shape, definiert durch ID, eine Position im Z-Order nach vorne.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| shapeId | long | ID of shape.long |
+
+### bringToFront(long shapeId) {#bringToFront-long-}
+```
+public void bringToFront(long shapeId)
+```
+
+
+Bringt ein Shape, definiert durch ID, an die Spitze des Z-Order.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| shapeId | long | ID of shape.long |
+
+### centerDrawing() {#centerDrawing--}
+```
+public void centerDrawing()
+```
+
+
+Centers a page's shapes with respect to the extent of the page. Centering shapes does not change their position relative to each other.
+
+### connectShapesViaConnector(Shape shapeFrom, int placeFrom, Shape shapeTo, int placeTo, Shape connector) {#connectShapesViaConnector-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-}
+```
+public void connectShapesViaConnector(Shape shapeFrom, int placeFrom, Shape shapeTo, int placeTo, Shape connector)
+```
+
+
+Verbinde Shapes über einen Connector.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| shapeFrom | [Shape](../../com.aspose.diagram/shape) | The shape where the connector begins [Shape](../../com.aspose.diagram/shape). |
+| placeFrom | int | Der Ort auf der ersten Form, an dem der Connector verbunden wird Aspose.Diagram.Manipulation.ConnectionPointPlace. |
+| shapeTo | [Shape](../../com.aspose.diagram/shape) | Die Form, in der der Connector endet [Shape](../../com.aspose.diagram/shape). |
+| placeTo | int | Der Ort auf der zweiten Form, an dem der Connector verbunden wird Aspose.Diagram.Manipulation.ConnectionPointPlace. |
+| connector | [Shape](../../com.aspose.diagram/shape) | Die Form mit dem Typ Dynamischer Connector [Shape](../../com.aspose.diagram/shape). |
+
+### connectShapesViaConnector(long shapeFromId, int placeFrom, long shapeToId, int placeTo, long connectorId) {#connectShapesViaConnector-long-int-long-int-long-}
+```
+public void connectShapesViaConnector(long shapeFromId, int placeFrom, long shapeToId, int placeTo, long connectorId)
+```
+
+
+Verbinde Shapes über einen Connector.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| shapeFromId | long | Die ID der Form, in der der Connector beginnt [Shape](../../com.aspose.diagram/shape). |
+| placeFrom | int | Der Ort auf der ersten Form, an dem der Connector verbunden wird Aspose.Diagram.Manipulation.ConnectionPointPlace. |
+| shapeToId | long | Die ID der Form, in der der Connector endet [Shape](../../com.aspose.diagram/shape). |
+| placeTo | int | Der Ort auf der zweiten Form, an dem der Connector verbunden wird Aspose.Diagram.Manipulation.ConnectionPointPlace. |
+| connectorId | long | Die ID der Form mit dem Typ Dynamischer Connector [Shape](../../com.aspose.diagram/shape). |
+
+### connectShapesViaConnector(long shapeFromId, String fromConnectionName, long shapeToId, String toConnectionName, long connectorId) {#connectShapesViaConnector-long-java.lang.String-long-java.lang.String-long-}
+```
+public void connectShapesViaConnector(long shapeFromId, String fromConnectionName, long shapeToId, String toConnectionName, long connectorId)
+```
+
+
+Verbinde Shapes über einen Connector.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| shapeFromId | long | Die ID der Form, in der der Connector beginnt [Shape](../../com.aspose.diagram/shape). |
+| fromConnectionName | java.lang.String | Der Verbindungsname auf der ersten Form, an dem der Connector verbunden wird. |
+| shapeToId | long | Die ID der Form, in der der Connector endet [Shape](../../com.aspose.diagram/shape). |
+| toConnectionName | java.lang.String | Der Verbindungsname auf der zweiten Form, an dem der Connector verbunden wird. |
+| connectorId | long | Die ID der Form mit dem Typ Dynamischer Connector [Shape](../../com.aspose.diagram/shape). |
+
+### connectShapesViaConnectorIndex(Shape shapeFrom, int fromIndex, Shape shapeTo, int toIndex, Shape connector) {#connectShapesViaConnectorIndex-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-}
+```
+public void connectShapesViaConnectorIndex(Shape shapeFrom, int fromIndex, Shape shapeTo, int toIndex, Shape connector)
+```
+
+
+Verbinde Shapes über den Connector-Index.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| shapeFrom | [Shape](../../com.aspose.diagram/shape) | The shape where the connector begins [Shape](../../com.aspose.diagram/shape). |
+| fromIndex | int | Der Index der Verbindung auf der ersten Form |
+| shapeTo | [Shape](../../com.aspose.diagram/shape) | Die Form, in der der Connector endet [Shape](../../com.aspose.diagram/shape). |
+| toIndex | int | Der Index der Verbindung auf der zweiten Form |
+| connector | [Shape](../../com.aspose.diagram/shape) | Die Form mit dem Typ Dynamischer Connector [Shape](../../com.aspose.diagram/shape). |
+
+### connectShapesViaConnectorIndex(long shapeFromId, int fromIndex, long shapeToId, int toIndex, long connectorId) {#connectShapesViaConnectorIndex-long-int-long-int-long-}
+```
+public void connectShapesViaConnectorIndex(long shapeFromId, int fromIndex, long shapeToId, int toIndex, long connectorId)
+```
+
+
+Verbinde Shapes über den Connector-Index.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| shapeFromId | long | Die ID der Form, in der der Connector beginnt [Shape](../../com.aspose.diagram/shape). |
+| fromIndex | int | Der Index der Verbindung auf der ersten Form |
+| shapeToId | long | Die ID der Form, in der der Connector endet [Shape](../../com.aspose.diagram/shape). |
+| toIndex | int | Der Index der Verbindung auf der zweiten Form |
+| connectorId | long | Die ID der Form mit dem Typ Dynamischer Connector [Shape](../../com.aspose.diagram/shape). |
+
+### copy(Page source) {#copy-com.aspose.diagram.Page-}
+```
+public void copy(Page source)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| source | [Page](../../com.aspose.diagram/page) |  |
+
+### dispose() {#dispose--}
+```
+public void dispose()
+```
+
+
+Führt anwendungsspezifische Aufgaben aus, die mit dem Freigeben, Freisetzen oder Zurücksetzen nicht verwalteter Ressourcen verbunden sind.
+
+### drawEllipse(double pinX, double pinY, double width, double height) {#drawEllipse-double-double-double-double-}
+```
+public long drawEllipse(double pinX, double pinY, double width, double height)
+```
+
+
+Der Vorgang des Zeichnens einer Ellipse.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| pinX | double | Gibt die x‑Koordinate des Pins der Form (Rotationszentrum) in Bezug auf die Seite an. |
+| pinY | double | Gibt die y‑Koordinate des Pins der Form (Rotationszentrum) in Bezug auf die Seite an. |
+| Breite | double | Gibt die Breite der Form an |
+| Höhe | double | Gibt die Höhe der Form an |
+
+**Returns:**
+long -
+### drawLine(double beginX, double beginY, double endX, double endY) {#drawLine-double-double-double-double-}
+```
+public long drawLine(double beginX, double beginY, double endX, double endY)
+```
+
+
+Der Vorgang des Zeichnens einer einzelnen Linie.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| beginX | double | Gibt die Anfangs-x-Koordinate der Position der Form in Bezug auf die Seite an. |
+| beginY | double | Gibt die Anfangs-y-Koordinate der Position der Form in Bezug auf die Seite an. |
+| endX | double | Gibt die End-x-Koordinate der Position der Form in Bezug auf die Seite an. |
+| endY | double | Gibt die End‑Y‑Koordinate der Position der Form in Bezug auf die Seite an. |
+
+**Returns:**
+long - Die eindeutige ID der Form innerhalb der Formensammlung auf der angegebenen Seite.
+### drawLine(double pinX, double pinY, double width, double height, double[] xyArray) {#drawLine-double-double-double-double-double---}
+```
+public long drawLine(double pinX, double pinY, double width, double height, double[] xyArray)
+```
+
+
+Der Vorgang des Zeichnens einer Linie.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| pinX | double | Gibt die x‑Koordinate des Pins der Form (Rotationszentrum) in Bezug auf die Seite an. |
+| pinY | double | Gibt die y‑Koordinate des Pins der Form (Rotationszentrum) in Bezug auf die Seite an. |
+| Breite | double | Gibt die Breite der Form an |
+| Höhe | double | Gibt die Höhe der Form an |
+| xyArray | double[] | Ein Array aus abwechselnden x‑ und y‑Werten, das Punkte in der neuen Form definiert. |
+
+**Returns:**
+long - Die eindeutige ID der Form innerhalb der Formensammlung auf der angegebenen Seite.
+### drawPolyline(double pinX, double pinY, double width, double height, double[] xyArray) {#drawPolyline-double-double-double-double-double---}
+```
+public long drawPolyline(double pinX, double pinY, double width, double height, double[] xyArray)
+```
+
+
+Der Vorgang des Zeichnens einer Polylinie.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| pinX | double | Gibt die x‑Koordinate des Pins der Form (Rotationszentrum) in Bezug auf die Seite an. |
+| pinY | double | Gibt die y‑Koordinate des Pins der Form (Rotationszentrum) in Bezug auf die Seite an. |
+| Breite | double | Gibt die Breite der Form an |
+| Höhe | double | Gibt die Höhe der Form an |
+| xyArray | double[] | Ein Array aus abwechselnden x‑ und y‑Werten, das Punkte in der neuen Form definiert. |
+
+**Returns:**
+long - Die eindeutige ID der Form innerhalb der Formensammlung auf der angegebenen Seite.
+### drawRectangle(double pinX, double pinY, double width, double height) {#drawRectangle-double-double-double-double-}
+```
+public long drawRectangle(double pinX, double pinY, double width, double height)
+```
+
+
+Der Vorgang des Zeichnens eines Rechtecks.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| pinX | double | Gibt die x‑Koordinate des Pins der Form (Rotationszentrum) in Bezug auf die Seite an. |
+| pinY | double | Gibt die y‑Koordinate des Pins der Form (Rotationszentrum) in Bezug auf die Seite an. |
+| Breite | double | Gibt die Breite der Form an |
+| Höhe | double | Gibt die Höhe der Form an |
+
+**Returns:**
+long - Die eindeutige ID der Form innerhalb der Formensammlung auf der angegebenen Seite.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAssociatedPage() {#getAssociatedPage--}
+```
+public Page getAssociatedPage()
+```
+
+
+Die ID der ursprünglichen Zeichenblattseite, die von Prüfern der Zeichnung in separaten Markup-Overlays markiert wurde.
+
+**Returns:**
+[Page](../../com.aspose.diagram/page)
+### getBackPage() {#getBackPage--}
+```
+public Page getBackPage()
+```
+
+
+Die Hintergrundseite der Seite.
+
+**Returns:**
+[Page](../../com.aspose.diagram/page)
+### getBackground() {#getBackground--}
+```
+public int getBackground()
+```
+
+
+Ein Flag, das angibt, ob die Seite eine Hintergrundseite ist.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConnects() {#getConnects--}
+```
+public ConnectCollection getConnects()
+```
+
+
+Enthält ein Connect-Element für jede Verbindung zwischen zwei Formen in einer Zeichnung.
+
+**Returns:**
+[ConnectCollection](../../com.aspose.diagram/connectcollection)
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+Die eindeutige ID des Elements innerhalb seines übergeordneten Elements.
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Der Name des Elements.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+Der universelle Name des Elements.
+
+**Returns:**
+java.lang.String
+### getPageSheet() {#getPageSheet--}
+```
+public PageSheet getPageSheet()
+```
+
+
+Enthält Elemente, die das Seitenblatt für ein Seiten‑ oder Master‑Element definieren.
+
+**Returns:**
+[PageSheet](../../com.aspose.diagram/pagesheet)
+### getPages() {#getPages--}
+```
+public PageCollection getPages()
+```
+
+
+Seitensammlung.
+
+**Returns:**
+[PageCollection](../../com.aspose.diagram/pagecollection)
+### getReviewerID() {#getReviewerID--}
+```
+public int getReviewerID()
+```
+
+
+Die ID des Prüfers, der mit dem Markup-Overlay verknüpft ist.
+
+**Returns:**
+int
+### getShapes() {#getShapes--}
+```
+public ShapeCollection getShapes()
+```
+
+
+Formensammlung.
+
+**Returns:**
+[ShapeCollection](../../com.aspose.diagram/shapecollection)
+### getViewCenterX() {#getViewCenterX--}
+```
+public double getViewCenterX()
+```
+
+
+ViewCenterX und ViewCenterY geben einen Mittelpunkt auf einer Seite an, den eine neue Ansicht (Fenster) beim ersten Öffnen annimmt.
+
+**Returns:**
+double
+### getViewCenterY() {#getViewCenterY--}
+```
+public double getViewCenterY()
+```
+
+
+ViewCenterX und ViewCenterY geben einen Mittelpunkt auf einer Seite an, den eine neue Ansicht (Fenster) beim ersten Öffnen annimmt.
+
+**Returns:**
+double
+### getViewScale() {#getViewScale--}
+```
+public double getViewScale()
+```
+
+
+Der standardmäßige Vergrößerungsfaktor, der verwendet wird, wenn eine neue Ansicht (Fenster) der Seite geöffnet wird. Zum Beispiel 1 = 100 %; 1,5 = 150 % und so weiter.
+
+**Returns:**
+double
+### glueShapeToConnectorBeginX(long shapeFromId, String connectionName, long connectorId) {#glueShapeToConnectorBeginX-long-java.lang.String-long-}
+```
+public void glueShapeToConnectorBeginX(long shapeFromId, String connectionName, long connectorId)
+```
+
+
+Form an Connector's BeginX anheften
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| shapeFromId | long | Die ID der Form, in der der Connector beginnt [Shape](../../com.aspose.diagram/shape). |
+| connectionName | java.lang.String | Der Verbindungsname an der Form, an der der Connector angeschlossen wird. |
+| connectorId | long | Die ID der Form mit dem Typ Dynamischer Connector [Shape](../../com.aspose.diagram/shape). |
+
+### glueShapeToConnectorEndX(long shapeToId, String connectionName, long connectorId) {#glueShapeToConnectorEndX-long-java.lang.String-long-}
+```
+public void glueShapeToConnectorEndX(long shapeToId, String connectionName, long connectorId)
+```
+
+
+Form an Connector's EndX anheften
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| shapeToId | long | Die ID der Form, in der der Connector endet [Shape](../../com.aspose.diagram/shape). |
+| connectionName | java.lang.String | Der Verbindungsname auf der zweiten Form, an dem der Connector verbunden wird. |
+| connectorId | long | Die ID der Form mit dem Typ Dynamischer Connector [Shape](../../com.aspose.diagram/shape). |
+
+### glueShapes(Shape shapeFrom, int placeTo, Shape shapeTo) {#glueShapes-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-}
+```
+public void glueShapes(Shape shapeFrom, int placeTo, Shape shapeTo)
+```
+
+
+Formen anheften.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| shapeFrom | [Shape](../../com.aspose.diagram/shape) | Die Form, die von [Shape](../../com.aspose.diagram/shape) geklebt wird. |
+| placeTo | int | Der Ort auf der ersten Form, an dem Aspose.Diagram.Manipulation.ConnectionPointPlace geklebt wird. |
+| shapeTo | [Shape](../../com.aspose.diagram/shape) | Die Form, an die [Shape](../../com.aspose.diagram/shape) geklebt wird. |
+
+### glueShapes(long shapeFromId, int placeTo, long shapeToId) {#glueShapes-long-int-long-}
+```
+public void glueShapes(long shapeFromId, int placeTo, long shapeToId)
+```
+
+
+Formen anheften
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| shapeFromId | long | Die ID der Form, die von [Shape](../../com.aspose.diagram/shape) geklebt wird. |
+| placeTo | int | Der Ort auf der ersten Form, an dem Aspose.Diagram.Manipulation.ConnectionPointPlace geklebt wird. |
+| shapeToId | long | Die ID der Form, an die [Shape](../../com.aspose.diagram/shape) geklebt wird. |
+
+### glueShapesInContainer(long shapeFromId, int shapeToBeginConnectionIndex, int shapeToEndConnectionIndex, long shapeToId) {#glueShapesInContainer-long-int-int-long-}
+```
+public void glueShapesInContainer(long shapeFromId, int shapeToBeginConnectionIndex, int shapeToEndConnectionIndex, long shapeToId)
+```
+
+
+Formen im Container anheften
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| shapeFromId | long | Die ID der Form, die von [Shape](../../com.aspose.diagram/shape) geklebt wird. |
+| shapeToBeginConnectionIndex | int | Der Ort am ersten Verbindungsindex, an dem geklebt wird. |
+| shapeToEndConnectionIndex | int | Der Ort am Endverbindungsindex, an dem geklebt wird. |
+| shapeToId | long | Die ID der Form, an die [Shape](../../com.aspose.diagram/shape) geklebt wird. |
+
+### glueShapesInContainer(long shapeFromId, String shapeToBeginConnectionName, String shapeToEndConnectionName, long shapeToId) {#glueShapesInContainer-long-java.lang.String-java.lang.String-long-}
+```
+public void glueShapesInContainer(long shapeFromId, String shapeToBeginConnectionName, String shapeToEndConnectionName, long shapeToId)
+```
+
+
+Formen im Container mithilfe des Verbindungsnamens anheften
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| shapeFromId | long | Die ID der Form, die von [Shape](../../com.aspose.diagram/shape) geklebt wird. |
+| shapeToBeginConnectionName | java.lang.String | Der Ort am ersten Verbindungsnamen, an dem geklebt wird. |
+| shapeToEndConnectionName | java.lang.String | Der Ort am Endverbindungsnamen, an dem geklebt wird. |
+| shapeToId | long | Die ID der Form, an die [Shape](../../com.aspose.diagram/shape) geklebt wird. |
+
+### glueShapesInContainerByID(long shapeFromId, int shapeToBeginConnectionID, int shapeToEndConnectionID, long shapeToId) {#glueShapesInContainerByID-long-int-int-long-}
+```
+public void glueShapesInContainerByID(long shapeFromId, int shapeToBeginConnectionID, int shapeToEndConnectionID, long shapeToId)
+```
+
+
+Formen im Container nach Verbindungs-ID anheften
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| shapeFromId | long | Die ID der Form, die von [Shape](../../com.aspose.diagram/shape) geklebt wird. |
+| shapeToBeginConnectionID | int | Der Ort an der ersten Verbindungs-ID, an dem geklebt wird. |
+| shapeToEndConnectionID | int | Der Ort an der Endverbindungs-ID, an dem geklebt wird. |
+| shapeToId | long | Die ID der Form, an die [Shape](../../com.aspose.diagram/shape) geklebt wird. |
+
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### layout(LayoutOptions options) {#layout-com.aspose.diagram.LayoutOptions-}
+```
+public void layout(LayoutOptions options)
+```
+
+
+Ordnet die Formen an und/oder leitet die Connectoren für die Seite um.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| options | [LayoutOptions](../../com.aspose.diagram/layoutoptions) | Verwendung von [LayoutOptions](../../com.aspose.diagram/layoutoptions), um Layout‑Optionen zu konfigurieren. |
+
+### moveTo(int index) {#moveTo-int-}
+```
+public void moveTo(int index)
+```
+
+
+Verschiebt die Seite an einen anderen Ort in den Seiten.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Zielseitenindex. |
+
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### sendBackward(long shapeId) {#sendBackward-long-}
+```
+public void sendBackward(long shapeId)
+```
+
+
+Verschiebt eine Form, definiert durch ID, um eine Position im Z-Order zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| shapeId | long | ID of shape.long |
+
+### sendToBack(long shapeId) {#sendToBack-long-}
+```
+public void sendToBack(long shapeId)
+```
+
+
+Verschiebt eine Form, definiert durch ID, an das Ende des Z-Order.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| shapeId | long | ID of shape.long |
+
+### setAssociatedPage(Page value) {#setAssociatedPage-com.aspose.diagram.Page-}
+```
+public void setAssociatedPage(Page value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getAssociatedPage()](../../com.aspose.diagram/page\#getAssociatedPage--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [Page](../../com.aspose.diagram/page) |  |
+
+### setBackPage(Page value) {#setBackPage-com.aspose.diagram.Page-}
+```
+public void setBackPage(Page value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getBackPage()](../../com.aspose.diagram/page\#getBackPage--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [Page](../../com.aspose.diagram/page) |  |
+
+### setBackground(int value) {#setBackground-int-}
+```
+public void setBackground(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getBackground()](../../com.aspose.diagram/page\#getBackground--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getID()](../../com.aspose.diagram/page\#getID--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getName()](../../com.aspose.diagram/page\#getName--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getNameU()](../../com.aspose.diagram/page\#getNameU--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setPages(PageCollection value) {#setPages-com.aspose.diagram.PageCollection-}
+```
+public void setPages(PageCollection value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getPages()](../../com.aspose.diagram/page\#getPages--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [PageCollection](../../com.aspose.diagram/pagecollection) |  |
+
+### setPresetTheme(int value) {#setPresetTheme-int-}
+```
+public void setPresetTheme(int value)
+```
+
+
+Ein vordefiniertes Design auf dieser Seite anwenden
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setPresetThemeQuickStyle(int value) {#setPresetThemeQuickStyle-int-}
+```
+public void setPresetThemeQuickStyle(int value)
+```
+
+
+Ein vordefinierter Designvarianten‑Quickstyle auf dieser Seite anwenden
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setPresetThemeVariant(int value) {#setPresetThemeVariant-int-}
+```
+public void setPresetThemeVariant(int value)
+```
+
+
+Eine vordefinierte Designvariante auf dieser Seite anwenden
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setReviewerID(int value) {#setReviewerID-int-}
+```
+public void setReviewerID(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getReviewerID()](../../com.aspose.diagram/page\#getReviewerID--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setViewCenterX(double value) {#setViewCenterX-double-}
+```
+public void setViewCenterX(double value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getViewCenterX()](../../com.aspose.diagram/page\#getViewCenterX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double |  |
+
+### setViewCenterY(double value) {#setViewCenterY-double-}
+```
+public void setViewCenterY(double value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getViewCenterY()](../../com.aspose.diagram/page\#getViewCenterY--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double |  |
+
+### setViewScale(double value) {#setViewScale-double-}
+```
+public void setViewScale(double value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getViewScale()](../../com.aspose.diagram/page\#getViewScale--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/pagecollection/_index.md
+++ b/german/java/com.aspose.diagram/pagecollection/_index.md
@@ -1,0 +1,259 @@
+---
+title: PageCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: Seitensammlung.
+type: docs
+weight: 261
+url: /de/java/com.aspose.diagram/pagecollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class PageCollection extends Collection
+```
+
+Seitensammlung.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [add(Page page)](#add-com.aspose.diagram.Page-) | Füge die Seite zur Sammlung hinzu. |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [dispose()](#dispose--) | Führt anwendungsspezifische Aufgaben aus, die mit dem Freigeben, Freisetzen oder Zurücksetzen nicht verwalteter Ressourcen verbunden sind. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [getPage(int ID)](#getPage-int-) | Liefert das Element mit der angegebenen ID. |
+| [getPage(String name)](#getPage-java.lang.String-) | Liefert das Element mit dem angegebenen Namen. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Page page)](#remove-com.aspose.diagram.Page-) | Entferne die Seite aus der Sammlung. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Page page) {#add-com.aspose.diagram.Page-}
+```
+public int add(Page page)
+```
+
+
+Füge die Seite zur Sammlung hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| page | [Page](../../com.aspose.diagram/page) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### dispose() {#dispose--}
+```
+public void dispose()
+```
+
+
+Führt anwendungsspezifische Aufgaben aus, die mit dem Freigeben, Freisetzen oder Zurücksetzen nicht verwalteter Ressourcen verbunden sind.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Page get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[Page](../../com.aspose.diagram/page) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### getPage(int ID) {#getPage-int-}
+```
+public Page getPage(int ID)
+```
+
+
+Liefert das Element mit der angegebenen ID.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| ID | int |  |
+
+**Returns:**
+[Page](../../com.aspose.diagram/page) - 
+### getPage(String name) {#getPage-java.lang.String-}
+```
+public Page getPage(String name)
+```
+
+
+Liefert das Element mit dem angegebenen Namen.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Name | java.lang.String |  |
+
+**Returns:**
+[Page](../../com.aspose.diagram/page) - 
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Page page) {#remove-com.aspose.diagram.Page-}
+```
+public void remove(Page page)
+```
+
+
+Entferne die Seite aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| page | [Page](../../com.aspose.diagram/page) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/pageendsavingargs/_index.md
+++ b/german/java/com.aspose.diagram/pageendsavingargs/_index.md
@@ -1,0 +1,172 @@
+---
+title: PageEndSavingArgs
+second_title: Aspose.Diagram for Java API-Referenz
+description: Informationen für eine Seite beenden den Speicherungsprozess.
+type: docs
+weight: 262
+url: /de/java/com.aspose.diagram/pageendsavingargs/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.PageSavingArgs](../../com.aspose.diagram/pagesavingargs)
+```
+public class PageEndSavingArgs extends PageSavingArgs
+```
+
+Informationen für eine Seite beenden den Speicherungsprozess.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getPageCount()](#getPageCount--) | Gesamtseitenzahl. |
+| [getPageIndex()](#getPageIndex--) | Aktueller Seitenindex, nullbasiert. |
+| [hasMorePages()](#hasMorePages--) | Ein Wert, der angibt, ob weitere Seiten ausgegeben werden sollen. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setHasMorePages(boolean value)](#setHasMorePages-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [hasMorePages()](../../com.aspose.diagram/pageendsavingargs\#hasMorePages--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+Gesamtseitenzahl.
+
+**Returns:**
+int
+### getPageIndex() {#getPageIndex--}
+```
+public int getPageIndex()
+```
+
+
+Aktueller Seitenindex, nullbasiert.
+
+**Returns:**
+int
+### hasMorePages() {#hasMorePages--}
+```
+public boolean hasMorePages()
+```
+
+
+Ein Wert, der angibt, ob weitere Seiten ausgegeben werden sollen. Der Standardwert ist true.
+
+**Returns:**
+boolean
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setHasMorePages(boolean value) {#setHasMorePages-boolean-}
+```
+public void setHasMorePages(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [hasMorePages()](../../com.aspose.diagram/pageendsavingargs\#hasMorePages--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/pagelayout/_index.md
+++ b/german/java/com.aspose.diagram/pagelayout/_index.md
@@ -1,0 +1,458 @@
+---
+title: PageLayout
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält Zellen, die die Seitengestaltungseinstellungen für Formen und Verbinder steuern, wie z. B. den Abstand zwischen allen Formen auf der Seite, den Abstand zwischen allen Verbindern auf der Seite und den Routing‑Stil für alle Verbinder auf der Seite.
+type: docs
+weight: 263
+url: /de/java/com.aspose.diagram/pagelayout/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PageLayout
+```
+
+Enthält Zellen, die die Seitengestaltungseinstellungen für Formen und Verbinder steuern, wie z. B. den Abstand zwischen allen Formen auf der Seite, den Abstand zwischen allen Verbindern auf der Seite und den Routing‑Stil für alle Verbinder auf der Seite.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAvenueSizeX()](#getAvenueSizeX--) | Bestimmt den vertikalen Abstand zwischen Formen auf der Zeichenfläche, wenn Sie Microsoft Visio zum Anordnen von Formen auf der Zeichenfläche verwenden. |
+| [getAvenueSizeY()](#getAvenueSizeY--) | Bestimmt den vertikalen Abstand zwischen Formen auf der Zeichenfläche, wenn Sie Microsoft Visio zum Anordnen von Formen auf der Zeichenfläche verwenden. |
+| [getAvoidPageBreaks()](#getAvoidPageBreaks--) | Gibt an, wie Formen auf der Seite platziert werden, wenn Formen angeordnet werden, nachdem ein Benutzer „Formen anordnen“ (Form‑Menü) auswählt. |
+| [getBlockSizeX()](#getBlockSizeX--) | Bestimmt die vertikale Blockgröße, den Bereich, in den jede Ihrer Formen auf der Zeichenfläche passen muss, wenn Sie Microsoft Visio zum Anordnen von Formen auf der Zeichenfläche verwenden. |
+| [getBlockSizeY()](#getBlockSizeY--) | Bestimmt den horizontalen Abstand zwischen Formen auf der Zeichenfläche, wenn Sie Microsoft Visio zum Anordnen von Formen auf der Zeichenfläche verwenden. |
+| [getClass()](#getClass--) |  |
+| [getCtrlAsInput()](#getCtrlAsInput--) | Bestimmt, welche Form das übergeordnete Element ist, wenn Formen über Steuergriffe verwendet werden. |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getDynamicsOff()](#getDynamicsOff--) | Gibt an, ob platzierbare Formen verschoben werden und Verbinder um andere Formen und Verbinder auf der Zeichenfläche herum umgeleitet werden. |
+| [getEnableGrid()](#getEnableGrid--) | Gibt an, ob Microsoft Visio Formen anhand eines internen Seitengitters anordnet, wenn der Benutzer Lay Out Shapes (Shape‑Menü) auswählt. |
+| [getLineAdjustFrom()](#getLineAdjustFrom--) | Gibt an, welche dynamischen Verbinder auseinandergezogen werden sollen, wenn sie übereinander geroutet werden. |
+| [getLineAdjustTo()](#getLineAdjustTo--) | Gibt an, welche dynamischen Verbinder übereinander ausgerichtet werden sollen, wenn sie übereinander geroutet werden. |
+| [getLineJumpCode()](#getLineJumpCode--) | Gibt den Linien‑Sprungstil für alle Verbinder auf der Zeichen‑Seite an, die keinen lokalen Linien‑Sprungstil haben. |
+| [getLineJumpFactorX()](#getLineJumpFactorX--) | Gibt die Größe von Liniensprüngen auf horizontalen Segmenten dynamischer Verbinder auf der Seite an, als Prozentsatz des Werts des Elements LineToLineX (das den horizontalen Abstand zwischen allen Verbindern auf der Zeichenfläche festlegt). |
+| [getLineJumpFactorY()](#getLineJumpFactorY--) | Gibt die Größe von Liniensprüngen auf vertikalen Segmenten dynamischer Verbinder auf der Seite an, als Prozentsatz des Werts des Elements LineToLineY (das den vertikalen Abstand zwischen allen Verbindern auf der Zeichenfläche festlegt). |
+| [getLineJumpStyle()](#getLineJumpStyle--) | Gibt die Richtung von Liniensprüngen auf horizontalen Segmenten dynamischer Verbinder auf der Zeichenfläche an, für die keine lokale Sprungrichtung festgelegt wurde. |
+| [getLineRouteExt()](#getLineRouteExt--) | Gibt das Standard‑Aussehen für alle Verbinder auf einer Seite an. |
+| [getLineToLineX()](#getLineToLineX--) | Gibt den minimalen horizontalen Abstand zwischen dynamischen Verbindern auf der Zeichenfläche an. |
+| [getLineToLineY()](#getLineToLineY--) | Gibt den minimalen vertikalen Abstand zwischen dynamischen Verbindern auf der Zeichenfläche an. |
+| [getLineToNodeX()](#getLineToNodeX--) | Gibt den minimalen vertikalen Abstand zwischen dynamischen Verbindern und Formen auf der Zeichenfläche an. |
+| [getLineToNodeY()](#getLineToNodeY--) | Bestimmt die horizontale Blockgröße, den Bereich, in den jede Ihrer Formen auf der Zeichenfläche passen muss, wenn Sie Microsoft Visio zum Anordnen von Formen auf der Zeichenfläche verwenden. |
+| [getPageLineJumpDirX()](#getPageLineJumpDirX--) | Gibt die Richtung von Liniensprüngen auf vertikalen dynamischen Verbindern auf der Zeichenfläche an, für die keine lokale Sprungrichtung festgelegt wurde. |
+| [getPageLineJumpDirY()](#getPageLineJumpDirY--) | Gibt den minimalen horizontalen Abstand zwischen dynamischen Verbindern und Formen auf der Zeichenfläche an. |
+| [getPageShapeSplit()](#getPageShapeSplit--) | Gibt an, ob Formen auf der Seite automatisch aufgeteilt werden können. |
+| [getPlaceDepth()](#getPlaceDepth--) | Gibt an, ob platzierbare Formen weggeschoben werden, wenn der Benutzer eine platzierbare Form in die Nähe einer anderen platzierbaren Form auf der Zeichenfläche zieht. |
+| [getPlaceFlip()](#getPlaceFlip--) | Gibt an, wie platzierbare Formen auf einer Seite gedreht und/oder gespiegelt werden, wenn Formen mit dem Befehl „Formen anordnen“ in Microsoft Visio angeordnet werden. |
+| [getPlaceStyle()](#getPlaceStyle--) | Gibt den Routing‑Stil und die Richtung für alle dynamischen Verbinder auf der Zeichenfläche an, die keinen lokalen Routing‑Stil haben. |
+| [getPlowCode()](#getPlowCode--) | Bestimmt die dynamischen Verbinder, zu denen Sprünge hinzugefügt werden sollen. |
+| [getResizePage()](#getResizePage--) | Gibt an, ob die Seite vergrößert werden soll, um die Zeichnung zu umfassen, nachdem ein Benutzer Lay Out Shapes (Shapes‑Menü) ausgewählt hat. |
+| [getRouteStyle()](#getRouteStyle--) | Für eine automatisch angeordnete Zeichnung gibt die Methode an, mit der die Zeichnung vor der Erstellung des Layouts analysiert wird, und bestimmt den Layouttyp. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/pagelayout\\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAvenueSizeX() {#getAvenueSizeX--}
+```
+public DoubleValue getAvenueSizeX()
+```
+
+
+Bestimmt den vertikalen Abstand zwischen Formen auf der Zeichenfläche, wenn Sie Microsoft Visio zum Anordnen von Formen auf der Zeichenfläche verwenden.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getAvenueSizeY() {#getAvenueSizeY--}
+```
+public DoubleValue getAvenueSizeY()
+```
+
+
+Bestimmt den vertikalen Abstand zwischen Formen auf der Zeichenfläche, wenn Sie Microsoft Visio zum Anordnen von Formen auf der Zeichenfläche verwenden.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getAvoidPageBreaks() {#getAvoidPageBreaks--}
+```
+public BoolValue getAvoidPageBreaks()
+```
+
+
+Gibt an, wie Formen auf der Seite platziert werden, wenn Formen angeordnet werden, nachdem ein Benutzer „Formen anordnen“ (Form‑Menü) auswählt.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getBlockSizeX() {#getBlockSizeX--}
+```
+public DoubleValue getBlockSizeX()
+```
+
+
+Bestimmt die vertikale Blockgröße, den Bereich, in den jede Ihrer Formen auf der Zeichenfläche passen muss, wenn Sie Microsoft Visio zum Anordnen von Formen auf der Zeichenfläche verwenden.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBlockSizeY() {#getBlockSizeY--}
+```
+public DoubleValue getBlockSizeY()
+```
+
+
+Bestimmt den horizontalen Abstand zwischen Formen auf der Zeichenfläche, wenn Sie Microsoft Visio zum Anordnen von Formen auf der Zeichenfläche verwenden.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCtrlAsInput() {#getCtrlAsInput--}
+```
+public BoolValue getCtrlAsInput()
+```
+
+
+Bestimmt, welche Form das übergeordnete Element ist, wenn Formen über Steuergriffe verwendet werden. Dieses Element legt das Verhalten aller Formen auf der Zeichenfläche fest.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getDynamicsOff() {#getDynamicsOff--}
+```
+public BoolValue getDynamicsOff()
+```
+
+
+Gibt an, ob platzierbare Formen verschoben werden und Verbinder um andere Formen und Verbinder auf der Zeichenfläche herum umgeleitet werden.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getEnableGrid() {#getEnableGrid--}
+```
+public BoolValue getEnableGrid()
+```
+
+
+Gibt an, ob Microsoft Visio Formen anhand eines internen Seitengitters anordnet, wenn der Benutzer Lay Out Shapes (Shape‑Menü) auswählt.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLineAdjustFrom() {#getLineAdjustFrom--}
+```
+public LineAdjustFrom getLineAdjustFrom()
+```
+
+
+Gibt an, welche dynamischen Verbinder auseinandergezogen werden sollen, wenn sie übereinander geroutet werden.
+
+**Returns:**
+[LineAdjustFrom](../../com.aspose.diagram/lineadjustfrom)
+### getLineAdjustTo() {#getLineAdjustTo--}
+```
+public LineAdjustTo getLineAdjustTo()
+```
+
+
+Gibt an, welche dynamischen Verbinder übereinander ausgerichtet werden sollen, wenn sie übereinander geroutet werden.
+
+**Returns:**
+[LineAdjustTo](../../com.aspose.diagram/lineadjustto)
+### getLineJumpCode() {#getLineJumpCode--}
+```
+public LineJumpCode getLineJumpCode()
+```
+
+
+Gibt den Linien‑Sprungstil für alle Verbinder auf der Zeichen‑Seite an, die keinen lokalen Linien‑Sprungstil haben.
+
+**Returns:**
+[LineJumpCode](../../com.aspose.diagram/linejumpcode)
+### getLineJumpFactorX() {#getLineJumpFactorX--}
+```
+public DoubleValue getLineJumpFactorX()
+```
+
+
+Gibt die Größe von Liniensprüngen auf horizontalen Segmenten dynamischer Verbinder auf der Seite an, als Prozentsatz des Werts des Elements LineToLineX (das den horizontalen Abstand zwischen allen Verbindern auf der Zeichenfläche festlegt). Der Wert dieses Elements liegt zwischen 0 und 10.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLineJumpFactorY() {#getLineJumpFactorY--}
+```
+public DoubleValue getLineJumpFactorY()
+```
+
+
+Gibt die Größe von Liniensprüngen auf vertikalen Segmenten dynamischer Verbinder auf der Seite an, als Prozentsatz des Werts des Elements LineToLineY (das den vertikalen Abstand zwischen allen Verbindern auf der Zeichenfläche festlegt). Dieses Element kann einen Wert von 0 bis 10 enthalten.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLineJumpStyle() {#getLineJumpStyle--}
+```
+public LineJumpStyle getLineJumpStyle()
+```
+
+
+Gibt die Richtung von Liniensprüngen auf horizontalen Segmenten dynamischer Verbinder auf der Zeichenfläche an, für die keine lokale Sprungrichtung festgelegt wurde.
+
+**Returns:**
+[LineJumpStyle](../../com.aspose.diagram/linejumpstyle)
+### getLineRouteExt() {#getLineRouteExt--}
+```
+public LineRouteExt getLineRouteExt()
+```
+
+
+Gibt das Standard‑Aussehen für alle Verbinder auf einer Seite an.
+
+**Returns:**
+[LineRouteExt](../../com.aspose.diagram/linerouteext)
+### getLineToLineX() {#getLineToLineX--}
+```
+public DoubleValue getLineToLineX()
+```
+
+
+Gibt den minimalen horizontalen Abstand zwischen dynamischen Verbindern auf der Zeichenfläche an.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLineToLineY() {#getLineToLineY--}
+```
+public DoubleValue getLineToLineY()
+```
+
+
+Gibt den minimalen vertikalen Abstand zwischen dynamischen Verbindern auf der Zeichenfläche an.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLineToNodeX() {#getLineToNodeX--}
+```
+public DoubleValue getLineToNodeX()
+```
+
+
+Gibt den minimalen vertikalen Abstand zwischen dynamischen Verbindern und Formen auf der Zeichenfläche an.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLineToNodeY() {#getLineToNodeY--}
+```
+public DoubleValue getLineToNodeY()
+```
+
+
+Bestimmt die horizontale Blockgröße, den Bereich, in den jede Ihrer Formen auf der Zeichenfläche passen muss, wenn Sie Microsoft Visio zum Anordnen von Formen auf der Zeichenfläche verwenden.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getPageLineJumpDirX() {#getPageLineJumpDirX--}
+```
+public PageLineJumpDirX getPageLineJumpDirX()
+```
+
+
+Gibt die Richtung von Liniensprüngen auf vertikalen dynamischen Verbindern auf der Zeichenfläche an, für die keine lokale Sprungrichtung festgelegt wurde.
+
+**Returns:**
+[PageLineJumpDirX](../../com.aspose.diagram/pagelinejumpdirx)
+### getPageLineJumpDirY() {#getPageLineJumpDirY--}
+```
+public PageLineJumpDirY getPageLineJumpDirY()
+```
+
+
+Gibt den minimalen horizontalen Abstand zwischen dynamischen Verbindern und Formen auf der Zeichenfläche an.
+
+**Returns:**
+[PageLineJumpDirY](../../com.aspose.diagram/pagelinejumpdiry)
+### getPageShapeSplit() {#getPageShapeSplit--}
+```
+public BoolValue getPageShapeSplit()
+```
+
+
+Gibt an, ob Formen auf der Seite automatisch aufgeteilt werden können.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getPlaceDepth() {#getPlaceDepth--}
+```
+public PlaceDepth getPlaceDepth()
+```
+
+
+Gibt an, ob platzierbare Formen weggeschoben werden, wenn der Benutzer eine platzierbare Form in die Nähe einer anderen platzierbaren Form auf der Zeichenfläche zieht.
+
+**Returns:**
+[PlaceDepth](../../com.aspose.diagram/placedepth)
+### getPlaceFlip() {#getPlaceFlip--}
+```
+public PlaceFlip getPlaceFlip()
+```
+
+
+Gibt an, wie platzierbare Formen auf einer Seite gedreht und/oder rotiert werden, wenn Formen mit dem Befehl „Lay Out Shapes“ in Microsoft Visio angeordnet werden. Die folgenden hexadezimalen Werte sind zulässig.
+
+**Returns:**
+[PlaceFlip](../../com.aspose.diagram/placeflip)
+### getPlaceStyle() {#getPlaceStyle--}
+```
+public PlaceStyle getPlaceStyle()
+```
+
+
+Gibt den Routing‑Stil und die Richtung für alle dynamischen Verbinder auf der Zeichenfläche an, die keinen lokalen Routing‑Stil haben.
+
+**Returns:**
+[PlaceStyle](../../com.aspose.diagram/placestyle)
+### getPlowCode() {#getPlowCode--}
+```
+public BoolValue getPlowCode()
+```
+
+
+Bestimmt die dynamischen Verbinder, zu denen Sprünge hinzugefügt werden sollen.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getResizePage() {#getResizePage--}
+```
+public BoolValue getResizePage()
+```
+
+
+Gibt an, ob die Seite vergrößert werden soll, um die Zeichnung zu umfassen, nachdem ein Benutzer Lay Out Shapes (Shapes‑Menü) ausgewählt hat.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getRouteStyle() {#getRouteStyle--}
+```
+public RouteStyle getRouteStyle()
+```
+
+
+Für eine automatisch angeordnete Zeichnung gibt die Methode an, mit der die Zeichnung vor der Erstellung des Layouts analysiert wird, und bestimmt den Layouttyp.
+
+**Returns:**
+[RouteStyle](../../com.aspose.diagram/routestyle)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/pagelayout\\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/pagelinejumpdirx/_index.md
+++ b/german/java/com.aspose.diagram/pagelinejumpdirx/_index.md
@@ -1,0 +1,179 @@
+---
+title: PageLineJumpDirX
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt die Richtung von Liniensprüngen auf horizontalen Segmenten dynamischer Verbinder auf der Zeichenfläche an, für die Sie keine lokale Sprungrichtung festgelegt haben.
+type: docs
+weight: 264
+url: /de/java/com.aspose.diagram/pagelinejumpdirx/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PageLineJumpDirX
+```
+
+Gibt die Richtung von Liniensprüngen auf horizontalen Segmenten dynamischer Verbinder auf der Zeichenfläche an, für die keine lokale Sprungrichtung festgelegt wurde.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [PageLineJumpDirX(int value)](#PageLineJumpDirX-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Gibt die Richtung von Liniensprüngen auf horizontalen Segmenten dynamischer Verbinder auf der Zeichenfläche an, für die keine lokale Sprungrichtung festgelegt wurde. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/pagelinejumpdirx\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageLineJumpDirX(int value) {#PageLineJumpDirX-int-}
+```
+public PageLineJumpDirX(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Gibt die Richtung von Liniensprüngen auf horizontalen Segmenten dynamischer Verbinder auf der Zeichenfläche an, für die keine lokale Sprungrichtung festgelegt wurde.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/pagelinejumpdirx\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/pagelinejumpdirxvalue/_index.md
+++ b/german/java/com.aspose.diagram/pagelinejumpdirxvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: PageLineJumpDirXValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt die Richtung von Liniensprüngen auf horizontalen Segmenten dynamischer Verbinder auf der Zeichenfläche an, für die Sie keine lokale Sprungrichtung festgelegt haben.
+type: docs
+weight: 265
+url: /de/java/com.aspose.diagram/pagelinejumpdirxvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PageLineJumpDirXValue
+```
+
+Gibt die Richtung von Liniensprüngen auf horizontalen Segmenten dynamischer Verbinder auf der Zeichenfläche an, für die keine lokale Sprungrichtung festgelegt wurde.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [DEFAULT_UP](#DEFAULT-UP) | Standard nach oben. |
+| [DOWN](#DOWN) | Unten |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+| [UP](#UP) | Nach oben. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DEFAULT_UP {#DEFAULT-UP}
+```
+public static final int DEFAULT_UP
+```
+
+
+Standard nach oben.
+
+### DOWN {#DOWN}
+```
+public static final int DOWN
+```
+
+
+Unten
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### UP {#UP}
+```
+public static final int UP
+```
+
+
+Nach oben.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/pagelinejumpdiry/_index.md
+++ b/german/java/com.aspose.diagram/pagelinejumpdiry/_index.md
@@ -1,0 +1,179 @@
+---
+title: PageLineJumpDirY
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt die Richtung der Zeilsprünge bei vertikalen dynamischen Verbindern auf der Zeichenfläche an, für die Sie keine lokale Sprungrichtung festgelegt haben.
+type: docs
+weight: 266
+url: /de/java/com.aspose.diagram/pagelinejumpdiry/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PageLineJumpDirY
+```
+
+Gibt die Richtung von Liniensprüngen auf vertikalen dynamischen Verbindern auf der Zeichenfläche an, für die keine lokale Sprungrichtung festgelegt wurde.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [PageLineJumpDirY(int value)](#PageLineJumpDirY-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Gibt die Richtung von Liniensprüngen auf vertikalen dynamischen Verbindern auf der Zeichenfläche an, für die keine lokale Sprungrichtung festgelegt wurde. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/pagelinejumpdiry\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageLineJumpDirY(int value) {#PageLineJumpDirY-int-}
+```
+public PageLineJumpDirY(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Gibt die Richtung von Liniensprüngen auf vertikalen dynamischen Verbindern auf der Zeichenfläche an, für die keine lokale Sprungrichtung festgelegt wurde.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/pagelinejumpdiry\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/pagelinejumpdiryvalue/_index.md
+++ b/german/java/com.aspose.diagram/pagelinejumpdiryvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: PageLineJumpDirYValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt die Richtung der Zeilsprünge bei vertikalen dynamischen Verbindern auf der Zeichenfläche an, für die Sie keine lokale Sprungrichtung festgelegt haben.
+type: docs
+weight: 267
+url: /de/java/com.aspose.diagram/pagelinejumpdiryvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PageLineJumpDirYValue
+```
+
+Gibt die Richtung von Liniensprüngen auf vertikalen dynamischen Verbindern auf der Zeichenfläche an, für die keine lokale Sprungrichtung festgelegt wurde.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [DEFAULTLEFT](#DEFAULTLEFT) | Standard links. |
+| [LEFT](#LEFT) | Links. |
+| [RIGHT](#RIGHT) | Rechts. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DEFAULTLEFT {#DEFAULTLEFT}
+```
+public static final int DEFAULTLEFT
+```
+
+
+Standard links.
+
+### LEFT {#LEFT}
+```
+public static final int LEFT
+```
+
+
+Links.
+
+### RIGHT {#RIGHT}
+```
+public static final int RIGHT
+```
+
+
+Rechts.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/pageprops/_index.md
+++ b/german/java/com.aspose.diagram/pageprops/_index.md
@@ -1,0 +1,315 @@
+---
+title: PageProps
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält Zellen, die Seitenattribute wie Seitenbreite, -höhe und Maßstab steuern.
+type: docs
+weight: 268
+url: /de/java/com.aspose.diagram/pageprops/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PageProps
+```
+
+Enthält Zellen, die Seitenattribute steuern, wie Seitenbreite, -höhe und Maßstab.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getDrawingResizeType()](#getDrawingResizeType--) | Bestimmt, ob die Zeichenfläche automatisch an das Diagramm angepasst wird. |
+| [getDrawingScale()](#getDrawingScale--) | Stellt den Wert der Zeicheneinheit im aktuellen Zeichnungsmaßstab dar. |
+| [getDrawingScaleType()](#getDrawingScaleType--) | Gibt den Typ der Zeichenmaßstabes an, der für eine Seite verwendet werden soll. |
+| [getDrawingSizeType()](#getDrawingSizeType--) | Gibt die Zeichenflächegröße einer Seite an. |
+| [getInhibitSnap()](#getInhibitSnap--) | Gibt an, ob die Formen auf einer Vordergrundseite an anderen Objekten auf der Seite und an Formen auf der Hintergrundseite einrasten. |
+| [getPageHeight()](#getPageHeight--) | Gibt die Höhe der Seite in Zeicheneinheiten an. |
+| [getPageScale()](#getPageScale--) | Gibt den Wert der Standardseiteneinheit im aktuellen Zeichnungsmaßstab an. |
+| [getPageWidth()](#getPageWidth--) | Gibt die Breite der Seite in Zeicheneinheiten an. |
+| [getShdwObliqueAngle()](#getShdwObliqueAngle--) | Enthält eine Zahl, die den Winkel der schrägen Richtung angibt, wenn der Standard-Seiten-Schatten-Typ angewendet wird. |
+| [getShdwOffsetX()](#getShdwOffsetX--) | Gibt den Abstand in Seiteneinheiten an, um den der Abwurfschatten einer Form horizontal von der Form versetzt ist. |
+| [getShdwOffsetY()](#getShdwOffsetY--) | Gibt den Abstand in Seiteneinheiten an, um den der Abwurfschatten einer Form vertikal von der Form versetzt ist. |
+| [getShdwScaleFactor()](#getShdwScaleFactor--) | Gibt den Prozentsatz an, um den ein Formschatten vergrößert oder verkleinert wird. |
+| [getShdwType()](#getShdwType--) | Zeigt den Standard‑Schattentyp für eine Seite an. |
+| [getUIVisibility()](#getUIVisibility--) | Bestimmt, ob der Seitenname in der Benutzeroberfläche (UI) angezeigt wird. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/pageprops\\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getDrawingResizeType() {#getDrawingResizeType--}
+```
+public DrawingResizeType getDrawingResizeType()
+```
+
+
+Bestimmt, ob die Zeichenfläche automatisch an das Diagramm angepasst wird.
+
+**Returns:**
+[DrawingResizeType](../../com.aspose.diagram/drawingresizetype)
+### getDrawingScale() {#getDrawingScale--}
+```
+public DoubleValue getDrawingScale()
+```
+
+
+Stellt den Wert der Zeicheneinheit im aktuellen Zeichnungsmaßstab dar. Der Zeichnungsmaßstab für die Seite ist das Verhältnis der im PageScale-Element enthaltenen Seiteneinheit zur Zeicheneinheit. Die Einheiten dieses Elements bestimmen die Standard-Längeneinheiten (DL) für die Seite.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDrawingScaleType() {#getDrawingScaleType--}
+```
+public DrawingScaleType getDrawingScaleType()
+```
+
+
+Gibt den Typ der Zeichenmaßstabes an, der für eine Seite verwendet werden soll.
+
+**Returns:**
+[DrawingScaleType](../../com.aspose.diagram/drawingscaletype)
+### getDrawingSizeType() {#getDrawingSizeType--}
+```
+public DrawingSizeType getDrawingSizeType()
+```
+
+
+Gibt die Zeichenflächegröße einer Seite an.
+
+**Returns:**
+[DrawingSizeType](../../com.aspose.diagram/drawingsizetype)
+### getInhibitSnap() {#getInhibitSnap--}
+```
+public BoolValue getInhibitSnap()
+```
+
+
+Gibt an, ob die Formen auf einer Vordergrundseite an anderen Objekten auf der Seite und an Formen auf der Hintergrundseite einrasten.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getPageHeight() {#getPageHeight--}
+```
+public DoubleValue getPageHeight()
+```
+
+
+Gibt die Höhe der Seite in Zeicheneinheiten an.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getPageScale() {#getPageScale--}
+```
+public DoubleValue getPageScale()
+```
+
+
+Gibt den Wert der Standard-Seiteneinheit im aktuellen Zeichnungsmaßstab an. Der Zeichnungsmaßstab für die Seite ist das Verhältnis der Seiteneinheit im PageScale-Element zur im DrawingScale-Element dargestellten Zeicheneinheit.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getPageWidth() {#getPageWidth--}
+```
+public DoubleValue getPageWidth()
+```
+
+
+Gibt die Breite der Seite in Zeicheneinheiten an.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShdwObliqueAngle() {#getShdwObliqueAngle--}
+```
+public DoubleValue getShdwObliqueAngle()
+```
+
+
+Enthält eine Zahl, die den Winkel der schrägen Richtung angibt, wenn der Standard-Seiten-Schatten-Typ angewendet wird.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShdwOffsetX() {#getShdwOffsetX--}
+```
+public DoubleValue getShdwOffsetX()
+```
+
+
+Gibt den Abstand in Seiteneinheiten an, um den der Abwurfschatten einer Form horizontal von der Form versetzt ist.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShdwOffsetY() {#getShdwOffsetY--}
+```
+public DoubleValue getShdwOffsetY()
+```
+
+
+Gibt den Abstand in Seiteneinheiten an, um den der Abwurfschatten einer Form vertikal von der Form versetzt ist.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShdwScaleFactor() {#getShdwScaleFactor--}
+```
+public DoubleValue getShdwScaleFactor()
+```
+
+
+Gibt den Prozentsatz an, um den ein Formschatten vergrößert oder verkleinert wird.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShdwType() {#getShdwType--}
+```
+public ShdwType getShdwType()
+```
+
+
+Zeigt den Standard‑Schattentyp für eine Seite an.
+
+**Returns:**
+[ShdwType](../../com.aspose.diagram/shdwtype)
+### getUIVisibility() {#getUIVisibility--}
+```
+public UIVisibility getUIVisibility()
+```
+
+
+Bestimmt, ob der Seitenname in der Benutzeroberfläche (UI) angezeigt wird. Ein Wert von eins gibt an, dass die Seite nicht sichtbar ist; ein Wert von null gibt an, dass die Seite sichtbar ist.
+
+**Returns:**
+[UIVisibility](../../com.aspose.diagram/uivisibility)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/pageprops\\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/pagesavingargs/_index.md
+++ b/german/java/com.aspose.diagram/pagesavingargs/_index.md
@@ -1,0 +1,147 @@
+---
+title: PageSavingArgs
+second_title: Aspose.Diagram for Java API-Referenz
+description: Informationen für einen Seiten‑Speicherungsprozess.
+type: docs
+weight: 269
+url: /de/java/com.aspose.diagram/pagesavingargs/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PageSavingArgs
+```
+
+Informationen für einen Seiten‑Speicherungsprozess.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getPageCount()](#getPageCount--) | Gesamtseitenzahl. |
+| [getPageIndex()](#getPageIndex--) | Aktueller Seitenindex, nullbasiert. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+Gesamtseitenzahl.
+
+**Returns:**
+int
+### getPageIndex() {#getPageIndex--}
+```
+public int getPageIndex()
+```
+
+
+Aktueller Seitenindex, nullbasiert.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/pagesheet/_index.md
+++ b/german/java/com.aspose.diagram/pagesheet/_index.md
@@ -1,0 +1,426 @@
+---
+title: PageSheet
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält Elemente, die das Seitenblatt für ein Seiten‑ oder Master‑Element definieren.
+type: docs
+weight: 270
+url: /de/java/com.aspose.diagram/pagesheet/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PageSheet
+```
+
+Enthält Elemente, die das Seitenblatt für ein Seiten‑ oder Master‑Element definieren.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [copy(PageSheet source)](#copy-com.aspose.diagram.PageSheet-) | Kopiert das pagesheet von einem Quellobjekt. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getActs()](#getActs--) | Enthält eine Sammlung von Act-Elementen. |
+| [getAnnotations()](#getAnnotations--) | Enthält Elemente, die Informationen über in einer Dokumentseite eingefügte Kommentare enthalten. |
+| [getClass()](#getClass--) |  |
+| [getConnectionABCDs()](#getConnectionABCDs--) | Enthält eine Sammlung von ConnectionABCD-Elementen. |
+| [getConnections()](#getConnections--) | Enthält eine Sammlung von Connection-Elementen. |
+| [getFillStyle()](#getFillStyle--) | StyleSheet-Element, von dem das PageSheet die Füllformatierung erbt. |
+| [getForeign()](#getForeign--) | Enthält Elemente, die die Breite und Höhe eines Objekts aus einem anderen Programm angeben, das in einem Microsoft Visio-Dokument verwendet wird. |
+| [getForeignData()](#getForeignData--) | Enthält einen MIME (Multipurpose Internet Mail Extensions) codierten BLOB von Bilddaten, wie Windows-Metadatei, Bitmap oder OLE-Daten. |
+| [getHyperlinks()](#getHyperlinks--) | Enthält eine Sammlung von Hyperlink-Elementen. |
+| [getLayers()](#getLayers--) | Enthält eine Sammlung von Layer-Elementen. |
+| [getLineStyle()](#getLineStyle--) | StyleSheet-Element, von dem das PageSheet die Linienformatierung erbt. |
+| [getPageLayout()](#getPageLayout--) | Enthält ein Diagram, das die Seitengestaltungseinstellungen für Formen und Verbinder steuert, wie z. B. den Abstand zwischen allen Formen auf der Seite, den Abstand zwischen allen Verbindern auf der Seite und den Routingsstil für alle Verbinder auf der Seite. |
+| [getPageProps()](#getPageProps--) | Enthält Diagram, das Seitenattribute steuert, wie Seitenbreite, -höhe und Maßstab. |
+| [getPrintProps()](#getPrintProps--) | Enthält Elemente, die steuern, wie die Zeichenfläche auf der Druckerseite formatiert (angezeigt) wird. |
+| [getProps()](#getProps--) | Enthält eine Sammlung von Prop-Elementen. |
+| [getRulerGrid()](#getRulerGrid--) | Enthält Elemente, die die Einstellungen der Lineale und des Rasters der Seite festlegen. |
+| [getScratchs()](#getScratchs--) | Enthält eine Sammlung von Scratch-Elementen. |
+| [getSmartTagDefs()](#getSmartTagDefs--) | Enthält eine Sammlung von SmartTagDef-Elementen. |
+| [getTextStyle()](#getTextStyle--) | StyleSheet-Element, von dem das PageSheet die Textformatierung erbt. |
+| [getUniqueID()](#getUniqueID--) | Ein GUID (global eindeutiger Bezeichner) für das Element. |
+| [getUsers()](#getUsers--) | Enthält eine Sammlung von User-Elementen. |
+| [getXForm()](#getXForm--) | Enthält Elemente, die allgemeine Positionsinformationen zu einer Form angeben. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setFillStyle(StyleSheet value)](#setFillStyle-com.aspose.diagram.StyleSheet-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getFillStyle()](../../com.aspose.diagram/pagesheet\#getFillStyle--) |
+| [setLineStyle(StyleSheet value)](#setLineStyle-com.aspose.diagram.StyleSheet-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getLineStyle()](../../com.aspose.diagram/pagesheet\#getLineStyle--) |
+| [setTextStyle(StyleSheet value)](#setTextStyle-com.aspose.diagram.StyleSheet-) | For the description of this property, please see [getTextStyle()](../../com.aspose.diagram/pagesheet\#getTextStyle--) |
+| [setUniqueID(UUID value)](#setUniqueID-java.util.UUID-) | For the description of this property, please see [getUniqueID()](../../com.aspose.diagram/pagesheet\#getUniqueID--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### copy(PageSheet source) {#copy-com.aspose.diagram.PageSheet-}
+```
+public void copy(PageSheet source)
+```
+
+
+Kopiert das pagesheet von einem Quellobjekt.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| source | [PageSheet](../../com.aspose.diagram/pagesheet) | source pagesheet. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getActs() {#getActs--}
+```
+public ActCollection getActs()
+```
+
+
+Enthält eine Sammlung von Act-Elementen.
+
+**Returns:**
+[ActCollection](../../com.aspose.diagram/actcollection)
+### getAnnotations() {#getAnnotations--}
+```
+public AnnotationCollection getAnnotations()
+```
+
+
+Enthält Elemente, die Informationen über in einer Dokumentseite eingefügte Kommentare enthalten.
+
+**Returns:**
+[AnnotationCollection](../../com.aspose.diagram/annotationcollection)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConnectionABCDs() {#getConnectionABCDs--}
+```
+public ConnectionABCDCollection getConnectionABCDs()
+```
+
+
+Enthält eine Sammlung von ConnectionABCD-Elementen.
+
+**Returns:**
+[ConnectionABCDCollection](../../com.aspose.diagram/connectionabcdcollection)
+### getConnections() {#getConnections--}
+```
+public ConnectionCollection getConnections()
+```
+
+
+Enthält eine Sammlung von Connection-Elementen.
+
+**Returns:**
+[ConnectionCollection](../../com.aspose.diagram/connectioncollection)
+### getFillStyle() {#getFillStyle--}
+```
+public StyleSheet getFillStyle()
+```
+
+
+StyleSheet-Element, von dem das PageSheet die Füllformatierung erbt.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getForeign() {#getForeign--}
+```
+public Foreign getForeign()
+```
+
+
+Enthält Elemente, die die Breite und Höhe eines aus einem anderen Programm stammenden Objekts in einem Microsoft Visio-Dokument angeben. Außerdem enthält es Elemente, die den Abstand angeben, um den das Bild des Objekts innerhalb seiner Ränder versetzt ist.
+
+**Returns:**
+[Foreign](../../com.aspose.diagram/foreign)
+### getForeignData() {#getForeignData--}
+```
+public ForeignData getForeignData()
+```
+
+
+Enthält einen MIME (Multipurpose Internet Mail Extensions) codierten BLOB von Bilddaten, wie Windows-Metadatei, Bitmap oder OLE-Daten.
+
+**Returns:**
+[ForeignData](../../com.aspose.diagram/foreigndata)
+### getHyperlinks() {#getHyperlinks--}
+```
+public HyperlinkCollection getHyperlinks()
+```
+
+
+Enthält eine Sammlung von Hyperlink-Elementen.
+
+**Returns:**
+[HyperlinkCollection](../../com.aspose.diagram/hyperlinkcollection)
+### getLayers() {#getLayers--}
+```
+public LayerCollection getLayers()
+```
+
+
+Enthält eine Sammlung von Layer-Elementen.
+
+**Returns:**
+[LayerCollection](../../com.aspose.diagram/layercollection)
+### getLineStyle() {#getLineStyle--}
+```
+public StyleSheet getLineStyle()
+```
+
+
+StyleSheet-Element, von dem das PageSheet die Linienformatierung erbt.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getPageLayout() {#getPageLayout--}
+```
+public PageLayout getPageLayout()
+```
+
+
+Enthält ein Diagram, das die Seitengestaltungseinstellungen für Formen und Verbinder steuert, wie z. B. den Abstand zwischen allen Formen auf der Seite, den Abstand zwischen allen Verbindern auf der Seite und den Routingsstil für alle Verbinder auf der Seite.
+
+**Returns:**
+[PageLayout](../../com.aspose.diagram/pagelayout)
+### getPageProps() {#getPageProps--}
+```
+public PageProps getPageProps()
+```
+
+
+Enthält Diagram, das Seitenattribute steuert, wie Seitenbreite, -höhe und Maßstab.
+
+**Returns:**
+[PageProps](../../com.aspose.diagram/pageprops)
+### getPrintProps() {#getPrintProps--}
+```
+public PrintProps getPrintProps()
+```
+
+
+Enthält Elemente, die steuern, wie die Zeichenfläche auf der Druckerseite formatiert (angezeigt) wird.
+
+**Returns:**
+[PrintProps](../../com.aspose.diagram/printprops)
+### getProps() {#getProps--}
+```
+public PropCollection getProps()
+```
+
+
+Enthält eine Sammlung von Prop-Elementen.
+
+**Returns:**
+[PropCollection](../../com.aspose.diagram/propcollection)
+### getRulerGrid() {#getRulerGrid--}
+```
+public RulerGrid getRulerGrid()
+```
+
+
+Enthält Elemente, die die Einstellungen der Lineale und des Rasters der Seite festlegen.
+
+**Returns:**
+[RulerGrid](../../com.aspose.diagram/rulergrid)
+### getScratchs() {#getScratchs--}
+```
+public ScratchCollection getScratchs()
+```
+
+
+Enthält eine Sammlung von Scratch-Elementen.
+
+**Returns:**
+[ScratchCollection](../../com.aspose.diagram/scratchcollection)
+### getSmartTagDefs() {#getSmartTagDefs--}
+```
+public SmartTagDefCollection getSmartTagDefs()
+```
+
+
+Enthält eine Sammlung von SmartTagDef-Elementen.
+
+**Returns:**
+[SmartTagDefCollection](../../com.aspose.diagram/smarttagdefcollection)
+### getTextStyle() {#getTextStyle--}
+```
+public StyleSheet getTextStyle()
+```
+
+
+StyleSheet-Element, von dem das PageSheet die Textformatierung erbt.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getUniqueID() {#getUniqueID--}
+```
+public UUID getUniqueID()
+```
+
+
+Ein GUID (global eindeutiger Bezeichner) für das Element.
+
+**Returns:**
+java.util.UUID
+### getUsers() {#getUsers--}
+```
+public UserCollection getUsers()
+```
+
+
+Enthält eine Sammlung von User-Elementen.
+
+**Returns:**
+[UserCollection](../../com.aspose.diagram/usercollection)
+### getXForm() {#getXForm--}
+```
+public XForm getXForm()
+```
+
+
+Enthält Elemente, die allgemeine Positionsinformationen zu einer Form angeben.
+
+**Returns:**
+[XForm](../../com.aspose.diagram/xform)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setFillStyle(StyleSheet value) {#setFillStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setFillStyle(StyleSheet value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getFillStyle()](../../com.aspose.diagram/pagesheet\#getFillStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setLineStyle(StyleSheet value) {#setLineStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setLineStyle(StyleSheet value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getLineStyle()](../../com.aspose.diagram/pagesheet\#getLineStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setTextStyle(StyleSheet value) {#setTextStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setTextStyle(StyleSheet value)
+```
+
+
+For the description of this property, please see [getTextStyle()](../../com.aspose.diagram/pagesheet\#getTextStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setUniqueID(UUID value) {#setUniqueID-java.util.UUID-}
+```
+public void setUniqueID(UUID value)
+```
+
+
+For the description of this property, please see [getUniqueID()](../../com.aspose.diagram/pagesheet\#getUniqueID--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.util.UUID |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/pagesize/_index.md
+++ b/german/java/com.aspose.diagram/pagesize/_index.md
@@ -1,0 +1,233 @@
+---
+title: PageSize
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält Informationen zur Seitengröße der erzeugten Bilder.
+type: docs
+weight: 271
+url: /de/java/com.aspose.diagram/pagesize/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PageSize
+```
+
+Enthält Informationen zur Seitengröße der erzeugten Bilder.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [PageSize(int paperSizeFormat)](#PageSize-int-) | Initialisiert eine neue Instanz dieser Klasse, die verwendet werden kann, um die Seitengröße für die erzeugten Bilder festzulegen. |
+| [PageSize(float width, float height)](#PageSize-float-float-) | Initialisiert eine neue Instanz dieser Klasse, die verwendet werden kann, um die Seitengröße für die erzeugten Bilder festzulegen. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getHeight()](#getHeight--) | Die Seitenhöhe in Punkten für die erzeugten Bilder. |
+| [getPaperSizeFormat()](#getPaperSizeFormat--) | Das Papiergrößenformat für die erzeugten Bilder. |
+| [getWidth()](#getWidth--) | Die Seitenbreite in Punkten für die erzeugten Bilder. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setHeight(float value)](#setHeight-float-) | Für die Beschreibung dieser Eigenschaft siehe [getHeight()](../../com.aspose.diagram/pagesize\#getHeight--) |
+| [setPaperSizeFormat(int value)](#setPaperSizeFormat-int-) | Für die Beschreibung dieser Eigenschaft siehe [getPaperSizeFormat()](../../com.aspose.diagram/pagesize\#getPaperSizeFormat--) |
+| [setWidth(float value)](#setWidth-float-) | Für die Beschreibung dieser Eigenschaft siehe [getWidth()](../../com.aspose.diagram/pagesize\#getWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageSize(int paperSizeFormat) {#PageSize-int-}
+```
+public PageSize(int paperSizeFormat)
+```
+
+
+Initialisiert eine neue Instanz dieser Klasse, die verwendet werden kann, um die Seitengröße für die erzeugten Bilder festzulegen.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| paperSizeFormat | int | Kann Aspose.Diagram.Saving.PaperSizeFormat sein. |
+
+### PageSize(float width, float height) {#PageSize-float-float-}
+```
+public PageSize(float width, float height)
+```
+
+
+Initialisiert eine neue Instanz dieser Klasse, die verwendet werden kann, um die Seitengröße für die erzeugten Bilder festzulegen.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Breite | float | Seitenbreite in Punkten für die erzeugten Bilder. |
+| Höhe | float | Seitenhöhe in Punkten für die erzeugten Bilder. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getHeight() {#getHeight--}
+```
+public float getHeight()
+```
+
+
+die Seitenhöhe in Punkten für die generierten Bilder. Der Wert muss > 0 sein. Wenn Height gesetzt ist, muss Width ebenfalls gesetzt sein.
+
+**Returns:**
+float
+### getPaperSizeFormat() {#getPaperSizeFormat--}
+```
+public int getPaperSizeFormat()
+```
+
+
+das Papiergrößenformat für die generierten Bilder. Kann Aspose.Diagram.Saving.PaperSizeFormat sein.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public float getWidth()
+```
+
+
+die Seitenbreite in Punkten für die generierten Bilder. Der Wert muss > 0 sein. Wenn Width gesetzt ist, muss Height ebenfalls gesetzt sein.
+
+**Returns:**
+float
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setHeight(float value) {#setHeight-float-}
+```
+public void setHeight(float value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getHeight()](../../com.aspose.diagram/pagesize\#getHeight--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | float |  |
+
+### setPaperSizeFormat(int value) {#setPaperSizeFormat-int-}
+```
+public void setPaperSizeFormat(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getPaperSizeFormat()](../../com.aspose.diagram/pagesize\#getPaperSizeFormat--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setWidth(float value) {#setWidth-float-}
+```
+public void setWidth(float value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getWidth()](../../com.aspose.diagram/pagesize\#getWidth--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | float |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/pagestartsavingargs/_index.md
+++ b/german/java/com.aspose.diagram/pagestartsavingargs/_index.md
@@ -1,0 +1,172 @@
+---
+title: PageStartSavingArgs
+second_title: Aspose.Diagram for Java API-Referenz
+description: Informationen für eine Seite starten den Speicherungsprozess.
+type: docs
+weight: 272
+url: /de/java/com.aspose.diagram/pagestartsavingargs/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.PageSavingArgs](../../com.aspose.diagram/pagesavingargs)
+```
+public class PageStartSavingArgs extends PageSavingArgs
+```
+
+Informationen für eine Seite starten den Speicherungsprozess.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getPageCount()](#getPageCount--) | Gesamtseitenzahl. |
+| [getPageIndex()](#getPageIndex--) | Aktueller Seitenindex, nullbasiert. |
+| [hashCode()](#hashCode--) |  |
+| [isToOutput()](#isToOutput--) | Ein Wert, der angibt, ob die Seite ausgegeben werden soll. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setToOutput(boolean value)](#setToOutput-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isToOutput()](../../com.aspose.diagram/pagestartsavingargs\#isToOutput--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+Gesamtseitenzahl.
+
+**Returns:**
+int
+### getPageIndex() {#getPageIndex--}
+```
+public int getPageIndex()
+```
+
+
+Aktueller Seitenindex, nullbasiert.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isToOutput() {#isToOutput--}
+```
+public boolean isToOutput()
+```
+
+
+Ein Wert, der angibt, ob die Seite ausgegeben werden soll. Der Standardwert ist true.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setToOutput(boolean value) {#setToOutput-boolean-}
+```
+public void setToOutput(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isToOutput()](../../com.aspose.diagram/pagestartsavingargs\#isToOutput--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/papersizeformat/_index.md
+++ b/german/java/com.aspose.diagram/papersizeformat/_index.md
@@ -1,0 +1,435 @@
+---
+title: PaperSizeFormat
+second_title: Aspose.Diagram for Java API-Referenz
+description: Aufzählung für die Auswahl des Papiergrößen‑Formats beim Speichern.
+type: docs
+weight: 273
+url: /de/java/com.aspose.diagram/papersizeformat/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PaperSizeFormat
+```
+
+Aufzählung für die Auswahl des Papiergrößen‑Formats beim Speichern.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [A_0](#A-0) | A0 Papierformat(841mm x 1189mm). |
+| [A_1](#A-1) | A1 Papierformat(594mm x 841mm). |
+| [A_2](#A-2) | A2 Papierformat(420mm x 594mm). |
+| [A_3](#A-3) | A3 Papierformat(297mm x 420mm). |
+| [A_4](#A-4) | A4 Papierformat(210mm x 297mm). |
+| [A_5](#A-5) | A5 Papierformat(148mm x 210mm). |
+| [A_6](#A-6) | A6 Papierformat(105mm x 148mm). |
+| [A_7](#A-7) | A7 Papierformat(74mm x 105mm). |
+| [B_0](#B-0) | B0 Papierformat(1000mm x 1414mm). |
+| [B_1](#B-1) | B1 Papierformat(707mm x 1000mm). |
+| [B_2](#B-2) | B2 Papierformat(500mm x 707mm). |
+| [B_3](#B-3) | B3 paper size format(353mm x 500mm). |
+| [B_4](#B-4) | B4 paper size format(250mm x 353mm). |
+| [B_5](#B-5) | B5 paper size format(176mm x 250mm). |
+| [B_6](#B-6) | B6 paper size format(125mm x 176mm). |
+| [B_7](#B-7) | B7 paper size format(88mm x 125mm). |
+| [COM_10](#COM-10) | COM10 paper size format(104.78mm x 241.3mm). |
+| [COM_9](#COM-9) | COM9 paper size format(98.4mm x 225.4mInterpolationMode:Invalidm). |
+| [CUSTOM](#CUSTOM) | Custom paper size format. |
+| [C_0](#C-0) | C0 paper size format(917mm x 1297mm). |
+| [C_1](#C-1) | C1 paper size format(648mm x 917mm). |
+| [C_2](#C-2) | C2 paper size format(458mm x 648mm). |
+| [C_3](#C-3) | C3 paper size format(324mm x 458mm). |
+| [C_4](#C-4) | C4 paper size format(229mm x 324mm). |
+| [C_5](#C-5) | C5 paper size format(162mm x 229mm). |
+| [C_6](#C-6) | C6 paper size format(114mm x 162mm). |
+| [C_7](#C-7) | C7 paper size format(81mm x 114mm). |
+| [DL](#DL) | DL paper size format(110mm x 220mm). |
+| [EXECUTIVE](#EXECUTIVE) | Executive paper size format(184.15mm x 266.7mm). |
+| [LEGAL](#LEGAL) | Legal paper size format(215.9mm x 355.6mm). |
+| [LEGAL_13](#LEGAL-13) | Legal13 paper size format(215.9mm x 330.2mm). |
+| [LETTER](#LETTER) | Letter paper size format(215.9mm x 279.7mm). |
+| [MONARCH](#MONARCH) | Monarch paper size format(98.4mm x 190.5mm). |
+| [TABLOID](#TABLOID) | Tabloid paper size format(279.4mm x 431.8mm). |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### A_0 {#A-0}
+```
+public static final int A_0
+```
+
+
+A0 Papierformat(841mm x 1189mm).
+
+### A_1 {#A-1}
+```
+public static final int A_1
+```
+
+
+A1 Papierformat(594mm x 841mm).
+
+### A_2 {#A-2}
+```
+public static final int A_2
+```
+
+
+A2 Papierformat(420mm x 594mm).
+
+### A_3 {#A-3}
+```
+public static final int A_3
+```
+
+
+A3 Papierformat(297mm x 420mm).
+
+### A_4 {#A-4}
+```
+public static final int A_4
+```
+
+
+A4 Papierformat(210mm x 297mm).
+
+### A_5 {#A-5}
+```
+public static final int A_5
+```
+
+
+A5 Papierformat(148mm x 210mm).
+
+### A_6 {#A-6}
+```
+public static final int A_6
+```
+
+
+A6 Papierformat(105mm x 148mm).
+
+### A_7 {#A-7}
+```
+public static final int A_7
+```
+
+
+A7 Papierformat(74mm x 105mm).
+
+### B_0 {#B-0}
+```
+public static final int B_0
+```
+
+
+B0 Papierformat(1000mm x 1414mm).
+
+### B_1 {#B-1}
+```
+public static final int B_1
+```
+
+
+B1 Papierformat(707mm x 1000mm).
+
+### B_2 {#B-2}
+```
+public static final int B_2
+```
+
+
+B2 Papierformat(500mm x 707mm).
+
+### B_3 {#B-3}
+```
+public static final int B_3
+```
+
+
+B3 paper size format(353mm x 500mm).
+
+### B_4 {#B-4}
+```
+public static final int B_4
+```
+
+
+B4 paper size format(250mm x 353mm).
+
+### B_5 {#B-5}
+```
+public static final int B_5
+```
+
+
+B5 paper size format(176mm x 250mm).
+
+### B_6 {#B-6}
+```
+public static final int B_6
+```
+
+
+B6 paper size format(125mm x 176mm).
+
+### B_7 {#B-7}
+```
+public static final int B_7
+```
+
+
+B7 paper size format(88mm x 125mm).
+
+### COM_10 {#COM-10}
+```
+public static final int COM_10
+```
+
+
+COM10 paper size format(104.78mm x 241.3mm).
+
+### COM_9 {#COM-9}
+```
+public static final int COM_9
+```
+
+
+COM9 paper size format(98.4mm x 225.4mInterpolationMode:Invalidm).
+
+### CUSTOM {#CUSTOM}
+```
+public static final int CUSTOM
+```
+
+
+Custom paper size format.
+
+### C_0 {#C-0}
+```
+public static final int C_0
+```
+
+
+C0 paper size format(917mm x 1297mm).
+
+### C_1 {#C-1}
+```
+public static final int C_1
+```
+
+
+C1 paper size format(648mm x 917mm).
+
+### C_2 {#C-2}
+```
+public static final int C_2
+```
+
+
+C2 paper size format(458mm x 648mm).
+
+### C_3 {#C-3}
+```
+public static final int C_3
+```
+
+
+C3 paper size format(324mm x 458mm).
+
+### C_4 {#C-4}
+```
+public static final int C_4
+```
+
+
+C4 paper size format(229mm x 324mm).
+
+### C_5 {#C-5}
+```
+public static final int C_5
+```
+
+
+C5 paper size format(162mm x 229mm).
+
+### C_6 {#C-6}
+```
+public static final int C_6
+```
+
+
+C6 paper size format(114mm x 162mm).
+
+### C_7 {#C-7}
+```
+public static final int C_7
+```
+
+
+C7 paper size format(81mm x 114mm).
+
+### DL {#DL}
+```
+public static final int DL
+```
+
+
+DL paper size format(110mm x 220mm).
+
+### EXECUTIVE {#EXECUTIVE}
+```
+public static final int EXECUTIVE
+```
+
+
+Executive paper size format(184.15mm x 266.7mm).
+
+### LEGAL {#LEGAL}
+```
+public static final int LEGAL
+```
+
+
+Legal paper size format(215.9mm x 355.6mm).
+
+### LEGAL_13 {#LEGAL-13}
+```
+public static final int LEGAL_13
+```
+
+
+Legal13 paper size format(215.9mm x 330.2mm).
+
+### LETTER {#LETTER}
+```
+public static final int LETTER
+```
+
+
+Letter paper size format(215.9mm x 279.7mm).
+
+### MONARCH {#MONARCH}
+```
+public static final int MONARCH
+```
+
+
+Monarch paper size format(98.4mm x 190.5mm).
+
+### TABLOID {#TABLOID}
+```
+public static final int TABLOID
+```
+
+
+Tabloid paper size format(279.4mm x 431.8mm).
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/para/_index.md
+++ b/german/java/com.aspose.diagram/para/_index.md
@@ -1,0 +1,549 @@
+---
+title: Para
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält die Absatzformatierungselemente für den Text der Formen, wie Einzüge, Zeilenabstand, Aufzählungszeichen und horizontale Ausrichtung der Absätze.
+type: docs
+weight: 274
+url: /de/java/com.aspose.diagram/para/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Para
+```
+
+Enthält die Absatzformatierungselemente für den Text der Form, wie Einzüge, Zeilenabstand, Aufzählungszeichen und horizontale Ausrichtung der Absätze.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [Para()](#Para--) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBullet()](#getBullet--) | Bestimmt den Aufzählungszeichenstil. |
+| [getBulletFont()](#getBulletFont--) | Gibt die Nummer der Schriftart an, die zum Formatieren des Textes verwendet wird, wenn ein benutzerdefinierter Aufzählungszeichen-String angegeben ist und der Wert im Bullet-Element ungleich Null ist. |
+| [getBulletFontSize()](#getBulletFontSize--) | Gibt die Größe eines Aufzählungszeichens an. |
+| [getBulletStr()](#getBulletStr--) | \"Verwendet, um einen benutzerdefinierten Aufzählungszeichenstil zu erstellen. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getFlags()](#getFlags--) | Gibt an, ob die Textausrichtung von links nach rechts oder von rechts nach links erfolgt. |
+| [getHorzAlign()](#getHorzAlign--) | Gibt die horizontale Ausrichtung des Textes im Textblock der Form an. |
+| [getIX()](#getIX--) | Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements. |
+| [getIndFirst()](#getIndFirst--) | Gibt den Abstand an, um den die erste Zeile jedes Absatzes im Textblock der Form vom linken Einzug des Absatzes eingerückt ist. |
+| [getIndLeft()](#getIndLeft--) | Gibt den Abstand an, um den alle Textzeilen eines Absatzes vom linken Rand des Textblocks eingerückt sind. |
+| [getIndRight()](#getIndRight--) | Gibt den Abstand an, um den alle Textzeilen in einem Absatz vom rechten Rand des Textblocks eingerückt sind. |
+| [getLocalizeBulletFont()](#getLocalizeBulletFont--) | Gibt an, ob die Aufzählungs‑Schriftart lokalisiert (in eine andere Sprache übersetzt) werden soll. |
+| [getSpAfter()](#getSpAfter--) | Gibt die Menge des nach jedem Absatz im Textblock der Form eingefügten Abstandes an. |
+| [getSpBefore()](#getSpBefore--) | Gibt die Menge des vor jedem Absatz im Textblock der Form eingefügten Abstandes an. |
+| [getSpLine()](#getSpLine--) | Gibt den Abstand zwischen einer Textzeile und der nächsten an, wobei 100 % der Höhe einer Textzeile entspricht. |
+| [getTextPosAfterBullet()](#getTextPosAfterBullet--) | Stellt den Abstand zwischen der ersten Zeile des Absatzes und dem Aufzählungszeichen dar. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setBullet(Bullet value)](#setBullet-com.aspose.diagram.Bullet-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getBullet()](../../com.aspose.diagram/para\#getBullet--) |
+| [setBulletFont(IntValue value)](#setBulletFont-com.aspose.diagram.IntValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getBulletFont()](../../com.aspose.diagram/para\#getBulletFont--) |
+| [setBulletFontSize(DoubleValue value)](#setBulletFontSize-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getBulletFontSize()](../../com.aspose.diagram/para\#getBulletFontSize--) |
+| [setBulletStr(Str2Value value)](#setBulletStr-com.aspose.diagram.Str2Value-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getBulletStr()](../../com.aspose.diagram/para\#getBulletStr--) |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/para\#getDel--) |
+| [setFlags(BoolValue value)](#setFlags-com.aspose.diagram.BoolValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getFlags()](../../com.aspose.diagram/para\#getFlags--) |
+| [setHorzAlign(HorzAlign value)](#setHorzAlign-com.aspose.diagram.HorzAlign-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getHorzAlign()](../../com.aspose.diagram/para\#getHorzAlign--) |
+| [setIX(int value)](#setIX-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getIX()](../../com.aspose.diagram/para\#getIX--) |
+| [setIndFirst(DoubleValue value)](#setIndFirst-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getIndFirst()](../../com.aspose.diagram/para\#getIndFirst--) |
+| [setIndLeft(DoubleValue value)](#setIndLeft-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getIndLeft()](../../com.aspose.diagram/para\#getIndLeft--) |
+| [setIndRight(DoubleValue value)](#setIndRight-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getIndRight()](../../com.aspose.diagram/para\#getIndRight--) |
+| [setLocalizeBulletFont(LocalizeFont value)](#setLocalizeBulletFont-com.aspose.diagram.LocalizeFont-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getLocalizeBulletFont()](../../com.aspose.diagram/para\#getLocalizeBulletFont--) |
+| [setSpAfter(DoubleValue value)](#setSpAfter-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getSpAfter()](../../com.aspose.diagram/para\#getSpAfter--) |
+| [setSpBefore(DoubleValue value)](#setSpBefore-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getSpBefore()](../../com.aspose.diagram/para\#getSpBefore--) |
+| [setSpLine(DoubleValue value)](#setSpLine-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getSpLine()](../../com.aspose.diagram/para\#getSpLine--) |
+| [setTextPosAfterBullet(DoubleValue value)](#setTextPosAfterBullet-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getTextPosAfterBullet()](../../com.aspose.diagram/para\#getTextPosAfterBullet--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Para() {#Para--}
+```
+public Para()
+```
+
+
+Konstruktor.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBullet() {#getBullet--}
+```
+public Bullet getBullet()
+```
+
+
+Bestimmt den Aufzählungszeichenstil.
+
+**Returns:**
+[Bullet](../../com.aspose.diagram/bullet)
+### getBulletFont() {#getBulletFont--}
+```
+public IntValue getBulletFont()
+```
+
+
+Gibt die Nummer der Schriftart an, die zum Formatieren des Textes verwendet wird, wenn ein benutzerdefinierter Aufzählungszeichen-String angegeben ist und der Wert im Bullet-Element ungleich Null ist.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getBulletFontSize() {#getBulletFontSize--}
+```
+public DoubleValue getBulletFontSize()
+```
+
+
+Gibt die Größe eines Aufzählungszeichens an.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBulletStr() {#getBulletStr--}
+```
+public Str2Value getBulletStr()
+```
+
+
+"Wird verwendet, um einen benutzerdefinierten Aufzählungsstil zu erstellen. Geben Sie den Stil als Zeichenkette (innerhalb von Anführungszeichen) ein. Zum Beispiel könnten Sie die Zeichenkette ""ooo."""
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getFlags() {#getFlags--}
+```
+public BoolValue getFlags()
+```
+
+
+Gibt an, ob die Textausrichtung von links nach rechts oder von rechts nach links erfolgt.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getHorzAlign() {#getHorzAlign--}
+```
+public HorzAlign getHorzAlign()
+```
+
+
+Gibt die horizontale Ausrichtung des Textes im Textblock der Form an.
+
+**Returns:**
+[HorzAlign](../../com.aspose.diagram/horzalign)
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements.
+
+**Returns:**
+int
+### getIndFirst() {#getIndFirst--}
+```
+public DoubleValue getIndFirst()
+```
+
+
+Gibt den Abstand an, um den die erste Zeile jedes Absatzes im Textblock der Form vom linken Einzug des Absatzes eingerückt ist. Dieser Wert ist unabhängig von der Skalierung der Zeichnung. Wird die Zeichnung skaliert, bleibt der Einzug der ersten Zeile unverändert.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getIndLeft() {#getIndLeft--}
+```
+public DoubleValue getIndLeft()
+```
+
+
+Gibt den Abstand an, um den alle Textzeilen in einem Absatz vom linken Rand des Textblocks eingerückt sind. Dieser Wert ist unabhängig von der Skalierung der Zeichnung. Wird die Zeichnung skaliert, bleibt der linke Einzug unverändert.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getIndRight() {#getIndRight--}
+```
+public DoubleValue getIndRight()
+```
+
+
+Gibt den Abstand an, um den alle Textzeilen in einem Absatz vom rechten Rand des Textblocks eingerückt sind. Dieser Wert ist unabhängig vom Maßstab der Zeichnung. Wenn die Zeichnung skaliert wird, bleibt der rechte Einzug unverändert.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLocalizeBulletFont() {#getLocalizeBulletFont--}
+```
+public LocalizeFont getLocalizeBulletFont()
+```
+
+
+Gibt an, ob die Aufzählungs‑Schriftart lokalisiert (in eine andere Sprache übersetzt) werden soll.
+
+**Returns:**
+[LocalizeFont](../../com.aspose.diagram/localizefont)
+### getSpAfter() {#getSpAfter--}
+```
+public DoubleValue getSpAfter()
+```
+
+
+Gibt die Menge des nach jedem Absatz im Textblock der Form eingefügten Abstandes an.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getSpBefore() {#getSpBefore--}
+```
+public DoubleValue getSpBefore()
+```
+
+
+Gibt die Menge des vor jedem Absatz im Textblock der Form eingefügten Abstandes an.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getSpLine() {#getSpLine--}
+```
+public DoubleValue getSpLine()
+```
+
+
+Gibt den Abstand zwischen einer Textzeile und der nächsten an, wobei 100 % der Höhe einer Textzeile entspricht.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTextPosAfterBullet() {#getTextPosAfterBullet--}
+```
+public DoubleValue getTextPosAfterBullet()
+```
+
+
+Stellt den Abstand zwischen der ersten Zeile des Absatzes und dem Aufzählungszeichen dar.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setBullet(Bullet value) {#setBullet-com.aspose.diagram.Bullet-}
+```
+public void setBullet(Bullet value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getBullet()](../../com.aspose.diagram/para\#getBullet--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [Bullet](../../com.aspose.diagram/bullet) |  |
+
+### setBulletFont(IntValue value) {#setBulletFont-com.aspose.diagram.IntValue-}
+```
+public void setBulletFont(IntValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getBulletFont()](../../com.aspose.diagram/para\#getBulletFont--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setBulletFontSize(DoubleValue value) {#setBulletFontSize-com.aspose.diagram.DoubleValue-}
+```
+public void setBulletFontSize(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getBulletFontSize()](../../com.aspose.diagram/para\#getBulletFontSize--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setBulletStr(Str2Value value) {#setBulletStr-com.aspose.diagram.Str2Value-}
+```
+public void setBulletStr(Str2Value value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getBulletStr()](../../com.aspose.diagram/para\#getBulletStr--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [Str2Value](../../com.aspose.diagram/str2value) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/para\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setFlags(BoolValue value) {#setFlags-com.aspose.diagram.BoolValue-}
+```
+public void setFlags(BoolValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getFlags()](../../com.aspose.diagram/para\#getFlags--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setHorzAlign(HorzAlign value) {#setHorzAlign-com.aspose.diagram.HorzAlign-}
+```
+public void setHorzAlign(HorzAlign value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getHorzAlign()](../../com.aspose.diagram/para\#getHorzAlign--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [HorzAlign](../../com.aspose.diagram/horzalign) |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getIX()](../../com.aspose.diagram/para\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setIndFirst(DoubleValue value) {#setIndFirst-com.aspose.diagram.DoubleValue-}
+```
+public void setIndFirst(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getIndFirst()](../../com.aspose.diagram/para\#getIndFirst--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setIndLeft(DoubleValue value) {#setIndLeft-com.aspose.diagram.DoubleValue-}
+```
+public void setIndLeft(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getIndLeft()](../../com.aspose.diagram/para\#getIndLeft--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setIndRight(DoubleValue value) {#setIndRight-com.aspose.diagram.DoubleValue-}
+```
+public void setIndRight(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getIndRight()](../../com.aspose.diagram/para\#getIndRight--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setLocalizeBulletFont(LocalizeFont value) {#setLocalizeBulletFont-com.aspose.diagram.LocalizeFont-}
+```
+public void setLocalizeBulletFont(LocalizeFont value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getLocalizeBulletFont()](../../com.aspose.diagram/para\#getLocalizeBulletFont--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [LocalizeFont](../../com.aspose.diagram/localizefont) |  |
+
+### setSpAfter(DoubleValue value) {#setSpAfter-com.aspose.diagram.DoubleValue-}
+```
+public void setSpAfter(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getSpAfter()](../../com.aspose.diagram/para\#getSpAfter--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setSpBefore(DoubleValue value) {#setSpBefore-com.aspose.diagram.DoubleValue-}
+```
+public void setSpBefore(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getSpBefore()](../../com.aspose.diagram/para\#getSpBefore--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setSpLine(DoubleValue value) {#setSpLine-com.aspose.diagram.DoubleValue-}
+```
+public void setSpLine(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getSpLine()](../../com.aspose.diagram/para\#getSpLine--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTextPosAfterBullet(DoubleValue value) {#setTextPosAfterBullet-com.aspose.diagram.DoubleValue-}
+```
+public void setTextPosAfterBullet(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getTextPosAfterBullet()](../../com.aspose.diagram/para\#getTextPosAfterBullet--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/paracollection/_index.md
+++ b/german/java/com.aspose.diagram/paracollection/_index.md
@@ -1,0 +1,234 @@
+---
+title: ParaCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: Absatzsammlung.
+type: docs
+weight: 275
+url: /de/java/com.aspose.diagram/paracollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ParaCollection extends Collection
+```
+
+Absatzsammlung.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [add(Para item)](#add-com.aspose.diagram.Para-) | Fügen Sie das Para-Objekt zur Sammlung hinzu. |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [getPara(int IX)](#getPara-int-) | Gibt das Element am angegebenen Index IX zurück. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Para item)](#remove-com.aspose.diagram.Para-) | Entfernen Sie das Para-Objekt aus der Sammlung. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Para item) {#add-com.aspose.diagram.Para-}
+```
+public int add(Para item)
+```
+
+
+Fügen Sie das Para-Objekt zur Sammlung hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [Para](../../com.aspose.diagram/para) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Para get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[Para](../../com.aspose.diagram/para) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### getPara(int IX) {#getPara-int-}
+```
+public Para getPara(int IX)
+```
+
+
+Liefert das Element am angegebenen Index IX. Gibt Null zurück, wenn das Element nicht existiert.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| IX | int |  |
+
+**Returns:**
+[Para](../../com.aspose.diagram/para) - 
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Para item) {#remove-com.aspose.diagram.Para-}
+```
+public void remove(Para item)
+```
+
+
+Entfernen Sie das Para-Objekt aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [Para](../../com.aspose.diagram/para) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/pdfcompliance/_index.md
+++ b/german/java/com.aspose.diagram/pdfcompliance/_index.md
@@ -1,0 +1,156 @@
+---
+title: PdfCompliance
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt das PDF‑Konformitätsniveau für die Ausgabedatei an.
+type: docs
+weight: 276
+url: /de/java/com.aspose.diagram/pdfcompliance/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PdfCompliance
+```
+
+Gibt das PDF‑Konformitätsniveau für die Ausgabedatei an.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [PDF_15](#PDF-15) | Die Ausgabedatei wird PDF 1.5 konform sein. |
+| [PDF_A_1_A](#PDF-A-1-A) | Die Ausgabedatei wird PDF/A-1a konform sein. |
+| [PDF_A_1_B](#PDF-A-1-B) | Die Ausgabedatei wird PDF/A-1b konform sein. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PDF_15 {#PDF-15}
+```
+public static final int PDF_15
+```
+
+
+Die Ausgabedatei wird PDF 1.5 konform sein.
+
+### PDF_A_1_A {#PDF-A-1-A}
+```
+public static final int PDF_A_1_A
+```
+
+
+Die Ausgabedatei wird PDF/A-1a konform sein.
+
+### PDF_A_1_B {#PDF-A-1-B}
+```
+public static final int PDF_A_1_B
+```
+
+
+Die Ausgabedatei wird PDF/A-1b konform sein.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/pdfdigitalsignaturehashalgorithm/_index.md
+++ b/german/java/com.aspose.diagram/pdfdigitalsignaturehashalgorithm/_index.md
@@ -1,0 +1,174 @@
+---
+title: PdfDigitalSignatureHashAlgorithm
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt den digitalen Hash‑Algorithmus an, der von der digitalen Signatur verwendet wird.
+type: docs
+weight: 277
+url: /de/java/com.aspose.diagram/pdfdigitalsignaturehashalgorithm/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PdfDigitalSignatureHashAlgorithm
+```
+
+Gibt den digitalen Hash‑Algorithmus an, der von der digitalen Signatur verwendet wird.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [MD_5](#MD-5) | SHA-1-Hash-Algorithmus. |
+| [SHA_1](#SHA-1) | SHA-1-Hash-Algorithmus. |
+| [SHA_256](#SHA-256) | SHA-256-Hash-Algorithmus. |
+| [SHA_384](#SHA-384) | SHA-384-Hash-Algorithmus. |
+| [SHA_512](#SHA-512) | SHA-512-Hash-Algorithmus. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### MD_5 {#MD-5}
+```
+public static final int MD_5
+```
+
+
+SHA-1-Hash-Algorithmus.
+
+### SHA_1 {#SHA-1}
+```
+public static final int SHA_1
+```
+
+
+SHA-1-Hash-Algorithmus.
+
+### SHA_256 {#SHA-256}
+```
+public static final int SHA_256
+```
+
+
+SHA-256-Hash-Algorithmus.
+
+### SHA_384 {#SHA-384}
+```
+public static final int SHA_384
+```
+
+
+SHA-384-Hash-Algorithmus.
+
+### SHA_512 {#SHA-512}
+```
+public static final int SHA_512
+```
+
+
+SHA-512-Hash-Algorithmus.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/pdfencryptionalgorithm/_index.md
+++ b/german/java/com.aspose.diagram/pdfencryptionalgorithm/_index.md
@@ -1,0 +1,147 @@
+---
+title: PdfEncryptionAlgorithm
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt den zu verwendenden Verschlüsselungsalgorithmus zum Verschlüsseln eines PDF‑Dokuments an.
+type: docs
+weight: 278
+url: /de/java/com.aspose.diagram/pdfencryptionalgorithm/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PdfEncryptionAlgorithm
+```
+
+Gibt den zu verwendenden Verschlüsselungsalgorithmus zum Verschlüsseln eines PDF‑Dokuments an.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [RC_4_128](#RC-4-128) | RC4-Verschlüsselung, Schlüssellänge von 128 Bit. |
+| [RC_4_40](#RC-4-40) | RC4-Verschlüsselung, Schlüssellänge von 40 Bit. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RC_4_128 {#RC-4-128}
+```
+public static final int RC_4_128
+```
+
+
+RC4-Verschlüsselung, Schlüssellänge von 128 Bit.
+
+### RC_4_40 {#RC-4-40}
+```
+public static final int RC_4_40
+```
+
+
+RC4-Verschlüsselung, Schlüssellänge von 40 Bit.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/pdfencryptiondetails/_index.md
+++ b/german/java/com.aspose.diagram/pdfencryptiondetails/_index.md
@@ -1,0 +1,245 @@
+---
+title: PdfEncryptionDetails
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält Details zur PDF‑Verschlüsselung.
+type: docs
+weight: 279
+url: /de/java/com.aspose.diagram/pdfencryptiondetails/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PdfEncryptionDetails
+```
+
+Enthält Details zur PDF‑Verschlüsselung.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [PdfEncryptionDetails(String userPassword, String ownerPassword, int encryptionAlgorithm)](#PdfEncryptionDetails-java.lang.String-java.lang.String-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getEncryptionAlgorithm()](#getEncryptionAlgorithm--) | der Verschlüsselungsmodus. |
+| [getOwnerPassword()](#getOwnerPassword--) | das Owner-Passwort. |
+| [getPermissions()](#getPermissions--) | die Berechtigungen. |
+| [getUserPassword()](#getUserPassword--) | das User-Passwort. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setEncryptionAlgorithm(int value)](#setEncryptionAlgorithm-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getEncryptionAlgorithm()](../../com.aspose.diagram/pdfencryptiondetails\#getEncryptionAlgorithm--) |
+| [setOwnerPassword(String value)](#setOwnerPassword-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getOwnerPassword()](../../com.aspose.diagram/pdfencryptiondetails\#getOwnerPassword--) |
+| [setPermissions(int value)](#setPermissions-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getPermissions()](../../com.aspose.diagram/pdfencryptiondetails\#getPermissions--) |
+| [setUserPassword(String value)](#setUserPassword-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getUserPassword()](../../com.aspose.diagram/pdfencryptiondetails\#getUserPassword--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PdfEncryptionDetails(String userPassword, String ownerPassword, int encryptionAlgorithm) {#PdfEncryptionDetails-java.lang.String-java.lang.String-int-}
+```
+public PdfEncryptionDetails(String userPassword, String ownerPassword, int encryptionAlgorithm)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| userPassword | java.lang.String |  |
+| ownerPassword | java.lang.String |  |
+| encryptionAlgorithm | int |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getEncryptionAlgorithm() {#getEncryptionAlgorithm--}
+```
+public int getEncryptionAlgorithm()
+```
+
+
+der Verschlüsselungsmodus.
+
+**Returns:**
+int
+### getOwnerPassword() {#getOwnerPassword--}
+```
+public String getOwnerPassword()
+```
+
+
+das Owner-Passwort. Das Öffnen des Dokuments mit dem korrekten Owner-Passwort (unter der Annahme, dass es nicht dasselbe wie das User-Passwort ist) ermöglicht vollen (Owner-) Zugriff auf das Dokument. Dieser uneingeschränkte Zugriff beinhaltet die Möglichkeit, die Dokument\\u9225\\u6a9a-Passwörter und Zugriffsberechtigungen zu ändern.
+
+**Returns:**
+java.lang.String
+### getPermissions() {#getPermissions--}
+```
+public int getPermissions()
+```
+
+
+die Berechtigungen.
+
+**Returns:**
+int
+### getUserPassword() {#getUserPassword--}
+```
+public String getUserPassword()
+```
+
+
+das User-Passwort. Das Öffnen des Dokuments mit dem korrekten User-Passwort (oder das Öffnen eines Dokuments, das kein User-Passwort hat) ermöglicht zusätzliche Vorgänge, die gemäß den im Dokument\\u9225\\u6a9a-Verschlüsselungswörterbuch angegebenen Benutzerzugriffsberechtigungen ausgeführt werden.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setEncryptionAlgorithm(int value) {#setEncryptionAlgorithm-int-}
+```
+public void setEncryptionAlgorithm(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getEncryptionAlgorithm()](../../com.aspose.diagram/pdfencryptiondetails\#getEncryptionAlgorithm--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setOwnerPassword(String value) {#setOwnerPassword-java.lang.String-}
+```
+public void setOwnerPassword(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getOwnerPassword()](../../com.aspose.diagram/pdfencryptiondetails\#getOwnerPassword--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setPermissions(int value) {#setPermissions-int-}
+```
+public void setPermissions(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getPermissions()](../../com.aspose.diagram/pdfencryptiondetails\#getPermissions--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setUserPassword(String value) {#setUserPassword-java.lang.String-}
+```
+public void setUserPassword(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getUserPassword()](../../com.aspose.diagram/pdfencryptiondetails\#getUserPassword--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/pdfpermissions/_index.md
+++ b/german/java/com.aspose.diagram/pdfpermissions/_index.md
@@ -1,0 +1,219 @@
+---
+title: PdfPermissions
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt die Benutzerberechtigungen für das PDF‑Dokument an.
+type: docs
+weight: 280
+url: /de/java/com.aspose.diagram/pdfpermissions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PdfPermissions
+```
+
+Gibt die Benutzerberechtigungen für das PDF‑Dokument an.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [ALLOW_ALL](#ALLOW-ALL) | Erlaubt alle Vorgänge am PDF-Dokument. |
+| [CONTENT_COPY](#CONTENT-COPY) | Erlaubt das Kopieren oder anderweitige Extrahieren von Text und Grafiken aus dem Dokument, einschließlich der Extraktion für Barrierefreiheitszwecke. |
+| [CONTENT_COPY_FOR_ACCESSIBILITY](#CONTENT-COPY-FOR-ACCESSIBILITY) | Erlaubt das Extrahieren von Text und Grafiken zur Unterstützung der Barrierefreiheit für behinderte Nutzer oder zu anderen Zwecken. |
+| [DISALLOW_ALL](#DISALLOW-ALL) | Verweigert alle Vorgänge am PDF-Dokument. |
+| [DOCUMENT_ASSEMBLY](#DOCUMENT-ASSEMBLY) | Erlaubt das Zusammenstellen des Dokuments: Einfügen, Drehen oder Löschen von Seiten sowie das Erstellen von Navigationselementen wie Lesezeichen oder Miniaturbildern. |
+| [FILL_IN](#FILL-IN) | Erlaubt das Ausfüllen von Formularen und das Signieren des Dokuments. |
+| [HIGH_RESOLUTION_PRINTING](#HIGH-RESOLUTION-PRINTING) | Erlaubt das Drucken des Dokuments in höchstmöglicher Auflösung. Bei Verwendung von RC4 40‑Bit‑Verschlüsselung wird diese Option ignoriert und das Drucken in hoher Auflösung ist erlaubt, wenn Printing gesetzt ist. |
+| [MODIFY_ANNOTATIONS](#MODIFY-ANNOTATIONS) | Ermöglicht das Hinzufügen oder Ändern von Textanmerkungen. |
+| [MODIFY_CONTENTS](#MODIFY-CONTENTS) | Ermöglicht das Ändern des Dokuments\u9225\u6a9a-Inhalts. |
+| [PRINTING](#PRINTING) | Ermöglicht das Drucken des Dokuments. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALLOW_ALL {#ALLOW-ALL}
+```
+public static final int ALLOW_ALL
+```
+
+
+Erlaubt alle Vorgänge am PDF-Dokument.
+
+### CONTENT_COPY {#CONTENT-COPY}
+```
+public static final int CONTENT_COPY
+```
+
+
+Erlaubt das Kopieren oder anderweitige Extrahieren von Text und Grafiken aus dem Dokument, einschließlich der Extraktion für Barrierefreiheitszwecke.
+
+### CONTENT_COPY_FOR_ACCESSIBILITY {#CONTENT-COPY-FOR-ACCESSIBILITY}
+```
+public static final int CONTENT_COPY_FOR_ACCESSIBILITY
+```
+
+
+Ermöglicht das Extrahieren von Text und Grafiken zur Unterstützung der Barrierefreiheit für behinderte Benutzer oder für andere Zwecke. Bei Verwendung von RC4‑40‑Bit‑Verschlüsselung wird diese Option ignoriert und die Barrierefreiheit ist immer erlaubt, wenn ContentCopy gesetzt ist.
+
+### DISALLOW_ALL {#DISALLOW-ALL}
+```
+public static final int DISALLOW_ALL
+```
+
+
+Verweigert alle Vorgänge am PDF-Dokument. Dies ist der Standardwert.
+
+### DOCUMENT_ASSEMBLY {#DOCUMENT-ASSEMBLY}
+```
+public static final int DOCUMENT_ASSEMBLY
+```
+
+
+Ermöglicht das Zusammenstellen des Dokuments: Einfügen, Drehen oder Löschen von Seiten sowie das Erstellen von Navigationselementen wie Lesezeichen oder Miniaturbildern. Bei Verwendung von RC4‑40‑Bit‑Verschlüsselung wird diese Option ignoriert und das Zusammenstellen des Dokuments ist erlaubt, wenn ModifyContents gesetzt ist.
+
+### FILL_IN {#FILL-IN}
+```
+public static final int FILL_IN
+```
+
+
+Ermöglicht das Ausfüllen von Formularen und das Signieren des Dokuments. Bei Verwendung von RC4‑40‑Bit‑Verschlüsselung wird diese Option ignoriert und das Ausfüllen von Formularen ist immer erlaubt, wenn ModifyAnnotations gesetzt ist.
+
+### HIGH_RESOLUTION_PRINTING {#HIGH-RESOLUTION-PRINTING}
+```
+public static final int HIGH_RESOLUTION_PRINTING
+```
+
+
+Erlaubt das Drucken des Dokuments in höchstmöglicher Auflösung. Bei Verwendung von RC4 40‑Bit‑Verschlüsselung wird diese Option ignoriert und das Drucken in hoher Auflösung ist erlaubt, wenn Printing gesetzt ist.
+
+### MODIFY_ANNOTATIONS {#MODIFY-ANNOTATIONS}
+```
+public static final int MODIFY_ANNOTATIONS
+```
+
+
+Ermöglicht das Hinzufügen oder Ändern von Textanmerkungen. Bei Verwendung von RC4‑40‑Bit‑Verschlüsselung erlaubt diese Option zudem das Ausfüllen von Formularfeldern.
+
+### MODIFY_CONTENTS {#MODIFY-CONTENTS}
+```
+public static final int MODIFY_CONTENTS
+```
+
+
+Ermöglicht das Ändern des Dokuments\u9225\u6a9a-Inhalts.
+
+### PRINTING {#PRINTING}
+```
+public static final int PRINTING
+```
+
+
+Ermöglicht das Drucken des Dokuments.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/pdfsaveoptions/_index.md
+++ b/german/java/com.aspose.diagram/pdfsaveoptions/_index.md
@@ -1,0 +1,679 @@
+---
+title: PdfSaveOptions
+second_title: Aspose.Diagram for Java API-Referenz
+description: Ermöglicht das Angeben zusätzlicher Optionen beim Rendern von Diagrammseiten zu PDF.
+type: docs
+weight: 281
+url: /de/java/com.aspose.diagram/pdfsaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.SaveOptions](../../com.aspose.diagram/saveoptions), [com.aspose.diagram.RenderingSaveOptions](../../com.aspose.diagram/renderingsaveoptions)
+```
+public class PdfSaveOptions extends RenderingSaveOptions
+```
+
+Ermöglicht das Angeben zusätzlicher Optionen beim Rendern von Diagrammseiten zu PDF.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [PdfSaveOptions()](#PdfSaveOptions--) | Initialisiert eine neue Instanz dieser Klasse, die verwendet werden kann, um ein Dokument im Format Aspose.Diagram.SaveFileFormat zu speichern. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | Erstellt ein Speicheroptionen-Objekt einer Klasse, die für das angegebene Speicherformat geeignet ist. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCompliance()](#getCompliance--) | Gewünschtes Konformitätsniveau für das erzeugte PDF-Dokument. |
+| [getDefaultFont()](#getDefaultFont--) | Wenn Zeichen im Diagramm Unicode sind und nicht mit dem korrekten Schriftwert gesetzt werden oder die Schriftart nicht lokal installiert ist, können sie in PDF, Bild oder XPS als Block erscheinen. |
+| [getEmfRenderSetting()](#getEmfRenderSetting--) | Einstellung zum Rendern von Emf-Metadateien. |
+| [getEncryptionDetails()](#getEncryptionDetails--) | Ein Verschlüsselungsdetail. |
+| [getEnlargePage()](#getEnlargePage--) | Gibt an, ob die Seite vergrößert werden soll. |
+| [getExportGuideShapes()](#getExportGuideShapes--) | Definiert, ob die Leitlinienformen exportiert werden sollen oder nicht. |
+| [getExportHiddenPage()](#getExportHiddenPage--) | Definiert, ob die versteckte Seite exportiert werden soll oder nicht. |
+| [getHorizontalResolution()](#getHorizontalResolution--) | die horizontale Auflösung für erzeugte Bilder, in Punkten pro Zoll. |
+| [getJpegQuality()](#getJpegQuality--) | Gibt die Qualität der JPEG-Kompression für Bilder an (falls JPEG-Kompression verwendet wird). |
+| [getPageCount()](#getPageCount--) | die Anzahl der Seiten, die im PDF gerendert werden sollen. |
+| [getPageIndex()](#getPageIndex--) | der nullbasierte Index der ersten zu rendernden Seite. |
+| [getPageSavingCallback()](#getPageSavingCallback--) | Steuert/zeigt den Fortschritt des Seiten‑Speichervorgangs an. |
+| [getPageSize()](#getPageSize--) | die Seitengröße für die erzeugten Bilder. |
+| [getSaveForegroundPagesOnly()](#getSaveForegroundPagesOnly--) | Gibt an, ob alle Seiten als Bild gespeichert werden oder nur der Vordergrund. |
+| [getSaveFormat()](#getSaveFormat--) | Gibt das Format an, in dem die gerenderten Diagrammseiten gespeichert werden, wenn dieses Speicheroptionen-Objekt verwendet wird. |
+| [getShapes()](#getShapes--) | Formen zum Rendern. |
+| [getSplitMultiPages()](#getSplitMultiPages--) | Definiert, ob das Diagramm gemäß den Seiteneinstellungen in mehrere Seiten aufgeteilt wird. |
+| [getTextCompression()](#getTextCompression--) | Gibt den Kompressionstyp an, der für alle Inhaltsströme außer Bildern verwendet wird. |
+| [getVerticalResolution()](#getVerticalResolution--) | die vertikale Auflösung für erzeugte Bilder, in Punkten pro Zoll. |
+| [getWarningCallback()](#getWarningCallback--) | Warnungs-Callback. |
+| [hashCode()](#hashCode--) |  |
+| [isExportComments()](#isExportComments--) | Definiert, ob Kommentare exportiert werden sollen oder nicht. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCompliance(int value)](#setCompliance-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getCompliance()](../../com.aspose.diagram/pdfsaveoptions\#getCompliance--) |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDefaultFont()](../../com.aspose.diagram/saveoptions\\#getDefaultFont--) |
+| [setEmfRenderSetting(int value)](#setEmfRenderSetting-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\\#getEmfRenderSetting--) |
+| [setEncryptionDetails(PdfEncryptionDetails value)](#setEncryptionDetails-com.aspose.diagram.PdfEncryptionDetails-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getEncryptionDetails()](../../com.aspose.diagram/pdfsaveoptions\#getEncryptionDetails--) |
+| [setEnlargePage(boolean value)](#setEnlargePage-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--) |
+| [setExportComments(boolean value)](#setExportComments-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--) |
+| [setExportGuideShapes(boolean value)](#setExportGuideShapes-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--) |
+| [setExportHiddenPage(boolean value)](#setExportHiddenPage-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getExportHiddenPage()](../../com.aspose.diagram/pdfsaveoptions\#getExportHiddenPage--) |
+| [setHorizontalResolution(int value)](#setHorizontalResolution-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getHorizontalResolution()](../../com.aspose.diagram/pdfsaveoptions\#getHorizontalResolution--) |
+| [setJpegQuality(int value)](#setJpegQuality-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getJpegQuality()](../../com.aspose.diagram/pdfsaveoptions\#getJpegQuality--) |
+| [setPageCount(int value)](#setPageCount-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getPageCount()](../../com.aspose.diagram/pdfsaveoptions\#getPageCount--) |
+| [setPageIndex(int value)](#setPageIndex-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getPageIndex()](../../com.aspose.diagram/pdfsaveoptions\#getPageIndex--) |
+| [setPageSavingCallback(IPageSavingCallback value)](#setPageSavingCallback-com.aspose.diagram.IPageSavingCallback-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getPageSavingCallback()](../../com.aspose.diagram/pdfsaveoptions\#getPageSavingCallback--) |
+| [setPageSize(PageSize value)](#setPageSize-com.aspose.diagram.PageSize-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--) |
+| [setSaveForegroundPagesOnly(boolean value)](#setSaveForegroundPagesOnly-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getSaveForegroundPagesOnly()](../../com.aspose.diagram/pdfsaveoptions\#getSaveForegroundPagesOnly--) |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getSaveFormat()](../../com.aspose.diagram/pdfsaveoptions\#getSaveFormat--) |
+| [setShapes(ShapeCollection value)](#setShapes-com.aspose.diagram.ShapeCollection-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--) |
+| [setSplitMultiPages(boolean value)](#setSplitMultiPages-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getSplitMultiPages()](../../com.aspose.diagram/pdfsaveoptions\#getSplitMultiPages--) |
+| [setTextCompression(int value)](#setTextCompression-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getTextCompression()](../../com.aspose.diagram/pdfsaveoptions\#getTextCompression--) |
+| [setVerticalResolution(int value)](#setVerticalResolution-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getVerticalResolution()](../../com.aspose.diagram/pdfsaveoptions\#getVerticalResolution--) |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PdfSaveOptions() {#PdfSaveOptions--}
+```
+public PdfSaveOptions()
+```
+
+
+Initialisiert eine neue Instanz dieser Klasse, die verwendet werden kann, um ein Dokument im Format Aspose.Diagram.SaveFileFormat zu speichern.
+
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+Erstellt ein Speicheroptionen-Objekt einer Klasse, die für das angegebene Speicherformat geeignet ist.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| saveFormat | int | Das Aspose.Diagram.SaveFileFormat, für das ein Save-Optionen-Objekt erstellt werden soll. |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCompliance() {#getCompliance--}
+```
+public int getCompliance()
+```
+
+
+Gewünschtes Konformitätsniveau für das erzeugte PDF-Dokument. Standard ist PdfCompliance.PDF\_15.
+
+**Returns:**
+int
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+Wenn Zeichen im Diagramm Unicode sind und nicht mit dem korrekten Schriftwert gesetzt werden oder die Schriftart nicht lokal installiert ist, können sie im PDF, Bild oder XPS als Block erscheinen. Setzen Sie die DefaultFont, z. B. MingLiu oder MS Gothic, um diese Zeichen anzuzeigen.
+
+**Returns:**
+java.lang.String
+### getEmfRenderSetting() {#getEmfRenderSetting--}
+```
+public int getEmfRenderSetting()
+```
+
+
+Einstellung für das Rendern von EMF-Metadateien. EMF-Metadateien, die als "EMF+ Dual" identifiziert werden, können sowohl EMF+-Datensätze als auch EMF-Datensätze enthalten. Jeder Datensatztyp kann zum Rendern des Bildes verwendet werden, nur EMF+-Datensätze oder nur EMF-Datensätze. Wenn EmfPlusPrefer gesetzt ist, werden EMF+-Datensätze geparst, andernfalls werden nur EMF-Datensätze geparst. Der Standardwert ist EmfOnly"/>.
+
+**Returns:**
+int
+### getEncryptionDetails() {#getEncryptionDetails--}
+```
+public PdfEncryptionDetails getEncryptionDetails()
+```
+
+
+Ein Verschlüsselungsdetail. Wenn nicht gesetzt, wird keine Verschlüsselung durchgeführt.
+
+**Returns:**
+[PdfEncryptionDetails](../../com.aspose.diagram/pdfencryptiondetails)
+### getEnlargePage() {#getEnlargePage--}
+```
+public boolean getEnlargePage()
+```
+
+
+Gibt an, ob die Seite vergrößert werden soll. Wenn true – Seite vergrößern. Wenn false – Seite nicht vergrößern. Der Standardwert ist true.
+
+**Returns:**
+boolean
+### getExportGuideShapes() {#getExportGuideShapes--}
+```
+public boolean getExportGuideShapes()
+```
+
+
+Definiert, ob Leitlinienformen exportiert werden sollen oder nicht. Standardwert ist true.
+
+**Returns:**
+boolean
+### getExportHiddenPage() {#getExportHiddenPage--}
+```
+public boolean getExportHiddenPage()
+```
+
+
+Definiert, ob versteckte Seiten exportiert werden sollen oder nicht. Standardwert ist true.
+
+**Returns:**
+boolean
+### getHorizontalResolution() {#getHorizontalResolution--}
+```
+public int getHorizontalResolution()
+```
+
+
+die horizontale Auflösung für erzeugte Bilder, in Punkten pro Zoll. Gilt für die Bildgenerierungsmethode, außer bei EMF-Formatbildern. Der Standardwert ist 96.
+
+**Returns:**
+int
+### getJpegQuality() {#getJpegQuality--}
+```
+public int getJpegQuality()
+```
+
+
+Gibt die Qualität der JPEG-Kompression für Bilder an (falls JPEG-Kompression verwendet wird). Standard ist 95.
+
+**Returns:**
+int
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+die Anzahl der Seiten, die im PDF gerendert werden sollen. Standard ist MaxValue, was bedeutet, dass alle Seiten des Diagramms gerendert werden.
+
+**Returns:**
+int
+### getPageIndex() {#getPageIndex--}
+```
+public int getPageIndex()
+```
+
+
+Der nullbasierte Index der ersten zu rendernden Seite. Standard ist 0.
+
+**Returns:**
+int
+### getPageSavingCallback() {#getPageSavingCallback--}
+```
+public IPageSavingCallback getPageSavingCallback()
+```
+
+
+Steuert/zeigt den Fortschritt des Seiten‑Speichervorgangs an.
+
+**Returns:**
+[IPageSavingCallback](../../com.aspose.diagram/ipagesavingcallback)
+### getPageSize() {#getPageSize--}
+```
+public PageSize getPageSize()
+```
+
+
+die Seitengröße für die erzeugten Bilder. Kann [PageSize](../../com.aspose.diagram/pagesize) oder null sein. Der Standardwert ist null. Wenn PageSize null ist, wird die Seitengröße für das erzeugte Bild aus dem Quell‑Diagramm übernommen.
+
+**Returns:**
+[PageSize](../../com.aspose.diagram/pagesize)
+### getSaveForegroundPagesOnly() {#getSaveForegroundPagesOnly--}
+```
+public boolean getSaveForegroundPagesOnly()
+```
+
+
+Legt fest, ob alle Seiten im Bild gespeichert werden oder nur der Vordergrund. Wenn true – werden nur Vordergrundseiten gerendert (mit Hintergrund, falls vorhanden). Wenn false – werden Vordergrundseiten gerendert (mit Hintergrund, falls vorhanden) und danach leere Hintergrundseiten. Kann nur true zurückgeben, wenn PageCount > 1. Der Standardwert ist false.
+
+**Returns:**
+boolean
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+Gibt das Format an, in dem die gerenderten Diagrammseiten gespeichert werden, wenn dieses Speicheroptionsobjekt verwendet wird. Kann nur Aspose.Diagram.SaveFileFormat sein.
+
+**Returns:**
+int
+### getShapes() {#getShapes--}
+```
+public ShapeCollection getShapes()
+```
+
+
+Zu rendernde Shapes. Standardanzahl ist 0.
+
+**Returns:**
+[ShapeCollection](../../com.aspose.diagram/shapecollection)
+### getSplitMultiPages() {#getSplitMultiPages--}
+```
+public boolean getSplitMultiPages()
+```
+
+
+Definiert, ob das Diagramm gemäß den Seiteneinstellungen in mehrere Seiten aufgeteilt wird. Standardwert ist false.
+
+**Returns:**
+boolean
+### getTextCompression() {#getTextCompression--}
+```
+public int getTextCompression()
+```
+
+
+Gibt den Kompressionstyp an, der für alle Inhaltsströme außer Bildern verwendet wird. Standard ist PdfTextCompression.FLATE.
+
+**Returns:**
+int
+### getVerticalResolution() {#getVerticalResolution--}
+```
+public int getVerticalResolution()
+```
+
+
+Die vertikale Auflösung für erzeugte Bilder, in Punkten pro Zoll. Gilt für die Bildgenerierungsmethode, außer für Emf-Formatbilder. Der Standardwert ist 96.
+
+**Returns:**
+int
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+Warnungs-Callback.
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExportComments() {#isExportComments--}
+```
+public boolean isExportComments()
+```
+
+
+Legt fest, ob Kommentare exportiert werden sollen oder nicht. Der Standardwert ist false.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCompliance(int value) {#setCompliance-int-}
+```
+public void setCompliance(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getCompliance()](../../com.aspose.diagram/pdfsaveoptions\#getCompliance--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDefaultFont()](../../com.aspose.diagram/saveoptions\\#getDefaultFont--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setEmfRenderSetting(int value) {#setEmfRenderSetting-int-}
+```
+public void setEmfRenderSetting(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\\#getEmfRenderSetting--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setEncryptionDetails(PdfEncryptionDetails value) {#setEncryptionDetails-com.aspose.diagram.PdfEncryptionDetails-}
+```
+public void setEncryptionDetails(PdfEncryptionDetails value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getEncryptionDetails()](../../com.aspose.diagram/pdfsaveoptions\#getEncryptionDetails--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [PdfEncryptionDetails](../../com.aspose.diagram/pdfencryptiondetails) |  |
+
+### setEnlargePage(boolean value) {#setEnlargePage-boolean-}
+```
+public void setEnlargePage(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setExportComments(boolean value) {#setExportComments-boolean-}
+```
+public void setExportComments(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setExportGuideShapes(boolean value) {#setExportGuideShapes-boolean-}
+```
+public void setExportGuideShapes(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setExportHiddenPage(boolean value) {#setExportHiddenPage-boolean-}
+```
+public void setExportHiddenPage(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getExportHiddenPage()](../../com.aspose.diagram/pdfsaveoptions\#getExportHiddenPage--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setHorizontalResolution(int value) {#setHorizontalResolution-int-}
+```
+public void setHorizontalResolution(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getHorizontalResolution()](../../com.aspose.diagram/pdfsaveoptions\#getHorizontalResolution--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setJpegQuality(int value) {#setJpegQuality-int-}
+```
+public void setJpegQuality(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getJpegQuality()](../../com.aspose.diagram/pdfsaveoptions\#getJpegQuality--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setPageCount(int value) {#setPageCount-int-}
+```
+public void setPageCount(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getPageCount()](../../com.aspose.diagram/pdfsaveoptions\#getPageCount--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setPageIndex(int value) {#setPageIndex-int-}
+```
+public void setPageIndex(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getPageIndex()](../../com.aspose.diagram/pdfsaveoptions\#getPageIndex--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setPageSavingCallback(IPageSavingCallback value) {#setPageSavingCallback-com.aspose.diagram.IPageSavingCallback-}
+```
+public void setPageSavingCallback(IPageSavingCallback value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getPageSavingCallback()](../../com.aspose.diagram/pdfsaveoptions\#getPageSavingCallback--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [IPageSavingCallback](../../com.aspose.diagram/ipagesavingcallback) |  |
+
+### setPageSize(PageSize value) {#setPageSize-com.aspose.diagram.PageSize-}
+```
+public void setPageSize(PageSize value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [PageSize](../../com.aspose.diagram/pagesize) |  |
+
+### setSaveForegroundPagesOnly(boolean value) {#setSaveForegroundPagesOnly-boolean-}
+```
+public void setSaveForegroundPagesOnly(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getSaveForegroundPagesOnly()](../../com.aspose.diagram/pdfsaveoptions\#getSaveForegroundPagesOnly--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getSaveFormat()](../../com.aspose.diagram/pdfsaveoptions\#getSaveFormat--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setShapes(ShapeCollection value) {#setShapes-com.aspose.diagram.ShapeCollection-}
+```
+public void setShapes(ShapeCollection value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [ShapeCollection](../../com.aspose.diagram/shapecollection) |  |
+
+### setSplitMultiPages(boolean value) {#setSplitMultiPages-boolean-}
+```
+public void setSplitMultiPages(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getSplitMultiPages()](../../com.aspose.diagram/pdfsaveoptions\#getSplitMultiPages--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setTextCompression(int value) {#setTextCompression-int-}
+```
+public void setTextCompression(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getTextCompression()](../../com.aspose.diagram/pdfsaveoptions\#getTextCompression--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setVerticalResolution(int value) {#setVerticalResolution-int-}
+```
+public void setVerticalResolution(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getVerticalResolution()](../../com.aspose.diagram/pdfsaveoptions\#getVerticalResolution--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/pdftextcompression/_index.md
+++ b/german/java/com.aspose.diagram/pdftextcompression/_index.md
@@ -1,0 +1,147 @@
+---
+title: PdfTextCompression
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt einen Kompressionstyp an, der auf alle Inhalte der PDF‑Datei außer Bildern angewendet wird.
+type: docs
+weight: 282
+url: /de/java/com.aspose.diagram/pdftextcompression/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PdfTextCompression
+```
+
+Gibt einen Kompressionstyp an, der auf alle Inhalte der PDF‑Datei außer Bildern angewendet wird.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [FLATE](#FLATE) | Flate (ZIP)-Kompression. |
+| [NONE](#NONE) | Keine Kompression. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FLATE {#FLATE}
+```
+public static final int FLATE
+```
+
+
+Flate (ZIP)-Kompression.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Keine Kompression.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/pinposvalue/_index.md
+++ b/german/java/com.aspose.diagram/pinposvalue/_index.md
@@ -1,0 +1,219 @@
+---
+title: PinPosValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt die Pin‑Position für die Form an.
+type: docs
+weight: 283
+url: /de/java/com.aspose.diagram/pinposvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PinPosValue
+```
+
+Gibt die Pin‑Position für die Form an.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [BOTTOM_CENTER](#BOTTOM-CENTER) | unten-mitte |
+| [BOTTOM_LEFT](#BOTTOM-LEFT) | unten-links. |
+| [BOTTOM_RIGHT](#BOTTOM-RIGHT) | unten-rechts |
+| [CENTER_CENTER](#CENTER-CENTER) | mitte-mitte |
+| [CENTER_LEFT](#CENTER-LEFT) | mitte-links. |
+| [CENTER_RIGHT](#CENTER-RIGHT) | mitte-rechts |
+| [TOP_CENTER](#TOP-CENTER) | oben-mitte |
+| [TOP_LEFT](#TOP-LEFT) | links-oben |
+| [TOP_RIGHT](#TOP-RIGHT) | oben-rechts |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOTTOM_CENTER {#BOTTOM-CENTER}
+```
+public static final int BOTTOM_CENTER
+```
+
+
+unten-mitte
+
+### BOTTOM_LEFT {#BOTTOM-LEFT}
+```
+public static final int BOTTOM_LEFT
+```
+
+
+unten-links.
+
+### BOTTOM_RIGHT {#BOTTOM-RIGHT}
+```
+public static final int BOTTOM_RIGHT
+```
+
+
+unten-rechts
+
+### CENTER_CENTER {#CENTER-CENTER}
+```
+public static final int CENTER_CENTER
+```
+
+
+mitte-mitte
+
+### CENTER_LEFT {#CENTER-LEFT}
+```
+public static final int CENTER_LEFT
+```
+
+
+mitte-links.
+
+### CENTER_RIGHT {#CENTER-RIGHT}
+```
+public static final int CENTER_RIGHT
+```
+
+
+mitte-rechts
+
+### TOP_CENTER {#TOP-CENTER}
+```
+public static final int TOP_CENTER
+```
+
+
+oben-mitte
+
+### TOP_LEFT {#TOP-LEFT}
+```
+public static final int TOP_LEFT
+```
+
+
+links-oben
+
+### TOP_RIGHT {#TOP-RIGHT}
+```
+public static final int TOP_RIGHT
+```
+
+
+oben-rechts
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/pixeloffsetmode/_index.md
+++ b/german/java/com.aspose.diagram/pixeloffsetmode/_index.md
@@ -1,0 +1,183 @@
+---
+title: PixelOffsetMode
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt an, wie Pixel beim Rendern versetzt werden.
+type: docs
+weight: 284
+url: /de/java/com.aspose.diagram/pixeloffsetmode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PixelOffsetMode
+```
+
+Gibt an, wie Pixel beim Rendern versetzt werden.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [DEFAULT](#DEFAULT) | Gibt den Standardmodus an. |
+| [HALF](#HALF) | Gibt an, dass Pixel um -0,5 Einheiten sowohl horizontal als auch vertikal verschoben werden, für schnelle Kantenglättung. |
+| [HIGH_QUALITY](#HIGH-QUALITY) | Gibt eine hochwertige, langsame Darstellung an. |
+| [HIGH_SPEED](#HIGH-SPEED) | Gibt eine schnelle, niedrige Qualitätsdarstellung an. |
+| [INVALID](#INVALID) | Gibt einen ungültigen Modus an. |
+| [NONE](#NONE) | Gibt keine Pixelverschiebung an. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DEFAULT {#DEFAULT}
+```
+public static final int DEFAULT
+```
+
+
+Gibt den Standardmodus an.
+
+### HALF {#HALF}
+```
+public static final int HALF
+```
+
+
+Gibt an, dass Pixel um -0,5 Einheiten sowohl horizontal als auch vertikal verschoben werden, für schnelle Kantenglättung.
+
+### HIGH_QUALITY {#HIGH-QUALITY}
+```
+public static final int HIGH_QUALITY
+```
+
+
+Gibt eine hochwertige, langsame Darstellung an.
+
+### HIGH_SPEED {#HIGH-SPEED}
+```
+public static final int HIGH_SPEED
+```
+
+
+Gibt eine schnelle, niedrige Qualitätsdarstellung an.
+
+### INVALID {#INVALID}
+```
+public static final int INVALID
+```
+
+
+Gibt einen ungültigen Modus an.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Gibt keine Pixelverschiebung an.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/placedepth/_index.md
+++ b/german/java/com.aspose.diagram/placedepth/_index.md
@@ -1,0 +1,179 @@
+---
+title: PlaceDepth
+second_title: Aspose.Diagram for Java API-Referenz
+description: Für eine automatisch angeordnete Zeichnung gibt an, welche Methode verwendet wird, um die Zeichnung vor der Erstellung des Layouts zu analysieren, und bestimmt den Layouttyp.
+type: docs
+weight: 285
+url: /de/java/com.aspose.diagram/placedepth/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PlaceDepth
+```
+
+Für eine automatisch angeordnete Zeichnung gibt die Methode an, mit der die Zeichnung vor der Erstellung des Layouts analysiert wird, und bestimmt den Layouttyp.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [PlaceDepth(int value)](#PlaceDepth-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Für eine automatisch angeordnete Zeichnung gibt die Methode an, mit der die Zeichnung vor der Erstellung des Layouts analysiert wird, und bestimmt den Layouttyp. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/placedepth\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PlaceDepth(int value) {#PlaceDepth-int-}
+```
+public PlaceDepth(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Für eine automatisch angeordnete Zeichnung gibt die Methode an, mit der die Zeichnung vor der Erstellung des Layouts analysiert wird, und bestimmt den Layouttyp.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/placedepth\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/placedepthvalue/_index.md
+++ b/german/java/com.aspose.diagram/placedepthvalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: PlaceDepthValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Für eine automatisch angeordnete Zeichnung gibt an, welche Methode verwendet wird, um die Zeichnung vor der Erstellung des Layouts zu analysieren, und bestimmt den Layouttyp.
+type: docs
+weight: 286
+url: /de/java/com.aspose.diagram/placedepthvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PlaceDepthValue
+```
+
+Für eine automatisch angeordnete Zeichnung gibt die Methode an, mit der die Zeichnung vor der Erstellung des Layouts analysiert wird, und bestimmt den Layouttyp.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [DEEP](#DEEP) | Tief. |
+| [MEDIUM](#MEDIUM) | Mittel. |
+| [PAGE_DEFAULT](#PAGE-DEFAULT) | Seitenstandard. |
+| [SHALLOW](#SHALLOW) | Flach. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DEEP {#DEEP}
+```
+public static final int DEEP
+```
+
+
+Tief.
+
+### MEDIUM {#MEDIUM}
+```
+public static final int MEDIUM
+```
+
+
+Mittel.
+
+### PAGE_DEFAULT {#PAGE-DEFAULT}
+```
+public static final int PAGE_DEFAULT
+```
+
+
+Seitenstandard.
+
+### SHALLOW {#SHALLOW}
+```
+public static final int SHALLOW
+```
+
+
+Flach.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/placeflip/_index.md
+++ b/german/java/com.aspose.diagram/placeflip/_index.md
@@ -1,0 +1,179 @@
+---
+title: PlaceFlip
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt an, wie platzierbare Formen auf einer Seite gedreht und/oder gespiegelt werden, wenn Formen mit dem Befehl „Formen anordnen“ in Microsoft Visio angeordnet werden.
+type: docs
+weight: 287
+url: /de/java/com.aspose.diagram/placeflip/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PlaceFlip
+```
+
+Gibt an, wie platzierbare Formen auf einer Seite gedreht und/oder rotiert werden, wenn Formen mit dem Befehl „Lay Out Shapes“ in Microsoft Visio angeordnet werden. Die folgenden hexadezimalen Werte sind zulässig.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [PlaceFlip(int value)](#PlaceFlip-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Gibt an, wie platzierbare Formen auf einer Seite gedreht und/oder gespiegelt werden, wenn Formen mit dem Befehl „Formen anordnen“ in Microsoft Visio angeordnet werden. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | For the description of this property, please see [getValue()](../../com.aspose.diagram/placeflip\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PlaceFlip(int value) {#PlaceFlip-int-}
+```
+public PlaceFlip(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Gibt an, wie platzierbare Formen auf einer Seite gedreht und/oder rotiert werden, wenn Formen mit dem Befehl „Lay Out Shapes“ in Microsoft Visio angeordnet werden. Die folgenden hexadezimalen Werte sind zulässig.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+For the description of this property, please see [getValue()](../../com.aspose.diagram/placeflip\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/placeflipvalue/_index.md
+++ b/german/java/com.aspose.diagram/placeflipvalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: PlaceFlipValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt an, wie platzierbare Formen auf einer Seite gedreht und/oder gespiegelt werden, wenn Formen mit dem Befehl „Formen anordnen“ in Microsoft Visio angeordnet werden.
+type: docs
+weight: 288
+url: /de/java/com.aspose.diagram/placeflipvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PlaceFlipValue
+```
+
+Gibt an, wie platzierbare Formen auf einer Seite gedreht und/oder rotiert werden, wenn Formen mit dem Befehl „Lay Out Shapes“ in Microsoft Visio angeordnet werden. Die folgenden hexadezimalen Werte sind zulässig.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [DEFAULT_NO_FLIP](#DEFAULT-NO-FLIP) | Standard. |
+| [FLIP_90_INCREMENTS](#FLIP-90-INCREMENTS) | Drehen in 90-Grad-Schritten. |
+| [FLIP_HORIZONTAL](#FLIP-HORIZONTAL) | Horizontal spiegeln. |
+| [FLIP_VERTICAL](#FLIP-VERTICAL) | Vertikal spiegeln. |
+| [NO_FLIP](#NO-FLIP) | Keine Spiegelung. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DEFAULT_NO_FLIP {#DEFAULT-NO-FLIP}
+```
+public static final int DEFAULT_NO_FLIP
+```
+
+
+Standard. Nicht spiegeln.
+
+### FLIP_90_INCREMENTS {#FLIP-90-INCREMENTS}
+```
+public static final int FLIP_90_INCREMENTS
+```
+
+
+Drehen in 90-Grad-Schritten.
+
+### FLIP_HORIZONTAL {#FLIP-HORIZONTAL}
+```
+public static final int FLIP_HORIZONTAL
+```
+
+
+Horizontal spiegeln.
+
+### FLIP_VERTICAL {#FLIP-VERTICAL}
+```
+public static final int FLIP_VERTICAL
+```
+
+
+Vertikal spiegeln.
+
+### NO_FLIP {#NO-FLIP}
+```
+public static final int NO_FLIP
+```
+
+
+Keine Spiegelung.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/placestyle/_index.md
+++ b/german/java/com.aspose.diagram/placestyle/_index.md
@@ -1,0 +1,179 @@
+---
+title: PlaceStyle
+second_title: Aspose.Diagram for Java API-Referenz
+description: Specifies how shapes are placed on the page when shapes are laid out when a user selects Lay Out Shapes Shape menu.
+type: docs
+weight: 289
+url: /de/java/com.aspose.diagram/placestyle/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PlaceStyle
+```
+
+Gibt an, wie Formen auf der Seite platziert werden, wenn Formen angeordnet werden, nachdem ein Benutzer „Formen anordnen“ (Form‑Menü) auswählt.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [PlaceStyle(int value)](#PlaceStyle-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Gibt an, wie Formen auf der Seite platziert werden, wenn Formen angeordnet werden, nachdem ein Benutzer „Formen anordnen“ (Form‑Menü) auswählt. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/placestyle\\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PlaceStyle(int value) {#PlaceStyle-int-}
+```
+public PlaceStyle(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Gibt an, wie Formen auf der Seite platziert werden, wenn Formen angeordnet werden, nachdem ein Benutzer „Formen anordnen“ (Form‑Menü) auswählt.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/placestyle\\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/placestylevalue/_index.md
+++ b/german/java/com.aspose.diagram/placestylevalue/_index.md
@@ -1,0 +1,201 @@
+---
+title: PlaceStyleValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Specifies how shapes are placed on the page when shapes are laid out when a user selects Lay Out Shapes Shape menu.
+type: docs
+weight: 290
+url: /de/java/com.aspose.diagram/placestylevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PlaceStyleValue
+```
+
+Gibt an, wie Formen auf der Seite platziert werden, wenn Formen angeordnet werden, nachdem ein Benutzer „Formen anordnen“ (Form‑Menü) auswählt.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [BOTTOM_TO_TOP](#BOTTOM-TO-TOP) | Bottom to top. |
+| [CIRCULAR](#CIRCULAR) | Circular. |
+| [DEFAULT_RADIAL](#DEFAULT-RADIAL) | Standard. |
+| [LEFT_TO_RIGHT](#LEFT-TO-RIGHT) | Left to right. |
+| [RADIAL](#RADIAL) | Radial. |
+| [RIGHT_TO_LEFT](#RIGHT-TO-LEFT) | Right to left. |
+| [TOP_TO_BOTTOM](#TOP-TO-BOTTOM) | Top to bottom. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOTTOM_TO_TOP {#BOTTOM-TO-TOP}
+```
+public static final int BOTTOM_TO_TOP
+```
+
+
+Bottom to top.
+
+### CIRCULAR {#CIRCULAR}
+```
+public static final int CIRCULAR
+```
+
+
+Circular.
+
+### DEFAULT_RADIAL {#DEFAULT-RADIAL}
+```
+public static final int DEFAULT_RADIAL
+```
+
+
+Default. Radial.
+
+### LEFT_TO_RIGHT {#LEFT-TO-RIGHT}
+```
+public static final int LEFT_TO_RIGHT
+```
+
+
+Left to right.
+
+### RADIAL {#RADIAL}
+```
+public static final int RADIAL
+```
+
+
+Radial.
+
+### RIGHT_TO_LEFT {#RIGHT-TO-LEFT}
+```
+public static final int RIGHT_TO_LEFT
+```
+
+
+Right to left.
+
+### TOP_TO_BOTTOM {#TOP-TO-BOTTOM}
+```
+public static final int TOP_TO_BOTTOM
+```
+
+
+Top to bottom.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/polylineto/_index.md
+++ b/german/java/com.aspose.diagram/polylineto/_index.md
@@ -1,0 +1,274 @@
+---
+title: PolylineTo
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält x- und y-Koordinaten des letzten Punktes einer Polylinie und einer Polylinienformel.
+type: docs
+weight: 291
+url: /de/java/com.aspose.diagram/polylineto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class PolylineTo extends Coordinate
+```
+
+Enthält x- und y-Koordinaten des letzten Punktes einer Polylinie und eine Polylinien-Formel. Die Koordinaten werden in den X- und Y-Elementen angegeben, und die Formel wird im A-Element angegeben.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [PolylineTo()](#PolylineTo--) | Erstellt eine Instanz der Klasse [PolylineTo](../../com.aspose.diagram/polylineto). |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | Die Polylinien-Formel. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getIX()](#getIX--) | Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements. |
+| [getX()](#getX--) | Die x-Koordinate des Endknotens einer Polylinie. |
+| [getY()](#getY--) | Die y-Koordinate des Endknotens einer Polylinie. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(StrValue value)](#setA-com.aspose.diagram.StrValue-) | Für die Beschreibung dieser Eigenschaft, bitte siehe [getA()](../../com.aspose.diagram/polylineto\#getA--) |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft, bitte siehe [getDel()](../../com.aspose.diagram/polylineto\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Für die Beschreibung dieser Eigenschaft, bitte siehe [getIX()](../../com.aspose.diagram/polylineto\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft, bitte siehe [getX()](../../com.aspose.diagram/polylineto\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft, bitte siehe [getY()](../../com.aspose.diagram/polylineto\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PolylineTo() {#PolylineTo--}
+```
+public PolylineTo()
+```
+
+
+Erstellt eine Instanz der Klasse [PolylineTo](../../com.aspose.diagram/polylineto).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public StrValue getA()
+```
+
+
+Die Polylinien-Formel.
+
+**Returns:**
+[StrValue](../../com.aspose.diagram/strvalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+Die x-Koordinate des Endknotens einer Polylinie.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+Die y-Koordinate des Endknotens einer Polylinie.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(StrValue value) {#setA-com.aspose.diagram.StrValue-}
+```
+public void setA(StrValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft, bitte siehe [getA()](../../com.aspose.diagram/polylineto\#getA--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [StrValue](../../com.aspose.diagram/strvalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft, bitte siehe [getDel()](../../com.aspose.diagram/polylineto\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft, bitte siehe [getIX()](../../com.aspose.diagram/polylineto\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft, bitte siehe [getX()](../../com.aspose.diagram/polylineto\#getX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft, bitte siehe [getY()](../../com.aspose.diagram/polylineto\#getY--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/polylinetocollection/_index.md
+++ b/german/java/com.aspose.diagram/polylinetocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: PolylineToCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: PolylineTo Sammlung.
+type: docs
+weight: 292
+url: /de/java/com.aspose.diagram/polylinetocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class PolylineToCollection extends Collection
+```
+
+PolylineTo Sammlung.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public PolylineTo get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[PolylineTo](../../com.aspose.diagram/polylineto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/pos/_index.md
+++ b/german/java/com.aspose.diagram/pos/_index.md
@@ -1,0 +1,204 @@
+---
+title: Pos
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt die Position des Textes der Form relativ zur Grundlinie an.
+type: docs
+weight: 293
+url: /de/java/com.aspose.diagram/pos/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Pos
+```
+
+Gibt die Position des Textes der Shape relativ zur Grundlinie an.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [Pos(int value)](#Pos-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Gibt die Position des Textes der Shape relativ zur Grundlinie an. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getUfe()](../../com.aspose.diagram/pos\#getUfe--) |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/pos\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Pos(int value) {#Pos-int-}
+```
+public Pos(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Gibt die Position des Textes der Shape relativ zur Grundlinie an.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getUfe()](../../com.aspose.diagram/pos\#getUfe--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/pos\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/posvalue/_index.md
+++ b/german/java/com.aspose.diagram/posvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: PosValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt die Position des Textes der Form relativ zur Grundlinie an.
+type: docs
+weight: 294
+url: /de/java/com.aspose.diagram/posvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PosValue
+```
+
+Gibt die Position des Textes der Shape relativ zur Grundlinie an.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [NORMAL_POSITION](#NORMAL-POSITION) | Normale Position. |
+| [SUBSCRIPT](#SUBSCRIPT) | Tiefgestellt. |
+| [SUPERSCRIPT](#SUPERSCRIPT) | Hochgestellt. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### NORMAL_POSITION {#NORMAL-POSITION}
+```
+public static final int NORMAL_POSITION
+```
+
+
+Normale Position.
+
+### SUBSCRIPT {#SUBSCRIPT}
+```
+public static final int SUBSCRIPT
+```
+
+
+Tiefgestellt.
+
+### SUPERSCRIPT {#SUPERSCRIPT}
+```
+public static final int SUPERSCRIPT
+```
+
+
+Hochgestellt.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/pp/_index.md
+++ b/german/java/com.aspose.diagram/pp/_index.md
@@ -1,0 +1,154 @@
+---
+title: Pp
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt den Beginn eines Absatz-Eigenschaften-Laufs an.
+type: docs
+weight: 295
+url: /de/java/com.aspose.diagram/pp/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.FormatTxt](../../com.aspose.diagram/formattxt)
+```
+public class Pp extends FormatTxt
+```
+
+Gibt den Beginn eines Absatz‑Eigenschafts‑Runs an. Der Run ist bis zum Ende des Textes oder bis zum nächsten definiert.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [Pp(int IX)](#Pp-int-) | Konstruktor |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getValue()](#getValue--) | Value |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Pp(int IX) {#Pp-int-}
+```
+public Pp(int IX)
+```
+
+
+Konstruktor
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| IX | int | Der Index des Para‑Elements, das die auf diesen Run angewendete Formatierung angibt. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+Value
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/presetcameratype/_index.md
+++ b/german/java/com.aspose.diagram/presetcameratype/_index.md
@@ -1,0 +1,687 @@
+---
+title: PresetCameraType
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt verschiedene algorithmische Methoden zum Einstellen aller Kameraeigenschaften einschließlich Position dar.
+type: docs
+weight: 296
+url: /de/java/com.aspose.diagram/presetcameratype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PresetCameraType
+```
+
+Stellt verschiedene algorithmische Methoden zum Einstellen aller Kameraeigenschaften, einschließlich Position, dar.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [ISOMETRIC_BOTTOM_DOWN](#ISOMETRIC-BOTTOM-DOWN) |  |
+| [ISOMETRIC_BOTTOM_UP](#ISOMETRIC-BOTTOM-UP) |  |
+| [ISOMETRIC_LEFT_DOWN](#ISOMETRIC-LEFT-DOWN) |  |
+| [ISOMETRIC_LEFT_UP](#ISOMETRIC-LEFT-UP) |  |
+| [ISOMETRIC_OFF_AXIS_1_LEFT](#ISOMETRIC-OFF-AXIS-1-LEFT) |  |
+| [ISOMETRIC_OFF_AXIS_1_RIGHT](#ISOMETRIC-OFF-AXIS-1-RIGHT) |  |
+| [ISOMETRIC_OFF_AXIS_1_TOP](#ISOMETRIC-OFF-AXIS-1-TOP) |  |
+| [ISOMETRIC_OFF_AXIS_2_LEFT](#ISOMETRIC-OFF-AXIS-2-LEFT) |  |
+| [ISOMETRIC_OFF_AXIS_2_RIGHT](#ISOMETRIC-OFF-AXIS-2-RIGHT) |  |
+| [ISOMETRIC_OFF_AXIS_2_TOP](#ISOMETRIC-OFF-AXIS-2-TOP) |  |
+| [ISOMETRIC_OFF_AXIS_3_BOTTOM](#ISOMETRIC-OFF-AXIS-3-BOTTOM) |  |
+| [ISOMETRIC_OFF_AXIS_3_LEFT](#ISOMETRIC-OFF-AXIS-3-LEFT) |  |
+| [ISOMETRIC_OFF_AXIS_3_RIGHT](#ISOMETRIC-OFF-AXIS-3-RIGHT) |  |
+| [ISOMETRIC_OFF_AXIS_4_BOTTOM](#ISOMETRIC-OFF-AXIS-4-BOTTOM) |  |
+| [ISOMETRIC_OFF_AXIS_4_LEFT](#ISOMETRIC-OFF-AXIS-4-LEFT) |  |
+| [ISOMETRIC_OFF_AXIS_4_RIGHT](#ISOMETRIC-OFF-AXIS-4-RIGHT) |  |
+| [ISOMETRIC_RIGHT_DOWN](#ISOMETRIC-RIGHT-DOWN) |  |
+| [ISOMETRIC_RIGHT_UP](#ISOMETRIC-RIGHT-UP) |  |
+| [ISOMETRIC_TOP_DOWN](#ISOMETRIC-TOP-DOWN) |  |
+| [ISOMETRIC_TOP_UP](#ISOMETRIC-TOP-UP) |  |
+| [LEGACY_OBLIQUE_BOTTOM](#LEGACY-OBLIQUE-BOTTOM) |  |
+| [LEGACY_OBLIQUE_BOTTOM_LEFT](#LEGACY-OBLIQUE-BOTTOM-LEFT) |  |
+| [LEGACY_OBLIQUE_BOTTOM_RIGHT](#LEGACY-OBLIQUE-BOTTOM-RIGHT) |  |
+| [LEGACY_OBLIQUE_FRONT](#LEGACY-OBLIQUE-FRONT) |  |
+| [LEGACY_OBLIQUE_LEFT](#LEGACY-OBLIQUE-LEFT) |  |
+| [LEGACY_OBLIQUE_RIGHT](#LEGACY-OBLIQUE-RIGHT) |  |
+| [LEGACY_OBLIQUE_TOP](#LEGACY-OBLIQUE-TOP) |  |
+| [LEGACY_OBLIQUE_TOP_LEFT](#LEGACY-OBLIQUE-TOP-LEFT) |  |
+| [LEGACY_OBLIQUE_TOP_RIGHT](#LEGACY-OBLIQUE-TOP-RIGHT) |  |
+| [LEGACY_PERSPECTIVE_BOTTOM](#LEGACY-PERSPECTIVE-BOTTOM) |  |
+| [LEGACY_PERSPECTIVE_BOTTOM_LEFT](#LEGACY-PERSPECTIVE-BOTTOM-LEFT) |  |
+| [LEGACY_PERSPECTIVE_BOTTOM_RIGHT](#LEGACY-PERSPECTIVE-BOTTOM-RIGHT) |  |
+| [LEGACY_PERSPECTIVE_FRONT](#LEGACY-PERSPECTIVE-FRONT) |  |
+| [LEGACY_PERSPECTIVE_LEFT](#LEGACY-PERSPECTIVE-LEFT) |  |
+| [LEGACY_PERSPECTIVE_RIGHT](#LEGACY-PERSPECTIVE-RIGHT) |  |
+| [LEGACY_PERSPECTIVE_TOP](#LEGACY-PERSPECTIVE-TOP) |  |
+| [LEGACY_PERSPECTIVE_TOP_LEFT](#LEGACY-PERSPECTIVE-TOP-LEFT) |  |
+| [LEGACY_PERSPECTIVE_TOP_RIGHT](#LEGACY-PERSPECTIVE-TOP-RIGHT) |  |
+| [OBLIQUE_BOTTOM](#OBLIQUE-BOTTOM) |  |
+| [OBLIQUE_BOTTOM_LEFT](#OBLIQUE-BOTTOM-LEFT) |  |
+| [OBLIQUE_BOTTOM_RIGHT](#OBLIQUE-BOTTOM-RIGHT) |  |
+| [OBLIQUE_LEFT](#OBLIQUE-LEFT) |  |
+| [OBLIQUE_RIGHT](#OBLIQUE-RIGHT) |  |
+| [OBLIQUE_TOP](#OBLIQUE-TOP) |  |
+| [OBLIQUE_TOP_LEFT](#OBLIQUE-TOP-LEFT) |  |
+| [OBLIQUE_TOP_RIGHT](#OBLIQUE-TOP-RIGHT) |  |
+| [ORTHOGRAPHIC_FRONT](#ORTHOGRAPHIC-FRONT) |  |
+| [PERSPECTIVE_ABOVE](#PERSPECTIVE-ABOVE) |  |
+| [PERSPECTIVE_ABOVE_LEFT_FACING](#PERSPECTIVE-ABOVE-LEFT-FACING) |  |
+| [PERSPECTIVE_ABOVE_RIGHT_FACING](#PERSPECTIVE-ABOVE-RIGHT-FACING) |  |
+| [PERSPECTIVE_BELOW](#PERSPECTIVE-BELOW) |  |
+| [PERSPECTIVE_CONTRASTING_LEFT_FACING](#PERSPECTIVE-CONTRASTING-LEFT-FACING) |  |
+| [PERSPECTIVE_CONTRASTING_RIGHT_FACING](#PERSPECTIVE-CONTRASTING-RIGHT-FACING) |  |
+| [PERSPECTIVE_FRONT](#PERSPECTIVE-FRONT) |  |
+| [PERSPECTIVE_HEROIC_EXTREME_LEFT_FACING](#PERSPECTIVE-HEROIC-EXTREME-LEFT-FACING) |  |
+| [PERSPECTIVE_HEROIC_EXTREME_RIGHT_FACING](#PERSPECTIVE-HEROIC-EXTREME-RIGHT-FACING) |  |
+| [PERSPECTIVE_HEROIC_LEFT_FACING](#PERSPECTIVE-HEROIC-LEFT-FACING) |  |
+| [PERSPECTIVE_HEROIC_RIGHT_FACING](#PERSPECTIVE-HEROIC-RIGHT-FACING) |  |
+| [PERSPECTIVE_LEFT](#PERSPECTIVE-LEFT) |  |
+| [PERSPECTIVE_RELAXED](#PERSPECTIVE-RELAXED) |  |
+| [PERSPECTIVE_RELAXED_MODERATELY](#PERSPECTIVE-RELAXED-MODERATELY) |  |
+| [PERSPECTIVE_RIGHT](#PERSPECTIVE-RIGHT) |  |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ISOMETRIC_BOTTOM_DOWN {#ISOMETRIC-BOTTOM-DOWN}
+```
+public static final int ISOMETRIC_BOTTOM_DOWN
+```
+
+
+
+
+### ISOMETRIC_BOTTOM_UP {#ISOMETRIC-BOTTOM-UP}
+```
+public static final int ISOMETRIC_BOTTOM_UP
+```
+
+
+
+
+### ISOMETRIC_LEFT_DOWN {#ISOMETRIC-LEFT-DOWN}
+```
+public static final int ISOMETRIC_LEFT_DOWN
+```
+
+
+
+
+### ISOMETRIC_LEFT_UP {#ISOMETRIC-LEFT-UP}
+```
+public static final int ISOMETRIC_LEFT_UP
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_1_LEFT {#ISOMETRIC-OFF-AXIS-1-LEFT}
+```
+public static final int ISOMETRIC_OFF_AXIS_1_LEFT
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_1_RIGHT {#ISOMETRIC-OFF-AXIS-1-RIGHT}
+```
+public static final int ISOMETRIC_OFF_AXIS_1_RIGHT
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_1_TOP {#ISOMETRIC-OFF-AXIS-1-TOP}
+```
+public static final int ISOMETRIC_OFF_AXIS_1_TOP
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_2_LEFT {#ISOMETRIC-OFF-AXIS-2-LEFT}
+```
+public static final int ISOMETRIC_OFF_AXIS_2_LEFT
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_2_RIGHT {#ISOMETRIC-OFF-AXIS-2-RIGHT}
+```
+public static final int ISOMETRIC_OFF_AXIS_2_RIGHT
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_2_TOP {#ISOMETRIC-OFF-AXIS-2-TOP}
+```
+public static final int ISOMETRIC_OFF_AXIS_2_TOP
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_3_BOTTOM {#ISOMETRIC-OFF-AXIS-3-BOTTOM}
+```
+public static final int ISOMETRIC_OFF_AXIS_3_BOTTOM
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_3_LEFT {#ISOMETRIC-OFF-AXIS-3-LEFT}
+```
+public static final int ISOMETRIC_OFF_AXIS_3_LEFT
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_3_RIGHT {#ISOMETRIC-OFF-AXIS-3-RIGHT}
+```
+public static final int ISOMETRIC_OFF_AXIS_3_RIGHT
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_4_BOTTOM {#ISOMETRIC-OFF-AXIS-4-BOTTOM}
+```
+public static final int ISOMETRIC_OFF_AXIS_4_BOTTOM
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_4_LEFT {#ISOMETRIC-OFF-AXIS-4-LEFT}
+```
+public static final int ISOMETRIC_OFF_AXIS_4_LEFT
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_4_RIGHT {#ISOMETRIC-OFF-AXIS-4-RIGHT}
+```
+public static final int ISOMETRIC_OFF_AXIS_4_RIGHT
+```
+
+
+
+
+### ISOMETRIC_RIGHT_DOWN {#ISOMETRIC-RIGHT-DOWN}
+```
+public static final int ISOMETRIC_RIGHT_DOWN
+```
+
+
+
+
+### ISOMETRIC_RIGHT_UP {#ISOMETRIC-RIGHT-UP}
+```
+public static final int ISOMETRIC_RIGHT_UP
+```
+
+
+
+
+### ISOMETRIC_TOP_DOWN {#ISOMETRIC-TOP-DOWN}
+```
+public static final int ISOMETRIC_TOP_DOWN
+```
+
+
+
+
+### ISOMETRIC_TOP_UP {#ISOMETRIC-TOP-UP}
+```
+public static final int ISOMETRIC_TOP_UP
+```
+
+
+
+
+### LEGACY_OBLIQUE_BOTTOM {#LEGACY-OBLIQUE-BOTTOM}
+```
+public static final int LEGACY_OBLIQUE_BOTTOM
+```
+
+
+
+
+### LEGACY_OBLIQUE_BOTTOM_LEFT {#LEGACY-OBLIQUE-BOTTOM-LEFT}
+```
+public static final int LEGACY_OBLIQUE_BOTTOM_LEFT
+```
+
+
+
+
+### LEGACY_OBLIQUE_BOTTOM_RIGHT {#LEGACY-OBLIQUE-BOTTOM-RIGHT}
+```
+public static final int LEGACY_OBLIQUE_BOTTOM_RIGHT
+```
+
+
+
+
+### LEGACY_OBLIQUE_FRONT {#LEGACY-OBLIQUE-FRONT}
+```
+public static final int LEGACY_OBLIQUE_FRONT
+```
+
+
+
+
+### LEGACY_OBLIQUE_LEFT {#LEGACY-OBLIQUE-LEFT}
+```
+public static final int LEGACY_OBLIQUE_LEFT
+```
+
+
+
+
+### LEGACY_OBLIQUE_RIGHT {#LEGACY-OBLIQUE-RIGHT}
+```
+public static final int LEGACY_OBLIQUE_RIGHT
+```
+
+
+
+
+### LEGACY_OBLIQUE_TOP {#LEGACY-OBLIQUE-TOP}
+```
+public static final int LEGACY_OBLIQUE_TOP
+```
+
+
+
+
+### LEGACY_OBLIQUE_TOP_LEFT {#LEGACY-OBLIQUE-TOP-LEFT}
+```
+public static final int LEGACY_OBLIQUE_TOP_LEFT
+```
+
+
+
+
+### LEGACY_OBLIQUE_TOP_RIGHT {#LEGACY-OBLIQUE-TOP-RIGHT}
+```
+public static final int LEGACY_OBLIQUE_TOP_RIGHT
+```
+
+
+
+
+### LEGACY_PERSPECTIVE_BOTTOM {#LEGACY-PERSPECTIVE-BOTTOM}
+```
+public static final int LEGACY_PERSPECTIVE_BOTTOM
+```
+
+
+
+
+### LEGACY_PERSPECTIVE_BOTTOM_LEFT {#LEGACY-PERSPECTIVE-BOTTOM-LEFT}
+```
+public static final int LEGACY_PERSPECTIVE_BOTTOM_LEFT
+```
+
+
+
+
+### LEGACY_PERSPECTIVE_BOTTOM_RIGHT {#LEGACY-PERSPECTIVE-BOTTOM-RIGHT}
+```
+public static final int LEGACY_PERSPECTIVE_BOTTOM_RIGHT
+```
+
+
+
+
+### LEGACY_PERSPECTIVE_FRONT {#LEGACY-PERSPECTIVE-FRONT}
+```
+public static final int LEGACY_PERSPECTIVE_FRONT
+```
+
+
+
+
+### LEGACY_PERSPECTIVE_LEFT {#LEGACY-PERSPECTIVE-LEFT}
+```
+public static final int LEGACY_PERSPECTIVE_LEFT
+```
+
+
+
+
+### LEGACY_PERSPECTIVE_RIGHT {#LEGACY-PERSPECTIVE-RIGHT}
+```
+public static final int LEGACY_PERSPECTIVE_RIGHT
+```
+
+
+
+
+### LEGACY_PERSPECTIVE_TOP {#LEGACY-PERSPECTIVE-TOP}
+```
+public static final int LEGACY_PERSPECTIVE_TOP
+```
+
+
+
+
+### LEGACY_PERSPECTIVE_TOP_LEFT {#LEGACY-PERSPECTIVE-TOP-LEFT}
+```
+public static final int LEGACY_PERSPECTIVE_TOP_LEFT
+```
+
+
+
+
+### LEGACY_PERSPECTIVE_TOP_RIGHT {#LEGACY-PERSPECTIVE-TOP-RIGHT}
+```
+public static final int LEGACY_PERSPECTIVE_TOP_RIGHT
+```
+
+
+
+
+### OBLIQUE_BOTTOM {#OBLIQUE-BOTTOM}
+```
+public static final int OBLIQUE_BOTTOM
+```
+
+
+
+
+### OBLIQUE_BOTTOM_LEFT {#OBLIQUE-BOTTOM-LEFT}
+```
+public static final int OBLIQUE_BOTTOM_LEFT
+```
+
+
+
+
+### OBLIQUE_BOTTOM_RIGHT {#OBLIQUE-BOTTOM-RIGHT}
+```
+public static final int OBLIQUE_BOTTOM_RIGHT
+```
+
+
+
+
+### OBLIQUE_LEFT {#OBLIQUE-LEFT}
+```
+public static final int OBLIQUE_LEFT
+```
+
+
+
+
+### OBLIQUE_RIGHT {#OBLIQUE-RIGHT}
+```
+public static final int OBLIQUE_RIGHT
+```
+
+
+
+
+### OBLIQUE_TOP {#OBLIQUE-TOP}
+```
+public static final int OBLIQUE_TOP
+```
+
+
+
+
+### OBLIQUE_TOP_LEFT {#OBLIQUE-TOP-LEFT}
+```
+public static final int OBLIQUE_TOP_LEFT
+```
+
+
+
+
+### OBLIQUE_TOP_RIGHT {#OBLIQUE-TOP-RIGHT}
+```
+public static final int OBLIQUE_TOP_RIGHT
+```
+
+
+
+
+### ORTHOGRAPHIC_FRONT {#ORTHOGRAPHIC-FRONT}
+```
+public static final int ORTHOGRAPHIC_FRONT
+```
+
+
+
+
+### PERSPECTIVE_ABOVE {#PERSPECTIVE-ABOVE}
+```
+public static final int PERSPECTIVE_ABOVE
+```
+
+
+
+
+### PERSPECTIVE_ABOVE_LEFT_FACING {#PERSPECTIVE-ABOVE-LEFT-FACING}
+```
+public static final int PERSPECTIVE_ABOVE_LEFT_FACING
+```
+
+
+
+
+### PERSPECTIVE_ABOVE_RIGHT_FACING {#PERSPECTIVE-ABOVE-RIGHT-FACING}
+```
+public static final int PERSPECTIVE_ABOVE_RIGHT_FACING
+```
+
+
+
+
+### PERSPECTIVE_BELOW {#PERSPECTIVE-BELOW}
+```
+public static final int PERSPECTIVE_BELOW
+```
+
+
+
+
+### PERSPECTIVE_CONTRASTING_LEFT_FACING {#PERSPECTIVE-CONTRASTING-LEFT-FACING}
+```
+public static final int PERSPECTIVE_CONTRASTING_LEFT_FACING
+```
+
+
+
+
+### PERSPECTIVE_CONTRASTING_RIGHT_FACING {#PERSPECTIVE-CONTRASTING-RIGHT-FACING}
+```
+public static final int PERSPECTIVE_CONTRASTING_RIGHT_FACING
+```
+
+
+
+
+### PERSPECTIVE_FRONT {#PERSPECTIVE-FRONT}
+```
+public static final int PERSPECTIVE_FRONT
+```
+
+
+
+
+### PERSPECTIVE_HEROIC_EXTREME_LEFT_FACING {#PERSPECTIVE-HEROIC-EXTREME-LEFT-FACING}
+```
+public static final int PERSPECTIVE_HEROIC_EXTREME_LEFT_FACING
+```
+
+
+
+
+### PERSPECTIVE_HEROIC_EXTREME_RIGHT_FACING {#PERSPECTIVE-HEROIC-EXTREME-RIGHT-FACING}
+```
+public static final int PERSPECTIVE_HEROIC_EXTREME_RIGHT_FACING
+```
+
+
+
+
+### PERSPECTIVE_HEROIC_LEFT_FACING {#PERSPECTIVE-HEROIC-LEFT-FACING}
+```
+public static final int PERSPECTIVE_HEROIC_LEFT_FACING
+```
+
+
+
+
+### PERSPECTIVE_HEROIC_RIGHT_FACING {#PERSPECTIVE-HEROIC-RIGHT-FACING}
+```
+public static final int PERSPECTIVE_HEROIC_RIGHT_FACING
+```
+
+
+
+
+### PERSPECTIVE_LEFT {#PERSPECTIVE-LEFT}
+```
+public static final int PERSPECTIVE_LEFT
+```
+
+
+
+
+### PERSPECTIVE_RELAXED {#PERSPECTIVE-RELAXED}
+```
+public static final int PERSPECTIVE_RELAXED
+```
+
+
+
+
+### PERSPECTIVE_RELAXED_MODERATELY {#PERSPECTIVE-RELAXED-MODERATELY}
+```
+public static final int PERSPECTIVE_RELAXED_MODERATELY
+```
+
+
+
+
+### PERSPECTIVE_RIGHT {#PERSPECTIVE-RIGHT}
+```
+public static final int PERSPECTIVE_RIGHT
+```
+
+
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/presetcolormatricsvalue/_index.md
+++ b/german/java/com.aspose.diagram/presetcolormatricsvalue/_index.md
@@ -1,0 +1,192 @@
+---
+title: PresetColorMatricsValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Wird verwendet, um die Farbeigenschaft der Shape-Designstile festzulegen
+type: docs
+weight: 297
+url: /de/java/com.aspose.diagram/presetcolormatricsvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PresetColorMatricsValue
+```
+
+Wird verwendet, um die Farbeigenschaft von Shape theme style festzulegen.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [COLOR_1](#COLOR-1) | Farbe1. |
+| [COLOR_2](#COLOR-2) | Farbe2. |
+| [COLOR_3](#COLOR-3) | Farbe3. |
+| [COLOR_4](#COLOR-4) | Farbe4. |
+| [COLOR_5](#COLOR-5) | Farbe5. |
+| [COLOR_6](#COLOR-6) | Farbe6. |
+| [COLOR_7](#COLOR-7) | Farbe7. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### COLOR_1 {#COLOR-1}
+```
+public static final int COLOR_1
+```
+
+
+Farbe1.
+
+### COLOR_2 {#COLOR-2}
+```
+public static final int COLOR_2
+```
+
+
+Farbe2.
+
+### COLOR_3 {#COLOR-3}
+```
+public static final int COLOR_3
+```
+
+
+Farbe3.
+
+### COLOR_4 {#COLOR-4}
+```
+public static final int COLOR_4
+```
+
+
+Farbe4.
+
+### COLOR_5 {#COLOR-5}
+```
+public static final int COLOR_5
+```
+
+
+Farbe5.
+
+### COLOR_6 {#COLOR-6}
+```
+public static final int COLOR_6
+```
+
+
+Farbe6.
+
+### COLOR_7 {#COLOR-7}
+```
+public static final int COLOR_7
+```
+
+
+Farbe7.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/presetquickstylevalue/_index.md
+++ b/german/java/com.aspose.diagram/presetquickstylevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: PresetQuickStyleValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt den Schnellstilwert des Themas an.
+type: docs
+weight: 298
+url: /de/java/com.aspose.diagram/presetquickstylevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PresetQuickStyleValue
+```
+
+Gibt den Schnellstilwert des Themas an.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [VARIANT_STYLE_1](#VARIANT-STYLE-1) | VariantStyle1. |
+| [VARIANT_STYLE_2](#VARIANT-STYLE-2) | VariantStyle2. |
+| [VARIANT_STYLE_3](#VARIANT-STYLE-3) | VariantStyle3. |
+| [VARIANT_STYLE_4](#VARIANT-STYLE-4) | VariantStyle4. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### VARIANT_STYLE_1 {#VARIANT-STYLE-1}
+```
+public static final int VARIANT_STYLE_1
+```
+
+
+VariantStyle1.
+
+### VARIANT_STYLE_2 {#VARIANT-STYLE-2}
+```
+public static final int VARIANT_STYLE_2
+```
+
+
+VariantStyle2.
+
+### VARIANT_STYLE_3 {#VARIANT-STYLE-3}
+```
+public static final int VARIANT_STYLE_3
+```
+
+
+VariantStyle3.
+
+### VARIANT_STYLE_4 {#VARIANT-STYLE-4}
+```
+public static final int VARIANT_STYLE_4
+```
+
+
+VariantStyle4.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/presetshadowtype/_index.md
+++ b/german/java/com.aspose.diagram/presetshadowtype/_index.md
@@ -1,0 +1,354 @@
+---
+title: PresetShadowType
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt den voreingestellten Schattentyp dar.
+type: docs
+weight: 299
+url: /de/java/com.aspose.diagram/presetshadowtype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PresetShadowType
+```
+
+Stellt den voreingestellten Schattentyp dar.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [BELOW](#BELOW) | Äußerer Schatten unten. |
+| [CUSTOM](#CUSTOM) | Benutzerdefinierter Schatten. |
+| [INSIDE_BOTTOM](#INSIDE-BOTTOM) | Innerer Schatten unten innen. |
+| [INSIDE_CENTER](#INSIDE-CENTER) | Innerer Schatten in der Mitte. |
+| [INSIDE_DIAGONAL_BOTTOM_LEFT](#INSIDE-DIAGONAL-BOTTOM-LEFT) | Innerer Schatten diagonal unten links innen. |
+| [INSIDE_DIAGONAL_BOTTOM_RIGHT](#INSIDE-DIAGONAL-BOTTOM-RIGHT) | Innerer Schatten diagonal unten rechts innen. |
+| [INSIDE_DIAGONAL_TOP_LEFT](#INSIDE-DIAGONAL-TOP-LEFT) | Innerer Schatten diagonal oben links innen. |
+| [INSIDE_DIAGONAL_TOP_RIGHT](#INSIDE-DIAGONAL-TOP-RIGHT) | Innerer Schatten diagonal oben rechts innen. |
+| [INSIDE_LEFT](#INSIDE-LEFT) | Innerer Schatten links innen. |
+| [INSIDE_RIGHT](#INSIDE-RIGHT) | Innerer Schatten rechts innen. |
+| [INSIDE_TOP](#INSIDE-TOP) | Innerer Schatten oben innen. |
+| [NO_SHADOW](#NO-SHADOW) | Kein Schatten. |
+| [OFFSET_BOTTOM](#OFFSET-BOTTOM) | Äußerer Schatten Versatz unten. |
+| [OFFSET_CENTER](#OFFSET-CENTER) | Äußerer Schatten Versatz Mitte. |
+| [OFFSET_DIAGONAL_BOTTOM_LEFT](#OFFSET-DIAGONAL-BOTTOM-LEFT) | Äußerer Schatten Versatz diagonal unten links. |
+| [OFFSET_DIAGONAL_BOTTOM_RIGHT](#OFFSET-DIAGONAL-BOTTOM-RIGHT) | Äußerer Schatten Versatz diagonal unten rechts. |
+| [OFFSET_DIAGONAL_TOP_LEFT](#OFFSET-DIAGONAL-TOP-LEFT) | Äußerer Schatten Versatz diagonal oben links. |
+| [OFFSET_DIAGONAL_TOP_RIGHT](#OFFSET-DIAGONAL-TOP-RIGHT) | Äußerer Schatten Versatz diagonal oben rechts. |
+| [OFFSET_LEFT](#OFFSET-LEFT) | Äußerer Schatten Versatz links. |
+| [OFFSET_RIGHT](#OFFSET-RIGHT) | Äußerer Schatten Versatz rechts. |
+| [OFFSET_TOP](#OFFSET-TOP) | Äußerer Schatten Versatz oben. |
+| [PERSPECTIVE_DIAGONAL_LOWER_LEFT](#PERSPECTIVE-DIAGONAL-LOWER-LEFT) | Äußerer Schatten Perspektive diagonal unten links. |
+| [PERSPECTIVE_DIAGONAL_LOWER_RIGHT](#PERSPECTIVE-DIAGONAL-LOWER-RIGHT) | Äußerer Schatten Perspektive diagonal unten rechts. |
+| [PERSPECTIVE_DIAGONAL_UPPER_LEFT](#PERSPECTIVE-DIAGONAL-UPPER-LEFT) | Äußerer Schatten Perspektive diagonal oben links. |
+| [PERSPECTIVE_DIAGONAL_UPPER_RIGHT](#PERSPECTIVE-DIAGONAL-UPPER-RIGHT) | Äußerer Schatten Perspektive diagonal oben rechts. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BELOW {#BELOW}
+```
+public static final int BELOW
+```
+
+
+Äußerer Schatten unten.
+
+### CUSTOM {#CUSTOM}
+```
+public static final int CUSTOM
+```
+
+
+Benutzerdefinierter Schatten.
+
+### INSIDE_BOTTOM {#INSIDE-BOTTOM}
+```
+public static final int INSIDE_BOTTOM
+```
+
+
+Innerer Schatten unten innen.
+
+### INSIDE_CENTER {#INSIDE-CENTER}
+```
+public static final int INSIDE_CENTER
+```
+
+
+Innerer Schatten in der Mitte.
+
+### INSIDE_DIAGONAL_BOTTOM_LEFT {#INSIDE-DIAGONAL-BOTTOM-LEFT}
+```
+public static final int INSIDE_DIAGONAL_BOTTOM_LEFT
+```
+
+
+Innerer Schatten diagonal unten links innen.
+
+### INSIDE_DIAGONAL_BOTTOM_RIGHT {#INSIDE-DIAGONAL-BOTTOM-RIGHT}
+```
+public static final int INSIDE_DIAGONAL_BOTTOM_RIGHT
+```
+
+
+Innerer Schatten diagonal unten rechts innen.
+
+### INSIDE_DIAGONAL_TOP_LEFT {#INSIDE-DIAGONAL-TOP-LEFT}
+```
+public static final int INSIDE_DIAGONAL_TOP_LEFT
+```
+
+
+Innerer Schatten diagonal oben links innen.
+
+### INSIDE_DIAGONAL_TOP_RIGHT {#INSIDE-DIAGONAL-TOP-RIGHT}
+```
+public static final int INSIDE_DIAGONAL_TOP_RIGHT
+```
+
+
+Innerer Schatten diagonal oben rechts innen.
+
+### INSIDE_LEFT {#INSIDE-LEFT}
+```
+public static final int INSIDE_LEFT
+```
+
+
+Innerer Schatten links innen.
+
+### INSIDE_RIGHT {#INSIDE-RIGHT}
+```
+public static final int INSIDE_RIGHT
+```
+
+
+Innerer Schatten rechts innen.
+
+### INSIDE_TOP {#INSIDE-TOP}
+```
+public static final int INSIDE_TOP
+```
+
+
+Innerer Schatten oben innen.
+
+### NO_SHADOW {#NO-SHADOW}
+```
+public static final int NO_SHADOW
+```
+
+
+Kein Schatten.
+
+### OFFSET_BOTTOM {#OFFSET-BOTTOM}
+```
+public static final int OFFSET_BOTTOM
+```
+
+
+Äußerer Schatten Versatz unten.
+
+### OFFSET_CENTER {#OFFSET-CENTER}
+```
+public static final int OFFSET_CENTER
+```
+
+
+Äußerer Schatten Versatz Mitte.
+
+### OFFSET_DIAGONAL_BOTTOM_LEFT {#OFFSET-DIAGONAL-BOTTOM-LEFT}
+```
+public static final int OFFSET_DIAGONAL_BOTTOM_LEFT
+```
+
+
+Äußerer Schatten Versatz diagonal unten links.
+
+### OFFSET_DIAGONAL_BOTTOM_RIGHT {#OFFSET-DIAGONAL-BOTTOM-RIGHT}
+```
+public static final int OFFSET_DIAGONAL_BOTTOM_RIGHT
+```
+
+
+Äußerer Schatten Versatz diagonal unten rechts.
+
+### OFFSET_DIAGONAL_TOP_LEFT {#OFFSET-DIAGONAL-TOP-LEFT}
+```
+public static final int OFFSET_DIAGONAL_TOP_LEFT
+```
+
+
+Äußerer Schatten Versatz diagonal oben links.
+
+### OFFSET_DIAGONAL_TOP_RIGHT {#OFFSET-DIAGONAL-TOP-RIGHT}
+```
+public static final int OFFSET_DIAGONAL_TOP_RIGHT
+```
+
+
+Äußerer Schatten Versatz diagonal oben rechts.
+
+### OFFSET_LEFT {#OFFSET-LEFT}
+```
+public static final int OFFSET_LEFT
+```
+
+
+Äußerer Schatten Versatz links.
+
+### OFFSET_RIGHT {#OFFSET-RIGHT}
+```
+public static final int OFFSET_RIGHT
+```
+
+
+Äußerer Schatten Versatz rechts.
+
+### OFFSET_TOP {#OFFSET-TOP}
+```
+public static final int OFFSET_TOP
+```
+
+
+Äußerer Schatten Versatz oben.
+
+### PERSPECTIVE_DIAGONAL_LOWER_LEFT {#PERSPECTIVE-DIAGONAL-LOWER-LEFT}
+```
+public static final int PERSPECTIVE_DIAGONAL_LOWER_LEFT
+```
+
+
+Äußerer Schatten Perspektive diagonal unten links.
+
+### PERSPECTIVE_DIAGONAL_LOWER_RIGHT {#PERSPECTIVE-DIAGONAL-LOWER-RIGHT}
+```
+public static final int PERSPECTIVE_DIAGONAL_LOWER_RIGHT
+```
+
+
+Äußerer Schatten Perspektive diagonal unten rechts.
+
+### PERSPECTIVE_DIAGONAL_UPPER_LEFT {#PERSPECTIVE-DIAGONAL-UPPER-LEFT}
+```
+public static final int PERSPECTIVE_DIAGONAL_UPPER_LEFT
+```
+
+
+Äußerer Schatten Perspektive diagonal oben links.
+
+### PERSPECTIVE_DIAGONAL_UPPER_RIGHT {#PERSPECTIVE-DIAGONAL-UPPER-RIGHT}
+```
+public static final int PERSPECTIVE_DIAGONAL_UPPER_RIGHT
+```
+
+
+Äußerer Schatten Perspektive diagonal oben rechts.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/presetstylematricsvalue/_index.md
+++ b/german/java/com.aspose.diagram/presetstylematricsvalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: PresetStyleMatricsValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Wird verwendet, um die Eigenschaft von Shape theme style festzulegen.
+type: docs
+weight: 300
+url: /de/java/com.aspose.diagram/presetstylematricsvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PresetStyleMatricsValue
+```
+
+Wird verwendet, um die Eigenschaft von Shape theme style festzulegen.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [STYLE_1](#STYLE-1) | Style1 |
+| [STYLE_2](#STYLE-2) | Style2 |
+| [STYLE_3](#STYLE-3) | Style3 |
+| [STYLE_4](#STYLE-4) | Style4 |
+| [STYLE_5](#STYLE-5) | Style5 |
+| [STYLE_6](#STYLE-6) | Style6 |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### STYLE_1 {#STYLE-1}
+```
+public static final int STYLE_1
+```
+
+
+Style1
+
+### STYLE_2 {#STYLE-2}
+```
+public static final int STYLE_2
+```
+
+
+Style2
+
+### STYLE_3 {#STYLE-3}
+```
+public static final int STYLE_3
+```
+
+
+Style3
+
+### STYLE_4 {#STYLE-4}
+```
+public static final int STYLE_4
+```
+
+
+Style4
+
+### STYLE_5 {#STYLE-5}
+```
+public static final int STYLE_5
+```
+
+
+Style5
+
+### STYLE_6 {#STYLE-6}
+```
+public static final int STYLE_6
+```
+
+
+Style6
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/presetthemevalue/_index.md
+++ b/german/java/com.aspose.diagram/presetthemevalue/_index.md
@@ -1,0 +1,372 @@
+---
+title: PresetThemeValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt den Themenwert an.
+type: docs
+weight: 301
+url: /de/java/com.aspose.diagram/presetthemevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PresetThemeValue
+```
+
+Gibt den Themenwert an.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [BUBBLE](#BUBBLE) | Blase |
+| [CLOUDS](#CLOUDS) | Wolken |
+| [DAYBREAK](#DAYBREAK) | Morgendämmerung |
+| [FACET](#FACET) | Facette |
+| [GEMSTONE](#GEMSTONE) | Edelstein |
+| [INTEGRAL](#INTEGRAL) | Integral |
+| [ION](#ION) | Ion |
+| [LINEAR](#LINEAR) | Linear |
+| [LINES](#LINES) | Lines |
+| [MARKER](#MARKER) | Marker |
+| [NO_THEME](#NO-THEME) | NoTheme |
+| [OFFICE](#OFFICE) | Office |
+| [ORGANIC](#ORGANIC) | Organic |
+| [PARALLEL](#PARALLEL) | Parallel |
+| [PEN](#PEN) | Pen |
+| [PENCIL](#PENCIL) | Pencil |
+| [PROMINENCE](#PROMINENCE) | Prominence |
+| [RADIANCE](#RADIANCE) | Radiance |
+| [RETROSPECT](#RETROSPECT) | Retrospect |
+| [SEQUENCE](#SEQUENCE) | Sequence |
+| [SHADE](#SHADE) | Shade |
+| [SIMPLE](#SIMPLE) | Simple |
+| [SLICE](#SLICE) | Slice |
+| [SMOKE](#SMOKE) | Smoke |
+| [WHISP](#WHISP) | Whisp |
+| [WHITE_BOARD](#WHITE-BOARD) | WhiteBoard |
+| [ZEPHYR](#ZEPHYR) | Zephyr |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BUBBLE {#BUBBLE}
+```
+public static final int BUBBLE
+```
+
+
+Blase
+
+### CLOUDS {#CLOUDS}
+```
+public static final int CLOUDS
+```
+
+
+Wolken
+
+### DAYBREAK {#DAYBREAK}
+```
+public static final int DAYBREAK
+```
+
+
+Morgendämmerung
+
+### FACET {#FACET}
+```
+public static final int FACET
+```
+
+
+Facette
+
+### GEMSTONE {#GEMSTONE}
+```
+public static final int GEMSTONE
+```
+
+
+Edelstein
+
+### INTEGRAL {#INTEGRAL}
+```
+public static final int INTEGRAL
+```
+
+
+Integral
+
+### ION {#ION}
+```
+public static final int ION
+```
+
+
+Ion
+
+### LINEAR {#LINEAR}
+```
+public static final int LINEAR
+```
+
+
+Linear
+
+### LINES {#LINES}
+```
+public static final int LINES
+```
+
+
+Lines
+
+### MARKER {#MARKER}
+```
+public static final int MARKER
+```
+
+
+Marker
+
+### NO_THEME {#NO-THEME}
+```
+public static final int NO_THEME
+```
+
+
+NoTheme
+
+### OFFICE {#OFFICE}
+```
+public static final int OFFICE
+```
+
+
+Office
+
+### ORGANIC {#ORGANIC}
+```
+public static final int ORGANIC
+```
+
+
+Organic
+
+### PARALLEL {#PARALLEL}
+```
+public static final int PARALLEL
+```
+
+
+Parallel
+
+### PEN {#PEN}
+```
+public static final int PEN
+```
+
+
+Pen
+
+### PENCIL {#PENCIL}
+```
+public static final int PENCIL
+```
+
+
+Pencil
+
+### PROMINENCE {#PROMINENCE}
+```
+public static final int PROMINENCE
+```
+
+
+Prominence
+
+### RADIANCE {#RADIANCE}
+```
+public static final int RADIANCE
+```
+
+
+Radiance
+
+### RETROSPECT {#RETROSPECT}
+```
+public static final int RETROSPECT
+```
+
+
+Retrospect
+
+### SEQUENCE {#SEQUENCE}
+```
+public static final int SEQUENCE
+```
+
+
+Sequence
+
+### SHADE {#SHADE}
+```
+public static final int SHADE
+```
+
+
+Shade
+
+### SIMPLE {#SIMPLE}
+```
+public static final int SIMPLE
+```
+
+
+Simple
+
+### SLICE {#SLICE}
+```
+public static final int SLICE
+```
+
+
+Slice
+
+### SMOKE {#SMOKE}
+```
+public static final int SMOKE
+```
+
+
+Smoke
+
+### WHISP {#WHISP}
+```
+public static final int WHISP
+```
+
+
+Whisp
+
+### WHITE_BOARD {#WHITE-BOARD}
+```
+public static final int WHITE_BOARD
+```
+
+
+WhiteBoard
+
+### ZEPHYR {#ZEPHYR}
+```
+public static final int ZEPHYR
+```
+
+
+Zephyr
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/presetthemevariantvalue/_index.md
+++ b/german/java/com.aspose.diagram/presetthemevariantvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: PresetThemeVariantValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt den Variantenwert des Themas an.
+type: docs
+weight: 302
+url: /de/java/com.aspose.diagram/presetthemevariantvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PresetThemeVariantValue
+```
+
+Gibt den Variantenwert des Themas an.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [VARIANT_1](#VARIANT-1) | Variant1. |
+| [VARIANT_2](#VARIANT-2) | Variant2. |
+| [VARIANT_3](#VARIANT-3) | Variant3. |
+| [VARIANT_4](#VARIANT-4) | Variant4. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### VARIANT_1 {#VARIANT-1}
+```
+public static final int VARIANT_1
+```
+
+
+Variant1.
+
+### VARIANT_2 {#VARIANT-2}
+```
+public static final int VARIANT_2
+```
+
+
+Variant2.
+
+### VARIANT_3 {#VARIANT-3}
+```
+public static final int VARIANT_3
+```
+
+
+Variant3.
+
+### VARIANT_4 {#VARIANT-4}
+```
+public static final int VARIANT_4
+```
+
+
+Variant4.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/previewscope/_index.md
+++ b/german/java/com.aspose.diagram/previewscope/_index.md
@@ -1,0 +1,179 @@
+---
+title: PreviewScope
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt an, ob das Dokument eine Vorschau enthält und, falls ja, ob die Vorschau nur die erste Seite oder alle Seiten im Dokument anzeigt.
+type: docs
+weight: 303
+url: /de/java/com.aspose.diagram/previewscope/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PreviewScope
+```
+
+Gibt an, ob das Dokument eine Vorschau enthält und, falls ja, ob die Vorschau nur die erste Seite oder alle Seiten im Dokument zeigt.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [PreviewScope(int value)](#PreviewScope-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Gibt an, ob das Dokument eine Vorschau enthält und, falls ja, ob die Vorschau nur die erste Seite oder alle Seiten im Dokument zeigt. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe [getValue()](../../com.aspose.diagram/previewscope\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PreviewScope(int value) {#PreviewScope-int-}
+```
+public PreviewScope(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Gibt an, ob das Dokument eine Vorschau enthält und, falls ja, ob die Vorschau nur die erste Seite oder alle Seiten im Dokument zeigt.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getValue()](../../com.aspose.diagram/previewscope\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/previewscopevalue/_index.md
+++ b/german/java/com.aspose.diagram/previewscopevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: PreviewScopeValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt an, ob das Dokument eine Vorschau enthält und, falls ja, ob die Vorschau nur die erste Seite oder alle Seiten im Dokument anzeigt.
+type: docs
+weight: 304
+url: /de/java/com.aspose.diagram/previewscopevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PreviewScopeValue
+```
+
+Gibt an, ob das Dokument eine Vorschau enthält und, falls ja, ob die Vorschau nur die erste Seite oder alle Seiten im Dokument zeigt.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [ALL_PAGES](#ALL-PAGES) | Alle Seiten. |
+| [FIRST_PAGE](#FIRST-PAGE) | Erste Seite. |
+| [NO_PREVIEW](#NO-PREVIEW) | Keine Vorschau. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALL_PAGES {#ALL-PAGES}
+```
+public static final int ALL_PAGES
+```
+
+
+Alle Seiten.
+
+### FIRST_PAGE {#FIRST-PAGE}
+```
+public static final int FIRST_PAGE
+```
+
+
+Erste Seite.
+
+### NO_PREVIEW {#NO-PREVIEW}
+```
+public static final int NO_PREVIEW
+```
+
+
+Keine Vorschau.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/printpageorientation/_index.md
+++ b/german/java/com.aspose.diagram/printpageorientation/_index.md
@@ -1,0 +1,180 @@
+---
+title: PrintPageOrientation
+second_title: Aspose.Diagram for Java API-Referenz
+description: Bestimmt, ob die Seite im Hoch- oder Querformat gedruckt wird.
+type: docs
+weight: 305
+url: /de/java/com.aspose.diagram/printpageorientation/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PrintPageOrientation
+```
+
+Bestimmt, ob die Seite im Hoch- oder Querformat gedruckt wird.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [PrintPageOrientation(PrintProps pp, int value)](#PrintPageOrientation-com.aspose.diagram.PrintProps-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Bestimmt, ob die Seite im Hoch- oder Querformat gedruckt wird. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | For the description of this property, please see [getValue()](../../com.aspose.diagram/printpageorientation\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PrintPageOrientation(PrintProps pp, int value) {#PrintPageOrientation-com.aspose.diagram.PrintProps-int-}
+```
+public PrintPageOrientation(PrintProps pp, int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| pp | [PrintProps](../../com.aspose.diagram/printprops) |  |
+| Wert | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Bestimmt, ob die Seite im Hoch- oder Querformat gedruckt wird.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+For the description of this property, please see [getValue()](../../com.aspose.diagram/printpageorientation\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/printpageorientationvalue/_index.md
+++ b/german/java/com.aspose.diagram/printpageorientationvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: PrintPageOrientationValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Bestimmt, ob die Seite im Hoch- oder Querformat gedruckt wird.
+type: docs
+weight: 306
+url: /de/java/com.aspose.diagram/printpageorientationvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PrintPageOrientationValue
+```
+
+Bestimmt, ob die Seite im Hoch- oder Querformat gedruckt wird.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [LANDSCAPE](#LANDSCAPE) | Querformat. |
+| [PORTRAIT](#PORTRAIT) | Hochformat. |
+| [SAME_AS_PRINTER](#SAME-AS-PRINTER) | Wie der Drucker. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LANDSCAPE {#LANDSCAPE}
+```
+public static final int LANDSCAPE
+```
+
+
+Querformat.
+
+### PORTRAIT {#PORTRAIT}
+```
+public static final int PORTRAIT
+```
+
+
+Hochformat.
+
+### SAME_AS_PRINTER {#SAME-AS-PRINTER}
+```
+public static final int SAME_AS_PRINTER
+```
+
+
+Wie der Drucker.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/printprops/_index.md
+++ b/german/java/com.aspose.diagram/printprops/_index.md
@@ -1,0 +1,315 @@
+---
+title: PrintProps
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält Elemente, die bestimmen, wie die Zeichenblattseite auf der Druckerseite formatiert wird.
+type: docs
+weight: 307
+url: /de/java/com.aspose.diagram/printprops/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PrintProps
+```
+
+Enthält Elemente, die steuern, wie die Zeichenfläche auf der Druckerseite formatiert (angezeigt) wird.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCenterX()](#getCenterX--) | Bestimmt, ob die Zeichenblattseite horizontal auf der gedruckten Seite zentriert ist. |
+| [getCenterY()](#getCenterY--) | Bestimmt, ob die Zeichenblattseite vertikal auf der gedruckten Seite zentriert ist. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getOnPage()](#getOnPage--) | Gibt an, ob die Zeichnung auf einer bestimmten Anzahl von Druckerseiten gedruckt wird. |
+| [getPageBottomMargin()](#getPageBottomMargin--) | Gibt den Rand am unteren Rand der gedruckten Seite an. |
+| [getPageLeftMargin()](#getPageLeftMargin--) | Gibt den Rand an der linken Seite der gedruckten Seite an. |
+| [getPageRightMargin()](#getPageRightMargin--) | Gibt den Rand an der rechten Seite der gedruckten Seite an. |
+| [getPageTopMargin()](#getPageTopMargin--) | Gibt den Rand am oberen Rand der Druckerseite an. |
+| [getPagesX()](#getPagesX--) | Bestimmt die Anzahl der Druckerseiten, auf denen die Zeichenblattseite horizontal angepasst wird. |
+| [getPagesY()](#getPagesY--) | Bestimmt die Anzahl der Druckerseiten, auf denen die Zeichenblattseite vertikal angepasst wird. |
+| [getPaperKind()](#getPaperKind--) | Gibt den Papiertyp an, auf dem die Seite gedruckt werden soll. |
+| [getPaperSource()](#getPaperSource--) | Bestimmt die Papierquelle für die Seite. |
+| [getPrintGrid()](#getPrintGrid--) | Gibt an, ob das Raster beim Drucken einer Dokumentenseite gedruckt werden soll. |
+| [getPrintPageOrientation()](#getPrintPageOrientation--) | Bestimmt, ob die Seite im Hoch- oder Querformat gedruckt wird. |
+| [getScaleX()](#getScaleX--) | Gibt den Prozentsatz der Vergrößerung der Zeichenblattseite auf der Druckerseite in x‑Richtung (horizontal) an. |
+| [getScaleY()](#getScaleY--) | Gibt den Prozentsatz der Vergrößerung der Zeichenfläche auf der Druckerseite in y‑Richtung (vertikal) an. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/printprops\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCenterX() {#getCenterX--}
+```
+public BoolValue getCenterX()
+```
+
+
+Bestimmt, ob die Zeichenblattseite horizontal auf der gedruckten Seite zentriert ist.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getCenterY() {#getCenterY--}
+```
+public BoolValue getCenterY()
+```
+
+
+Bestimmt, ob die Zeichenblattseite vertikal auf der gedruckten Seite zentriert ist.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getOnPage() {#getOnPage--}
+```
+public BoolValue getOnPage()
+```
+
+
+Gibt an, ob die Zeichnung auf einer bestimmten Anzahl von Druckerseiten gedruckt wird.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getPageBottomMargin() {#getPageBottomMargin--}
+```
+public DoubleValue getPageBottomMargin()
+```
+
+
+Gibt den Rand am unteren Rand der gedruckten Seite an.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getPageLeftMargin() {#getPageLeftMargin--}
+```
+public DoubleValue getPageLeftMargin()
+```
+
+
+Gibt den Rand an der linken Seite der gedruckten Seite an.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getPageRightMargin() {#getPageRightMargin--}
+```
+public DoubleValue getPageRightMargin()
+```
+
+
+Gibt den Rand an der rechten Seite der gedruckten Seite an.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getPageTopMargin() {#getPageTopMargin--}
+```
+public DoubleValue getPageTopMargin()
+```
+
+
+Gibt den Rand am oberen Rand der Druckerseite an.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getPagesX() {#getPagesX--}
+```
+public IntValue getPagesX()
+```
+
+
+Bestimmt die Anzahl der Druckerseiten, auf denen die Zeichenblattseite horizontal angepasst wird.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getPagesY() {#getPagesY--}
+```
+public IntValue getPagesY()
+```
+
+
+Bestimmt die Anzahl der Druckerseiten, auf denen die Zeichenblattseite vertikal angepasst wird.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getPaperKind() {#getPaperKind--}
+```
+public IntValue getPaperKind()
+```
+
+
+Gibt den Papiertyp an, auf dem die Seite gedruckt werden soll.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getPaperSource() {#getPaperSource--}
+```
+public IntValue getPaperSource()
+```
+
+
+Bestimmt die Papierquelle für die Seite.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getPrintGrid() {#getPrintGrid--}
+```
+public BoolValue getPrintGrid()
+```
+
+
+Gibt an, ob das Raster beim Drucken einer Dokumentenseite gedruckt werden soll.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getPrintPageOrientation() {#getPrintPageOrientation--}
+```
+public PrintPageOrientation getPrintPageOrientation()
+```
+
+
+Bestimmt, ob die Seite im Hoch- oder Querformat gedruckt wird.
+
+**Returns:**
+[PrintPageOrientation](../../com.aspose.diagram/printpageorientation)
+### getScaleX() {#getScaleX--}
+```
+public DoubleValue getScaleX()
+```
+
+
+Gibt den Prozentsatz der Vergrößerung der Zeichenblattseite auf der Druckerseite in x‑Richtung (horizontal) an.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getScaleY() {#getScaleY--}
+```
+public DoubleValue getScaleY()
+```
+
+
+Gibt den Prozentsatz der Vergrößerung der Zeichenfläche auf der Druckerseite in y‑Richtung (vertikal) an.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/printprops\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/printsaveoptions/_index.md
+++ b/german/java/com.aspose.diagram/printsaveoptions/_index.md
@@ -1,0 +1,429 @@
+---
+title: PrintSaveOptions
+second_title: Aspose.Diagram for Java API-Referenz
+description: Ermöglicht das Angeben zusätzlicher Optionen beim Drucken des Diagramms.
+type: docs
+weight: 308
+url: /de/java/com.aspose.diagram/printsaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.SaveOptions](../../com.aspose.diagram/saveoptions), [com.aspose.diagram.RenderingSaveOptions](../../com.aspose.diagram/renderingsaveoptions)
+```
+public class PrintSaveOptions extends RenderingSaveOptions
+```
+
+Ermöglicht das Angeben zusätzlicher Optionen beim Drucken des Diagramms.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [PrintSaveOptions()](#PrintSaveOptions--) | Initialisiert eine neue Instanz dieser Klasse |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | Erstellt ein Speicheroptionen-Objekt einer Klasse, die für das angegebene Speicherformat geeignet ist. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDefaultFont()](#getDefaultFont--) | Wenn Zeichen im Diagramm Unicode sind und nicht mit dem korrekten Schriftwert gesetzt werden oder die Schriftart nicht lokal installiert ist, können sie in PDF, Bild oder XPS als Block erscheinen. |
+| [getEmfRenderSetting()](#getEmfRenderSetting--) | Einstellung zum Rendern von Emf-Metadateien. |
+| [getEnlargePage()](#getEnlargePage--) | Gibt an, ob die Seite vergrößert werden soll. |
+| [getExportGuideShapes()](#getExportGuideShapes--) | Definiert, ob die Leitlinienformen exportiert werden sollen oder nicht. |
+| [getPageCount()](#getPageCount--) | Die Anzahl der Seiten, die beim Speichern in einer mehrseitigen Datei gerendert werden. |
+| [getPageSize()](#getPageSize--) | die Seitengröße für die erzeugten Bilder. |
+| [getSaveForegroundPagesOnly()](#getSaveForegroundPagesOnly--) | Gibt an, ob alle Seiten gedruckt werden oder nur der Vordergrund. |
+| [getSaveFormat()](#getSaveFormat--) | Gibt das Format an, in dem das Dokument gespeichert wird, wenn dieses SaveOptions‑Objekt verwendet wird. |
+| [getShapes()](#getShapes--) | Formen zum Rendern. |
+| [getWarningCallback()](#getWarningCallback--) | Warnungs-Callback. |
+| [hashCode()](#hashCode--) |  |
+| [isExportComments()](#isExportComments--) | Definiert, ob Kommentare exportiert werden sollen oder nicht. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDefaultFont()](../../com.aspose.diagram/saveoptions\\#getDefaultFont--) |
+| [setEmfRenderSetting(int value)](#setEmfRenderSetting-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\\#getEmfRenderSetting--) |
+| [setEnlargePage(boolean value)](#setEnlargePage-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--) |
+| [setExportComments(boolean value)](#setExportComments-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--) |
+| [setExportGuideShapes(boolean value)](#setExportGuideShapes-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--) |
+| [setPageCount(int value)](#setPageCount-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getPageCount()](../../com.aspose.diagram/printsaveoptions\#getPageCount--) |
+| [setPageSize(PageSize value)](#setPageSize-com.aspose.diagram.PageSize-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--) |
+| [setSaveForegroundPagesOnly(boolean value)](#setSaveForegroundPagesOnly-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getSaveForegroundPagesOnly()](../../com.aspose.diagram/printsaveoptions\#getSaveForegroundPagesOnly--) |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getSaveFormat()](../../com.aspose.diagram/saveoptions\#getSaveFormat--) |
+| [setShapes(ShapeCollection value)](#setShapes-com.aspose.diagram.ShapeCollection-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--) |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PrintSaveOptions() {#PrintSaveOptions--}
+```
+public PrintSaveOptions()
+```
+
+
+Initialisiert eine neue Instanz dieser Klasse
+
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+Erstellt ein Speicheroptionen-Objekt einer Klasse, die für das angegebene Speicherformat geeignet ist.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| saveFormat | int | Das Aspose.Diagram.SaveFileFormat, für das ein Save-Optionen-Objekt erstellt werden soll. |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+Wenn Zeichen im Diagramm Unicode sind und nicht mit dem korrekten Schriftwert gesetzt werden oder die Schriftart nicht lokal installiert ist, können sie im PDF, Bild oder XPS als Block erscheinen. Setzen Sie die DefaultFont, z. B. MingLiu oder MS Gothic, um diese Zeichen anzuzeigen.
+
+**Returns:**
+java.lang.String
+### getEmfRenderSetting() {#getEmfRenderSetting--}
+```
+public int getEmfRenderSetting()
+```
+
+
+Einstellung für das Rendern von EMF-Metadateien. EMF-Metadateien, die als "EMF+ Dual" identifiziert werden, können sowohl EMF+-Datensätze als auch EMF-Datensätze enthalten. Jeder Datensatztyp kann zum Rendern des Bildes verwendet werden, nur EMF+-Datensätze oder nur EMF-Datensätze. Wenn EmfPlusPrefer gesetzt ist, werden EMF+-Datensätze geparst, andernfalls werden nur EMF-Datensätze geparst. Der Standardwert ist EmfOnly"/>.
+
+**Returns:**
+int
+### getEnlargePage() {#getEnlargePage--}
+```
+public boolean getEnlargePage()
+```
+
+
+Gibt an, ob die Seite vergrößert werden soll. Wenn true – Seite vergrößern. Wenn false – Seite nicht vergrößern. Der Standardwert ist true.
+
+**Returns:**
+boolean
+### getExportGuideShapes() {#getExportGuideShapes--}
+```
+public boolean getExportGuideShapes()
+```
+
+
+Definiert, ob Leitlinienformen exportiert werden sollen oder nicht. Standardwert ist true.
+
+**Returns:**
+boolean
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+Die Anzahl der Seiten, die beim Speichern in einer mehrseitigen Datei gerendert werden. Standard ist MaxValue, was bedeutet, dass alle Seiten des Diagramms gedruckt werden.
+
+**Returns:**
+int
+### getPageSize() {#getPageSize--}
+```
+public PageSize getPageSize()
+```
+
+
+die Seitengröße für die erzeugten Bilder. Kann [PageSize](../../com.aspose.diagram/pagesize) oder null sein. Der Standardwert ist null. Wenn PageSize null ist, wird die Seitengröße für das erzeugte Bild aus dem Quell‑Diagramm übernommen.
+
+**Returns:**
+[PageSize](../../com.aspose.diagram/pagesize)
+### getSaveForegroundPagesOnly() {#getSaveForegroundPagesOnly--}
+```
+public boolean getSaveForegroundPagesOnly()
+```
+
+
+Gibt an, ob alle Seiten gedruckt werden oder nur der Vordergrund. Wenn true – werden nur Vordergrundseiten gedruckt (mit Hintergrund, falls vorhanden). Wenn false – werden Vordergrundseiten gedruckt (mit Hintergrund, falls vorhanden), danach leere Hintergrundseiten. Kann nur true zurückgeben, wenn PageCount > 1. Der Standardwert ist false.
+
+**Returns:**
+boolean
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+Gibt das Format an, in dem das Dokument gespeichert wird, wenn dieses SaveOptions‑Objekt verwendet wird.
+
+**Returns:**
+int
+### getShapes() {#getShapes--}
+```
+public ShapeCollection getShapes()
+```
+
+
+Zu rendernde Shapes. Standardanzahl ist 0.
+
+**Returns:**
+[ShapeCollection](../../com.aspose.diagram/shapecollection)
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+Warnungs-Callback.
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExportComments() {#isExportComments--}
+```
+public boolean isExportComments()
+```
+
+
+Legt fest, ob Kommentare exportiert werden sollen oder nicht. Der Standardwert ist false.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDefaultFont()](../../com.aspose.diagram/saveoptions\\#getDefaultFont--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setEmfRenderSetting(int value) {#setEmfRenderSetting-int-}
+```
+public void setEmfRenderSetting(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\\#getEmfRenderSetting--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setEnlargePage(boolean value) {#setEnlargePage-boolean-}
+```
+public void setEnlargePage(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setExportComments(boolean value) {#setExportComments-boolean-}
+```
+public void setExportComments(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setExportGuideShapes(boolean value) {#setExportGuideShapes-boolean-}
+```
+public void setExportGuideShapes(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setPageCount(int value) {#setPageCount-int-}
+```
+public void setPageCount(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getPageCount()](../../com.aspose.diagram/printsaveoptions\#getPageCount--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setPageSize(PageSize value) {#setPageSize-com.aspose.diagram.PageSize-}
+```
+public void setPageSize(PageSize value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [PageSize](../../com.aspose.diagram/pagesize) |  |
+
+### setSaveForegroundPagesOnly(boolean value) {#setSaveForegroundPagesOnly-boolean-}
+```
+public void setSaveForegroundPagesOnly(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getSaveForegroundPagesOnly()](../../com.aspose.diagram/printsaveoptions\#getSaveForegroundPagesOnly--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getSaveFormat()](../../com.aspose.diagram/saveoptions\#getSaveFormat--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setShapes(ShapeCollection value) {#setShapes-com.aspose.diagram.ShapeCollection-}
+```
+public void setShapes(ShapeCollection value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [ShapeCollection](../../com.aspose.diagram/shapecollection) |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/prop/_index.md
+++ b/german/java/com.aspose.diagram/prop/_index.md
@@ -1,0 +1,384 @@
+---
+title: Prop
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält Elemente zur Definition benutzerdefinierter Eigenschaften und Elemente zur Zuordnung von Daten zu einer Form.
+type: docs
+weight: 309
+url: /de/java/com.aspose.diagram/prop/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Prop
+```
+
+Enthält Elemente zur Definition benutzerdefinierter Eigenschaften und Elemente zur Zuordnung von Daten zu einer Form.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [Prop()](#Prop--) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCalendar()](#getCalendar--) | Bestimmt den Kalender, der für benutzerdefinierte Eigenschaften, Textfelder und Formeln von Elementen verwendet wird. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getFormat()](#getFormat--) | Format element specifies the formatting of a custom property that is a string, fixed list, number, variable list, date or time, duration, or currency. |
+| [getID()](#getID--) | Die eindeutige ID des Elements innerhalb seines übergeordneten Elements. |
+| [getIX()](#getIX--) | Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements. |
+| [getInvisible()](#getInvisible--) | Invisible element specifies whether the custom property is visible in the Custom Properties dialog box in Microsoft Visio. |
+| [getLabel()](#getLabel--) | Specifies the label that appears to users in the Custom Properties dialog box. |
+| [getLangID()](#getLangID--) | Gibt die Locale-ID (LCID) der Sprache an, in der die Zellformel, der Text, die benutzerdefinierte Eigenschaft oder der Kommentar eingegeben wurde. |
+| [getName()](#getName--) | Der Name des Elements. |
+| [getNameU()](#getNameU--) | Der universelle Name des Elements. |
+| [getPrompt()](#getPrompt--) | Prompt element specifies descriptive or instructional text that appears to users in the Custom Properties dialog box when the property is selected. |
+| [getSortKey()](#getSortKey--) | It specifies a key that determines the order in which custom properties are listed in the application's user interface. |
+| [getType()](#getType--) | Typ gibt einen Datentyp für den benutzerdefinierten Eigenschaftswert an. |
+| [getValue()](#getValue--) | Enthält lösungsspezifische, wohlgeformte XML‑Daten, die in einem expliziten Namensraum vorangestellt sind und zusammen mit einem Dokument gespeichert werden. |
+| [getVerify()](#getVerify--) | Specifies whether the user is queried to enter custom property information for a shape when an instance is created or the shape is duplicated or copied. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | For the description of this property, please see [getDel()](../../com.aspose.diagram/prop\#getDel--) |
+| [setID(int value)](#setID-int-) | For the description of this property, please see [getID()](../../com.aspose.diagram/prop\#getID--) |
+| [setIX(int value)](#setIX-int-) | For the description of this property, please see [getIX()](../../com.aspose.diagram/prop\#getIX--) |
+| [setName(String value)](#setName-java.lang.String-) | For the description of this property, please see [getName()](../../com.aspose.diagram/prop\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getNameU()](../../com.aspose.diagram/prop\#getNameU--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Prop() {#Prop--}
+```
+public Prop()
+```
+
+
+Konstruktor.
+
+### deepClone() {#deepClone--}
+```
+public Prop deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+[Prop](../../com.aspose.diagram/prop) - 
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCalendar() {#getCalendar--}
+```
+public Calendar getCalendar()
+```
+
+
+Bestimmt den Kalender, der für benutzerdefinierte Eigenschaften, Textfelder und Formeln von Elementen verwendet wird.
+
+**Returns:**
+[Calendar](../../com.aspose.diagram/calendar)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getFormat() {#getFormat--}
+```
+public StrValue getFormat()
+```
+
+
+Das Format-Element gibt die Formatierung einer benutzerdefinierten Eigenschaft an, die ein Zeichenfolge, eine feste Liste, eine Zahl, eine variable Liste, ein Datum oder eine Uhrzeit, eine Dauer oder eine Währung ist. Der Typ der benutzerdefinierten Eigenschaft wird im entsprechenden Typ-Element angegeben.
+
+**Returns:**
+[StrValue](../../com.aspose.diagram/strvalue)
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+Die eindeutige ID des Elements innerhalb seines übergeordneten Elements.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements.
+
+**Returns:**
+int
+### getInvisible() {#getInvisible--}
+```
+public BoolValue getInvisible()
+```
+
+
+Invisible element specifies whether the custom property is visible in the Custom Properties dialog box in Microsoft Visio.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLabel() {#getLabel--}
+```
+public Str2Value getLabel()
+```
+
+
+Specifies the label that appears to users in the Custom Properties dialog box.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getLangID() {#getLangID--}
+```
+public IntValue getLangID()
+```
+
+
+Gibt die Locale-ID (LCID) der Sprache an, in der die Zellformel, der Text, die benutzerdefinierte Eigenschaft oder der Kommentar eingegeben wurde.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Der Name des Elements.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+Der universelle Name des Elements.
+
+**Returns:**
+java.lang.String
+### getPrompt() {#getPrompt--}
+```
+public Str2Value getPrompt()
+```
+
+
+Das Prompt-Element gibt beschreibenden oder anleitenden Text an, der Benutzern im Dialogfeld „Benutzerdefinierte Eigenschaften“ angezeigt wird, wenn die Eigenschaft ausgewählt ist. Dieser Text erscheint auch als Tooltip, wenn der Mauszeiger über der Eigenschaft im Fenster „Benutzerdefinierte Eigenschaften“ verweilt.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getSortKey() {#getSortKey--}
+```
+public Str2Value getSortKey()
+```
+
+
+It specifies a key that determines the order in which custom properties are listed in the application's user interface.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getType() {#getType--}
+```
+public TypeProp getType()
+```
+
+
+Typ gibt einen Datentyp für den benutzerdefinierten Eigenschaftswert an.
+
+**Returns:**
+[TypeProp](../../com.aspose.diagram/typeprop)
+### getValue() {#getValue--}
+```
+public Value getValue()
+```
+
+
+Enthält lösungsspezifische, wohlgeformte XML‑Daten, die in einem expliziten Namensraum vorangestellt sind und zusammen mit einem Dokument gespeichert werden.
+
+**Returns:**
+[Value](../../com.aspose.diagram/value)
+### getVerify() {#getVerify--}
+```
+public BoolValue getVerify()
+```
+
+
+Specifies whether the user is queried to enter custom property information for a shape when an instance is created or the shape is duplicated or copied.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+For the description of this property, please see [getDel()](../../com.aspose.diagram/prop\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+For the description of this property, please see [getID()](../../com.aspose.diagram/prop\#getID--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+For the description of this property, please see [getIX()](../../com.aspose.diagram/prop\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+For the description of this property, please see [getName()](../../com.aspose.diagram/prop\#getName--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getNameU()](../../com.aspose.diagram/prop\#getNameU--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/propcollection/_index.md
+++ b/german/java/com.aspose.diagram/propcollection/_index.md
@@ -1,0 +1,250 @@
+---
+title: PropCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: Prop Sammlung.
+type: docs
+weight: 310
+url: /de/java/com.aspose.diagram/propcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class PropCollection extends Collection
+```
+
+Prop Sammlung.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [add(Prop item)](#add-com.aspose.diagram.Prop-) | Fügen Sie das Prop-Objekt zur Sammlung hinzu. |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [getProp(int ID)](#getProp-int-) | Liefert das Element mit der angegebenen ID. |
+| [getProp(String name)](#getProp-java.lang.String-) | Liefert das Element mit dem angegebenen Namen. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Prop item)](#remove-com.aspose.diagram.Prop-) | Entfernen Sie das Prop-Objekt aus der Sammlung. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Prop item) {#add-com.aspose.diagram.Prop-}
+```
+public int add(Prop item)
+```
+
+
+Fügen Sie das Prop-Objekt zur Sammlung hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [Prop](../../com.aspose.diagram/prop) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Prop get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[Prop](../../com.aspose.diagram/prop) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### getProp(int ID) {#getProp-int-}
+```
+public Prop getProp(int ID)
+```
+
+
+Liefert das Element mit der angegebenen ID.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| ID | int |  |
+
+**Returns:**
+[Prop](../../com.aspose.diagram/prop) - 
+### getProp(String name) {#getProp-java.lang.String-}
+```
+public Prop getProp(String name)
+```
+
+
+Liefert das Element mit dem angegebenen Namen.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Name | java.lang.String |  |
+
+**Returns:**
+[Prop](../../com.aspose.diagram/prop) - 
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Prop item) {#remove-com.aspose.diagram.Prop-}
+```
+public void remove(Prop item)
+```
+
+
+Entfernen Sie das Prop-Objekt aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [Prop](../../com.aspose.diagram/prop) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/proptype/_index.md
+++ b/german/java/com.aspose.diagram/proptype/_index.md
@@ -1,0 +1,165 @@
+---
+title: PropType
+second_title: Aspose.Diagram for Java API-Referenz
+description: Typ der Eigenschaft.
+type: docs
+weight: 311
+url: /de/java/com.aspose.diagram/proptype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PropType
+```
+
+Typ der Eigenschaft.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [BOOL](#BOOL) | Boolesch. |
+| [DATE](#DATE) | Datum. |
+| [NUMBER](#NUMBER) | Zahl. |
+| [STRING](#STRING) | Zeichenkette. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOOL {#BOOL}
+```
+public static final int BOOL
+```
+
+
+Boolesch.
+
+### DATE {#DATE}
+```
+public static final int DATE
+```
+
+
+Datum.
+
+### NUMBER {#NUMBER}
+```
+public static final int NUMBER
+```
+
+
+Zahl.
+
+### STRING {#STRING}
+```
+public static final int STRING
+```
+
+
+Zeichenkette.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/protection/_index.md
+++ b/german/java/com.aspose.diagram/protection/_index.md
@@ -1,0 +1,370 @@
+---
+title: Schutz
+second_title: Aspose.Diagram for Java API-Referenz
+description: Sperren hilft, unbeabsichtigte Änderungen an der Form zu verhindern, verhindert jedoch nicht, dass Microsoft Visio Werte unter anderen Umständen zurücksetzt.
+type: docs
+weight: 312
+url: /de/java/com.aspose.diagram/protection/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Protection
+```
+
+Das Sperren hilft, unbeabsichtigte Änderungen an der Form zu verhindern, verhindert jedoch nicht, dass Microsoft Visio Werte unter anderen Umständen zurücksetzt. Es schützt auch nicht vor Änderungen, die im ShapeSheet‑Fenster vorgenommen werden.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getLockAspect()](#getLockAspect--) | Gibt an, ob das Seitenverhältnis der Form gesperrt ist. |
+| [getLockBegin()](#getLockBegin--) | Gibt an, ob der Anfangspunkt einer 1-D-Form an einem bestimmten Ort gesperrt ist. |
+| [getLockCalcWH()](#getLockCalcWH--) | Gibt an, ob das Auswahlrechteck einer Form gesperrt ist, sodass es nicht neu berechnet wird, wenn ein Scheitelpunkt bearbeitet oder ein Elementtyp im Geom-Element geändert wird. |
+| [getLockCrop()](#getLockCrop--) | Gibt an, ob ein fremdes Objekt daran gehindert wird, mit dem Zuschneidewerkzeug in Microsoft Visio beschnitten zu werden. |
+| [getLockCustProp()](#getLockCustProp--) | Bestimmt, ob der Benutzer benutzerdefinierte Eigenschaften in der Benutzeroberfläche (UI) über das Dialogfeld „Define Custom Properties“ hinzufügen, löschen oder ändern kann. |
+| [getLockDelete()](#getLockDelete--) | Gibt an, ob eine Form vor dem Löschen geschützt ist. |
+| [getLockEnd()](#getLockEnd--) | Gibt an, ob der Endpunkt einer 1-D-Form an einem bestimmten Ort gesperrt ist. |
+| [getLockFormat()](#getLockFormat--) | Gibt an, ob die Formatierung einer Form gesperrt ist, sodass sie nicht geändert werden kann. |
+| [getLockFromGroupFormat()](#getLockFromGroupFormat--) | Ermöglicht es einer Unterform, Formatierungsänderungen zu blockieren, die auf eine übergeordnete Gruppierungsform in der Visio-Benutzeroberfläche angewendet werden und sonst auf einzelne Gruppierungsformen heruntergereicht würden. |
+| [getLockGroup()](#getLockGroup--) | Gibt an, ob eine Gruppe gesperrt ist, sodass sie nicht aufgelöst werden kann. |
+| [getLockHeight()](#getLockHeight--) | Gibt an, ob die Höhe der Form gesperrt ist. |
+| [getLockMoveX()](#getLockMoveX--) | Gibt an, ob die horizontale Position der Form gesperrt ist, sodass sie nicht horizontal verschoben werden kann. |
+| [getLockMoveY()](#getLockMoveY--) | Gibt an, ob die vertikale Position der Form gesperrt ist, sodass sie nicht vertikal verschoben werden kann. |
+| [getLockRotate()](#getLockRotate--) | Gibt an, ob die Form daran gehindert wird, mit dem Rotationswerkzeug oder den Befehlen „Rotate Left“ bzw. „Rotate Right“ in Microsoft Visio gedreht zu werden. |
+| [getLockSelect()](#getLockSelect--) | Gibt an, ob das Auswahlrechteck einer Form gesperrt ist, sodass es nicht neu berechnet wird, wenn ein Scheitelpunkt bearbeitet oder ein Elementtyp im Geom-Element geändert wird. |
+| [getLockTextEdit()](#getLockTextEdit--) | Gibt an, ob der Text einer Form gesperrt ist, sodass er nicht bearbeitet werden kann. |
+| [getLockThemeColors()](#getLockThemeColors--) | Verhindert, dass Benutzer Themenfarben auf die Form anwenden. |
+| [getLockThemeEffects()](#getLockThemeEffects--) | Verhindert, dass Benutzer Themen‑Effekte auf die Form anwenden. |
+| [getLockVtxEdit()](#getLockVtxEdit--) | Gibt an, ob die Scheitelpunkte einer Form gesperrt sind, sodass sie mit keinen Werkzeugen in der Symbolleiste bearbeitet werden können. |
+| [getLockWidth()](#getLockWidth--) | Gibt an, ob die Breite der Form gesperrt ist, sodass sie beim Ändern der Größe der Form unverändert bleibt. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/protection\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getLockAspect() {#getLockAspect--}
+```
+public BoolValue getLockAspect()
+```
+
+
+Gibt an, ob das Seitenverhältnis der Form gesperrt ist. Wenn gesperrt, kann die Form nur proportional skaliert werden; sie kann nicht in einer einzigen Dimension skaliert werden.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockBegin() {#getLockBegin--}
+```
+public BoolValue getLockBegin()
+```
+
+
+Gibt an, ob der Anfangspunkt einer 1-D-Form an einem bestimmten Ort gesperrt ist.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockCalcWH() {#getLockCalcWH--}
+```
+public BoolValue getLockCalcWH()
+```
+
+
+Gibt an, ob das Auswahlrechteck einer Form gesperrt ist, sodass es nicht neu berechnet wird, wenn ein Scheitelpunkt bearbeitet oder ein Elementtyp im Geom-Element geändert wird.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockCrop() {#getLockCrop--}
+```
+public BoolValue getLockCrop()
+```
+
+
+Gibt an, ob ein fremdes Objekt daran gehindert wird, mit dem Zuschneidewerkzeug in Microsoft Visio beschnitten zu werden.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockCustProp() {#getLockCustProp--}
+```
+public BoolValue getLockCustProp()
+```
+
+
+Bestimmt, ob der Benutzer benutzerdefinierte Eigenschaften in der Benutzeroberfläche (UI) über das Dialogfeld „Define Custom Properties“ hinzufügen, löschen oder ändern kann.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockDelete() {#getLockDelete--}
+```
+public BoolValue getLockDelete()
+```
+
+
+Gibt an, ob eine Form vor dem Löschen geschützt ist.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockEnd() {#getLockEnd--}
+```
+public BoolValue getLockEnd()
+```
+
+
+Gibt an, ob der Endpunkt einer 1-D-Form an einem bestimmten Ort gesperrt ist.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockFormat() {#getLockFormat--}
+```
+public BoolValue getLockFormat()
+```
+
+
+Gibt an, ob die Formatierung einer Form gesperrt ist, sodass sie nicht geändert werden kann. Insbesondere schützt dieses Element vor Änderungen der Text‑, Linien‑ und Füllformatierung oder davor, welches Style‑Element die Form erbt.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockFromGroupFormat() {#getLockFromGroupFormat--}
+```
+public BoolValue getLockFromGroupFormat()
+```
+
+
+Ermöglicht es einer Unterform, Formatierungsänderungen zu blockieren, die auf eine übergeordnete Gruppierungsform in der Visio-Benutzeroberfläche angewendet werden und sonst auf einzelne Gruppierungsformen heruntergereicht würden.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockGroup() {#getLockGroup--}
+```
+public BoolValue getLockGroup()
+```
+
+
+Gibt an, ob eine Gruppe gesperrt ist, sodass sie nicht aufgelöst werden kann.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockHeight() {#getLockHeight--}
+```
+public BoolValue getLockHeight()
+```
+
+
+Gibt an, ob die Höhe der Form gesperrt ist. Wenn gesperrt, bleibt ihre Höhe beim Ändern der Größe der Form unverändert.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockMoveX() {#getLockMoveX--}
+```
+public BoolValue getLockMoveX()
+```
+
+
+Gibt an, ob die horizontale Position der Form gesperrt ist, sodass sie nicht horizontal verschoben werden kann.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockMoveY() {#getLockMoveY--}
+```
+public BoolValue getLockMoveY()
+```
+
+
+Gibt an, ob die vertikale Position der Form gesperrt ist, sodass sie nicht vertikal verschoben werden kann.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockRotate() {#getLockRotate--}
+```
+public BoolValue getLockRotate()
+```
+
+
+Gibt an, ob die Form daran gehindert wird, mit dem Rotationswerkzeug oder den Befehlen „Rotate Left“ bzw. „Rotate Right“ in Microsoft Visio gedreht zu werden.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockSelect() {#getLockSelect--}
+```
+public BoolValue getLockSelect()
+```
+
+
+Gibt an, ob das Auswahlrechteck einer Form gesperrt ist, sodass es nicht neu berechnet wird, wenn ein Scheitelpunkt bearbeitet oder ein Elementtyp im Geom-Element geändert wird.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockTextEdit() {#getLockTextEdit--}
+```
+public BoolValue getLockTextEdit()
+```
+
+
+Gibt an, ob der Text einer Form gesperrt ist, sodass er nicht bearbeitet werden kann. Der Text kann jedoch weiterhin formatiert werden, indem ein Stil angewendet wird, über die Stil‑Optionen im Register Schriftart des Text‑Dialogfelds.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockThemeColors() {#getLockThemeColors--}
+```
+public BoolValue getLockThemeColors()
+```
+
+
+Verhindert, dass Benutzer Themenfarben auf die Form anwenden.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockThemeEffects() {#getLockThemeEffects--}
+```
+public BoolValue getLockThemeEffects()
+```
+
+
+Verhindert, dass Benutzer Themen‑Effekte auf die Form anwenden.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockVtxEdit() {#getLockVtxEdit--}
+```
+public BoolValue getLockVtxEdit()
+```
+
+
+Gibt an, ob die Scheitelpunkte einer Form gesperrt sind, sodass sie mit keinen Werkzeugen in der Symbolleiste bearbeitet werden können.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockWidth() {#getLockWidth--}
+```
+public BoolValue getLockWidth()
+```
+
+
+Gibt an, ob die Breite der Form gesperrt ist, sodass sie beim Ändern der Größe der Form unverändert bleibt.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/protection\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/radiobuttonactivexcontrol/_index.md
+++ b/german/java/com.aspose.diagram/radiobuttonactivexcontrol/_index.md
@@ -1,0 +1,679 @@
+---
+title: RadioButtonActiveXControl
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt ein RadioButton ActiveX-Steuerelement dar.
+type: docs
+weight: 313
+url: /de/java/com.aspose.diagram/radiobuttonactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol), [com.aspose.diagram.ToggleButtonActiveXControl](../../com.aspose.diagram/togglebuttonactivexcontrol)
+```
+public class RadioButtonActiveXControl extends ToggleButtonActiveXControl
+```
+
+Stellt ein RadioButton ActiveX-Steuerelement dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAccelerator()](#getAccelerator--) | Die Beschleunigungstaste für das Steuerelement. |
+| [getAlignment()](#getAlignment--) | Die Position der Beschriftung relativ zum Steuerelement. |
+| [getBackOleColor()](#getBackOleColor--) | die OLE‑Farbe des Hintergrunds. |
+| [getCaption()](#getCaption--) | Der beschreibende Text, der auf einem Steuerelement erscheint. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | die Binärdaten des Steuerelements. |
+| [getForeOleColor()](#getForeOleColor--) | die OLE‑Farbe des Vordergrunds. |
+| [getGroupName()](#getGroupName--) | Der Name der Gruppe. |
+| [getHeight()](#getHeight--) | die Höhe des Steuerelements in Punkt‑Einheiten. |
+| [getIMEMode()](#getIMEMode--) | der Standard‑Laufzeitmodus des Input Method Editors für das Steuerelement, wenn es den Fokus erhält. |
+| [getMouseIcon()](#getMouseIcon--) | ein benutzerdefiniertes Symbol, das als Mauszeiger für das Steuerelement angezeigt wird. |
+| [getMousePointer()](#getMousePointer--) | der Typ des als Mauszeiger für das Steuerelement angezeigten Symbols. |
+| [getPicture()](#getPicture--) | Die Daten des Bildes. |
+| [getPicturePosition()](#getPicturePosition--) | Der Ort des Bildes des Steuerelements relativ zu seiner Beschriftung. |
+| [getSpecialEffect()](#getSpecialEffect--) | der Spezialeffekt des Steuerelements. |
+| [getType()](#getType--) | Ermittelt den Typ des ActiveX-Steuerelements. |
+| [getValue()](#getValue--) | Gibt an, ob das Steuerelement aktiviert ist oder nicht. |
+| [getWidth()](#getWidth--) | die Breite des Steuerelements in Punkt-Einheiten. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | Gibt an, ob das Steuerelement automatisch die Größe ändert, um seinen gesamten Inhalt anzuzeigen. |
+| [isEnabled()](#isEnabled--) | Gibt an, ob das Steuerelement den Fokus erhalten und auf benutzergenerierte Ereignisse reagieren kann. |
+| [isLocked()](#isLocked--) | Gibt an, ob Daten im Steuerelement für die Bearbeitung gesperrt sind. |
+| [isTransparent()](#isTransparent--) | Gibt an, ob das Steuerelement transparent ist. |
+| [isTripleState()](#isTripleState--) | Gibt an, wie das angegebene Steuerelement Nullwerte darstellt. |
+| [isWordWrapped()](#isWordWrapped--) | Gibt an, ob der Inhalt des Steuerelements am Zeilenende automatisch umbrochen wird. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAccelerator(char value)](#setAccelerator-char-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getAccelerator()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getAccelerator--) |
+| [setAlignment(int value)](#setAlignment-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getAlignment()](../../com.aspose.diagram/radiobuttonactivexcontrol\#getAlignment--) |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setCaption(String value)](#setCaption-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getCaption()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getCaption--) |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setGroupName(String value)](#setGroupName-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getGroupName()](../../com.aspose.diagram/radiobuttonactivexcontrol\#getGroupName--) |
+| [setHeight(double value)](#setHeight-double-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setIMEMode(int value)](#setIMEMode-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) |
+| [setLocked(boolean value)](#setLocked-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | Für die Beschreibung dieser Eigenschaft siehe bitte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setPicture(byte[] value)](#setPicture-byte---) | Für die Beschreibung dieser Eigenschaft siehe bitte [getPicture()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getPicture--) |
+| [setPicturePosition(int value)](#setPicturePosition-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getPicturePosition()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getPicturePosition--) |
+| [setSpecialEffect(int value)](#setSpecialEffect-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getSpecialEffect()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getSpecialEffect--) |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) |
+| [setTripleState(boolean value)](#setTripleState-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isTripleState()](../../com.aspose.diagram/togglebuttonactivexcontrol\#isTripleState--) |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getValue--) |
+| [setWidth(double value)](#setWidth-double-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [setWordWrapped(boolean value)](#setWordWrapped-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isWordWrapped()](../../com.aspose.diagram/radiobuttonactivexcontrol\#isWordWrapped--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAccelerator() {#getAccelerator--}
+```
+public char getAccelerator()
+```
+
+
+Die Beschleunigungstaste für das Steuerelement.
+
+**Returns:**
+char
+### getAlignment() {#getAlignment--}
+```
+public int getAlignment()
+```
+
+
+Die Position der Beschriftung relativ zum Steuerelement.
+
+**Returns:**
+int
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+die OLE‑Farbe des Hintergrunds.
+
+**Returns:**
+int
+### getCaption() {#getCaption--}
+```
+public String getCaption()
+```
+
+
+Der beschreibende Text, der auf einem Steuerelement erscheint.
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+die Binärdaten des Steuerelements.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+Die OLE-Farbe des Vordergrunds. Gilt nicht für das Image-Steuerelement.
+
+**Returns:**
+int
+### getGroupName() {#getGroupName--}
+```
+public String getGroupName()
+```
+
+
+Der Name der Gruppe.
+
+**Returns:**
+java.lang.String
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+die Höhe des Steuerelements in Punkt‑Einheiten.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+der Standard‑Laufzeitmodus des Input Method Editors für das Steuerelement, wenn es den Fokus erhält.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+ein benutzerdefiniertes Symbol, das als Mauszeiger für das Steuerelement angezeigt wird.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+der Typ des als Mauszeiger für das Steuerelement angezeigten Symbols.
+
+**Returns:**
+int
+### getPicture() {#getPicture--}
+```
+public byte[] getPicture()
+```
+
+
+Die Daten des Bildes.
+
+**Returns:**
+byte[]
+### getPicturePosition() {#getPicturePosition--}
+```
+public int getPicturePosition()
+```
+
+
+Der Ort des Bildes des Steuerelements relativ zu seiner Beschriftung.
+
+**Returns:**
+int
+### getSpecialEffect() {#getSpecialEffect--}
+```
+public int getSpecialEffect()
+```
+
+
+der Spezialeffekt des Steuerelements.
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Ermittelt den Typ des ActiveX-Steuerelements.
+
+**Returns:**
+int
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Gibt an, ob das Steuerelement aktiviert ist oder nicht.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+die Breite des Steuerelements in Punkt-Einheiten.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+Gibt an, ob das Steuerelement automatisch die Größe ändert, um seinen gesamten Inhalt anzuzeigen.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+Gibt an, ob das Steuerelement den Fokus erhalten und auf benutzergenerierte Ereignisse reagieren kann.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+Gibt an, ob Daten im Steuerelement für die Bearbeitung gesperrt sind.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+Gibt an, ob das Steuerelement transparent ist.
+
+**Returns:**
+boolean
+### isTripleState() {#isTripleState--}
+```
+public boolean isTripleState()
+```
+
+
+Gibt an, wie das angegebene Steuerelement Nullwerte darstellt.
+
+| ------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| Einstellung | Beschreibung                                                                                                                                     |
+| True    | Das Steuerelement durchläuft die Zustände für Ja-, Nein- und Nullwerte. Das Steuerelement erscheint abgedunkelt (grau), wenn seine Value‑Eigenschaft auf Null gesetzt ist. |
+| False   | (Standard) Das Steuerelement durchläuft die Zustände für Ja‑ und Nein‑Werte. Nullwerte werden angezeigt, als wären sie Nein‑Werte.                           |
+
+|
+
+**Returns:**
+boolean
+### isWordWrapped() {#isWordWrapped--}
+```
+public boolean isWordWrapped()
+```
+
+
+Gibt an, ob der Inhalt des Steuerelements am Zeilenende automatisch umbrochen wird.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAccelerator(char value) {#setAccelerator-char-}
+```
+public void setAccelerator(char value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getAccelerator()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getAccelerator--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | char |  |
+
+### setAlignment(int value) {#setAlignment-int-}
+```
+public void setAlignment(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getAlignment()](../../com.aspose.diagram/radiobuttonactivexcontrol\#getAlignment--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setCaption(String value) {#setCaption-java.lang.String-}
+```
+public void setCaption(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getCaption()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getCaption--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setGroupName(String value) {#setGroupName-java.lang.String-}
+```
+public void setGroupName(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getGroupName()](../../com.aspose.diagram/radiobuttonactivexcontrol\#getGroupName--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setPicture(byte[] value) {#setPicture-byte---}
+```
+public void setPicture(byte[] value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getPicture()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getPicture--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | byte[] |  |
+
+### setPicturePosition(int value) {#setPicturePosition-int-}
+```
+public void setPicturePosition(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getPicturePosition()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getPicturePosition--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setSpecialEffect(int value) {#setSpecialEffect-int-}
+```
+public void setSpecialEffect(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getSpecialEffect()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getSpecialEffect--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setTripleState(boolean value) {#setTripleState-boolean-}
+```
+public void setTripleState(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isTripleState()](../../com.aspose.diagram/togglebuttonactivexcontrol\#isTripleState--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double |  |
+
+### setWordWrapped(boolean value) {#setWordWrapped-boolean-}
+```
+public void setWordWrapped(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isWordWrapped()](../../com.aspose.diagram/radiobuttonactivexcontrol\#isWordWrapped--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/rectanglealignmenttype/_index.md
+++ b/german/java/com.aspose.diagram/rectanglealignmenttype/_index.md
@@ -1,0 +1,210 @@
+---
+title: RectangleAlignmentType
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt dar, wie zwei Rechtecke relativ zueinander positioniert werden.
+type: docs
+weight: 314
+url: /de/java/com.aspose.diagram/rectanglealignmenttype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class RectangleAlignmentType
+```
+
+Stellt dar, wie zwei Rechtecke relativ zueinander positioniert werden.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [BOTTOM](#BOTTOM) | Unten |
+| [BOTTOM_LEFT](#BOTTOM-LEFT) | BottomLeft |
+| [BOTTOM_RIGHT](#BOTTOM-RIGHT) | BottomRight |
+| [CENTER](#CENTER) | Center |
+| [LEFT](#LEFT) | Left |
+| [RIGHT](#RIGHT) | Right |
+| [TOP](#TOP) | Top |
+| [TOP_LEFT](#TOP-LEFT) | TopLeft |
+| [TOP_RIGHT](#TOP-RIGHT) | TopRight |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOTTOM {#BOTTOM}
+```
+public static final int BOTTOM
+```
+
+
+Unten
+
+### BOTTOM_LEFT {#BOTTOM-LEFT}
+```
+public static final int BOTTOM_LEFT
+```
+
+
+BottomLeft
+
+### BOTTOM_RIGHT {#BOTTOM-RIGHT}
+```
+public static final int BOTTOM_RIGHT
+```
+
+
+BottomRight
+
+### CENTER {#CENTER}
+```
+public static final int CENTER
+```
+
+
+Center
+
+### LEFT {#LEFT}
+```
+public static final int LEFT
+```
+
+
+Left
+
+### RIGHT {#RIGHT}
+```
+public static final int RIGHT
+```
+
+
+Right
+
+### TOP {#TOP}
+```
+public static final int TOP
+```
+
+
+Top
+
+### TOP_LEFT {#TOP-LEFT}
+```
+public static final int TOP_LEFT
+```
+
+
+TopLeft
+
+### TOP_RIGHT {#TOP-RIGHT}
+```
+public static final int TOP_RIGHT
+```
+
+
+TopRight
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/reflectioneffecttype/_index.md
+++ b/german/java/com.aspose.diagram/reflectioneffecttype/_index.md
@@ -1,0 +1,226 @@
+---
+title: ReflectionEffectType
+second_title: Aspose.Diagram for Java API-Referenz
+description: 
+type: docs
+weight: 315
+url: /de/java/com.aspose.diagram/reflectioneffecttype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ReflectionEffectType
+```
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [CUSTOM](#CUSTOM) | Benutzerdefinierter Reflexionseffekt. |
+| [FULL_REFLECTION_4_PT_OFFSET](#FULL-REFLECTION-4-PT-OFFSET) | Vollständige Reflexion, 4 pt Versatz. |
+| [FULL_REFLECTION_8_PT_OFFSET](#FULL-REFLECTION-8-PT-OFFSET) | Vollständige Reflexion, 8 pt Versatz. |
+| [FULL_REFLECTION_TOUCHING](#FULL-REFLECTION-TOUCHING) | Vollständige Reflexion, berührend. |
+| [HALF_REFLECTION_4_PT_OFFSET](#HALF-REFLECTION-4-PT-OFFSET) | Halbe Reflexion, 4 pt Versatz. |
+| [HALF_REFLECTION_8_PT_OFFSET](#HALF-REFLECTION-8-PT-OFFSET) | Halbe Reflexion, 8 pt Versatz. |
+| [HALF_REFLECTION_TOUCHING](#HALF-REFLECTION-TOUCHING) | Halbe Reflexion, berührend. |
+| [NONE](#NONE) | Kein Reflexionseffekt. |
+| [TIGHT_REFLECTION_4_PT_OFFSET](#TIGHT-REFLECTION-4-PT-OFFSET) | Enge Reflexion, 4 pt Versatz. |
+| [TIGHT_REFLECTION_8_PT_OFFSET](#TIGHT-REFLECTION-8-PT-OFFSET) | Enge Reflexion, 8 pt Versatz. |
+| [TIGHT_REFLECTION_TOUCHING](#TIGHT-REFLECTION-TOUCHING) | Enge Reflexion, berührend. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CUSTOM {#CUSTOM}
+```
+public static final int CUSTOM
+```
+
+
+Benutzerdefinierter Reflexionseffekt.
+
+### FULL_REFLECTION_4_PT_OFFSET {#FULL-REFLECTION-4-PT-OFFSET}
+```
+public static final int FULL_REFLECTION_4_PT_OFFSET
+```
+
+
+Vollständige Reflexion, 4 pt Versatz.
+
+### FULL_REFLECTION_8_PT_OFFSET {#FULL-REFLECTION-8-PT-OFFSET}
+```
+public static final int FULL_REFLECTION_8_PT_OFFSET
+```
+
+
+Vollständige Reflexion, 8 pt Versatz.
+
+### FULL_REFLECTION_TOUCHING {#FULL-REFLECTION-TOUCHING}
+```
+public static final int FULL_REFLECTION_TOUCHING
+```
+
+
+Vollständige Reflexion, berührend.
+
+### HALF_REFLECTION_4_PT_OFFSET {#HALF-REFLECTION-4-PT-OFFSET}
+```
+public static final int HALF_REFLECTION_4_PT_OFFSET
+```
+
+
+Halbe Reflexion, 4 pt Versatz.
+
+### HALF_REFLECTION_8_PT_OFFSET {#HALF-REFLECTION-8-PT-OFFSET}
+```
+public static final int HALF_REFLECTION_8_PT_OFFSET
+```
+
+
+Halbe Reflexion, 8 pt Versatz.
+
+### HALF_REFLECTION_TOUCHING {#HALF-REFLECTION-TOUCHING}
+```
+public static final int HALF_REFLECTION_TOUCHING
+```
+
+
+Halbe Reflexion, berührend.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Kein Reflexionseffekt.
+
+### TIGHT_REFLECTION_4_PT_OFFSET {#TIGHT-REFLECTION-4-PT-OFFSET}
+```
+public static final int TIGHT_REFLECTION_4_PT_OFFSET
+```
+
+
+Enge Reflexion, 4 pt Versatz.
+
+### TIGHT_REFLECTION_8_PT_OFFSET {#TIGHT-REFLECTION-8-PT-OFFSET}
+```
+public static final int TIGHT_REFLECTION_8_PT_OFFSET
+```
+
+
+Enge Reflexion, 8 pt Versatz.
+
+### TIGHT_REFLECTION_TOUCHING {#TIGHT-REFLECTION-TOUCHING}
+```
+public static final int TIGHT_REFLECTION_TOUCHING
+```
+
+
+Enge Reflexion, berührend.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/relcubbezto/_index.md
+++ b/german/java/com.aspose.diagram/relcubbezto/_index.md
@@ -1,0 +1,349 @@
+---
+title: RelCubBezTo
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält x- und y-Koordinaten für die Punkte eines RelCubBezTo.
+type: docs
+weight: 316
+url: /de/java/com.aspose.diagram/relcubbezto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class RelCubBezTo extends Coordinate
+```
+
+Enthält x- und y-Koordinaten für die Punkte eines RelCubBezTo.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [RelCubBezTo()](#RelCubBezTo--) | Erstellt eine Instanz der Klasse [RelCubBezTo](../../com.aspose.diagram/relcubbezto). |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | Die x-Koordinate des Kontrollpunkts am Anfang der Kurve in relativen Koordinaten. |
+| [getB()](#getB--) | Die y-Koordinate des Kontrollpunkts am Anfang der Kurve in relativen Koordinaten. |
+| [getC()](#getC--) | Die x-Koordinate des Kontrollpunkts am Ende der Kurve in relativen Koordinaten. |
+| [getClass()](#getClass--) |  |
+| [getD()](#getD--) | Die y-Koordinate des Kontrollpunkts am Ende der Kurve in relativen Koordinaten. |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getIX()](#getIX--) | Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements. |
+| [getX()](#getX--) | Die x-Koordinate des Endpunkts in relativen Koordinaten. |
+| [getY()](#getY--) | Die y-Koordinate des Endpunkts in relativen Koordinaten. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getA()](../../com.aspose.diagram/relcubbezto\#getA--) |
+| [setB(DoubleValue value)](#setB-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getB()](../../com.aspose.diagram/relcubbezto\#getB--) |
+| [setC(DoubleValue value)](#setC-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getC()](../../com.aspose.diagram/relcubbezto\#getC--) |
+| [setD(DoubleValue value)](#setD-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getD()](../../com.aspose.diagram/relcubbezto\#getD--) |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/relcubbezto\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getIX()](../../com.aspose.diagram/relcubbezto\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getX()](../../com.aspose.diagram/relcubbezto\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getY()](../../com.aspose.diagram/relcubbezto\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RelCubBezTo() {#RelCubBezTo--}
+```
+public RelCubBezTo()
+```
+
+
+Erstellt eine Instanz der Klasse [RelCubBezTo](../../com.aspose.diagram/relcubbezto).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+Die x-Koordinate des Kontrollpunkts am Anfang der Kurve in relativen Koordinaten.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getB() {#getB--}
+```
+public DoubleValue getB()
+```
+
+
+Die y-Koordinate des Kontrollpunkts am Anfang der Kurve in relativen Koordinaten.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getC() {#getC--}
+```
+public DoubleValue getC()
+```
+
+
+Die x-Koordinate des Kontrollpunkts am Ende der Kurve in relativen Koordinaten.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getD() {#getD--}
+```
+public DoubleValue getD()
+```
+
+
+Die y-Koordinate des Kontrollpunkts am Ende der Kurve in relativen Koordinaten.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+Die x-Koordinate des Endpunkts in relativen Koordinaten.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+Die y-Koordinate des Endpunkts in relativen Koordinaten.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getA()](../../com.aspose.diagram/relcubbezto\#getA--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setB(DoubleValue value) {#setB-com.aspose.diagram.DoubleValue-}
+```
+public void setB(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getB()](../../com.aspose.diagram/relcubbezto\#getB--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setC(DoubleValue value) {#setC-com.aspose.diagram.DoubleValue-}
+```
+public void setC(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getC()](../../com.aspose.diagram/relcubbezto\#getC--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setD(DoubleValue value) {#setD-com.aspose.diagram.DoubleValue-}
+```
+public void setD(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getD()](../../com.aspose.diagram/relcubbezto\#getD--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/relcubbezto\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getIX()](../../com.aspose.diagram/relcubbezto\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getX()](../../com.aspose.diagram/relcubbezto\#getX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getY()](../../com.aspose.diagram/relcubbezto\#getY--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/relcubbeztocollection/_index.md
+++ b/german/java/com.aspose.diagram/relcubbeztocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: RelCubBezToCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: RelCubBezTo Sammlung.
+type: docs
+weight: 317
+url: /de/java/com.aspose.diagram/relcubbeztocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class RelCubBezToCollection extends Collection
+```
+
+RelCubBezTo Sammlung.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public RelCubBezTo get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[RelCubBezTo](../../com.aspose.diagram/relcubbezto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/relellipticalarcto/_index.md
+++ b/german/java/com.aspose.diagram/relellipticalarcto/_index.md
@@ -1,0 +1,349 @@
+---
+title: RelEllipticalArcTo
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält Elemente, die Informationen über einen elliptischen Bogen angeben. Koordinaten werden als relative Koordinaten angegeben.
+type: docs
+weight: 318
+url: /de/java/com.aspose.diagram/relellipticalarcto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class RelEllipticalArcTo extends Coordinate
+```
+
+Enthält Elemente, die Informationen über einen elliptischen Bogen angeben. Koordinaten werden als relative Koordinaten angegeben.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [RelEllipticalArcTo()](#RelEllipticalArcTo--) | Erstellt eine Instanz der Klasse [EllipticalArcTo](../../com.aspose.diagram/ellipticalarcto). |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | Die x‑Koordinate des Kontrollpunkts des Bogens. |
+| [getB()](#getB--) | Die y‑Koordinate des Kontrollpunkts eines Bogens. |
+| [getC()](#getC--) | Der Winkel der Hauptachse des Bogens relativ zur x‑Achse seines übergeordneten Elements. |
+| [getClass()](#getClass--) |  |
+| [getD()](#getD--) | Das Verhältnis der Hauptachse des Bogens zur Nebenachse. |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getIX()](#getIX--) | Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements. |
+| [getX()](#getX--) | Die x‑Koordinate des Endknotens eines elliptischen Bogens. |
+| [getY()](#getY--) | Die y‑Koordinate des Endknotens eines elliptischen Bogens. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getA()](../../com.aspose.diagram/relellipticalarcto\#getA--) |
+| [setB(DoubleValue value)](#setB-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getB()](../../com.aspose.diagram/relellipticalarcto\#getB--) |
+| [setC(DoubleValue value)](#setC-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getC()](../../com.aspose.diagram/relellipticalarcto\#getC--) |
+| [setD(DoubleValue value)](#setD-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getD()](../../com.aspose.diagram/relellipticalarcto\#getD--) |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/relellipticalarcto\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getIX()](../../com.aspose.diagram/relellipticalarcto\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getX()](../../com.aspose.diagram/relellipticalarcto\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getY()](../../com.aspose.diagram/relellipticalarcto\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RelEllipticalArcTo() {#RelEllipticalArcTo--}
+```
+public RelEllipticalArcTo()
+```
+
+
+Erstellt eine Instanz der Klasse [EllipticalArcTo](../../com.aspose.diagram/ellipticalarcto).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+Der x‑Koordinate des Kontrollpunkts des Bogens. Der Kontrollpunkt ist am besten etwa halbwegs zwischen dem Anfangs‑ und Endpunkt des Bogens positioniert. Andernfalls kann der Bogen zu einer extremen Größe anwachsen, um durch den Kontrollpunkt zu verlaufen, mit unvorhersehbaren Ergebnissen.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getB() {#getB--}
+```
+public DoubleValue getB()
+```
+
+
+Die y‑Koordinate des Kontrollpunkts eines Bogens.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getC() {#getC--}
+```
+public DoubleValue getC()
+```
+
+
+Der Winkel der Hauptachse des Bogens relativ zur x‑Achse seines übergeordneten Elements.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getD() {#getD--}
+```
+public DoubleValue getD()
+```
+
+
+Das Verhältnis der Hauptachse eines Bogens zu seiner Nebenachse. Trotz der üblichen Bedeutung dieser Wörter muss die Hauptachse nicht größer sein als die Nebenachse, sodass dieses Verhältnis nicht größer als 1 sein muss. Das Setzen dieses Elements auf einen Wert kleiner oder gleich 0 oder größer als 1000 kann zu unvorhersehbaren Ergebnissen führen.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+Die x‑Koordinate des Endknotens eines elliptischen Bogens.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+Die y‑Koordinate des Endknotens eines elliptischen Bogens.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getA()](../../com.aspose.diagram/relellipticalarcto\#getA--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setB(DoubleValue value) {#setB-com.aspose.diagram.DoubleValue-}
+```
+public void setB(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getB()](../../com.aspose.diagram/relellipticalarcto\#getB--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setC(DoubleValue value) {#setC-com.aspose.diagram.DoubleValue-}
+```
+public void setC(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getC()](../../com.aspose.diagram/relellipticalarcto\#getC--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setD(DoubleValue value) {#setD-com.aspose.diagram.DoubleValue-}
+```
+public void setD(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getD()](../../com.aspose.diagram/relellipticalarcto\#getD--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/relellipticalarcto\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getIX()](../../com.aspose.diagram/relellipticalarcto\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getX()](../../com.aspose.diagram/relellipticalarcto\#getX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getY()](../../com.aspose.diagram/relellipticalarcto\#getY--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/relellipticalarctocollection/_index.md
+++ b/german/java/com.aspose.diagram/relellipticalarctocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: RelEllipticalArcToCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: RelEllipticalArcTo  Sammlung.
+type: docs
+weight: 319
+url: /de/java/com.aspose.diagram/relellipticalarctocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class RelEllipticalArcToCollection extends Collection
+```
+
+RelEllipticalArcTo Sammlung.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public RelEllipticalArcTo get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[RelEllipticalArcTo](../../com.aspose.diagram/relellipticalarcto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/rellineto/_index.md
+++ b/german/java/com.aspose.diagram/rellineto/_index.md
@@ -1,0 +1,249 @@
+---
+title: RelLineTo
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält die x- und y-Koordinaten des Endknotens eines geraden Liniensegments.
+type: docs
+weight: 320
+url: /de/java/com.aspose.diagram/rellineto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class RelLineTo extends Coordinate
+```
+
+Enthält x- und y-Koordinaten des Endknotens eines geraden Liniensegments. Diese Koordinaten sind jeweils in den X- und Y-Elementen enthalten. Koordinaten werden als relative Koordinaten angegeben.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [RelLineTo()](#RelLineTo--) | Creates an instance of the [LineTo](../../com.aspose.diagram/lineto) class. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getIX()](#getIX--) | Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements. |
+| [getX()](#getX--) | The x-coordinate of the ending vertex of a straight line segment. |
+| [getY()](#getY--) | The y-coordinate of the ending vertex of a straight line segment. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | For the description of this property, please see [getDel()](../../com.aspose.diagram/rellineto\#getDel--) |
+| [setIX(int value)](#setIX-int-) | For the description of this property, please see [getIX()](../../com.aspose.diagram/rellineto\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | For the description of this property, please see [getX()](../../com.aspose.diagram/rellineto\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | For the description of this property, please see [getY()](../../com.aspose.diagram/rellineto\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RelLineTo() {#RelLineTo--}
+```
+public RelLineTo()
+```
+
+
+Creates an instance of the [LineTo](../../com.aspose.diagram/lineto) class.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+The x-coordinate of the ending vertex of a straight line segment.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+The y-coordinate of the ending vertex of a straight line segment.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+For the description of this property, please see [getDel()](../../com.aspose.diagram/rellineto\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+For the description of this property, please see [getIX()](../../com.aspose.diagram/rellineto\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+For the description of this property, please see [getX()](../../com.aspose.diagram/rellineto\#getX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+For the description of this property, please see [getY()](../../com.aspose.diagram/rellineto\#getY--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/rellinetocollection/_index.md
+++ b/german/java/com.aspose.diagram/rellinetocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: RelLineToCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: RelLineTo Sammlung.
+type: docs
+weight: 321
+url: /de/java/com.aspose.diagram/rellinetocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class RelLineToCollection extends Collection
+```
+
+RelLineTo Sammlung.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public RelLineTo get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[RelLineTo](../../com.aspose.diagram/rellineto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/relmoveto/_index.md
+++ b/german/java/com.aspose.diagram/relmoveto/_index.md
@@ -1,0 +1,249 @@
+---
+title: RelMoveTo
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält die x- und y-Koordinaten des ersten Scheitelpunkts einer Form oder die x- und y-Koordinaten des ersten Scheitelpunkts nach einem Pfadunterbruch. Koordinaten werden als relative Koordinaten angegeben.
+type: docs
+weight: 322
+url: /de/java/com.aspose.diagram/relmoveto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class RelMoveTo extends Coordinate
+```
+
+Enthält die x- und y-Koordinaten des ersten Scheitelpunkts einer Form oder die x- und y-Koordinaten des ersten Scheitelpunkts nach einem Unterbrechung im Pfad. Koordinaten werden als relative Koordinaten angegeben.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [RelMoveTo()](#RelMoveTo--) | Erstellt eine Instanz der Klasse [MoveTo](../../com.aspose.diagram/moveto). |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getIX()](#getIX--) | Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements. |
+| [getX()](#getX--) | Das X-Element stellt die x-Koordinate des ersten Scheitelpunkts eines Pfades dar. |
+| [getY()](#getY--) | Das Y-Element stellt die y-Koordinate des ersten Scheitelpunkts eines Pfades dar. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/relmoveto\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getIX()](../../com.aspose.diagram/relmoveto\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getX()](../../com.aspose.diagram/relmoveto\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getY()](../../com.aspose.diagram/relmoveto\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RelMoveTo() {#RelMoveTo--}
+```
+public RelMoveTo()
+```
+
+
+Erstellt eine Instanz der Klasse [MoveTo](../../com.aspose.diagram/moveto).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+Das X-Element stellt die x-Koordinate des ersten Scheitelpunkts eines Pfades dar. Wenn das MoveTo-Element zwischen zwei Elementen erscheint, stellt das X-Element die x-Koordinate des ersten Scheitelpunkts nach der Unterbrechung im Pfad dar.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+Das Y-Element stellt die y-Koordinate des ersten Scheitelpunkts eines Pfades dar. Wenn das MoveTo-Element zwischen zwei Elementen erscheint, stellt das Y-Element die y-Koordinate des ersten Scheitelpunkts nach der Unterbrechung im Pfad dar.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/relmoveto\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getIX()](../../com.aspose.diagram/relmoveto\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getX()](../../com.aspose.diagram/relmoveto\#getX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getY()](../../com.aspose.diagram/relmoveto\#getY--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/relmovetocollection/_index.md
+++ b/german/java/com.aspose.diagram/relmovetocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: RelMoveToCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: RelMoveTo Sammlung.
+type: docs
+weight: 323
+url: /de/java/com.aspose.diagram/relmovetocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class RelMoveToCollection extends Collection
+```
+
+RelMoveTo Sammlung.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public RelMoveTo get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[RelMoveTo](../../com.aspose.diagram/relmoveto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/relquadbezto/_index.md
+++ b/german/java/com.aspose.diagram/relquadbezto/_index.md
@@ -1,0 +1,299 @@
+---
+title: RelQuadBezTo
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält x- und y-Koordinaten für die Punkte eines RelQuadBezTo.
+type: docs
+weight: 324
+url: /de/java/com.aspose.diagram/relquadbezto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class RelQuadBezTo extends Coordinate
+```
+
+Enthält x- und y-Koordinaten für die Punkte eines RelQuadBezTo.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [RelQuadBezTo()](#RelQuadBezTo--) | Erstellt eine Instanz der Klasse [RelCubBezTo](../../com.aspose.diagram/relcubbezto). |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | Die x-Koordinate des Kontrollpunkts in relativen Koordinaten. |
+| [getB()](#getB--) | Die y-Koordinate des Kontrollpunkts in relativen Koordinaten. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getIX()](#getIX--) | Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements. |
+| [getX()](#getX--) | Die x-Koordinate des Endpunkts in relativen Koordinaten. |
+| [getY()](#getY--) | Die y-Koordinate des Endpunkts in relativen Koordinaten. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getA()](../../com.aspose.diagram/relquadbezto\#getA--) |
+| [setB(DoubleValue value)](#setB-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getB()](../../com.aspose.diagram/relquadbezto\#getB--) |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/relquadbezto\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getIX()](../../com.aspose.diagram/relquadbezto\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getX()](../../com.aspose.diagram/relquadbezto\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getY()](../../com.aspose.diagram/relquadbezto\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RelQuadBezTo() {#RelQuadBezTo--}
+```
+public RelQuadBezTo()
+```
+
+
+Erstellt eine Instanz der Klasse [RelCubBezTo](../../com.aspose.diagram/relcubbezto).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+Die x-Koordinate des Kontrollpunkts in relativen Koordinaten.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getB() {#getB--}
+```
+public DoubleValue getB()
+```
+
+
+Die y-Koordinate des Kontrollpunkts in relativen Koordinaten.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+Die x-Koordinate des Endpunkts in relativen Koordinaten.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+Die y-Koordinate des Endpunkts in relativen Koordinaten.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getA()](../../com.aspose.diagram/relquadbezto\#getA--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setB(DoubleValue value) {#setB-com.aspose.diagram.DoubleValue-}
+```
+public void setB(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getB()](../../com.aspose.diagram/relquadbezto\#getB--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/relquadbezto\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getIX()](../../com.aspose.diagram/relquadbezto\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getX()](../../com.aspose.diagram/relquadbezto\#getX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getY()](../../com.aspose.diagram/relquadbezto\#getY--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/relquadbeztocollection/_index.md
+++ b/german/java/com.aspose.diagram/relquadbeztocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: RelQuadBezToCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: RelQuadBezTo Sammlung.
+type: docs
+weight: 325
+url: /de/java/com.aspose.diagram/relquadbeztocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class RelQuadBezToCollection extends Collection
+```
+
+RelQuadBezTo Sammlung.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public RelQuadBezTo get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[RelQuadBezTo](../../com.aspose.diagram/relquadbezto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/removehiddeninfoitem/_index.md
+++ b/german/java/com.aspose.diagram/removehiddeninfoitem/_index.md
@@ -1,0 +1,183 @@
+---
+title: RemoveHiddenInfoItem
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt an, dass versteckte Informationen aus dem Diagramm entfernt werden.
+type: docs
+weight: 326
+url: /de/java/com.aspose.diagram/removehiddeninfoitem/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class RemoveHiddenInfoItem
+```
+
+Gibt an, dass versteckte Informationen aus dem Diagramm entfernt werden.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [DATA_RECORD_SETS](#DATA-RECORD-SETS) | DataRecordSets. |
+| [MASTERS](#MASTERS) | Masters. |
+| [PERSONAL_INFO](#PERSONAL-INFO) | PersonalInfo. |
+| [SHAPES](#SHAPES) | Shapes. |
+| [STYLES](#STYLES) | Styles. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DATA_RECORD_SETS {#DATA-RECORD-SETS}
+```
+public static final int DATA_RECORD_SETS
+```
+
+
+DataRecordSets.
+
+### MASTERS {#MASTERS}
+```
+public static final int MASTERS
+```
+
+
+Masters.
+
+### PERSONAL_INFO {#PERSONAL-INFO}
+```
+public static final int PERSONAL_INFO
+```
+
+
+PersonalInfo.
+
+### SHAPES {#SHAPES}
+```
+public static final int SHAPES
+```
+
+
+Shapes.
+
+### STYLES {#STYLES}
+```
+public static final int STYLES
+```
+
+
+Styles.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/renderingsaveoptions/_index.md
+++ b/german/java/com.aspose.diagram/renderingsaveoptions/_index.md
@@ -1,0 +1,366 @@
+---
+title: RenderingSaveOptions
+second_title: Aspose.Diagram for Java API-Referenz
+description: Dies ist eine abstrakte Basisklasse für Klassen, die dem Benutzer ermöglichen, zusätzliche Optionen beim Speichern eines Diagramms in einem bestimmten Format anzugeben.
+type: docs
+weight: 327
+url: /de/java/com.aspose.diagram/renderingsaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.SaveOptions](../../com.aspose.diagram/saveoptions)
+```
+public abstract class RenderingSaveOptions extends SaveOptions
+```
+
+Dies ist eine abstrakte Basisklasse für Klassen, die dem Benutzer ermöglichen, zusätzliche Optionen beim Speichern eines Diagramms in einem bestimmten Format anzugeben.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | Erstellt ein Speicheroptionen-Objekt einer Klasse, die für das angegebene Speicherformat geeignet ist. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDefaultFont()](#getDefaultFont--) | Wenn Zeichen im Diagramm Unicode sind und nicht mit dem korrekten Schriftwert gesetzt werden oder die Schriftart nicht lokal installiert ist, können sie in PDF, Bild oder XPS als Block erscheinen. |
+| [getEmfRenderSetting()](#getEmfRenderSetting--) | Einstellung zum Rendern von Emf-Metadateien. |
+| [getEnlargePage()](#getEnlargePage--) | Gibt an, ob die Seite vergrößert werden soll. |
+| [getExportGuideShapes()](#getExportGuideShapes--) | Definiert, ob die Leitlinienformen exportiert werden sollen oder nicht. |
+| [getPageSize()](#getPageSize--) | die Seitengröße für die erzeugten Bilder. |
+| [getSaveFormat()](#getSaveFormat--) | Gibt das Format an, in dem das Dokument gespeichert wird, wenn dieses SaveOptions‑Objekt verwendet wird. |
+| [getShapes()](#getShapes--) | Formen zum Rendern. |
+| [getWarningCallback()](#getWarningCallback--) | Warnungs-Callback. |
+| [hashCode()](#hashCode--) |  |
+| [isExportComments()](#isExportComments--) | Definiert, ob Kommentare exportiert werden sollen oder nicht. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDefaultFont()](../../com.aspose.diagram/saveoptions\\#getDefaultFont--) |
+| [setEmfRenderSetting(int value)](#setEmfRenderSetting-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\\#getEmfRenderSetting--) |
+| [setEnlargePage(boolean value)](#setEnlargePage-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--) |
+| [setExportComments(boolean value)](#setExportComments-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--) |
+| [setExportGuideShapes(boolean value)](#setExportGuideShapes-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--) |
+| [setPageSize(PageSize value)](#setPageSize-com.aspose.diagram.PageSize-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--) |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getSaveFormat()](../../com.aspose.diagram/saveoptions\#getSaveFormat--) |
+| [setShapes(ShapeCollection value)](#setShapes-com.aspose.diagram.ShapeCollection-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--) |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+Erstellt ein Speicheroptionen-Objekt einer Klasse, die für das angegebene Speicherformat geeignet ist.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| saveFormat | int | Das Aspose.Diagram.SaveFileFormat, für das ein Save-Optionen-Objekt erstellt werden soll. |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+Wenn Zeichen im Diagramm Unicode sind und nicht mit dem korrekten Schriftwert gesetzt werden oder die Schriftart nicht lokal installiert ist, können sie im PDF, Bild oder XPS als Block erscheinen. Setzen Sie die DefaultFont, z. B. MingLiu oder MS Gothic, um diese Zeichen anzuzeigen.
+
+**Returns:**
+java.lang.String
+### getEmfRenderSetting() {#getEmfRenderSetting--}
+```
+public int getEmfRenderSetting()
+```
+
+
+Einstellung für das Rendern von EMF-Metadateien. EMF-Metadateien, die als "EMF+ Dual" identifiziert werden, können sowohl EMF+-Datensätze als auch EMF-Datensätze enthalten. Jeder Datensatztyp kann zum Rendern des Bildes verwendet werden, nur EMF+-Datensätze oder nur EMF-Datensätze. Wenn EmfPlusPrefer gesetzt ist, werden EMF+-Datensätze geparst, andernfalls werden nur EMF-Datensätze geparst. Der Standardwert ist EmfOnly"/>.
+
+**Returns:**
+int
+### getEnlargePage() {#getEnlargePage--}
+```
+public boolean getEnlargePage()
+```
+
+
+Gibt an, ob die Seite vergrößert werden soll. Wenn true – Seite vergrößern. Wenn false – Seite nicht vergrößern. Der Standardwert ist true.
+
+**Returns:**
+boolean
+### getExportGuideShapes() {#getExportGuideShapes--}
+```
+public boolean getExportGuideShapes()
+```
+
+
+Definiert, ob Leitlinienformen exportiert werden sollen oder nicht. Standardwert ist true.
+
+**Returns:**
+boolean
+### getPageSize() {#getPageSize--}
+```
+public PageSize getPageSize()
+```
+
+
+die Seitengröße für die erzeugten Bilder. Kann [PageSize](../../com.aspose.diagram/pagesize) oder null sein. Der Standardwert ist null. Wenn PageSize null ist, wird die Seitengröße für das erzeugte Bild aus dem Quell‑Diagramm übernommen.
+
+**Returns:**
+[PageSize](../../com.aspose.diagram/pagesize)
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+Gibt das Format an, in dem das Dokument gespeichert wird, wenn dieses SaveOptions‑Objekt verwendet wird.
+
+**Returns:**
+int
+### getShapes() {#getShapes--}
+```
+public ShapeCollection getShapes()
+```
+
+
+Zu rendernde Shapes. Standardanzahl ist 0.
+
+**Returns:**
+[ShapeCollection](../../com.aspose.diagram/shapecollection)
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+Warnungs-Callback.
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExportComments() {#isExportComments--}
+```
+public boolean isExportComments()
+```
+
+
+Legt fest, ob Kommentare exportiert werden sollen oder nicht. Der Standardwert ist false.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDefaultFont()](../../com.aspose.diagram/saveoptions\\#getDefaultFont--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setEmfRenderSetting(int value) {#setEmfRenderSetting-int-}
+```
+public void setEmfRenderSetting(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\\#getEmfRenderSetting--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setEnlargePage(boolean value) {#setEnlargePage-boolean-}
+```
+public void setEnlargePage(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setExportComments(boolean value) {#setExportComments-boolean-}
+```
+public void setExportComments(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setExportGuideShapes(boolean value) {#setExportGuideShapes-boolean-}
+```
+public void setExportGuideShapes(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setPageSize(PageSize value) {#setPageSize-com.aspose.diagram.PageSize-}
+```
+public void setPageSize(PageSize value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [PageSize](../../com.aspose.diagram/pagesize) |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getSaveFormat()](../../com.aspose.diagram/saveoptions\#getSaveFormat--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setShapes(ShapeCollection value) {#setShapes-com.aspose.diagram.ShapeCollection-}
+```
+public void setShapes(ShapeCollection value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [ShapeCollection](../../com.aspose.diagram/shapecollection) |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/resizemode/_index.md
+++ b/german/java/com.aspose.diagram/resizemode/_index.md
@@ -1,0 +1,204 @@
+---
+title: ResizeMode
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt die aktuelle Einstellung für das Größenänderungsverhalten der Form an, wenn sie in einer Gruppe enthalten ist.
+type: docs
+weight: 328
+url: /de/java/com.aspose.diagram/resizemode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ResizeMode
+```
+
+Gibt die aktuelle Einstellung für das Größenänderungsverhalten der Form an, wenn sie in einer Gruppe enthalten ist.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [ResizeMode(int value)](#ResizeMode-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Gibt die aktuelle Einstellung für das Größenänderungsverhalten der Form an, wenn sie in einer Gruppe enthalten ist. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | For the description of this property, please see [getUfe()](../../com.aspose.diagram/resizemode\#getUfe--) |
+| [setValue(int value)](#setValue-int-) | For the description of this property, please see [getValue()](../../com.aspose.diagram/resizemode\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ResizeMode(int value) {#ResizeMode-int-}
+```
+public ResizeMode(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Gibt die aktuelle Einstellung für das Größenänderungsverhalten der Form an, wenn sie in einer Gruppe enthalten ist.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+For the description of this property, please see [getUfe()](../../com.aspose.diagram/resizemode\#getUfe--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+For the description of this property, please see [getValue()](../../com.aspose.diagram/resizemode\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/resizemodevalue/_index.md
+++ b/german/java/com.aspose.diagram/resizemodevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: ResizeModeValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt die aktuelle Einstellung für das Größenänderungsverhalten der Form an, wenn sie in einer Gruppe enthalten ist.
+type: docs
+weight: 329
+url: /de/java/com.aspose.diagram/resizemodevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ResizeModeValue
+```
+
+Gibt die aktuelle Einstellung für das Größenänderungsverhalten der Form an, wenn sie in einer Gruppe enthalten ist.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [REPOSITION_ONLY](#REPOSITION-ONLY) | Nur neu positionieren. |
+| [SCALE_WITH_GROUP](#SCALE-WITH-GROUP) | Skalieren mit Gruppe. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+| [USE_GROUP_SETTING](#USE-GROUP-SETTING) | Verwende die Gruppeneinstellung |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### REPOSITION_ONLY {#REPOSITION-ONLY}
+```
+public static final int REPOSITION_ONLY
+```
+
+
+Nur neu positionieren.
+
+### SCALE_WITH_GROUP {#SCALE-WITH-GROUP}
+```
+public static final int SCALE_WITH_GROUP
+```
+
+
+Skalieren mit Gruppe.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### USE_GROUP_SETTING {#USE-GROUP-SETTING}
+```
+public static final int USE_GROUP_SETTING
+```
+
+
+Verwende die Gruppeneinstellung
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/reviewer/_index.md
+++ b/german/java/com.aspose.diagram/reviewer/_index.md
@@ -1,0 +1,243 @@
+---
+title: Gutachter
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält Elemente, die Identifizierungsinformationen über einen Dokumentprüfer enthalten.
+type: docs
+weight: 330
+url: /de/java/com.aspose.diagram/reviewer/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Reviewer
+```
+
+Enthält Elemente, die Identifizierungsinformationen über einen Dokumentprüfer enthalten.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [Reviewer()](#Reviewer--) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getColor()](#getColor--) | Das Color-Element gibt einen RGB-Wert an, der die dem Markup eines Dokumentgutachters zugewiesene Farbe darstellt. |
+| [getCurrentIndex()](#getCurrentIndex--) | Gibt den Wert des MarkerIndex-Elements an, der hinzugefügt wird, wenn der aktuelle Gutachter einen weiteren Kommentar zum Dokument hinzufügt. |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getIX()](#getIX--) | Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements. |
+| [getInitials()](#getInitials--) | Enthält die Initialen eines Dokumentgutachters. |
+| [getName()](#getName--) | Das Name-Element gibt den Namen eines Dokumentgutachters an. |
+| [getReviewerID()](#getReviewerID--) | Enthält die ID-Nummer des Prüfers, der Markups zum Dokument hinzufügt. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/reviewer\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getIX()](../../com.aspose.diagram/reviewer\#getIX--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Reviewer() {#Reviewer--}
+```
+public Reviewer()
+```
+
+
+Konstruktor.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColor() {#getColor--}
+```
+public ColorValue getColor()
+```
+
+
+Das Color-Element gibt einen RGB-Wert an, der die dem Markup eines Dokumentgutachters zugewiesene Farbe darstellt.
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getCurrentIndex() {#getCurrentIndex--}
+```
+public IntValue getCurrentIndex()
+```
+
+
+Gibt den Wert des MarkerIndex-Elements an, der hinzugefügt wird, wenn der aktuelle Gutachter einen weiteren Kommentar zum Dokument hinzufügt.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements.
+
+**Returns:**
+int
+### getInitials() {#getInitials--}
+```
+public Str2Value getInitials()
+```
+
+
+Enthält die Initialen eines Dokumentgutachters.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getName() {#getName--}
+```
+public Str2Value getName()
+```
+
+
+Das Name-Element gibt den Namen eines Dokumentgutachters an.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getReviewerID() {#getReviewerID--}
+```
+public IntValue getReviewerID()
+```
+
+
+Enthält die ID-Nummer des Prüfers, der Markups zum Dokument hinzufügt.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/reviewer\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getIX()](../../com.aspose.diagram/reviewer\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/reviewercollection/_index.md
+++ b/german/java/com.aspose.diagram/reviewercollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: ReviewerCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: Reviewer Sammlung.
+type: docs
+weight: 331
+url: /de/java/com.aspose.diagram/reviewercollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ReviewerCollection extends Collection
+```
+
+Reviewer Sammlung.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [add(Reviewer item)](#add-com.aspose.diagram.Reviewer-) | Füge das Reviewer-Objekt zur Sammlung hinzu. |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Reviewer item)](#remove-com.aspose.diagram.Reviewer-) | Entferne das Reviewer-Objekt aus der Sammlung. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Reviewer item) {#add-com.aspose.diagram.Reviewer-}
+```
+public int add(Reviewer item)
+```
+
+
+Füge das Reviewer-Objekt zur Sammlung hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [Reviewer](../../com.aspose.diagram/reviewer) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Reviewer get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[Reviewer](../../com.aspose.diagram/reviewer) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Reviewer item) {#remove-com.aspose.diagram.Reviewer-}
+```
+public void remove(Reviewer item)
+```
+
+
+Entferne das Reviewer-Objekt aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [Reviewer](../../com.aspose.diagram/reviewer) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/rotationtype/_index.md
+++ b/german/java/com.aspose.diagram/rotationtype/_index.md
@@ -1,0 +1,179 @@
+---
+title: RotationType
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt den Typ des Schattens für eine Form an.
+type: docs
+weight: 332
+url: /de/java/com.aspose.diagram/rotationtype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class RotationType
+```
+
+Gibt den Typ des Schattens für eine Form an.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [RotationType(int value)](#RotationType-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Gibt den Typ der Abschrägung an. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/rotationtype\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RotationType(int value) {#RotationType-int-}
+```
+public RotationType(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Gibt den Typ der Abschrägung an.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/rotationtype\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/rotationtypevalue/_index.md
+++ b/german/java/com.aspose.diagram/rotationtypevalue/_index.md
@@ -1,0 +1,201 @@
+---
+title: RotationTypeValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt den Projektionstyp der Effekt‑Eigenschaften einer Form an.
+type: docs
+weight: 333
+url: /de/java/com.aspose.diagram/rotationtypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class RotationTypeValue
+```
+
+Gibt den Projektionstyp der Effekt‑Eigenschaften einer Form an.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [NONE](#NONE) | Gibt an, dass keine 3D-Effekt-Rotation erfolgt. |
+| [OBLIQUE_FROM_BOTTOM_LEFT](#OBLIQUE-FROM-BOTTOM-LEFT) | Gibt an, dass die Form eine schiefe Projektion von der unteren linken Ecke der Begrenzungsbox aus dreht. |
+| [OBLIQUE_FROM_BOTTOM_RIGHT](#OBLIQUE-FROM-BOTTOM-RIGHT) | Gibt an, dass die Form eine schiefe Projektion von der unteren rechten Ecke der Begrenzungsbox aus dreht. |
+| [OBLIQUE_FROM_TOP_LEFT](#OBLIQUE-FROM-TOP-LEFT) | Gibt an, dass die Form eine schiefe Projektion von der oberen linken Ecke der Begrenzungsbox aus dreht. |
+| [OBLIQUE_FROM_TOP_RIGHT](#OBLIQUE-FROM-TOP-RIGHT) | Gibt an, dass die Form eine schiefe Projektion von der oberen rechten Ecke der Begrenzungsbox aus dreht. |
+| [PARALLEL](#PARALLEL) | Gibt an, dass eine parallele Projektion auf die 3D-Effekt-Eigenschaften angewendet wird. |
+| [PERSPECTIVE](#PERSPECTIVE) | Gibt an, dass die Form in perspektivischer Projektion rotiert. |
+| [UNDEFINED](#UNDEFINED) | Keine Lichtvorrichtung. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Gibt an, dass keine 3D-Effekt-Rotation erfolgt.
+
+### OBLIQUE_FROM_BOTTOM_LEFT {#OBLIQUE-FROM-BOTTOM-LEFT}
+```
+public static final int OBLIQUE_FROM_BOTTOM_LEFT
+```
+
+
+Gibt an, dass die Form eine schiefe Projektion von der unteren linken Ecke der Begrenzungsbox aus dreht.
+
+### OBLIQUE_FROM_BOTTOM_RIGHT {#OBLIQUE-FROM-BOTTOM-RIGHT}
+```
+public static final int OBLIQUE_FROM_BOTTOM_RIGHT
+```
+
+
+Gibt an, dass die Form eine schiefe Projektion von der unteren rechten Ecke der Begrenzungsbox aus dreht.
+
+### OBLIQUE_FROM_TOP_LEFT {#OBLIQUE-FROM-TOP-LEFT}
+```
+public static final int OBLIQUE_FROM_TOP_LEFT
+```
+
+
+Gibt an, dass die Form eine schiefe Projektion von der oberen linken Ecke der Begrenzungsbox aus dreht.
+
+### OBLIQUE_FROM_TOP_RIGHT {#OBLIQUE-FROM-TOP-RIGHT}
+```
+public static final int OBLIQUE_FROM_TOP_RIGHT
+```
+
+
+Gibt an, dass die Form eine schiefe Projektion von der oberen rechten Ecke der Begrenzungsbox aus dreht.
+
+### PARALLEL {#PARALLEL}
+```
+public static final int PARALLEL
+```
+
+
+Gibt an, dass eine parallele Projektion auf die 3D-Effekt-Eigenschaften angewendet wird.
+
+### PERSPECTIVE {#PERSPECTIVE}
+```
+public static final int PERSPECTIVE
+```
+
+
+Gibt an, dass die Form in perspektivischer Projektion rotiert.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Keine Lichtvorrichtung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/routestyle/_index.md
+++ b/german/java/com.aspose.diagram/routestyle/_index.md
@@ -1,0 +1,179 @@
+---
+title: RouteStyle
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt den Routing-Stil und die Richtung für alle dynamischen Verbinder auf der Zeichenfläche an, die keinen lokalen Routing-Stil haben.
+type: docs
+weight: 334
+url: /de/java/com.aspose.diagram/routestyle/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class RouteStyle
+```
+
+Gibt den Routing‑Stil und die Richtung für alle dynamischen Verbinder auf der Zeichenfläche an, die keinen lokalen Routing‑Stil haben.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [RouteStyle(int value)](#RouteStyle-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Gibt den Routing‑Stil und die Richtung für alle dynamischen Verbinder auf der Zeichenfläche an, die keinen lokalen Routing‑Stil haben. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/routestyle\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RouteStyle(int value) {#RouteStyle-int-}
+```
+public RouteStyle(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Gibt den Routing‑Stil und die Richtung für alle dynamischen Verbinder auf der Zeichenfläche an, die keinen lokalen Routing‑Stil haben.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/routestyle\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/routestylevalue/_index.md
+++ b/german/java/com.aspose.diagram/routestylevalue/_index.md
@@ -1,0 +1,345 @@
+---
+title: RouteStyleValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt den Routing-Stil und die Richtung für alle dynamischen Verbinder auf der Zeichenfläche an, die keinen lokalen Routing-Stil haben.
+type: docs
+weight: 335
+url: /de/java/com.aspose.diagram/routestylevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class RouteStyleValue
+```
+
+Gibt den Routing‑Stil und die Richtung für alle dynamischen Verbinder auf der Zeichenfläche an, die keinen lokalen Routing‑Stil haben.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [CENTER_TO_CENTER](#CENTER-TO-CENTER) | Mitte zu Mitte. |
+| [DEFAULT_RIGHT_ANGLE](#DEFAULT-RIGHT-ANGLE) | Standard. |
+| [FLOWCHART_BOTTOM_TO_TOP](#FLOWCHART-BOTTOM-TO-TOP) | Flussdiagramm von unten nach oben. |
+| [FLOWCHART_LEFT_TO_RIGHT](#FLOWCHART-LEFT-TO-RIGHT) | Flussdiagramm von links nach rechts. |
+| [FLOWCHART_RIGHT_TO_LEFT](#FLOWCHART-RIGHT-TO-LEFT) | Flussdiagramm von rechts nach links. |
+| [FLOWCHART_TOP_TO_BOTTOM](#FLOWCHART-TOP-TO-BOTTOM) | Flussdiagramm von oben nach unten. |
+| [NETWORK](#NETWORK) | Netzwerk. |
+| [ORGANIZATION_CHART_BOTTOM_TO_TOP](#ORGANIZATION-CHART-BOTTOM-TO-TOP) | Organisationsdiagramm von unten nach oben. |
+| [ORGANIZATION_CHART_LEFT_TO_RIGHT](#ORGANIZATION-CHART-LEFT-TO-RIGHT) | Organization chart left to right. |
+| [ORGANIZATION_CHART_RIGHT_TO_LEFT](#ORGANIZATION-CHART-RIGHT-TO-LEFT) | Organization chart right to left. |
+| [ORGANIZATION_CHART_TOP_TO_BOTTOM](#ORGANIZATION-CHART-TOP-TO-BOTTOM) | Organization chart top to bottom. |
+| [RIGHT_ANGLE](#RIGHT-ANGLE) | Rechter Winkel. |
+| [SIMPLE_BOTTOM_TO_TOP](#SIMPLE-BOTTOM-TO-TOP) | Simple bottom to top. |
+| [SIMPLE_HORIZONTAL_VERTICAL](#SIMPLE-HORIZONTAL-VERTICAL) | Simple horizontal vertical. |
+| [SIMPLE_LEFT_TO_RIGHT](#SIMPLE-LEFT-TO-RIGHT) | Simple left to right. |
+| [SIMPLE_RIGHT_TO_LEFT](#SIMPLE-RIGHT-TO-LEFT) | Simple right to left. |
+| [SIMPLE_TOP_TO_BOTTOM](#SIMPLE-TOP-TO-BOTTOM) | Simple top to bottom. |
+| [SIMPLE_VERTICAL_HORIZONTAL](#SIMPLE-VERTICAL-HORIZONTAL) | Simple vertical horizontal. |
+| [STRAIGHT](#STRAIGHT) | Gerade. |
+| [TREE_BOTTOM_TO_TOP](#TREE-BOTTOM-TO-TOP) | Tree bottom to top. |
+| [TREE_LEFT_TO_RIGHT](#TREE-LEFT-TO-RIGHT) | Tree left to right. |
+| [TREE_RIGHT_TO_LEFT](#TREE-RIGHT-TO-LEFT) | Tree right to left. |
+| [TREE_TOP_TO_BOTTOM](#TREE-TOP-TO-BOTTOM) | Tree top to bottom. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CENTER_TO_CENTER {#CENTER-TO-CENTER}
+```
+public static final int CENTER_TO_CENTER
+```
+
+
+Mitte zu Mitte.
+
+### DEFAULT_RIGHT_ANGLE {#DEFAULT-RIGHT-ANGLE}
+```
+public static final int DEFAULT_RIGHT_ANGLE
+```
+
+
+Default. Right angle.
+
+### FLOWCHART_BOTTOM_TO_TOP {#FLOWCHART-BOTTOM-TO-TOP}
+```
+public static final int FLOWCHART_BOTTOM_TO_TOP
+```
+
+
+Flussdiagramm von unten nach oben.
+
+### FLOWCHART_LEFT_TO_RIGHT {#FLOWCHART-LEFT-TO-RIGHT}
+```
+public static final int FLOWCHART_LEFT_TO_RIGHT
+```
+
+
+Flussdiagramm von links nach rechts.
+
+### FLOWCHART_RIGHT_TO_LEFT {#FLOWCHART-RIGHT-TO-LEFT}
+```
+public static final int FLOWCHART_RIGHT_TO_LEFT
+```
+
+
+Flussdiagramm von rechts nach links.
+
+### FLOWCHART_TOP_TO_BOTTOM {#FLOWCHART-TOP-TO-BOTTOM}
+```
+public static final int FLOWCHART_TOP_TO_BOTTOM
+```
+
+
+Flussdiagramm von oben nach unten.
+
+### NETWORK {#NETWORK}
+```
+public static final int NETWORK
+```
+
+
+Netzwerk.
+
+### ORGANIZATION_CHART_BOTTOM_TO_TOP {#ORGANIZATION-CHART-BOTTOM-TO-TOP}
+```
+public static final int ORGANIZATION_CHART_BOTTOM_TO_TOP
+```
+
+
+Organisationsdiagramm von unten nach oben.
+
+### ORGANIZATION_CHART_LEFT_TO_RIGHT {#ORGANIZATION-CHART-LEFT-TO-RIGHT}
+```
+public static final int ORGANIZATION_CHART_LEFT_TO_RIGHT
+```
+
+
+Organization chart left to right.
+
+### ORGANIZATION_CHART_RIGHT_TO_LEFT {#ORGANIZATION-CHART-RIGHT-TO-LEFT}
+```
+public static final int ORGANIZATION_CHART_RIGHT_TO_LEFT
+```
+
+
+Organization chart right to left.
+
+### ORGANIZATION_CHART_TOP_TO_BOTTOM {#ORGANIZATION-CHART-TOP-TO-BOTTOM}
+```
+public static final int ORGANIZATION_CHART_TOP_TO_BOTTOM
+```
+
+
+Organization chart top to bottom.
+
+### RIGHT_ANGLE {#RIGHT-ANGLE}
+```
+public static final int RIGHT_ANGLE
+```
+
+
+Rechter Winkel.
+
+### SIMPLE_BOTTOM_TO_TOP {#SIMPLE-BOTTOM-TO-TOP}
+```
+public static final int SIMPLE_BOTTOM_TO_TOP
+```
+
+
+Simple bottom to top.
+
+### SIMPLE_HORIZONTAL_VERTICAL {#SIMPLE-HORIZONTAL-VERTICAL}
+```
+public static final int SIMPLE_HORIZONTAL_VERTICAL
+```
+
+
+Simple horizontal vertical.
+
+### SIMPLE_LEFT_TO_RIGHT {#SIMPLE-LEFT-TO-RIGHT}
+```
+public static final int SIMPLE_LEFT_TO_RIGHT
+```
+
+
+Simple left to right.
+
+### SIMPLE_RIGHT_TO_LEFT {#SIMPLE-RIGHT-TO-LEFT}
+```
+public static final int SIMPLE_RIGHT_TO_LEFT
+```
+
+
+Simple right to left.
+
+### SIMPLE_TOP_TO_BOTTOM {#SIMPLE-TOP-TO-BOTTOM}
+```
+public static final int SIMPLE_TOP_TO_BOTTOM
+```
+
+
+Simple top to bottom.
+
+### SIMPLE_VERTICAL_HORIZONTAL {#SIMPLE-VERTICAL-HORIZONTAL}
+```
+public static final int SIMPLE_VERTICAL_HORIZONTAL
+```
+
+
+Simple vertical horizontal.
+
+### STRAIGHT {#STRAIGHT}
+```
+public static final int STRAIGHT
+```
+
+
+Gerade.
+
+### TREE_BOTTOM_TO_TOP {#TREE-BOTTOM-TO-TOP}
+```
+public static final int TREE_BOTTOM_TO_TOP
+```
+
+
+Tree bottom to top.
+
+### TREE_LEFT_TO_RIGHT {#TREE-LEFT-TO-RIGHT}
+```
+public static final int TREE_LEFT_TO_RIGHT
+```
+
+
+Tree left to right.
+
+### TREE_RIGHT_TO_LEFT {#TREE-RIGHT-TO-LEFT}
+```
+public static final int TREE_RIGHT_TO_LEFT
+```
+
+
+Tree right to left.
+
+### TREE_TOP_TO_BOTTOM {#TREE-TOP-TO-BOTTOM}
+```
+public static final int TREE_TOP_TO_BOTTOM
+```
+
+
+Tree top to bottom.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/row/_index.md
+++ b/german/java/com.aspose.diagram/row/_index.md
@@ -1,0 +1,213 @@
+---
+title: Row
+second_title: Aspose.Diagram for Java API-Referenz
+description: Zeigt eine Zeile im Datenrecordset an.
+type: docs
+weight: 336
+url: /de/java/com.aspose.diagram/row/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Row
+```
+
+Zeigt eine Zeile im Datenrecordset an.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [Row()](#Row--) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getPageID()](#getPageID--) | Seiten-ID der Form. |
+| [getRowID()](#getRowID--) | Die ursprüngliche Zeilen-ID. |
+| [getShapeID()](#getShapeID--) | Form-ID der Form. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setPageID(long value)](#setPageID-long-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getPageID()](../../com.aspose.diagram/row\#getPageID--) |
+| [setRowID(long value)](#setRowID-long-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getRowID()](../../com.aspose.diagram/row\#getRowID--) |
+| [setShapeID(long value)](#setShapeID-long-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getShapeID()](../../com.aspose.diagram/row\#getShapeID--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Row() {#Row--}
+```
+public Row()
+```
+
+
+Konstruktor.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getPageID() {#getPageID--}
+```
+public long getPageID()
+```
+
+
+Seiten-ID der Form.
+
+**Returns:**
+long
+### getRowID() {#getRowID--}
+```
+public long getRowID()
+```
+
+
+Die ursprüngliche Zeilen-ID.
+
+**Returns:**
+long
+### getShapeID() {#getShapeID--}
+```
+public long getShapeID()
+```
+
+
+Form-ID der Form.
+
+**Returns:**
+long
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setPageID(long value) {#setPageID-long-}
+```
+public void setPageID(long value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getPageID()](../../com.aspose.diagram/row\#getPageID--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | long |  |
+
+### setRowID(long value) {#setRowID-long-}
+```
+public void setRowID(long value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getRowID()](../../com.aspose.diagram/row\#getRowID--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | long |  |
+
+### setShapeID(long value) {#setShapeID-long-}
+```
+public void setShapeID(long value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getShapeID()](../../com.aspose.diagram/row\#getShapeID--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | long |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/rowcollection/_index.md
+++ b/german/java/com.aspose.diagram/rowcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: RowCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: Row Sammlung.
+type: docs
+weight: 337
+url: /de/java/com.aspose.diagram/rowcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class RowCollection extends Collection
+```
+
+Row Sammlung.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [add(Row row)](#add-com.aspose.diagram.Row-) | Füge die Zeile zur Sammlung hinzu. |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Row row)](#remove-com.aspose.diagram.Row-) | Entferne die Zeile aus der Sammlung. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Row row) {#add-com.aspose.diagram.Row-}
+```
+public int add(Row row)
+```
+
+
+Füge die Zeile zur Sammlung hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| row | [Row](../../com.aspose.diagram/row) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Row get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[Row](../../com.aspose.diagram/row) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Row row) {#remove-com.aspose.diagram.Row-}
+```
+public void remove(Row row)
+```
+
+
+Entferne die Zeile aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| row | [Row](../../com.aspose.diagram/row) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/rule/_index.md
+++ b/german/java/com.aspose.diagram/rule/_index.md
@@ -1,0 +1,338 @@
+---
+title: Rule
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt eine einzelne Validierungsregel in einem Diagramm‑Validierungsregelset dar.
+type: docs
+weight: 338
+url: /de/java/com.aspose.diagram/rule/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Rule
+```
+
+Stellt eine einzelne Validierungsregel in einem Diagramm‑Validierungsregelset dar.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [Rule()](#Rule--) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCategory()](#getCategory--) | Gibt den im Kategorie-Spalte des Probleme-Fensters angezeigten Text an. |
+| [getClass()](#getClass--) |  |
+| [getDescription()](#getDescription--) | die Beschreibung der Validierungsregel, die in der Benutzeroberfläche angezeigt wird. |
+| [getID()](#getID--) | Gibt die eindeutige Kennung der Validierungsregel an. |
+| [getIgnored()](#getIgnored--) | Gibt an, ob die Validierungsregel derzeit ignoriert wird. |
+| [getNameU()](#getNameU--) | Gibt den universellen Namen der Validierungsregel an. |
+| [getRuleFilter()](#getRuleFilter--) | Gibt den logischen Ausdruck an, der bestimmt, ob die Validierungsregel auf ein Zielobjekt angewendet werden soll. |
+| [getRuleTarget()](#getRuleTarget--) | Gibt den Objekttyp an, auf den die Validierungsregel angewendet wird. |
+| [getRuleTest()](#getRuleTest--) | Gibt den logischen Ausdruck an, der bestimmt, ob das Zielobjekt die Validierungsregel erfüllt |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCategory(String value)](#setCategory-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getCategory()](../../com.aspose.diagram/rule\#getCategory--) |
+| [setDescription(String value)](#setDescription-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDescription()](../../com.aspose.diagram/rule\#getDescription--) |
+| [setID(long value)](#setID-long-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getID()](../../com.aspose.diagram/rule\#getID--) |
+| [setIgnored(int value)](#setIgnored-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getIgnored()](../../com.aspose.diagram/rule\#getIgnored--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getNameU()](../../com.aspose.diagram/rule\#getNameU--) |
+| [setRuleFilter(RuleValue value)](#setRuleFilter-com.aspose.diagram.RuleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getRuleFilter()](../../com.aspose.diagram/rule\#getRuleFilter--) |
+| [setRuleTarget(int value)](#setRuleTarget-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getRuleTarget()](../../com.aspose.diagram/rule\#getRuleTarget--) |
+| [setRuleTest(RuleValue value)](#setRuleTest-com.aspose.diagram.RuleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getRuleTest()](../../com.aspose.diagram/rule\#getRuleTest--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Rule() {#Rule--}
+```
+public Rule()
+```
+
+
+Konstruktor.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCategory() {#getCategory--}
+```
+public String getCategory()
+```
+
+
+Gibt den im Kategorie-Spalte des Probleme-Fensters angezeigten Text an. Standard ist eine leere Zeichenkette.
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDescription() {#getDescription--}
+```
+public String getDescription()
+```
+
+
+die Beschreibung der Validierungsregel, die in der Benutzeroberfläche angezeigt wird. Standard ist "Unknown".
+
+**Returns:**
+java.lang.String
+### getID() {#getID--}
+```
+public long getID()
+```
+
+
+Gibt die eindeutige Kennung der Validierungsregel an.
+
+**Returns:**
+long
+### getIgnored() {#getIgnored--}
+```
+public int getIgnored()
+```
+
+
+Gibt an, ob die Validierungsregel derzeit ignoriert wird. Standard ist False.
+
+**Returns:**
+int
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+Gibt den universellen Namen der Validierungsregel an.
+
+**Returns:**
+java.lang.String
+### getRuleFilter() {#getRuleFilter--}
+```
+public RuleValue getRuleFilter()
+```
+
+
+Gibt den logischen Ausdruck an, der bestimmt, ob die Validierungsregel auf ein Zielobjekt angewendet werden soll.
+
+**Returns:**
+[RuleValue](../../com.aspose.diagram/rulevalue)
+### getRuleTarget() {#getRuleTarget--}
+```
+public int getRuleTarget()
+```
+
+
+Gibt den Objekttyp an, auf den die Validierungsregel angewendet wird.
+
+**Returns:**
+int
+### getRuleTest() {#getRuleTest--}
+```
+public RuleValue getRuleTest()
+```
+
+
+Gibt den logischen Ausdruck an, der bestimmt, ob das Zielobjekt die Validierungsregel erfüllt
+
+**Returns:**
+[RuleValue](../../com.aspose.diagram/rulevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCategory(String value) {#setCategory-java.lang.String-}
+```
+public void setCategory(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getCategory()](../../com.aspose.diagram/rule\#getCategory--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setDescription(String value) {#setDescription-java.lang.String-}
+```
+public void setDescription(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDescription()](../../com.aspose.diagram/rule\#getDescription--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setID(long value) {#setID-long-}
+```
+public void setID(long value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getID()](../../com.aspose.diagram/rule\#getID--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | long |  |
+
+### setIgnored(int value) {#setIgnored-int-}
+```
+public void setIgnored(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getIgnored()](../../com.aspose.diagram/rule\#getIgnored--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getNameU()](../../com.aspose.diagram/rule\#getNameU--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setRuleFilter(RuleValue value) {#setRuleFilter-com.aspose.diagram.RuleValue-}
+```
+public void setRuleFilter(RuleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getRuleFilter()](../../com.aspose.diagram/rule\#getRuleFilter--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [RuleValue](../../com.aspose.diagram/rulevalue) |  |
+
+### setRuleTarget(int value) {#setRuleTarget-int-}
+```
+public void setRuleTarget(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getRuleTarget()](../../com.aspose.diagram/rule\#getRuleTarget--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setRuleTest(RuleValue value) {#setRuleTest-com.aspose.diagram.RuleValue-}
+```
+public void setRuleTest(RuleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getRuleTest()](../../com.aspose.diagram/rule\#getRuleTest--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [RuleValue](../../com.aspose.diagram/rulevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/rulecollection/_index.md
+++ b/german/java/com.aspose.diagram/rulecollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: RuleCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: Regel Sammlung.
+type: docs
+weight: 339
+url: /de/java/com.aspose.diagram/rulecollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class RuleCollection extends Collection
+```
+
+Regel Sammlung.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [add(Rule rule)](#add-com.aspose.diagram.Rule-) | Füge die Regel in die Sammlung hinzu. |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Rule rule)](#remove-com.aspose.diagram.Rule-) | Entferne die Regel aus der Sammlung. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Rule rule) {#add-com.aspose.diagram.Rule-}
+```
+public int add(Rule rule)
+```
+
+
+Füge die Regel in die Sammlung hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| rule | [Rule](../../com.aspose.diagram/rule) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Rule get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[Rule](../../com.aspose.diagram/rule) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Rule rule) {#remove-com.aspose.diagram.Rule-}
+```
+public void remove(Rule rule)
+```
+
+
+Entferne die Regel aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| rule | [Rule](../../com.aspose.diagram/rule) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/ruleinfo/_index.md
+++ b/german/java/com.aspose.diagram/ruleinfo/_index.md
@@ -1,0 +1,194 @@
+---
+title: RuleInfo
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt Informationen über die Validierungsregel an, auf die sich das übergeordnete Validierungsproblem bezieht.
+type: docs
+weight: 340
+url: /de/java/com.aspose.diagram/ruleinfo/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class RuleInfo
+```
+
+Gibt Informationen über die Validierungsregel an, auf die sich das übergeordnete Validierungsproblem bezieht.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [RuleInfo(long ruleSetID, long ruleID)](#RuleInfo-long-long-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getRuleId()](#getRuleId--) | Gibt die eindeutige Kennung der Validierungsregel an, auf die sich das übergeordnete Problem bezieht. |
+| [getRuleSetId()](#getRuleSetId--) | Gibt die eindeutige Kennung des Validierungsregelsets an, auf das sich das übergeordnete Problem bezieht. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setRuleId(long value)](#setRuleId-long-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getRuleId()](../../com.aspose.diagram/ruleinfo\\#getRuleId--) |
+| [setRuleSetId(long value)](#setRuleSetId-long-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getRuleSetId()](../../com.aspose.diagram/ruleinfo\\#getRuleSetId--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RuleInfo(long ruleSetID, long ruleID) {#RuleInfo-long-long-}
+```
+public RuleInfo(long ruleSetID, long ruleID)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| ruleSetID | long |  |
+| ruleID | long |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getRuleId() {#getRuleId--}
+```
+public long getRuleId()
+```
+
+
+Gibt die eindeutige Kennung der Validierungsregel an, auf die sich das übergeordnete Problem bezieht.
+
+**Returns:**
+long
+### getRuleSetId() {#getRuleSetId--}
+```
+public long getRuleSetId()
+```
+
+
+Gibt die eindeutige Kennung des Validierungsregelsets an, auf das sich das übergeordnete Problem bezieht.
+
+**Returns:**
+long
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setRuleId(long value) {#setRuleId-long-}
+```
+public void setRuleId(long value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getRuleId()](../../com.aspose.diagram/ruleinfo\\#getRuleId--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | long |  |
+
+### setRuleSetId(long value) {#setRuleSetId-long-}
+```
+public void setRuleSetId(long value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getRuleSetId()](../../com.aspose.diagram/ruleinfo\\#getRuleSetId--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | long |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/rulerdensity/_index.md
+++ b/german/java/com.aspose.diagram/rulerdensity/_index.md
@@ -1,0 +1,179 @@
+---
+title: RulerDensity
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt die horizontalen Unterteilungen auf dem Lineal für die Seite an.
+type: docs
+weight: 344
+url: /de/java/com.aspose.diagram/rulerdensity/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class RulerDensity
+```
+
+Gibt die horizontalen Unterteilungen auf dem Lineal für die Seite an.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [RulerDensity(int value)](#RulerDensity-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Gibt die horizontalen Unterteilungen auf dem Lineal für die Seite an. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/rulerdensity\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RulerDensity(int value) {#RulerDensity-int-}
+```
+public RulerDensity(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Gibt die horizontalen Unterteilungen auf dem Lineal für die Seite an.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/rulerdensity\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/rulerdensityvalue/_index.md
+++ b/german/java/com.aspose.diagram/rulerdensityvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: RulerDensityValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt die horizontalen Unterteilungen auf dem Lineal für die Seite an.
+type: docs
+weight: 345
+url: /de/java/com.aspose.diagram/rulerdensityvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class RulerDensityValue
+```
+
+Gibt die horizontalen Unterteilungen auf dem Lineal für die Seite an.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [COARSE](#COARSE) | Grob. |
+| [FINE](#FINE) | Fein. |
+| [NORMAL](#NORMAL) | Normal. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### COARSE {#COARSE}
+```
+public static final int COARSE
+```
+
+
+Grob.
+
+### FINE {#FINE}
+```
+public static final int FINE
+```
+
+
+Fein.
+
+### NORMAL {#NORMAL}
+```
+public static final int NORMAL
+```
+
+
+Normal.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/rulergrid/_index.md
+++ b/german/java/com.aspose.diagram/rulergrid/_index.md
@@ -1,0 +1,260 @@
+---
+title: RulerGrid
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält Elemente, die die Einstellungen der Seitenlineale und des Rasters festlegen.
+type: docs
+weight: 346
+url: /de/java/com.aspose.diagram/rulergrid/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class RulerGrid
+```
+
+Enthält Elemente, die die Einstellungen der Lineale und des Rasters der Seite festlegen.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getXGridDensity()](#getXGridDensity--) | Gibt den Nullpunkt auf dem y‑Achsen‑ (vertikalen) Lineal für die Seite an. |
+| [getXGridOrigin()](#getXGridOrigin--) | Gibt die horizontale Koordinate des Rasterursprungs für eine Seite an. |
+| [getXGridSpacing()](#getXGridSpacing--) | Gibt den Abstand zwischen horizontalen Linien in einem festen Raster an (das heißt, ein RulerGrid‑Element, bei dem das XGridDensity‑Element auf 0 gesetzt ist). |
+| [getXRulerDensity()](#getXRulerDensity--) | Gibt die horizontalen Unterteilungen auf dem Lineal für die Seite an. |
+| [getXRulerOrigin()](#getXRulerOrigin--) | Gibt den Nullpunkt auf dem x‑Achsen‑ (horizontalen) Lineal für die Seite an. |
+| [getYGridDensity()](#getYGridDensity--) | Gibt den Typ des vertikalen Rasters an, das für eine Seite verwendet werden soll. |
+| [getYGridOrigin()](#getYGridOrigin--) | Gibt den vertikalen Ursprung des Rasters auf der Seite an. |
+| [getYGridSpacing()](#getYGridSpacing--) | Gibt den Abstand zwischen vertikalen Linien in einem festen Raster an (das heißt, ein RulerGrid‑Element, bei dem das YGridDensity‑Element auf 0 gesetzt ist). |
+| [getYRulerDensity()](#getYRulerDensity--) | Gibt die vertikalen Unterteilungen auf dem Lineal für die Seite an. |
+| [getYRulerOrigin()](#getYRulerOrigin--) | Gibt den Nullpunkt auf dem y‑Achsen‑ (vertikalen) Lineal für die Seite an. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/rulergrid\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getXGridDensity() {#getXGridDensity--}
+```
+public GridDensity getXGridDensity()
+```
+
+
+Gibt den Nullpunkt auf dem y‑Achsen‑ (vertikalen) Lineal für die Seite an.
+
+**Returns:**
+[GridDensity](../../com.aspose.diagram/griddensity)
+### getXGridOrigin() {#getXGridOrigin--}
+```
+public DoubleValue getXGridOrigin()
+```
+
+
+Gibt die horizontale Koordinate des Rasterursprungs für eine Seite an.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getXGridSpacing() {#getXGridSpacing--}
+```
+public DoubleValue getXGridSpacing()
+```
+
+
+Gibt den Abstand zwischen horizontalen Linien in einem festen Raster an (das heißt, ein RulerGrid‑Element, bei dem das XGridDensity‑Element auf 0 gesetzt ist).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getXRulerDensity() {#getXRulerDensity--}
+```
+public RulerDensity getXRulerDensity()
+```
+
+
+Gibt die horizontalen Unterteilungen auf dem Lineal für die Seite an.
+
+**Returns:**
+[RulerDensity](../../com.aspose.diagram/rulerdensity)
+### getXRulerOrigin() {#getXRulerOrigin--}
+```
+public DoubleValue getXRulerOrigin()
+```
+
+
+Gibt den Nullpunkt auf dem x‑Achsen‑ (horizontalen) Lineal für die Seite an.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getYGridDensity() {#getYGridDensity--}
+```
+public GridDensity getYGridDensity()
+```
+
+
+Gibt den Typ des vertikalen Rasters an, das für eine Seite verwendet werden soll.
+
+**Returns:**
+[GridDensity](../../com.aspose.diagram/griddensity)
+### getYGridOrigin() {#getYGridOrigin--}
+```
+public DoubleValue getYGridOrigin()
+```
+
+
+Gibt den vertikalen Ursprung des Rasters auf der Seite an.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getYGridSpacing() {#getYGridSpacing--}
+```
+public DoubleValue getYGridSpacing()
+```
+
+
+Gibt den Abstand zwischen vertikalen Linien in einem festen Raster an (das heißt, ein RulerGrid‑Element, bei dem das YGridDensity‑Element auf 0 gesetzt ist).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getYRulerDensity() {#getYRulerDensity--}
+```
+public RulerDensity getYRulerDensity()
+```
+
+
+Gibt die vertikalen Unterteilungen auf dem Lineal für die Seite an.
+
+**Returns:**
+[RulerDensity](../../com.aspose.diagram/rulerdensity)
+### getYRulerOrigin() {#getYRulerOrigin--}
+```
+public DoubleValue getYRulerOrigin()
+```
+
+
+Gibt den Nullpunkt auf dem y‑Achsen‑ (vertikalen) Lineal für die Seite an.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/rulergrid\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/ruleset/_index.md
+++ b/german/java/com.aspose.diagram/ruleset/_index.md
@@ -1,0 +1,299 @@
+---
+title: RuleSet
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt ein Satz von Diagramm‑Validierungsregeln dar.
+type: docs
+weight: 341
+url: /de/java/com.aspose.diagram/ruleset/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class RuleSet
+```
+
+Stellt ein Satz von Diagramm‑Validierungsregeln dar.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [RuleSet()](#RuleSet--) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDescription()](#getDescription--) | Gibt die Beschreibung des Validierungsregelsets an, die in der Benutzeroberfläche angezeigt wird. |
+| [getEnabled()](#getEnabled--) | Gibt an, ob die Regeln im angegebenen Validierungsregelset geprüft werden, wenn die Validierung für das aktuelle Dokument ausgelöst wird. |
+| [getID()](#getID--) | Gibt den eindeutigen Bezeichner des Validierungsregelsets an. |
+| [getName()](#getName--) | Gibt den lokalen Namen des Validierungsregelsets an. |
+| [getNameU()](#getNameU--) | Gibt den universellen Namen des Validierungsregelsets an. |
+| [getRuleSetFlags()](#getRuleSetFlags--) | Gibt an, ob das Regelset in der Liste 'Zu prüfende Regeln' erscheint. |
+| [getRules()](#getRules--) | Regel Sammlung. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDescription(String value)](#setDescription-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDescription()](../../com.aspose.diagram/ruleset\#getDescription--) |
+| [setEnabled(int value)](#setEnabled-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getEnabled()](../../com.aspose.diagram/ruleset\#getEnabled--) |
+| [setID(long value)](#setID-long-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getID()](../../com.aspose.diagram/ruleset\#getID--) |
+| [setName(String value)](#setName-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getName()](../../com.aspose.diagram/ruleset\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getNameU()](../../com.aspose.diagram/ruleset\#getNameU--) |
+| [setRuleSetFlags(int value)](#setRuleSetFlags-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getRuleSetFlags()](../../com.aspose.diagram/ruleset\#getRuleSetFlags--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RuleSet() {#RuleSet--}
+```
+public RuleSet()
+```
+
+
+Konstruktor.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDescription() {#getDescription--}
+```
+public String getDescription()
+```
+
+
+Gibt die Beschreibung des Validierungsregelsets an, die in der Benutzeroberfläche angezeigt wird. Standard ist ein leerer String.
+
+**Returns:**
+java.lang.String
+### getEnabled() {#getEnabled--}
+```
+public int getEnabled()
+```
+
+
+Gibt an, ob die Regeln im angegebenen Validierungsregelset geprüft werden, wenn die Validierung für das aktuelle Dokument ausgelöst wird. Standard ist Wahr.
+
+**Returns:**
+int
+### getID() {#getID--}
+```
+public long getID()
+```
+
+
+Gibt den eindeutigen Bezeichner des Validierungsregelsets an.
+
+**Returns:**
+long
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Gibt den lokalen Namen des Validierungsregelsets an. Standardwert ist der Wert des NameU-Attributs.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+Gibt den universellen Namen des Validierungsregelsets an.
+
+**Returns:**
+java.lang.String
+### getRuleSetFlags() {#getRuleSetFlags--}
+```
+public int getRuleSetFlags()
+```
+
+
+Gibt an, ob das Regelset in der Liste 'Zu prüfende Regeln' erscheint.
+
+**Returns:**
+int
+### getRules() {#getRules--}
+```
+public RuleCollection getRules()
+```
+
+
+Regel Sammlung.
+
+**Returns:**
+[RuleCollection](../../com.aspose.diagram/rulecollection)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDescription(String value) {#setDescription-java.lang.String-}
+```
+public void setDescription(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDescription()](../../com.aspose.diagram/ruleset\#getDescription--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setEnabled(int value) {#setEnabled-int-}
+```
+public void setEnabled(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getEnabled()](../../com.aspose.diagram/ruleset\#getEnabled--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setID(long value) {#setID-long-}
+```
+public void setID(long value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getID()](../../com.aspose.diagram/ruleset\#getID--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | long |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getName()](../../com.aspose.diagram/ruleset\#getName--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getNameU()](../../com.aspose.diagram/ruleset\#getNameU--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setRuleSetFlags(int value) {#setRuleSetFlags-int-}
+```
+public void setRuleSetFlags(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getRuleSetFlags()](../../com.aspose.diagram/ruleset\#getRuleSetFlags--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/rulesetcollection/_index.md
+++ b/german/java/com.aspose.diagram/rulesetcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: RuleSetCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: RuleSet Sammlung.
+type: docs
+weight: 342
+url: /de/java/com.aspose.diagram/rulesetcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class RuleSetCollection extends Collection
+```
+
+RuleSet Sammlung.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [add(RuleSet ruleSet)](#add-com.aspose.diagram.RuleSet-) | Fügen Sie das ruleSet zur Sammlung hinzu. |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(RuleSet ruleSet)](#remove-com.aspose.diagram.RuleSet-) | Entfernen Sie das ruleSet aus der Sammlung. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(RuleSet ruleSet) {#add-com.aspose.diagram.RuleSet-}
+```
+public int add(RuleSet ruleSet)
+```
+
+
+Fügen Sie das ruleSet zur Sammlung hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| ruleSet | [RuleSet](../../com.aspose.diagram/ruleset) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public RuleSet get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[RuleSet](../../com.aspose.diagram/ruleset) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(RuleSet ruleSet) {#remove-com.aspose.diagram.RuleSet-}
+```
+public void remove(RuleSet ruleSet)
+```
+
+
+Entfernen Sie das ruleSet aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| ruleSet | [RuleSet](../../com.aspose.diagram/ruleset) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/rulevalue/_index.md
+++ b/german/java/com.aspose.diagram/rulevalue/_index.md
@@ -1,0 +1,194 @@
+---
+title: RuleValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Regelwert.
+type: docs
+weight: 343
+url: /de/java/com.aspose.diagram/rulevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class RuleValue
+```
+
+Regelwert.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [RuleValue(String formula, String value)](#RuleValue-java.lang.String-java.lang.String-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFormula()](#getFormula--) | Stellt die Formel des Elements dar. |
+| [getValue()](#getValue--) | Regelwert. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setFormula(String value)](#setFormula-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getFormula()](../../com.aspose.diagram/rulevalue\#getFormula--) |
+| [setValue(String value)](#setValue-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/rulevalue\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RuleValue(String formula, String value) {#RuleValue-java.lang.String-java.lang.String-}
+```
+public RuleValue(String formula, String value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| formula | java.lang.String |  |
+| Wert | java.lang.String |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFormula() {#getFormula--}
+```
+public String getFormula()
+```
+
+
+Stellt die Formel des Elements dar. Dieses Attribut kann einen der folgenden Zeichenketten enthalten: "someFormula", wenn die Formel lokal vorhanden ist, "No Formula", wenn die Formel lokal gelöscht oder blockiert wurde, oder "Inh", wenn die Formel vererbt ist. Wenn das Attribut nicht vorhanden ist, ist die Formel des Elements eine einfache Konstante.
+
+**Returns:**
+java.lang.String
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+Regelwert.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setFormula(String value) {#setFormula-java.lang.String-}
+```
+public void setFormula(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getFormula()](../../com.aspose.diagram/rulevalue\#getFormula--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setValue(String value) {#setValue-java.lang.String-}
+```
+public void setValue(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/rulevalue\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/savefileformat/_index.md
+++ b/german/java/com.aspose.diagram/savefileformat/_index.md
@@ -1,0 +1,309 @@
+---
+title: SaveFileFormat
+second_title: Aspose.Diagram for Java API-Referenz
+description: Aufzählung für die Auswahl des Diagrammformat‑Speicherns.
+type: docs
+weight: 348
+url: /de/java/com.aspose.diagram/savefileformat/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class SaveFileFormat
+```
+
+Aufzählung für die Auswahl des Diagrammformat‑Speicherns.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [BMP](#BMP) | Bmp-Bildformat. |
+| [EMF](#EMF) | EMF-Bildformat. |
+| [GIF](#GIF) | Gif-Format. |
+| [HTML](#HTML) | Html-Format. |
+| [JPEG](#JPEG) | Jpeg-Bildformat. |
+| [PDF](#PDF) | Pdf-Format. |
+| [PNG](#PNG) | Png-Bildformat. |
+| [SVG](#SVG) | Svg-Format. |
+| [TIFF](#TIFF) | Tiff-Bildformat. |
+| [VDX](#VDX) | MS Visio Vdx XML-Format. |
+| [VSDM](#VSDM) | MS Visio Vsdm-Dateiformat, das Makros ermöglicht. |
+| [VSDX](#VSDX) | MS Visio 2013 Vsdx-Dateiformat. |
+| [VSSM](#VSSM) | MS Visio Vssm-Dateiformat, das Makros ermöglicht. |
+| [VSSX](#VSSX) | MS Visio 2013 Vssx-Dateiformat |
+| [VSTM](#VSTM) | MS Visio Vstm-Dateiformat, das Makros ermöglicht. |
+| [VSTX](#VSTX) | MS Visio 2013 Vstx-Dateiformat, Vorlagendatei. |
+| [VSX](#VSX) | MS Visio Vsx XML-Stencil-Format. |
+| [VTX](#VTX) | MS Visio Vst XML-Vorlagenformat. |
+| [XAML](#XAML) | Xaml-Format. |
+| [XPS](#XPS) | Xps-Format. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BMP {#BMP}
+```
+public static final int BMP
+```
+
+
+Bmp-Bildformat.
+
+### EMF {#EMF}
+```
+public static final int EMF
+```
+
+
+EMF-Bildformat.
+
+### GIF {#GIF}
+```
+public static final int GIF
+```
+
+
+Gif-Format.
+
+### HTML {#HTML}
+```
+public static final int HTML
+```
+
+
+Html-Format.
+
+### JPEG {#JPEG}
+```
+public static final int JPEG
+```
+
+
+Jpeg-Bildformat.
+
+### PDF {#PDF}
+```
+public static final int PDF
+```
+
+
+Pdf-Format.
+
+### PNG {#PNG}
+```
+public static final int PNG
+```
+
+
+Png-Bildformat.
+
+### SVG {#SVG}
+```
+public static final int SVG
+```
+
+
+Svg-Format.
+
+### TIFF {#TIFF}
+```
+public static final int TIFF
+```
+
+
+Tiff-Bildformat.
+
+### VDX {#VDX}
+```
+public static final int VDX
+```
+
+
+MS Visio Vdx XML-Format.
+
+### VSDM {#VSDM}
+```
+public static final int VSDM
+```
+
+
+MS Visio Vsdm-Dateiformat, das Makros ermöglicht.
+
+### VSDX {#VSDX}
+```
+public static final int VSDX
+```
+
+
+MS Visio 2013 Vsdx-Dateiformat.
+
+### VSSM {#VSSM}
+```
+public static final int VSSM
+```
+
+
+MS Visio Vssm-Dateiformat, das Makros ermöglicht.
+
+### VSSX {#VSSX}
+```
+public static final int VSSX
+```
+
+
+MS Visio 2013 Vssx-Dateiformat
+
+### VSTM {#VSTM}
+```
+public static final int VSTM
+```
+
+
+MS Visio Vstm-Dateiformat, das Makros ermöglicht.
+
+### VSTX {#VSTX}
+```
+public static final int VSTX
+```
+
+
+MS Visio 2013 Vstx-Dateiformat, Vorlagendatei.
+
+### VSX {#VSX}
+```
+public static final int VSX
+```
+
+
+MS Visio Vsx XML-Stencil-Format.
+
+### VTX {#VTX}
+```
+public static final int VTX
+```
+
+
+MS Visio Vst XML-Vorlagenformat.
+
+### XAML {#XAML}
+```
+public static final int XAML
+```
+
+
+Xaml-Format.
+
+### XPS {#XPS}
+```
+public static final int XPS
+```
+
+
+Xps-Format.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/saveoptions/_index.md
+++ b/german/java/com.aspose.diagram/saveoptions/_index.md
@@ -1,0 +1,216 @@
+---
+title: SaveOptions
+second_title: Aspose.Diagram for Java API-Referenz
+description: Dies ist eine abstrakte Basisklasse für Klassen, die dem Benutzer ermöglichen, zusätzliche Optionen beim Speichern eines Diagramms in einem bestimmten Format anzugeben.
+type: docs
+weight: 349
+url: /de/java/com.aspose.diagram/saveoptions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public abstract class SaveOptions
+```
+
+Dies ist eine abstrakte Basisklasse für Klassen, die dem Benutzer ermöglichen, zusätzliche Optionen beim Speichern eines Diagramms in einem bestimmten Format anzugeben. Eine Instanz der SaveOptions‑Klasse oder einer abgeleiteten Klasse wird an die Stream‑Save‑ oder String‑Save‑Überladungen übergeben, damit der Benutzer benutzerdefinierte Optionen beim Speichern eines Dokuments festlegen kann.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | Erstellt ein Speicheroptionen-Objekt einer Klasse, die für das angegebene Speicherformat geeignet ist. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDefaultFont()](#getDefaultFont--) | Wenn Zeichen im Diagramm Unicode sind und nicht mit dem korrekten Schriftwert gesetzt werden oder die Schriftart nicht lokal installiert ist, können sie in PDF, Bild oder XPS als Block erscheinen. |
+| [getSaveFormat()](#getSaveFormat--) | Gibt das Format an, in dem das Dokument gespeichert wird, wenn dieses SaveOptions‑Objekt verwendet wird. |
+| [getWarningCallback()](#getWarningCallback--) | Warnungs-Callback. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDefaultFont()](../../com.aspose.diagram/saveoptions\\#getDefaultFont--) |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getSaveFormat()](../../com.aspose.diagram/saveoptions\#getSaveFormat--) |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+Erstellt ein Speicheroptionen-Objekt einer Klasse, die für das angegebene Speicherformat geeignet ist.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| saveFormat | int | Das Aspose.Diagram.SaveFileFormat, für das ein Save-Optionen-Objekt erstellt werden soll. |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+Wenn Zeichen im Diagramm Unicode sind und nicht mit dem korrekten Schriftwert gesetzt werden oder die Schriftart nicht lokal installiert ist, können sie im PDF, Bild oder XPS als Block erscheinen. Setzen Sie die DefaultFont, z. B. MingLiu oder MS Gothic, um diese Zeichen anzuzeigen.
+
+**Returns:**
+java.lang.String
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+Gibt das Format an, in dem das Dokument gespeichert wird, wenn dieses SaveOptions‑Objekt verwendet wird.
+
+**Returns:**
+int
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+Warnungs-Callback.
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDefaultFont()](../../com.aspose.diagram/saveoptions\\#getDefaultFont--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getSaveFormat()](../../com.aspose.diagram/saveoptions\#getSaveFormat--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/scratch/_index.md
+++ b/german/java/com.aspose.diagram/scratch/_index.md
@@ -1,0 +1,349 @@
+---
+title: Scratch
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält einen Arbeitsbereich zum Eingeben und Testen von Formeln, auf die von anderen Elementen verwiesen wird.
+type: docs
+weight: 350
+url: /de/java/com.aspose.diagram/scratch/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Scratch
+```
+
+Enthält einen Arbeitsbereich zum Eingeben und Testen von Formeln, auf die von anderen Elementen verwiesen wird. Dieses Element wird typischerweise verwendet, um wiederholte komplexe Berechnungen zu isolieren.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [Scratch()](#Scratch--) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | Ein vielseitiges Element. |
+| [getB()](#getB--) | Ein vielseitiges Scratch-Element. |
+| [getC()](#getC--) | Ein vielseitiges Element. |
+| [getClass()](#getClass--) |  |
+| [getD()](#getD--) | Ein vielseitiges Element. |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getIX()](#getIX--) | Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements. |
+| [getX()](#getX--) | Gibt eine x-Koordinate eines Shapes in lokalen Koordinaten an. |
+| [getY()](#getY--) | Gibt eine y-Koordinate eines Shapes in lokalen Koordinaten an. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(Value value)](#setA-com.aspose.diagram.Value-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getA()](../../com.aspose.diagram/scratch\#getA--) |
+| [setB(Value value)](#setB-com.aspose.diagram.Value-) | Für die Beschreibung dieser Eigenschaft siehe [getB()](../../com.aspose.diagram/scratch\#getB--) |
+| [setC(Value value)](#setC-com.aspose.diagram.Value-) | Für die Beschreibung dieser Eigenschaft siehe [getC()](../../com.aspose.diagram/scratch\#getC--) |
+| [setD(Value value)](#setD-com.aspose.diagram.Value-) | Für die Beschreibung dieser Eigenschaft siehe [getD()](../../com.aspose.diagram/scratch\#getD--) |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft siehe [getDel()](../../com.aspose.diagram/scratch\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Für die Beschreibung dieser Eigenschaft siehe [getIX()](../../com.aspose.diagram/scratch\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe [getX()](../../com.aspose.diagram/scratch\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe [getY()](../../com.aspose.diagram/scratch\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Scratch() {#Scratch--}
+```
+public Scratch()
+```
+
+
+Konstruktor.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public Value getA()
+```
+
+
+Ein vielseitiges Element.
+
+**Returns:**
+[Value](../../com.aspose.diagram/value)
+### getB() {#getB--}
+```
+public Value getB()
+```
+
+
+Ein vielseitiges Scratch-Element.
+
+**Returns:**
+[Value](../../com.aspose.diagram/value)
+### getC() {#getC--}
+```
+public Value getC()
+```
+
+
+Ein vielseitiges Element.
+
+**Returns:**
+[Value](../../com.aspose.diagram/value)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getD() {#getD--}
+```
+public Value getD()
+```
+
+
+Ein vielseitiges Element.
+
+**Returns:**
+[Value](../../com.aspose.diagram/value)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+Gibt eine x-Koordinate eines Objekts in lokalen Koordinaten an. Die folgende Tabelle beschreibt das X-Element basierend auf dem Element, das es enthält.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+Gibt eine y-Koordinate eines Objekts in lokalen Koordinaten an. Lokale Koordinaten sind solche, deren Bezugspunkt das Objekt und nicht die Seite ist.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(Value value) {#setA-com.aspose.diagram.Value-}
+```
+public void setA(Value value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getA()](../../com.aspose.diagram/scratch\#getA--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [Value](../../com.aspose.diagram/value) |  |
+
+### setB(Value value) {#setB-com.aspose.diagram.Value-}
+```
+public void setB(Value value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getB()](../../com.aspose.diagram/scratch\#getB--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [Value](../../com.aspose.diagram/value) |  |
+
+### setC(Value value) {#setC-com.aspose.diagram.Value-}
+```
+public void setC(Value value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getC()](../../com.aspose.diagram/scratch\#getC--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [Value](../../com.aspose.diagram/value) |  |
+
+### setD(Value value) {#setD-com.aspose.diagram.Value-}
+```
+public void setD(Value value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getD()](../../com.aspose.diagram/scratch\#getD--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [Value](../../com.aspose.diagram/value) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getDel()](../../com.aspose.diagram/scratch\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getIX()](../../com.aspose.diagram/scratch\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getX()](../../com.aspose.diagram/scratch\#getX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getY()](../../com.aspose.diagram/scratch\#getY--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/scratchcollection/_index.md
+++ b/german/java/com.aspose.diagram/scratchcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: ScratchCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: Scratch-Sammlung.
+type: docs
+weight: 351
+url: /de/java/com.aspose.diagram/scratchcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ScratchCollection extends Collection
+```
+
+Scratch-Sammlung.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [add(Scratch item)](#add-com.aspose.diagram.Scratch-) | Füge das Scratch-Objekt zur Sammlung hinzu. |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Scratch item)](#remove-com.aspose.diagram.Scratch-) | Entferne das Scratch-Objekt aus der Sammlung. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Scratch item) {#add-com.aspose.diagram.Scratch-}
+```
+public int add(Scratch item)
+```
+
+
+Füge das Scratch-Objekt zur Sammlung hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [Scratch](../../com.aspose.diagram/scratch) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Scratch get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[Scratch](../../com.aspose.diagram/scratch) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Scratch item) {#remove-com.aspose.diagram.Scratch-}
+```
+public void remove(Scratch item)
+```
+
+
+Entferne das Scratch-Objekt aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [Scratch](../../com.aspose.diagram/scratch) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/scrollbaractivexcontrol/_index.md
+++ b/german/java/com.aspose.diagram/scrollbaractivexcontrol/_index.md
@@ -1,0 +1,572 @@
+---
+title: ScrollBarActiveXControl
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt das ScrollBar-Steuerelement dar.
+type: docs
+weight: 352
+url: /de/java/com.aspose.diagram/scrollbaractivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol), [com.aspose.diagram.SpinButtonActiveXControl](../../com.aspose.diagram/spinbuttonactivexcontrol)
+```
+public class ScrollBarActiveXControl extends SpinButtonActiveXControl
+```
+
+Stellt das ScrollBar-Steuerelement dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBackOleColor()](#getBackOleColor--) | die OLE‑Farbe des Hintergrunds. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | die Binärdaten des Steuerelements. |
+| [getForeOleColor()](#getForeOleColor--) | die OLE‑Farbe des Vordergrunds. |
+| [getHeight()](#getHeight--) | die Höhe des Steuerelements in Punkt‑Einheiten. |
+| [getIMEMode()](#getIMEMode--) | der Standard‑Laufzeitmodus des Input Method Editors für das Steuerelement, wenn es den Fokus erhält. |
+| [getLargeChange()](#getLargeChange--) | der Betrag, um den sich die Eigenschaft Position ändert |
+| [getMax()](#getMax--) | der maximal zulässige Wert. |
+| [getMin()](#getMin--) | der minimal zulässige Wert. |
+| [getMouseIcon()](#getMouseIcon--) | ein benutzerdefiniertes Symbol, das als Mauszeiger für das Steuerelement angezeigt wird. |
+| [getMousePointer()](#getMousePointer--) | der Typ des als Mauszeiger für das Steuerelement angezeigten Symbols. |
+| [getOrientation()](#getOrientation--) | ob die SpinButton‑ oder ScrollBar‑Steuerung vertikal oder horizontal ausgerichtet ist. |
+| [getPosition()](#getPosition--) | der Wert. |
+| [getSmallChange()](#getSmallChange--) | der Betrag, um den sich die Eigenschaft Position ändert |
+| [getType()](#getType--) | Ermittelt den Typ des ActiveX-Steuerelements. |
+| [getWidth()](#getWidth--) | die Breite des Steuerelements in Punkt-Einheiten. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | Gibt an, ob das Steuerelement automatisch die Größe ändert, um seinen gesamten Inhalt anzuzeigen. |
+| [isEnabled()](#isEnabled--) | Gibt an, ob das Steuerelement den Fokus erhalten und auf benutzergenerierte Ereignisse reagieren kann. |
+| [isLocked()](#isLocked--) | Gibt an, ob Daten im Steuerelement für die Bearbeitung gesperrt sind. |
+| [isTransparent()](#isTransparent--) | Gibt an, ob das Steuerelement transparent ist. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setHeight(double value)](#setHeight-double-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setIMEMode(int value)](#setIMEMode-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) |
+| [setLargeChange(int value)](#setLargeChange-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getLargeChange()](../../com.aspose.diagram/scrollbaractivexcontrol\#getLargeChange--) |
+| [setLocked(boolean value)](#setLocked-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) |
+| [setMax(int value)](#setMax-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getMax()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getMax--) |
+| [setMin(int value)](#setMin-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getMin()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getMin--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | Für die Beschreibung dieser Eigenschaft siehe bitte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setOrientation(int value)](#setOrientation-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getOrientation()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getOrientation--) |
+| [setPosition(int value)](#setPosition-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getPosition()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getPosition--) |
+| [setSmallChange(int value)](#setSmallChange-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getSmallChange()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getSmallChange--) |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) |
+| [setWidth(double value)](#setWidth-double-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+die OLE‑Farbe des Hintergrunds.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+die Binärdaten des Steuerelements.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+Die OLE-Farbe des Vordergrunds. Gilt nicht für das Image-Steuerelement.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+die Höhe des Steuerelements in Punkt‑Einheiten.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+der Standard‑Laufzeitmodus des Input Method Editors für das Steuerelement, wenn es den Fokus erhält.
+
+**Returns:**
+int
+### getLargeChange() {#getLargeChange--}
+```
+public int getLargeChange()
+```
+
+
+der Betrag, um den sich die Eigenschaft Position ändert
+
+**Returns:**
+int
+### getMax() {#getMax--}
+```
+public int getMax()
+```
+
+
+der maximal zulässige Wert.
+
+**Returns:**
+int
+### getMin() {#getMin--}
+```
+public int getMin()
+```
+
+
+der minimal zulässige Wert.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+ein benutzerdefiniertes Symbol, das als Mauszeiger für das Steuerelement angezeigt wird.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+der Typ des als Mauszeiger für das Steuerelement angezeigten Symbols.
+
+**Returns:**
+int
+### getOrientation() {#getOrientation--}
+```
+public int getOrientation()
+```
+
+
+ob die SpinButton‑ oder ScrollBar‑Steuerung vertikal oder horizontal ausgerichtet ist.
+
+**Returns:**
+int
+### getPosition() {#getPosition--}
+```
+public int getPosition()
+```
+
+
+der Wert.
+
+**Returns:**
+int
+### getSmallChange() {#getSmallChange--}
+```
+public int getSmallChange()
+```
+
+
+der Betrag, um den sich die Eigenschaft Position ändert
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Ermittelt den Typ des ActiveX-Steuerelements.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+die Breite des Steuerelements in Punkt-Einheiten.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+Gibt an, ob das Steuerelement automatisch die Größe ändert, um seinen gesamten Inhalt anzuzeigen.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+Gibt an, ob das Steuerelement den Fokus erhalten und auf benutzergenerierte Ereignisse reagieren kann.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+Gibt an, ob Daten im Steuerelement für die Bearbeitung gesperrt sind.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+Gibt an, ob das Steuerelement transparent ist.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setLargeChange(int value) {#setLargeChange-int-}
+```
+public void setLargeChange(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getLargeChange()](../../com.aspose.diagram/scrollbaractivexcontrol\#getLargeChange--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setMax(int value) {#setMax-int-}
+```
+public void setMax(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getMax()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getMax--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setMin(int value) {#setMin-int-}
+```
+public void setMin(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getMin()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getMin--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setOrientation(int value) {#setOrientation-int-}
+```
+public void setOrientation(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getOrientation()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getOrientation--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setPosition(int value) {#setPosition-int-}
+```
+public void setPosition(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getPosition()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getPosition--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setSmallChange(int value) {#setSmallChange-int-}
+```
+public void setSmallChange(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getSmallChange()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getSmallChange--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/selectmode/_index.md
+++ b/german/java/com.aspose.diagram/selectmode/_index.md
@@ -1,0 +1,179 @@
+---
+title: SelectMode
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt an, wie der Benutzer eine Gruppenform und deren Mitglieder auswählt.
+type: docs
+weight: 353
+url: /de/java/com.aspose.diagram/selectmode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class SelectMode
+```
+
+Gibt an, wie der Benutzer eine Gruppenform und deren Mitglieder auswählt.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [SelectMode(int value)](#SelectMode-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Gibt an, wie der Benutzer eine Gruppenform und deren Mitglieder auswählt. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/selectmode\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SelectMode(int value) {#SelectMode-int-}
+```
+public SelectMode(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Gibt an, wie der Benutzer eine Gruppenform und deren Mitglieder auswählt.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/selectmode\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/selectmodevalue/_index.md
+++ b/german/java/com.aspose.diagram/selectmodevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: SelectModeValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt an, wie der Benutzer eine Gruppenform und deren Mitglieder auswählt.
+type: docs
+weight: 354
+url: /de/java/com.aspose.diagram/selectmodevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class SelectModeValue
+```
+
+Gibt an, wie der Benutzer eine Gruppenform und deren Mitglieder auswählt.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [GROUP_SHAPE_FIRST](#GROUP-SHAPE-FIRST) | Wählen Sie zuerst die Gruppenform aus. |
+| [GROUP_SHAPE_ONLY](#GROUP-SHAPE-ONLY) | Wählen Sie nur die Gruppenform aus. |
+| [MEMBERS_GROUP_FIRST](#MEMBERS-GROUP-FIRST) | Wählen Sie zuerst die Mitglieder der Gruppe aus. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GROUP_SHAPE_FIRST {#GROUP-SHAPE-FIRST}
+```
+public static final int GROUP_SHAPE_FIRST
+```
+
+
+Wählen Sie zuerst die Gruppenform aus.
+
+### GROUP_SHAPE_ONLY {#GROUP-SHAPE-ONLY}
+```
+public static final int GROUP_SHAPE_ONLY
+```
+
+
+Wählen Sie nur die Gruppenform aus.
+
+### MEMBERS_GROUP_FIRST {#MEMBERS-GROUP-FIRST}
+```
+public static final int MEMBERS_GROUP_FIRST
+```
+
+
+Wählen Sie zuerst die Mitglieder der Gruppe aus.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/shape/_index.md
+++ b/german/java/com.aspose.diagram/shape/_index.md
@@ -1,0 +1,1760 @@
+---
+title: Form
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält Elemente, die eine Form in einer Masterseite oder einem Gruppenelement definieren.
+type: docs
+weight: 355
+url: /de/java/com.aspose.diagram/shape/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Shape
+```
+
+Enthält Elemente, die eine Form in einem Master, einer Seite oder einem Gruppenform-Element definieren.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [Shape()](#Shape--) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [bringForward()](#bringForward--) | Verschiebt die Form um eine Position nach vorne in der Z‑Reihenfolge. |
+| [bringToFront()](#bringToFront--) | Verschiebt die Form an die Spitze der Z‑Reihenfolge. |
+| [centerDrawing()](#centerDrawing--) | Zentriere die Form relativ zur Ausdehnung der Seite. |
+| [connectedShapes(int flag, String categoryFilter)](#connectedShapes-int-java.lang.String-) | Gibt ein Array zurück, das die Bezeichner (IDs) der Formen enthält, die mit der Form verbunden sind. |
+| [copy(Shape source)](#copy-com.aspose.diagram.Shape-) |  |
+| [dependsOnShapes()](#dependsOnShapes--) | Gibt ein Array zurück, das die Bezeichner der Formen enthält, die von einer Form abhängen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getActiveXControl()](#getActiveXControl--) | Liefert das ActiveX‑Steuerelement. |
+| [getActs()](#getActs--) | Enthält eine Sammlung von Act-Elementen. |
+| [getAlign()](#getAlign--) | Gibt die Ausrichtung einer Form relativ zur Führungslinie oder zum Führungspunkt an, an dem die Form befestigt ist. |
+| [getChars()](#getChars--) | Enthält eine Sammlung von Char-Elementen. |
+| [getClass()](#getClass--) |  |
+| [getClippingPath()](#getClippingPath--) |  |
+| [getConnectionABCDs()](#getConnectionABCDs--) | Enthält eine Sammlung von ConnectionABCD-Elementen. |
+| [getConnections()](#getConnections--) | Enthält eine Sammlung von Connection-Elementen. |
+| [getConnectorRule()](#getConnectorRule--) | Gibt ein connectorRule zurück, das die Form‑ID und die Verbindung enthält, die mit der Form verbunden sind. |
+| [getConnectorsType()](#getConnectorsType--) | Connector‑Typ abrufen. |
+| [getControlData()](#getControlData--) | Liest die Daten des Steuerelements. |
+| [getControls()](#getControls--) | Enthält eine Sammlung von Control‑Elementen. |
+| [getData1()](#getData1--) | Enthält einen beliebigen Zeichenkettenwert, der verwendet wird, um zusätzliche Informationen über eine Form bereitzustellen. |
+| [getData2()](#getData2--) | Enthält einen beliebigen Zeichenkettenwert, der verwendet wird, um zusätzliche Informationen über eine Form bereitzustellen. |
+| [getData3()](#getData3--) | Enthält einen beliebigen Zeichenkettenwert, der verwendet wird, um zusätzliche Informationen über eine Form bereitzustellen. |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getDiagram()](#getDiagram--) | Stammelement der Visio-Objekthierarchie. |
+| [getDisplayText()](#getDisplayText--) | Den auf der Oberfläche angezeigten Text abrufen. |
+| [getEvent()](#getEvent--) | Enthält Elemente, die Formeln angeben, die Formereignisse steuern. |
+| [getFields()](#getFields--) | Enthält eine Sammlung von Field‑Elementen. |
+| [getFill()](#getFill--) | Enthält die aktuellen Füllformatierungswerte für die Form und den Formschatten, einschließlich Muster, Vordergrundfarbe und Hintergrundfarbe. |
+| [getFillStyle()](#getFillStyle--) | StyleSheet, von dem diese Form die Füllformatierung erbt. |
+| [getForeign()](#getForeign--) | Enthält Elemente, die die Breite und Höhe eines Objekts aus einem anderen Programm angeben, das in einem Microsoft Visio-Dokument verwendet wird. |
+| [getForeignData()](#getForeignData--) | Enthält einen MIME (Multipurpose Internet Mail Extensions) codierten BLOB von Bilddaten, wie Windows-Metadatei, Bitmap oder OLE-Daten. |
+| [getGeoms()](#getGeoms--) | Enthält eine Sammlung von Geom‑Elementen. |
+| [getGroup()](#getGroup--) | Enthält Elemente, die steuern, wie Sie Formen zu einer Gruppe hinzufügen, Gruppenmitglieder verschieben und Gruppen auswählen. |
+| [getHelp()](#getHelp--) | Enthält Elemente, die das Hilfedatei-Thema und die Copyright-Informationen des Shape-Elements angeben. |
+| [getHyperlinks()](#getHyperlinks--) | Enthält eine Sammlung von Hyperlink-Elementen. |
+| [getID()](#getID--) | Die eindeutige ID des Elements innerhalb seines übergeordneten Elements. |
+| [getImage()](#getImage--) | Enthält die Gamma-, Helligkeits-, Kontrast-, Unschärfe-, Schärfungs-, Rauschunterdrückungs- und Transparenzwerte für ein Bitmap. |
+| [getInheritChars()](#getInheritChars--) | Enthält die Zeichenwerte für die Form, die vom Master‑Shape geerbt werden. |
+| [getInheritFill()](#getInheritFill--) | Enthält die Füllformatierungswerte für die Form, die vom übergeordneten Stil und dem Master‑Shape geerbt werden. |
+| [getInheritGeoms()](#getInheritGeoms--) | Enthält die Geoms-Werte für die Form, die vom Master-Shape geerbt wird. |
+| [getInheritLine()](#getInheritLine--) | Enthält die Linienformatierungswerte für die Form, die vom übergeordneten Stil und dem Master-Shape geerbt wird. |
+| [getInheritParas()](#getInheritParas--) | Enthält die Paras für die Form, die vom übergeordneten Stil und dem Master-Shape geerbt wird. |
+| [getInheritProps()](#getInheritProps--) | Enthält die Props für die Form, die vom Master-Shape geerbt wird. |
+| [getInheritTextBlock()](#getInheritTextBlock--) | Enthält die Textblock-Werte für die Form, die vom übergeordneten Stil und dem Master-Shape geerbt wird. |
+| [getInheritUsers()](#getInheritUsers--) | Enthält die Benutzer für die Form, die vom Master-Shape geerbt wird. |
+| [getLayerMem()](#getLayerMem--) | Enthält das Element LayerMember, das jede Ebene angibt, der die Form zugewiesen ist. |
+| [getLayout()](#getLayout--) | Enthält Elemente, die die Platzierung von Formen und die Routing‑Einstellungen von Verbindern steuern. |
+| [getLine()](#getLine--) | Enthält Elemente, die Linienattribute für eine Form steuern, wie Muster, Stärke und Farbe. |
+| [getLineStyle()](#getLineStyle--) | StyleSheet, von dem diese Form die Linienformatierung erbt |
+| [getMaster()](#getMaster--) | Der Master, von dem die Form ihre Daten erbt. |
+| [getMasterShape()](#getMasterShape--) | Dieses Attribut darf nur in Formen vorhanden sein, die Mitglieder einer Gruppenform sind, und die Gruppe ist eine Instanz eines Masters. |
+| [getMisc()](#getMisc--) | Enthält Elemente, die das Hilfedatei-Thema und die Copyright-Informationen des Shape-Elements angeben. |
+| [getName()](#getName--) | Der Name des Elements. |
+| [getNameU()](#getNameU--) | Der universelle Name des Elements. |
+| [getOneD()](#getOneD--) | Bestimmt, ob sich die Form als eindimensionales (1‑D) Objekt verhält. |
+| [getPage()](#getPage--) | Stammelement der Visio-Objekthierarchie. |
+| [getParas()](#getParas--) | Enthält eine Sammlung von Para-Elementen. |
+| [getParentShape()](#getParentShape--) | Elternteil der Form. |
+| [getProps()](#getProps--) | Enthält eine Sammlung von Prop-Elementen. |
+| [getProtection()](#getProtection--) | Sperren hilft, unbeabsichtigte Änderungen an der Form zu verhindern, verhindert jedoch nicht, dass Microsoft Visio Werte unter anderen Umständen zurücksetzt. |
+| [getPureText()](#getPureText--) | Liefere die Textzeichenfolge |
+| [getRootShape()](#getRootShape--) | Gibt die übergeordnete Form einer Instanz zurück, wenn diese Form Teil einer Master-Instanz ist. |
+| [getScratchs()](#getScratchs--) | Enthält eine Sammlung von Scratch-Elementen. |
+| [getShapes()](#getShapes--) | Enthält eine Sammlung von Shape-Elementen. |
+| [getSmartTagDefs()](#getSmartTagDefs--) | Enthält eine Sammlung von SmartTagDef-Elementen. |
+| [getTabsCollection()](#getTabsCollection--) | Enthält eine Sammlung von Tab-Elementen. |
+| [getText()](#getText--) | Enthält den Text einer Form. |
+| [getTextBlock()](#getTextBlock--) | Enthält Elemente, die die Ausrichtung, Ränder und Standard-Tabstopp-Positionen des Textes im Textblock einer Form festlegen. |
+| [getTextStyle()](#getTextStyle--) | StyleSheet, von dem diese Form die Textformatierung erbt. |
+| [getTextXForm()](#getTextXForm--) | Enthält Elemente, die Positionsinformationen zum Textblock einer Form angeben. |
+| [getThreeDFormat()](#getThreeDFormat--) | Liefert das ThreeDFormat. |
+| [getTwoD()](#getTwoD--) | Bestimmt, ob sich die Form als zweidimensionales (2‑D) Objekt verhält. |
+| [getType()](#getType--) | Der Typ einer Form. |
+| [getUniqueID()](#getUniqueID--) | Eine GUID (global eindeutiger Bezeichner), die der Form zugewiesen ist. |
+| [getUsers()](#getUsers--) | Enthält eine Sammlung von User-Elementen. |
+| [getXForm()](#getXForm--) | Enthält Elemente, die allgemeine Positionsinformationen zu einer Form angeben. |
+| [getXForm1D()](#getXForm1D--) | Enthält x- und y-Koordinaten des Anfangs- und Endpunkts einer 1‑D‑Form. |
+| [getZOrderIndex()](#getZOrderIndex--) | Gibt den Index einer Form in der Z-Reihenfolge zurück, ausgenommen die Leitform. |
+| [gluedShapes(int flag, String categoryFilter, Shape otherShape)](#gluedShapes-int-java.lang.String-com.aspose.diagram.Shape-) | Gibt ein Array zurück, das die Bezeichner der Formen enthält, die an einer Form geklebt sind. |
+| [hashCode()](#hashCode--) |  |
+| [isConnected(Shape shape)](#isConnected-com.aspose.diagram.Shape-) | Gibt an, ob diese beiden Formen verbunden sind. |
+| [isContain(Shape shape)](#isContain-com.aspose.diagram.Shape-) | Gibt an, ob diese Form eine andere Form enthält. |
+| [isGlued(Shape shape)](#isGlued-com.aspose.diagram.Shape-) | Gibt an, ob diese beiden Formen geklebt sind. |
+| [isInGroup()](#isInGroup--) | Gibt an, ob diese Form in einer Gruppenform ist. |
+| [isIntersect(Shape shape)](#isIntersect-com.aspose.diagram.Shape-) | Gibt an, ob diese Form eine andere Form schneidet. |
+| [isTextEmpty()](#isTextEmpty--) | Gibt an, ob die Form Text hat und ob der Text leer ist oder nicht. |
+| [move(double dX, double dY)](#move-double-double-) | Verschiebt die Form um dX und dY Zoll von der aktuellen Position. |
+| [moveTo(double newPinX, double newPinY)](#moveTo-double-double-) | Verschiebt die Form an eine neue absolute Position auf der Seite. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [refreshData()](#refreshData--) | Aktualisiert die Position der Form einschließlich xform ,Verbindung und Geometrie, wenn der Text der Form oder anderer geändert wird . |
+| [replaceText(String text, String replaceText)](#replaceText-java.lang.String-java.lang.String-) | Ersetzt die Textzeichenkette einer Form . |
+| [sendBackward()](#sendBackward--) | Verschiebt die Form um eine Position im Z-Order zurück. |
+| [sendToBack()](#sendToBack--) | Verschiebt die Form an den hinteren Rand des Z-Order. |
+| [setAngle(double angle)](#setAngle-double-) | Setzt den neuen Winkel der Form. |
+| [setClippingPath(String value)](#setClippingPath-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getClippingPath()](../../com.aspose.diagram/shape\#getClippingPath--) |
+| [setConnectorsType(int type)](#setConnectorsType-int-) | Setzt den Typ der Anschlüsse |
+| [setData1(String value)](#setData1-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getData1()](../../com.aspose.diagram/shape\#getData1--) |
+| [setData2(String value)](#setData2-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getData2()](../../com.aspose.diagram/shape\#getData2--) |
+| [setData3(String value)](#setData3-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getData3()](../../com.aspose.diagram/shape\#getData3--) |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/shape\#getDel--) |
+| [setDiagram(Diagram value)](#setDiagram-com.aspose.diagram.Diagram-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDiagram()](../../com.aspose.diagram/shape\#getDiagram--) |
+| [setEvent(Event value)](#setEvent-com.aspose.diagram.Event-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getEvent()](../../com.aspose.diagram/shape\#getEvent--) |
+| [setFillStyle(StyleSheet value)](#setFillStyle-com.aspose.diagram.StyleSheet-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getFillStyle()](../../com.aspose.diagram/shape\#getFillStyle--) |
+| [setHeight(double height)](#setHeight-double-) | Setzt die neue Höhe der Form. |
+| [setID(long value)](#setID-long-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getID()](../../com.aspose.diagram/shape\#getID--) |
+| [setLineStyle(StyleSheet value)](#setLineStyle-com.aspose.diagram.StyleSheet-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getLineStyle()](../../com.aspose.diagram/shape\#getLineStyle--) |
+| [setMaster(Master value)](#setMaster-com.aspose.diagram.Master-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getMaster()](../../com.aspose.diagram/shape\#getMaster--) |
+| [setMasterShape(Shape value)](#setMasterShape-com.aspose.diagram.Shape-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getMasterShape()](../../com.aspose.diagram/shape\#getMasterShape--) |
+| [setName(String value)](#setName-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getName()](../../com.aspose.diagram/shape\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getNameU()](../../com.aspose.diagram/shape\#getNameU--) |
+| [setPage(Page value)](#setPage-com.aspose.diagram.Page-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getPage()](../../com.aspose.diagram/shape\#getPage--) |
+| [setParentShape(Shape value)](#setParentShape-com.aspose.diagram.Shape-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getParentShape()](../../com.aspose.diagram/shape\#getParentShape--) |
+| [setPresetTheme(int value)](#setPresetTheme-int-) | Wende ein vordefiniertes Design auf diese Form an |
+| [setPresetThemeQuickStyle(int value)](#setPresetThemeQuickStyle-int-) | Wende einen vordefinierten Designvarianten-Quickstyle auf diese Form an |
+| [setPresetThemeStyleMatrics(int styleIndex, int colorIndex)](#setPresetThemeStyleMatrics-int-int-) | Wende einen vordefinierten Designvarianten-Quickstyle auf diese Form an, wie Designstil-Optionen in der Dropdown-Liste der Formstile |
+| [setPresetThemeVariant(int value)](#setPresetThemeVariant-int-) | Wende eine vordefinierte Designvariante auf diese Form an |
+| [setProps(PropCollection value)](#setProps-com.aspose.diagram.PropCollection-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getProps()](../../com.aspose.diagram/shape\#getProps--) |
+| [setText(Text value)](#setText-com.aspose.diagram.Text-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getText()](../../com.aspose.diagram/shape\#getText--) |
+| [setTextStyle(StyleSheet value)](#setTextStyle-com.aspose.diagram.StyleSheet-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getTextStyle()](../../com.aspose.diagram/shape\#getTextStyle--) |
+| [setTwoD(boolean value)](#setTwoD-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getTwoD()](../../com.aspose.diagram/shape\#getTwoD--) |
+| [setType(int value)](#setType-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getType()](../../com.aspose.diagram/shape\#getType--) |
+| [setUniqueID(UUID value)](#setUniqueID-java.util.UUID-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getUniqueID()](../../com.aspose.diagram/shape\#getUniqueID--) |
+| [setWidth(double width)](#setWidth-double-) | Setzt die neue Breite der Form. |
+| [setXForm(XForm value)](#setXForm-com.aspose.diagram.XForm-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getXForm()](../../com.aspose.diagram/shape\#getXForm--) |
+| [setXForm1D(XForm1D value)](#setXForm1D-com.aspose.diagram.XForm1D-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getXForm1D()](../../com.aspose.diagram/shape\#getXForm1D--) |
+| [toHTML(InputStream stream, HTMLSaveOptions options)](#toHTML-java.io.InputStream-com.aspose.diagram.HTMLSaveOptions-) | Erstellt das HTML der Form und speichert es in einem Stream im angegebenen Format. |
+| [toHTML(OutputStream stream, HTMLSaveOptions options)](#toHTML-java.io.OutputStream-com.aspose.diagram.HTMLSaveOptions-) | Erstellt das HTML der Form und speichert es in einem Stream im angegebenen Format. |
+| [toHTML(String fileName, HTMLSaveOptions options)](#toHTML-java.lang.String-com.aspose.diagram.HTMLSaveOptions-) | Erstellt das HTML und speichert es in einer Datei. |
+| [toImage(InputStream stream, ImageSaveOptions options)](#toImage-java.io.InputStream-com.aspose.diagram.ImageSaveOptions-) | Erstellt das Bild der Form und speichert es in einem Stream im angegebenen Format. |
+| [toImage(OutputStream stream, ImageSaveOptions options)](#toImage-java.io.OutputStream-com.aspose.diagram.ImageSaveOptions-) | Erstellt das Bild der Form und speichert es in einem Stream im angegebenen Format. |
+| [toImage(String imageFile, ImageSaveOptions options)](#toImage-java.lang.String-com.aspose.diagram.ImageSaveOptions-) | Erstellt das Bild der Form und speichert es in einer Datei. |
+| [toPdf(InputStream stream)](#toPdf-java.io.InputStream-) | Erstellt das PDF der Form und speichert es in einem Stream. |
+| [toPdf(OutputStream stream)](#toPdf-java.io.OutputStream-) | Erstellt das PDF der Form und speichert es in einem Stream. |
+| [toPdf(String fileName)](#toPdf-java.lang.String-) | Speichert die Form in einer PDF-Datei. |
+| [toString()](#toString--) |  |
+| [toSvg(String imageFile, SVGSaveOptions options)](#toSvg-java.lang.String-com.aspose.diagram.SVGSaveOptions-) | Speichert die Form in einer SVG-Datei. |
+| [ungroup()](#ungroup--) | Form entgruppieren |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Shape() {#Shape--}
+```
+public Shape()
+```
+
+
+Konstruktor.
+
+### bringForward() {#bringForward--}
+```
+public void bringForward()
+```
+
+
+Verschiebt die Form um eine Position nach vorne in der Z‑Reihenfolge.
+
+### bringToFront() {#bringToFront--}
+```
+public void bringToFront()
+```
+
+
+Verschiebt die Form an die Spitze der Z‑Reihenfolge.
+
+### centerDrawing() {#centerDrawing--}
+```
+public void centerDrawing()
+```
+
+
+Zentriere die Form relativ zur Ausdehnung der Seite.
+
+### connectedShapes(int flag, String categoryFilter) {#connectedShapes-int-java.lang.String-}
+```
+public long[] connectedShapes(int flag, String categoryFilter)
+```
+
+
+Gibt ein Array zurück, das die Bezeichner (IDs) der Formen enthält, die mit der Form verbunden sind.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Flag | int | Filtert das Array der zurückgegebenen Form-IDs nach der Richtung der Verbinder. Siehe Anmerkungen für mögliche Werte Aspose.Diagram.ConnectedShapesFlags. |
+| categoryFilter | java.lang.String | Filtert das Array der zurückgegebenen Shape-IDs, indem es auf die IDs von Shapes beschränkt wird, die der angegebenen categoryString entsprechen. |
+
+**Returns:**
+long[] - IDs-Array.
+### copy(Shape source) {#copy-com.aspose.diagram.Shape-}
+```
+public void copy(Shape source)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| source | [Shape](../../com.aspose.diagram/shape) |  |
+
+### dependsOnShapes() {#dependsOnShapes--}
+```
+public long[] dependsOnShapes()
+```
+
+
+Gibt ein Array zurück, das die Bezeichner der Formen enthält, die von einer Form abhängen.
+
+**Returns:**
+long[] - IDs-Array.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getActiveXControl() {#getActiveXControl--}
+```
+public ActiveXControl getActiveXControl()
+```
+
+
+Liefert das ActiveX‑Steuerelement.
+
+**Returns:**
+[ActiveXControl](../../com.aspose.diagram/activexcontrol)
+### getActs() {#getActs--}
+```
+public ActCollection getActs()
+```
+
+
+Enthält eine Sammlung von Act-Elementen.
+
+**Returns:**
+[ActCollection](../../com.aspose.diagram/actcollection)
+### getAlign() {#getAlign--}
+```
+public Align getAlign()
+```
+
+
+Gibt die Ausrichtung einer Form in Bezug auf die Führung oder den Führungspunkt an, an dem die Form befestigt ist. Das Align-Element erscheint nur bei Formen, die an Führungen oder Führungspunkten befestigt sind.
+
+**Returns:**
+[Align](../../com.aspose.diagram/align)
+### getChars() {#getChars--}
+```
+public CharCollection getChars()
+```
+
+
+Enthält eine Sammlung von Char-Elementen.
+
+**Returns:**
+[CharCollection](../../com.aspose.diagram/charcollection)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getClippingPath() {#getClippingPath--}
+```
+public String getClippingPath()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getConnectionABCDs() {#getConnectionABCDs--}
+```
+public ConnectionABCDCollection getConnectionABCDs()
+```
+
+
+Enthält eine Sammlung von ConnectionABCD-Elementen.
+
+**Returns:**
+[ConnectionABCDCollection](../../com.aspose.diagram/connectionabcdcollection)
+### getConnections() {#getConnections--}
+```
+public ConnectionCollection getConnections()
+```
+
+
+Enthält eine Sammlung von Connection-Elementen.
+
+**Returns:**
+[ConnectionCollection](../../com.aspose.diagram/connectioncollection)
+### getConnectorRule() {#getConnectorRule--}
+```
+public ConnectorRule getConnectorRule()
+```
+
+
+Gibt ein connectorRule zurück, das die Form‑ID und die Verbindung enthält, die mit der Form verbunden sind.
+
+**Returns:**
+[ConnectorRule](../../com.aspose.diagram/connectorrule) - ConnectorRule.
+### getConnectorsType() {#getConnectorsType--}
+```
+public int getConnectorsType()
+```
+
+
+Connector‑Typ abrufen.
+
+**Returns:**
+int
+### getControlData() {#getControlData--}
+```
+public byte[] getControlData()
+```
+
+
+Liest die Daten des Steuerelements.
+
+**Returns:**
+byte[]
+### getControls() {#getControls--}
+```
+public ControlCollection getControls()
+```
+
+
+Enthält eine Sammlung von Control‑Elementen.
+
+**Returns:**
+[ControlCollection](../../com.aspose.diagram/controlcollection)
+### getData1() {#getData1--}
+```
+public String getData1()
+```
+
+
+Enthält einen beliebigen Zeichenkettenwert, der verwendet wird, um zusätzliche Informationen über eine Form bereitzustellen.
+
+**Returns:**
+java.lang.String
+### getData2() {#getData2--}
+```
+public String getData2()
+```
+
+
+Enthält einen beliebigen Zeichenkettenwert, der verwendet wird, um zusätzliche Informationen über eine Form bereitzustellen.
+
+**Returns:**
+java.lang.String
+### getData3() {#getData3--}
+```
+public String getData3()
+```
+
+
+Enthält einen beliebigen Zeichenkettenwert, der verwendet wird, um zusätzliche Informationen über eine Form bereitzustellen.
+
+**Returns:**
+java.lang.String
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Der Wert 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getDiagram() {#getDiagram--}
+```
+public Diagram getDiagram()
+```
+
+
+Stammelement der Visio-Objekthierarchie.
+
+**Returns:**
+[Diagram](../../com.aspose.diagram/diagram)
+### getDisplayText() {#getDisplayText--}
+```
+public String getDisplayText()
+```
+
+
+Den auf der Oberfläche angezeigten Text abrufen.
+
+**Returns:**
+java.lang.String
+### getEvent() {#getEvent--}
+```
+public Event getEvent()
+```
+
+
+Enthält Elemente, die Formeln angeben, die Formereignisse steuern.
+
+**Returns:**
+[Event](../../com.aspose.diagram/event)
+### getFields() {#getFields--}
+```
+public FieldCollection getFields()
+```
+
+
+Enthält eine Sammlung von Field‑Elementen.
+
+**Returns:**
+[FieldCollection](../../com.aspose.diagram/fieldcollection)
+### getFill() {#getFill--}
+```
+public Fill getFill()
+```
+
+
+Enthält die aktuellen Füllformatierungswerte für die Form und den Formschatten, einschließlich Muster, Vordergrundfarbe und Hintergrundfarbe.
+
+**Returns:**
+[Fill](../../com.aspose.diagram/fill)
+### getFillStyle() {#getFillStyle--}
+```
+public StyleSheet getFillStyle()
+```
+
+
+StyleSheet, von dem diese Form die Füllformatierung erbt.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getForeign() {#getForeign--}
+```
+public Foreign getForeign()
+```
+
+
+Enthält Elemente, die die Breite und Höhe eines aus einem anderen Programm stammenden Objekts in einem Microsoft Visio-Dokument angeben. Außerdem enthält es Elemente, die den Abstand angeben, um den das Bild des Objekts innerhalb seiner Ränder versetzt ist.
+
+**Returns:**
+[Foreign](../../com.aspose.diagram/foreign)
+### getForeignData() {#getForeignData--}
+```
+public ForeignData getForeignData()
+```
+
+
+Enthält einen MIME (Multipurpose Internet Mail Extensions) codierten BLOB von Bilddaten, wie Windows-Metadatei, Bitmap oder OLE-Daten.
+
+**Returns:**
+[ForeignData](../../com.aspose.diagram/foreigndata)
+### getGeoms() {#getGeoms--}
+```
+public GeomCollection getGeoms()
+```
+
+
+Enthält eine Sammlung von Geom‑Elementen.
+
+**Returns:**
+[GeomCollection](../../com.aspose.diagram/geomcollection)
+### getGroup() {#getGroup--}
+```
+public Group getGroup()
+```
+
+
+Enthält Elemente, die steuern, wie Sie Formen zu einer Gruppe hinzufügen, Gruppenmitglieder verschieben und Gruppen auswählen.
+
+**Returns:**
+[Group](../../com.aspose.diagram/group)
+### getHelp() {#getHelp--}
+```
+public Help getHelp()
+```
+
+
+Enthält Elemente, die das Hilfedatei-Thema und die Copyright-Informationen des Shape-Elements angeben.
+
+**Returns:**
+[Help](../../com.aspose.diagram/help)
+### getHyperlinks() {#getHyperlinks--}
+```
+public HyperlinkCollection getHyperlinks()
+```
+
+
+Enthält eine Sammlung von Hyperlink-Elementen.
+
+**Returns:**
+[HyperlinkCollection](../../com.aspose.diagram/hyperlinkcollection)
+### getID() {#getID--}
+```
+public long getID()
+```
+
+
+Die eindeutige ID des Elements innerhalb seines übergeordneten Elements.
+
+**Returns:**
+long
+### getImage() {#getImage--}
+```
+public Image getImage()
+```
+
+
+Enthält die Gamma-, Helligkeits-, Kontrast-, Unschärfe-, Schärfungs-, Rauschunterdrückungs- und Transparenzwerte für ein Bitmap.
+
+**Returns:**
+[Image](../../com.aspose.diagram/image)
+### getInheritChars() {#getInheritChars--}
+```
+public CharCollection getInheritChars()
+```
+
+
+Enthält die Zeichenwerte für die Form, die vom Master‑Shape geerbt werden.
+
+**Returns:**
+[CharCollection](../../com.aspose.diagram/charcollection)
+### getInheritFill() {#getInheritFill--}
+```
+public Fill getInheritFill()
+```
+
+
+Enthält die Füllformatierungswerte für die Form, die vom übergeordneten Stil und dem Master‑Shape geerbt werden.
+
+**Returns:**
+[Fill](../../com.aspose.diagram/fill)
+### getInheritGeoms() {#getInheritGeoms--}
+```
+public GeomCollection getInheritGeoms()
+```
+
+
+Enthält die Geoms-Werte für die Form, die vom Master-Shape geerbt wird.
+
+**Returns:**
+[GeomCollection](../../com.aspose.diagram/geomcollection)
+### getInheritLine() {#getInheritLine--}
+```
+public Line getInheritLine()
+```
+
+
+Enthält die Linienformatierungswerte für die Form, die vom übergeordneten Stil und dem Master-Shape geerbt wird.
+
+**Returns:**
+[Line](../../com.aspose.diagram/line)
+### getInheritParas() {#getInheritParas--}
+```
+public ParaCollection getInheritParas()
+```
+
+
+Enthält die Paras für die Form, die vom übergeordneten Stil und dem Master-Shape geerbt wird.
+
+**Returns:**
+[ParaCollection](../../com.aspose.diagram/paracollection)
+### getInheritProps() {#getInheritProps--}
+```
+public PropCollection getInheritProps()
+```
+
+
+Enthält die Props für die Form, die vom Master-Shape geerbt wird.
+
+**Returns:**
+[PropCollection](../../com.aspose.diagram/propcollection)
+### getInheritTextBlock() {#getInheritTextBlock--}
+```
+public TextBlock getInheritTextBlock()
+```
+
+
+Enthält die Textblock-Werte für die Form, die vom übergeordneten Stil und dem Master-Shape geerbt wird.
+
+**Returns:**
+[TextBlock](../../com.aspose.diagram/textblock)
+### getInheritUsers() {#getInheritUsers--}
+```
+public UserCollection getInheritUsers()
+```
+
+
+Enthält die Benutzer für die Form, die vom Master-Shape geerbt wird.
+
+**Returns:**
+[UserCollection](../../com.aspose.diagram/usercollection)
+### getLayerMem() {#getLayerMem--}
+```
+public LayerMem getLayerMem()
+```
+
+
+Enthält das Element LayerMember, das jede Ebene angibt, der die Form zugewiesen ist.
+
+**Returns:**
+[LayerMem](../../com.aspose.diagram/layermem)
+### getLayout() {#getLayout--}
+```
+public Layout getLayout()
+```
+
+
+Enthält Elemente, die die Platzierung von Formen und die Routing‑Einstellungen von Verbindern steuern.
+
+**Returns:**
+[Layout](../../com.aspose.diagram/layout)
+### getLine() {#getLine--}
+```
+public Line getLine()
+```
+
+
+Enthält Elemente, die die Linieneigenschaften für eine Form steuern, wie Muster, Stärke und Farbe. Diese Elemente bestimmen, ob die Linienenden formatiert sind (zum Beispiel mit einer Pfeilspitze), die Größe der Linienendformate, der Radius des Rundungskreises, der auf die Linie angewendet wird, und den Linientyp (rund oder eckig).
+
+**Returns:**
+[Line](../../com.aspose.diagram/line)
+### getLineStyle() {#getLineStyle--}
+```
+public StyleSheet getLineStyle()
+```
+
+
+StyleSheet, von dem diese Form die Linienformatierung erbt
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getMaster() {#getMaster--}
+```
+public Master getMaster()
+```
+
+
+Der Master, von dem die Form ihre Daten erbt.
+
+**Returns:**
+[Master](../../com.aspose.diagram/master)
+### getMasterShape() {#getMasterShape--}
+```
+public Shape getMasterShape()
+```
+
+
+Dieses Attribut kann nur in Shapes vorhanden sein, die Mitglieder eines Gruppenshapes sind, und die Gruppe ist eine Instanz eines Masters. Das Attribut enthält eine ID, die auf das entsprechende Untershape im Master verweist.
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape)
+### getMisc() {#getMisc--}
+```
+public Misc getMisc()
+```
+
+
+Enthält Elemente, die das Hilfedatei-Thema und die Copyright-Informationen des Shape-Elements angeben.
+
+**Returns:**
+[Misc](../../com.aspose.diagram/misc)
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Der Name des Elements.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+Der universelle Name des Elements.
+
+**Returns:**
+java.lang.String
+### getOneD() {#getOneD--}
+```
+public boolean getOneD()
+```
+
+
+Bestimmt, ob das Shape sich wie ein eindimensionales (1‑D) Objekt verhält. Nur lesbar.
+
+**Returns:**
+boolean
+### getPage() {#getPage--}
+```
+public Page getPage()
+```
+
+
+Stammelement der Visio-Objekthierarchie.
+
+**Returns:**
+[Page](../../com.aspose.diagram/page)
+### getParas() {#getParas--}
+```
+public ParaCollection getParas()
+```
+
+
+Enthält eine Sammlung von Para-Elementen.
+
+**Returns:**
+[ParaCollection](../../com.aspose.diagram/paracollection)
+### getParentShape() {#getParentShape--}
+```
+public Shape getParentShape()
+```
+
+
+Elternteil der Form.
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape)
+### getProps() {#getProps--}
+```
+public PropCollection getProps()
+```
+
+
+Enthält eine Sammlung von Prop-Elementen.
+
+**Returns:**
+[PropCollection](../../com.aspose.diagram/propcollection)
+### getProtection() {#getProtection--}
+```
+public Protection getProtection()
+```
+
+
+Das Sperren hilft, unbeabsichtigte Änderungen an der Form zu verhindern, verhindert jedoch nicht, dass Microsoft Visio Werte unter anderen Umständen zurücksetzt. Es schützt auch nicht vor Änderungen, die im ShapeSheet‑Fenster vorgenommen werden.
+
+**Returns:**
+[Protection](../../com.aspose.diagram/protection)
+### getPureText() {#getPureText--}
+```
+public String getPureText()
+```
+
+
+Liefere die Textzeichenfolge
+
+**Returns:**
+java.lang.String
+### getRootShape() {#getRootShape--}
+```
+public Shape getRootShape()
+```
+
+
+Gibt das Shape der obersten Ebene einer Instanz zurück, wenn dieses Shape Teil einer Master‑Instanz ist. Nur lesbar.
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape)
+### getScratchs() {#getScratchs--}
+```
+public ScratchCollection getScratchs()
+```
+
+
+Enthält eine Sammlung von Scratch-Elementen.
+
+**Returns:**
+[ScratchCollection](../../com.aspose.diagram/scratchcollection)
+### getShapes() {#getShapes--}
+```
+public ShapeCollection getShapes()
+```
+
+
+Enthält eine Sammlung von Shape-Elementen.
+
+**Returns:**
+[ShapeCollection](../../com.aspose.diagram/shapecollection)
+### getSmartTagDefs() {#getSmartTagDefs--}
+```
+public SmartTagDefCollection getSmartTagDefs()
+```
+
+
+Enthält eine Sammlung von SmartTagDef-Elementen.
+
+**Returns:**
+[SmartTagDefCollection](../../com.aspose.diagram/smarttagdefcollection)
+### getTabsCollection() {#getTabsCollection--}
+```
+public TabsCollection getTabsCollection()
+```
+
+
+Enthält eine Sammlung von Tab-Elementen.
+
+**Returns:**
+[TabsCollection](../../com.aspose.diagram/tabscollection)
+### getText() {#getText--}
+```
+public Text getText()
+```
+
+
+Enthält den Text einer Form.
+
+**Returns:**
+[Text](../../com.aspose.diagram/text)
+### getTextBlock() {#getTextBlock--}
+```
+public TextBlock getTextBlock()
+```
+
+
+Enthält Elemente, die die Ausrichtung, Ränder und Standard-Tabstopp-Positionen des Textes im Textblock einer Form festlegen.
+
+**Returns:**
+[TextBlock](../../com.aspose.diagram/textblock)
+### getTextStyle() {#getTextStyle--}
+```
+public StyleSheet getTextStyle()
+```
+
+
+StyleSheet, von dem diese Form die Textformatierung erbt.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getTextXForm() {#getTextXForm--}
+```
+public TextXForm getTextXForm()
+```
+
+
+Enthält Elemente, die Positionsinformationen zum Textblock einer Form angeben.
+
+**Returns:**
+[TextXForm](../../com.aspose.diagram/textxform)
+### getThreeDFormat() {#getThreeDFormat--}
+```
+public ThreeDFormat getThreeDFormat()
+```
+
+
+Liefert das ThreeDFormat.
+
+**Returns:**
+[ThreeDFormat](../../com.aspose.diagram/threedformat)
+### getTwoD() {#getTwoD--}
+```
+public boolean getTwoD()
+```
+
+
+Bestimmt, ob sich die Form als zweidimensionales (2‑D) Objekt verhält.
+
+**Returns:**
+boolean
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Der Typ eines Shapes. Er kann einer der folgenden Werte sein: Group, Shape, Guide oder Foreign.
+
+**Returns:**
+int
+### getUniqueID() {#getUniqueID--}
+```
+public UUID getUniqueID()
+```
+
+
+Eine GUID (global eindeutiger Bezeichner), die der Form zugewiesen ist.
+
+**Returns:**
+java.util.UUID
+### getUsers() {#getUsers--}
+```
+public UserCollection getUsers()
+```
+
+
+Enthält eine Sammlung von User-Elementen.
+
+**Returns:**
+[UserCollection](../../com.aspose.diagram/usercollection)
+### getXForm() {#getXForm--}
+```
+public XForm getXForm()
+```
+
+
+Enthält Elemente, die allgemeine Positionsinformationen zu einer Form angeben.
+
+**Returns:**
+[XForm](../../com.aspose.diagram/xform)
+### getXForm1D() {#getXForm1D--}
+```
+public XForm1D getXForm1D()
+```
+
+
+Enthält die x- und y-Koordinaten des Anfangs- und Endpunkts einer 1‑D‑Form. Dieses Element erscheint nur bei 1‑D‑Formen.
+
+**Returns:**
+[XForm1D](../../com.aspose.diagram/xform1d)
+### getZOrderIndex() {#getZOrderIndex--}
+```
+public int getZOrderIndex()
+```
+
+
+Gibt den Index einer Form in der Z-Reihenfolge zurück, ausgenommen die Leitform.
+
+**Returns:**
+int
+### gluedShapes(int flag, String categoryFilter, Shape otherShape) {#gluedShapes-int-java.lang.String-com.aspose.diagram.Shape-}
+```
+public long[] gluedShapes(int flag, String categoryFilter, Shape otherShape)
+```
+
+
+Gibt ein Array zurück, das die Bezeichner der Formen enthält, die an einer Form geklebt sind.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Flag | int | Die Dimensionalität und Richtungsabhängigkeit der Verbindungspunkte der zurückzugebenden Shapes. Siehe Anmerkungen für mögliche Werte Aspose.Diagram.GluedShapesFlags. |
+| categoryFilter | java.lang.String | Filtert das Array der zurückgegebenen Shape-IDs, indem es auf die IDs von Shapes beschränkt wird, die der angegebenen categoryString entsprechen. |
+| otherShape | [Shape](../../com.aspose.diagram/shape) | Optional: zusätzliches Shape, an das die zurückgegebenen Shapes ebenfalls geklebt werden müssen, kann [Shape](../../com.aspose.diagram/shape) oder null sein. |
+
+**Returns:**
+long[] - IDs-Array.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isConnected(Shape shape) {#isConnected-com.aspose.diagram.Shape-}
+```
+public boolean isConnected(Shape shape)
+```
+
+
+Gibt an, ob diese beiden Formen verbunden sind.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| shape | [Shape](../../com.aspose.diagram/shape) | shape |
+
+**Returns:**
+boolean
+### isContain(Shape shape) {#isContain-com.aspose.diagram.Shape-}
+```
+public boolean isContain(Shape shape)
+```
+
+
+Gibt an, ob diese Form eine andere Form enthält.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| shape | [Shape](../../com.aspose.diagram/shape) |  |
+
+**Returns:**
+boolean
+### isGlued(Shape shape) {#isGlued-com.aspose.diagram.Shape-}
+```
+public boolean isGlued(Shape shape)
+```
+
+
+Gibt an, ob diese beiden Formen geklebt sind.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| shape | [Shape](../../com.aspose.diagram/shape) | shape |
+
+**Returns:**
+boolean
+### isInGroup() {#isInGroup--}
+```
+public boolean isInGroup()
+```
+
+
+Gibt an, ob diese Form in einer Gruppenform ist.
+
+**Returns:**
+boolean
+### isIntersect(Shape shape) {#isIntersect-com.aspose.diagram.Shape-}
+```
+public boolean isIntersect(Shape shape)
+```
+
+
+Gibt an, ob diese Form eine andere Form schneidet.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| shape | [Shape](../../com.aspose.diagram/shape) |  |
+
+**Returns:**
+boolean
+### isTextEmpty() {#isTextEmpty--}
+```
+public boolean isTextEmpty()
+```
+
+
+Gibt an, ob die Form Text hat und ob der Text leer ist oder nicht.
+
+**Returns:**
+boolean
+### move(double dX, double dY) {#move-double-double-}
+```
+public void move(double dX, double dY)
+```
+
+
+Verschiebt die Form um dX und dY Zoll von der aktuellen Position.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| dX | double | X-Versatz double. |
+| dY | double | Y-Versatz double. |
+
+### moveTo(double newPinX, double newPinY) {#moveTo-double-double-}
+```
+public void moveTo(double newPinX, double newPinY)
+```
+
+
+Verschiebt die Form an eine neue absolute Position auf der Seite.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| newPinX | double | Neue x-Koordinate des Pins des Shapes (Rotationszentrum) in Bezug auf den Ursprung seines übergeordneten Elements. double. |
+| newPinY | double | Neue y-Koordinate des Pins des Shapes (Rotationszentrum) in Bezug auf den Ursprung seines übergeordneten Elements. double. |
+
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### refreshData() {#refreshData--}
+```
+public void refreshData()
+```
+
+
+Aktualisiert die Position des Shapes einschließlich xform, Verbindung und Geometrie, wenn der Text des Shapes oder anderer geändert wird. Wir sammeln Shape‑Daten wie den Text des Shapes und berechnen dann die Position des Shapes. Diese Methode wird nur verwendet, um Shape‑Daten zu aktualisieren.
+
+### replaceText(String text, String replaceText) {#replaceText-java.lang.String-java.lang.String-}
+```
+public void replaceText(String text, String replaceText)
+```
+
+
+Ersetzt die Textzeichenkette einer Form .
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| text | java.lang.String |  |
+| replaceText | java.lang.String |  |
+
+### sendBackward() {#sendBackward--}
+```
+public void sendBackward()
+```
+
+
+Verschiebt die Form um eine Position im Z-Order zurück.
+
+### sendToBack() {#sendToBack--}
+```
+public void sendToBack()
+```
+
+
+Verschiebt die Form an den hinteren Rand des Z-Order.
+
+### setAngle(double angle) {#setAngle-double-}
+```
+public void setAngle(double angle)
+```
+
+
+Setzt den neuen Winkel des Shapes. Die Einheit des Winkels ist Radiant.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| angle | double | Neuer Winkel, dessen Einheit Radiant und nicht Grad ist. double. |
+
+### setClippingPath(String value) {#setClippingPath-java.lang.String-}
+```
+public void setClippingPath(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getClippingPath()](../../com.aspose.diagram/shape\#getClippingPath--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setConnectorsType(int type) {#setConnectorsType-int-}
+```
+public void setConnectorsType(int type)
+```
+
+
+Setzt den Typ der Anschlüsse
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Typ | int |  |
+
+### setData1(String value) {#setData1-java.lang.String-}
+```
+public void setData1(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getData1()](../../com.aspose.diagram/shape\#getData1--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setData2(String value) {#setData2-java.lang.String-}
+```
+public void setData2(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getData2()](../../com.aspose.diagram/shape\#getData2--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setData3(String value) {#setData3-java.lang.String-}
+```
+public void setData3(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getData3()](../../com.aspose.diagram/shape\#getData3--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/shape\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setDiagram(Diagram value) {#setDiagram-com.aspose.diagram.Diagram-}
+```
+public void setDiagram(Diagram value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDiagram()](../../com.aspose.diagram/shape\#getDiagram--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [Diagram](../../com.aspose.diagram/diagram) |  |
+
+### setEvent(Event value) {#setEvent-com.aspose.diagram.Event-}
+```
+public void setEvent(Event value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getEvent()](../../com.aspose.diagram/shape\#getEvent--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [Event](../../com.aspose.diagram/event) |  |
+
+### setFillStyle(StyleSheet value) {#setFillStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setFillStyle(StyleSheet value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getFillStyle()](../../com.aspose.diagram/shape\#getFillStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setHeight(double height) {#setHeight-double-}
+```
+public void setHeight(double height)
+```
+
+
+Setzt die neue Höhe der Form.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Höhe | double | Neue heightdouble. |
+
+### setID(long value) {#setID-long-}
+```
+public void setID(long value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getID()](../../com.aspose.diagram/shape\#getID--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | long |  |
+
+### setLineStyle(StyleSheet value) {#setLineStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setLineStyle(StyleSheet value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getLineStyle()](../../com.aspose.diagram/shape\#getLineStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setMaster(Master value) {#setMaster-com.aspose.diagram.Master-}
+```
+public void setMaster(Master value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getMaster()](../../com.aspose.diagram/shape\#getMaster--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [Master](../../com.aspose.diagram/master) |  |
+
+### setMasterShape(Shape value) {#setMasterShape-com.aspose.diagram.Shape-}
+```
+public void setMasterShape(Shape value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getMasterShape()](../../com.aspose.diagram/shape\#getMasterShape--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [Shape](../../com.aspose.diagram/shape) |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getName()](../../com.aspose.diagram/shape\#getName--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getNameU()](../../com.aspose.diagram/shape\#getNameU--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setPage(Page value) {#setPage-com.aspose.diagram.Page-}
+```
+public void setPage(Page value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getPage()](../../com.aspose.diagram/shape\#getPage--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [Page](../../com.aspose.diagram/page) |  |
+
+### setParentShape(Shape value) {#setParentShape-com.aspose.diagram.Shape-}
+```
+public void setParentShape(Shape value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getParentShape()](../../com.aspose.diagram/shape\#getParentShape--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [Shape](../../com.aspose.diagram/shape) |  |
+
+### setPresetTheme(int value) {#setPresetTheme-int-}
+```
+public void setPresetTheme(int value)
+```
+
+
+Wende ein vordefiniertes Design auf diese Form an
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setPresetThemeQuickStyle(int value) {#setPresetThemeQuickStyle-int-}
+```
+public void setPresetThemeQuickStyle(int value)
+```
+
+
+Wende einen vordefinierten Designvarianten-Quickstyle auf diese Form an
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setPresetThemeStyleMatrics(int styleIndex, int colorIndex) {#setPresetThemeStyleMatrics-int-int-}
+```
+public void setPresetThemeStyleMatrics(int styleIndex, int colorIndex)
+```
+
+
+Wende einen vordefinierten Designvarianten-Quickstyle auf diese Form an, wie Designstil-Optionen in der Dropdown-Liste der Formstile
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| styleIndex | int | die Zeile der Stilmatrizen |
+| colorIndex | int | die Spalte der Stilmatrizen |
+
+### setPresetThemeVariant(int value) {#setPresetThemeVariant-int-}
+```
+public void setPresetThemeVariant(int value)
+```
+
+
+Wende eine vordefinierte Designvariante auf diese Form an
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setProps(PropCollection value) {#setProps-com.aspose.diagram.PropCollection-}
+```
+public void setProps(PropCollection value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getProps()](../../com.aspose.diagram/shape\#getProps--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [PropCollection](../../com.aspose.diagram/propcollection) |  |
+
+### setText(Text value) {#setText-com.aspose.diagram.Text-}
+```
+public void setText(Text value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getText()](../../com.aspose.diagram/shape\#getText--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [Text](../../com.aspose.diagram/text) |  |
+
+### setTextStyle(StyleSheet value) {#setTextStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setTextStyle(StyleSheet value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getTextStyle()](../../com.aspose.diagram/shape\#getTextStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setTwoD(boolean value) {#setTwoD-boolean-}
+```
+public void setTwoD(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getTwoD()](../../com.aspose.diagram/shape\#getTwoD--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setType(int value) {#setType-int-}
+```
+public void setType(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getType()](../../com.aspose.diagram/shape\#getType--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setUniqueID(UUID value) {#setUniqueID-java.util.UUID-}
+```
+public void setUniqueID(UUID value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getUniqueID()](../../com.aspose.diagram/shape\#getUniqueID--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.util.UUID |  |
+
+### setWidth(double width) {#setWidth-double-}
+```
+public void setWidth(double width)
+```
+
+
+Setzt die neue Breite der Form.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Breite | double | Neue widthdouble. |
+
+### setXForm(XForm value) {#setXForm-com.aspose.diagram.XForm-}
+```
+public void setXForm(XForm value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getXForm()](../../com.aspose.diagram/shape\#getXForm--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [XForm](../../com.aspose.diagram/xform) |  |
+
+### setXForm1D(XForm1D value) {#setXForm1D-com.aspose.diagram.XForm1D-}
+```
+public void setXForm1D(XForm1D value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getXForm1D()](../../com.aspose.diagram/shape\#getXForm1D--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [XForm1D](../../com.aspose.diagram/xform1d) |  |
+
+### toHTML(InputStream stream, HTMLSaveOptions options) {#toHTML-java.io.InputStream-com.aspose.diagram.HTMLSaveOptions-}
+```
+public void toHTML(InputStream stream, HTMLSaveOptions options)
+```
+
+
+Erstellt das HTML der Form und speichert es in einem Stream im angegebenen Format.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| stream | java.io.InputStream | Der Ausgabestream. |
+| options | [HTMLSaveOptions](../../com.aspose.diagram/htmlsaveoptions) | Zusätzliche HTML-Erstellungsoptionen |
+
+### toHTML(OutputStream stream, HTMLSaveOptions options) {#toHTML-java.io.OutputStream-com.aspose.diagram.HTMLSaveOptions-}
+```
+public void toHTML(OutputStream stream, HTMLSaveOptions options)
+```
+
+
+Erstellt das HTML der Form und speichert es in einem Stream im angegebenen Format.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| stream | java.io.OutputStream | Der Ausgabestream. |
+| options | [HTMLSaveOptions](../../com.aspose.diagram/htmlsaveoptions) | Zusätzliche HTML-Erstellungsoptionen |
+
+### toHTML(String fileName, HTMLSaveOptions options) {#toHTML-java.lang.String-com.aspose.diagram.HTMLSaveOptions-}
+```
+public void toHTML(String fileName, HTMLSaveOptions options)
+```
+
+
+Erstellt das HTML und speichert es in einer Datei.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fileName | java.lang.String |  |
+| options | [HTMLSaveOptions](../../com.aspose.diagram/htmlsaveoptions) | HTML-Speicheroptionen |
+
+### toImage(InputStream stream, ImageSaveOptions options) {#toImage-java.io.InputStream-com.aspose.diagram.ImageSaveOptions-}
+```
+public void toImage(InputStream stream, ImageSaveOptions options)
+```
+
+
+Erstellt das Bild der Form und speichert es in einem Stream im angegebenen Format.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| stream | java.io.InputStream | Der Ausgabestream. |
+| options | [ImageSaveOptions](../../com.aspose.diagram/imagesaveoptions) | Zusätzliche Bild-Erstellungsoptionen |
+
+### toImage(OutputStream stream, ImageSaveOptions options) {#toImage-java.io.OutputStream-com.aspose.diagram.ImageSaveOptions-}
+```
+public void toImage(OutputStream stream, ImageSaveOptions options)
+```
+
+
+Erstellt das Bild der Form und speichert es in einem Stream im angegebenen Format.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| stream | java.io.OutputStream | Der Ausgabestream. |
+| options | [ImageSaveOptions](../../com.aspose.diagram/imagesaveoptions) | Zusätzliche Bild-Erstellungsoptionen |
+
+### toImage(String imageFile, ImageSaveOptions options) {#toImage-java.lang.String-com.aspose.diagram.ImageSaveOptions-}
+```
+public void toImage(String imageFile, ImageSaveOptions options)
+```
+
+
+Erstellt das Formbild und speichert es in einer Datei. Die Erweiterung des Dateinamens bestimmt das Format des Bildes.
+
+Das Format des Bildes wird durch die Verwendung der Dateinamenerweiterung angegeben. Zum Beispiel, wenn Sie "myfile.png" angeben, wird das Bild im PNG-Format gespeichert. Die folgenden Dateierweiterungen werden erkannt: .bmp, .gif, .png, .jpg, .jpeg, .tiff, .tif, .emf.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| imageFile | java.lang.String | Der Bilddateiname mit vollständigem Pfad. |
+| options | [ImageSaveOptions](../../com.aspose.diagram/imagesaveoptions) | Zusätzliche Bild-Erstellungsoptionen |
+
+### toPdf(InputStream stream) {#toPdf-java.io.InputStream-}
+```
+public void toPdf(InputStream stream)
+```
+
+
+Erstellt das PDF der Form und speichert es in einem Stream.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| stream | java.io.InputStream | Der Ausgabestream. |
+
+### toPdf(OutputStream stream) {#toPdf-java.io.OutputStream-}
+```
+public void toPdf(OutputStream stream)
+```
+
+
+Erstellt das PDF der Form und speichert es in einem Stream.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| stream | java.io.OutputStream | Der Ausgabestream. |
+
+### toPdf(String fileName) {#toPdf-java.lang.String-}
+```
+public void toPdf(String fileName)
+```
+
+
+Speichert die Form in einer PDF-Datei.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| fileName | java.lang.String | der PDF-Dateiname mit vollständigem Pfad |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### toSvg(String imageFile, SVGSaveOptions options) {#toSvg-java.lang.String-com.aspose.diagram.SVGSaveOptions-}
+```
+public void toSvg(String imageFile, SVGSaveOptions options)
+```
+
+
+Speichert die Form in einer SVG-Datei.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| imageFile | java.lang.String |  |
+| options | [SVGSaveOptions](../../com.aspose.diagram/svgsaveoptions) |  |
+
+### ungroup() {#ungroup--}
+```
+public void ungroup()
+```
+
+
+Form entgruppieren
+
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/shapecollection/_index.md
+++ b/german/java/com.aspose.diagram/shapecollection/_index.md
@@ -1,0 +1,326 @@
+---
+title: ShapeCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: Sammlung von Formen.
+type: docs
+weight: 356
+url: /de/java/com.aspose.diagram/shapecollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ShapeCollection extends Collection
+```
+
+Sammlung von Formen.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [add(Shape item)](#add-com.aspose.diagram.Shape-) | Füge die Form zur Sammlung hinzu. |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [getShape(String name)](#getShape-java.lang.String-) | Liefert das Element mit dem angegebenen Namen. |
+| [getShape(long ID)](#getShape-long-) | Liefert das Element mit der angegebenen ID. |
+| [getShapeIncludingChild(int id)](#getShapeIncludingChild-int-) | Gibt das Element einschließlich seiner Kindform bei der angegebenen ID zurück. |
+| [getShapeIncludingChild(String name)](#getShapeIncludingChild-java.lang.String-) | Gibt das Element einschließlich seiner Kindform beim angegebenen Namen zurück. |
+| [group(Shape[] groupItems)](#group-com.aspose.diagram.Shape---) | Gruppiere die Formen. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Shape item)](#remove-com.aspose.diagram.Shape-) | Entferne die Form aus der Sammlung. |
+| [removeDependsOn(Shape item)](#removeDependsOn-com.aspose.diagram.Shape-) | Entferne die Formen einschließlich DEPENDSON-Formen aus der Sammlung. |
+| [toString()](#toString--) |  |
+| [unGroup(Shape groupShape)](#unGroup-com.aspose.diagram.Shape-) | Gruppierung der Form aufheben. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Shape item) {#add-com.aspose.diagram.Shape-}
+```
+public int add(Shape item)
+```
+
+
+Füge die Form zur Sammlung hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [Shape](../../com.aspose.diagram/shape) |  |
+
+**Returns:**
+int - ID
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Shape get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### getShape(String name) {#getShape-java.lang.String-}
+```
+public Shape getShape(String name)
+```
+
+
+Liefert das Element mit dem angegebenen Namen.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Name | java.lang.String |  |
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape) - 
+### getShape(long ID) {#getShape-long-}
+```
+public Shape getShape(long ID)
+```
+
+
+Liefert das Element mit der angegebenen ID.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| ID | long |  |
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape) - 
+### getShapeIncludingChild(int id) {#getShapeIncludingChild-int-}
+```
+public Shape getShapeIncludingChild(int id)
+```
+
+
+Gibt das Element einschließlich seiner Kindform bei der angegebenen ID zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| id | int |  |
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape) - 
+### getShapeIncludingChild(String name) {#getShapeIncludingChild-java.lang.String-}
+```
+public Shape getShapeIncludingChild(String name)
+```
+
+
+Gibt das Element einschließlich seiner Kindform beim angegebenen Namen zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Name | java.lang.String |  |
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape) - 
+### group(Shape[] groupItems) {#group-com.aspose.diagram.Shape---}
+```
+public Shape group(Shape[] groupItems)
+```
+
+
+Gruppiere die Formen. Die Form in den groupItems sollte nicht gruppiert werden. Die Form muss in dieser Shapes-Sammlung sein.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| groupItems | [Shape\[\]](../../com.aspose.diagram/shape) | die group items. |
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape) - Return the group shape.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Shape item) {#remove-com.aspose.diagram.Shape-}
+```
+public void remove(Shape item)
+```
+
+
+Entferne die Form aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [Shape](../../com.aspose.diagram/shape) | Form |
+
+### removeDependsOn(Shape item) {#removeDependsOn-com.aspose.diagram.Shape-}
+```
+public void removeDependsOn(Shape item)
+```
+
+
+Entferne die Formen einschließlich DEPENDSON-Formen aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [Shape](../../com.aspose.diagram/shape) | Form |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### unGroup(Shape groupShape) {#unGroup-com.aspose.diagram.Shape-}
+```
+public void unGroup(Shape groupShape)
+```
+
+
+Gruppierung der Form aufheben.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| groupShape | [Shape](../../com.aspose.diagram/shape) | die group shape. |
+
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/shapefixedcode/_index.md
+++ b/german/java/com.aspose.diagram/shapefixedcode/_index.md
@@ -1,0 +1,179 @@
+---
+title: ShapeFixedCode
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt das Platzierungsverhalten für eine platzierbare Form an.
+type: docs
+weight: 357
+url: /de/java/com.aspose.diagram/shapefixedcode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ShapeFixedCode
+```
+
+Gibt das Platzierungsverhalten für eine platzierbare Form an.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [ShapeFixedCode(int value)](#ShapeFixedCode-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Gibt das Platzierungsverhalten für eine platzierbare Form an. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/shapefixedcode\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ShapeFixedCode(int value) {#ShapeFixedCode-int-}
+```
+public ShapeFixedCode(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Gibt das Platzierungsverhalten für eine platzierbare Form an.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/shapefixedcode\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/shapefixedcodevalue/_index.md
+++ b/german/java/com.aspose.diagram/shapefixedcodevalue/_index.md
@@ -1,0 +1,192 @@
+---
+title: ShapeFixedCodeValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt das Platzierungsverhalten für eine platzierbare Form an.
+type: docs
+weight: 358
+url: /de/java/com.aspose.diagram/shapefixedcodevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ShapeFixedCodeValue
+```
+
+Gibt das Platzierungsverhalten für eine platzierbare Form an.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [ALLOW_ROUTING_TO_SIDES_WITH_CONNECTION_POINTS](#ALLOW-ROUTING-TO-SIDES-WITH-CONNECTION-POINTS) | Nur das Routing zu Seiten mit Verbindungspunkten zulassen. |
+| [IGNORE_CONNECTION_POINT](#IGNORE-CONNECTION-POINT) | Ignoriere die Positionen der Verbindungspunkte beim Routing. |
+| [NO_GLUE_TO_PERIMETER](#NO-GLUE-TO-PERIMETER) | Nicht an den Umfang dieser Form kleben. |
+| [NO_MOVE_ALLOW_SHAPES_PLACED](#NO-MOVE-ALLOW-SHAPES-PLACED) | Diese Form nicht verschieben, aber anderen platzierbaren Formen erlauben, darauf platziert zu werden. |
+| [NO_MOVE_AND_NO_ALLOW_SHAPES_PLACED](#NO-MOVE-AND-NO-ALLOW-SHAPES-PLACED) | Diese Form nicht verschieben und anderen platzierbaren Formen nicht erlauben, darauf platziert zu werden. |
+| [NO_MOVE_USING_LAY_OUT_SHAPES](#NO-MOVE-USING-LAY-OUT-SHAPES) | Diese Form nicht verschieben, wenn der Befehl „Lay Out Shapes“ in Microsoft Visio verwendet wird. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALLOW_ROUTING_TO_SIDES_WITH_CONNECTION_POINTS {#ALLOW-ROUTING-TO-SIDES-WITH-CONNECTION-POINTS}
+```
+public static final int ALLOW_ROUTING_TO_SIDES_WITH_CONNECTION_POINTS
+```
+
+
+Nur das Routing zu Seiten mit Verbindungspunkten zulassen.
+
+### IGNORE_CONNECTION_POINT {#IGNORE-CONNECTION-POINT}
+```
+public static final int IGNORE_CONNECTION_POINT
+```
+
+
+Ignoriere die Positionen der Verbindungspunkte beim Routing.
+
+### NO_GLUE_TO_PERIMETER {#NO-GLUE-TO-PERIMETER}
+```
+public static final int NO_GLUE_TO_PERIMETER
+```
+
+
+Nicht an den Umfang dieser Form kleben. Stattdessen an die Ausrichtungsbox der Form kleben.
+
+### NO_MOVE_ALLOW_SHAPES_PLACED {#NO-MOVE-ALLOW-SHAPES-PLACED}
+```
+public static final int NO_MOVE_ALLOW_SHAPES_PLACED
+```
+
+
+Diese Form nicht verschieben, aber anderen platzierbaren Formen erlauben, darauf platziert zu werden.
+
+### NO_MOVE_AND_NO_ALLOW_SHAPES_PLACED {#NO-MOVE-AND-NO-ALLOW-SHAPES-PLACED}
+```
+public static final int NO_MOVE_AND_NO_ALLOW_SHAPES_PLACED
+```
+
+
+Diese Form nicht verschieben und anderen platzierbaren Formen nicht erlauben, darauf platziert zu werden.
+
+### NO_MOVE_USING_LAY_OUT_SHAPES {#NO-MOVE-USING-LAY-OUT-SHAPES}
+```
+public static final int NO_MOVE_USING_LAY_OUT_SHAPES
+```
+
+
+Diese Form nicht verschieben, wenn der Befehl „Lay Out Shapes“ in Microsoft Visio verwendet wird.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/shapeplaceflip/_index.md
+++ b/german/java/com.aspose.diagram/shapeplaceflip/_index.md
@@ -1,0 +1,179 @@
+---
+title: ShapePlaceFlip
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt an, wie eine platzierbare Form auf der Seite umkippt und/oder rotiert, wenn ein Benutzer das Menü Lay Out Shapes Shapes auswählt.
+type: docs
+weight: 359
+url: /de/java/com.aspose.diagram/shapeplaceflip/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ShapePlaceFlip
+```
+
+Gibt an, wie eine platzierbare Form auf der Seite gedreht und/oder gespiegelt wird, wenn ein Benutzer Lay Out Shapes (Shapes‑Menü) auswählt.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [ShapePlaceFlip(int value)](#ShapePlaceFlip-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Gibt an, wie eine platzierbare Form auf der Seite gedreht und/oder gespiegelt wird, wenn ein Benutzer Lay Out Shapes (Shapes‑Menü) auswählt. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/shapeplaceflip\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ShapePlaceFlip(int value) {#ShapePlaceFlip-int-}
+```
+public ShapePlaceFlip(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Gibt an, wie eine platzierbare Form auf der Seite gedreht und/oder gespiegelt wird, wenn ein Benutzer Lay Out Shapes (Shapes‑Menü) auswählt.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/shapeplaceflip\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/shapeplaceflipvalue/_index.md
+++ b/german/java/com.aspose.diagram/shapeplaceflipvalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: ShapePlaceFlipValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt an, wie eine platzierbare Form auf der Seite umkippt und/oder rotiert, wenn ein Benutzer das Menü Lay Out Shapes Shapes auswählt.
+type: docs
+weight: 360
+url: /de/java/com.aspose.diagram/shapeplaceflipvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ShapePlaceFlipValue
+```
+
+Gibt an, wie eine platzierbare Form auf der Seite gedreht und/oder gespiegelt wird, wenn ein Benutzer Lay Out Shapes (Shapes‑Menü) auswählt.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [FLIP_90_DEGREE_INCREMENT_BETWEEN_0_AND_270](#FLIP-90-DEGREE-INCREMENT-BETWEEN-0-AND-270) | Drehen Sie in Schritten von 90 Grad zwischen 0 und 270. |
+| [FLIP_HORIZONTAL](#FLIP-HORIZONTAL) | Horizontal spiegeln. |
+| [FLIP_VERTICAL](#FLIP-VERTICAL) | Vertikal spiegeln. |
+| [NO_FLIP](#NO-FLIP) | Keine Spiegelung. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert |
+| [USE_PAGE_DEFAULT](#USE-PAGE-DEFAULT) | Verwenden Sie die Standardwerte der Seite. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FLIP_90_DEGREE_INCREMENT_BETWEEN_0_AND_270 {#FLIP-90-DEGREE-INCREMENT-BETWEEN-0-AND-270}
+```
+public static final int FLIP_90_DEGREE_INCREMENT_BETWEEN_0_AND_270
+```
+
+
+Drehen Sie in Schritten von 90 Grad zwischen 0 und 270.
+
+### FLIP_HORIZONTAL {#FLIP-HORIZONTAL}
+```
+public static final int FLIP_HORIZONTAL
+```
+
+
+Horizontal spiegeln.
+
+### FLIP_VERTICAL {#FLIP-VERTICAL}
+```
+public static final int FLIP_VERTICAL
+```
+
+
+Vertikal spiegeln.
+
+### NO_FLIP {#NO-FLIP}
+```
+public static final int NO_FLIP
+```
+
+
+Keine Spiegelung.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert
+
+### USE_PAGE_DEFAULT {#USE-PAGE-DEFAULT}
+```
+public static final int USE_PAGE_DEFAULT
+```
+
+
+Verwenden Sie die Standardwerte der Seite.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/shapeplacestyle/_index.md
+++ b/german/java/com.aspose.diagram/shapeplacestyle/_index.md
@@ -1,0 +1,179 @@
+---
+title: ShapePlaceStyle
+second_title: Aspose.Diagram for Java API-Referenz
+description: Bestimmt den Platzierungsstil für untergeordnete Elemente.
+type: docs
+weight: 361
+url: /de/java/com.aspose.diagram/shapeplacestyle/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ShapePlaceStyle
+```
+
+Bestimmt den Platzierungsstil für untergeordnete Elemente.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [ShapePlaceStyle(int value)](#ShapePlaceStyle-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Bestimmt das Erscheinungsbild eines Connectors. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/shapeplacestyle\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ShapePlaceStyle(int value) {#ShapePlaceStyle-int-}
+```
+public ShapePlaceStyle(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Bestimmt das Erscheinungsbild eines Connectors.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/shapeplacestyle\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/shapeplacestylevalue/_index.md
+++ b/german/java/com.aspose.diagram/shapeplacestylevalue/_index.md
@@ -1,0 +1,390 @@
+---
+title: ShapePlaceStyleValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Bestimmt den Platzierungsstil für untergeordnete Elemente.
+type: docs
+weight: 362
+url: /de/java/com.aspose.diagram/shapeplacestylevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ShapePlaceStyleValue
+```
+
+Bestimmt den Platzierungsstil für untergeordnete Elemente.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [PLACE_BOTTOM_TO_TOP](#PLACE-BOTTOM-TO-TOP) | Platzieren von unten nach oben. |
+| [PLACE_CIRCULAR](#PLACE-CIRCULAR) | Platzieren kreisförmig. |
+| [PLACE_COMPACT_DOWN_LEFT](#PLACE-COMPACT-DOWN-LEFT) | Platzieren kompakt nach unten links. |
+| [PLACE_COMPACT_DOWN_RIGHT](#PLACE-COMPACT-DOWN-RIGHT) | Platzieren kompakt nach unten rechts. |
+| [PLACE_COMPACT_LEFT_DOWN](#PLACE-COMPACT-LEFT-DOWN) | Platzieren kompakt links nach unten. |
+| [PLACE_COMPACT_LEFT_UP](#PLACE-COMPACT-LEFT-UP) | Platzieren kompakt links nach oben. |
+| [PLACE_COMPACT_RIGHT_DOWN](#PLACE-COMPACT-RIGHT-DOWN) | Platzieren kompakt rechts nach unten. |
+| [PLACE_COMPACT_RIGHT_UP](#PLACE-COMPACT-RIGHT-UP) | Platzieren kompakt rechts nach oben. |
+| [PLACE_COMPACT_UP_LEFT](#PLACE-COMPACT-UP-LEFT) | Platzieren kompakt nach oben links. |
+| [PLACE_COMPACT_UP_RIGHT](#PLACE-COMPACT-UP-RIGHT) | Platzieren kompakt nach oben rechts. |
+| [PLACE_DEFAULT](#PLACE-DEFAULT) | Standardplatzierung. |
+| [PLACE_HIERARCHY_BOTTOM_TO_CENTER](#PLACE-HIERARCHY-BOTTOM-TO-CENTER) | Hierarchie von unten nach Mitte platzieren. |
+| [PLACE_HIERARCHY_BOTTOM_TO_LEFT](#PLACE-HIERARCHY-BOTTOM-TO-LEFT) | Hierarchie von unten nach links platzieren. |
+| [PLACE_HIERARCHY_BOTTOM_TO_RIGHT](#PLACE-HIERARCHY-BOTTOM-TO-RIGHT) | Hierarchie von unten nach rechts platzieren. |
+| [PLACE_HIERARCHY_LEFT_TO_RIGHT_BOTTOM](#PLACE-HIERARCHY-LEFT-TO-RIGHT-BOTTOM) | hierarchie von links nach rechts unten platzieren. |
+| [PLACE_HIERARCHY_LEFT_TO_RIGHT_MIDDLE](#PLACE-HIERARCHY-LEFT-TO-RIGHT-MIDDLE) | Hierarchie von links nach rechts mittig platzieren. |
+| [PLACE_HIERARCHY_LEFT_TO_RIGHT_TOP](#PLACE-HIERARCHY-LEFT-TO-RIGHT-TOP) | Hierarchie von links nach rechts oben platzieren. |
+| [PLACE_HIERARCHY_RIGHT_TO_LEFT_BOTTOM](#PLACE-HIERARCHY-RIGHT-TO-LEFT-BOTTOM) | Hierarchie von rechts nach links unten platzieren. |
+| [PLACE_HIERARCHY_RIGHT_TO_LEFT_MIDDLE](#PLACE-HIERARCHY-RIGHT-TO-LEFT-MIDDLE) | Hierarchie von rechts nach links oben platzieren. |
+| [PLACE_HIERARCHY_RIGHT_TO_LEFT_TOP](#PLACE-HIERARCHY-RIGHT-TO-LEFT-TOP) | Hierarchie von rechts nach links oben platzieren. |
+| [PLACE_HIERARCHY_TOP_TO_BOTTOM_CENTER](#PLACE-HIERARCHY-TOP-TO-BOTTOM-CENTER) | Hierarchie von oben nach unten mittig platzieren. |
+| [PLACE_HIERARCHY_TOP_TO_BOTTOM_LEFT](#PLACE-HIERARCHY-TOP-TO-BOTTOM-LEFT) | Hierarchie von oben nach unten links platzieren. |
+| [PLACE_HIERARCHY_TOP_TO_BOTTOM_RIGHT](#PLACE-HIERARCHY-TOP-TO-BOTTOM-RIGHT) | Hierarchie von oben nach unten rechts platzieren. |
+| [PLACE_PARENT_DEFAULT](#PLACE-PARENT-DEFAULT) | Standard-Elternelement platzieren. |
+| [PLACE_RADIAL](#PLACE-RADIAL) | Radial platzieren. |
+| [PLACE_RIGHT_TO_LEFT](#PLACE-RIGHT-TO-LEFT) | Von rechts nach links platzieren. |
+| [PLACE_TOP_TO_BOTTOM](#PLACE-TOP-TO-BOTTOM) | Von oben nach unten platzieren. |
+| [PLACE_TO_RIGHT](#PLACE-TO-RIGHT) | Nach rechts platzieren. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PLACE_BOTTOM_TO_TOP {#PLACE-BOTTOM-TO-TOP}
+```
+public static final int PLACE_BOTTOM_TO_TOP
+```
+
+
+Platzieren von unten nach oben.
+
+### PLACE_CIRCULAR {#PLACE-CIRCULAR}
+```
+public static final int PLACE_CIRCULAR
+```
+
+
+Platzieren kreisförmig.
+
+### PLACE_COMPACT_DOWN_LEFT {#PLACE-COMPACT-DOWN-LEFT}
+```
+public static final int PLACE_COMPACT_DOWN_LEFT
+```
+
+
+Platzieren kompakt nach unten links.
+
+### PLACE_COMPACT_DOWN_RIGHT {#PLACE-COMPACT-DOWN-RIGHT}
+```
+public static final int PLACE_COMPACT_DOWN_RIGHT
+```
+
+
+Platzieren kompakt nach unten rechts.
+
+### PLACE_COMPACT_LEFT_DOWN {#PLACE-COMPACT-LEFT-DOWN}
+```
+public static final int PLACE_COMPACT_LEFT_DOWN
+```
+
+
+Platzieren kompakt links nach unten.
+
+### PLACE_COMPACT_LEFT_UP {#PLACE-COMPACT-LEFT-UP}
+```
+public static final int PLACE_COMPACT_LEFT_UP
+```
+
+
+Platzieren kompakt links nach oben.
+
+### PLACE_COMPACT_RIGHT_DOWN {#PLACE-COMPACT-RIGHT-DOWN}
+```
+public static final int PLACE_COMPACT_RIGHT_DOWN
+```
+
+
+Platzieren kompakt rechts nach unten.
+
+### PLACE_COMPACT_RIGHT_UP {#PLACE-COMPACT-RIGHT-UP}
+```
+public static final int PLACE_COMPACT_RIGHT_UP
+```
+
+
+Platzieren kompakt rechts nach oben.
+
+### PLACE_COMPACT_UP_LEFT {#PLACE-COMPACT-UP-LEFT}
+```
+public static final int PLACE_COMPACT_UP_LEFT
+```
+
+
+Platzieren kompakt nach oben links.
+
+### PLACE_COMPACT_UP_RIGHT {#PLACE-COMPACT-UP-RIGHT}
+```
+public static final int PLACE_COMPACT_UP_RIGHT
+```
+
+
+Platzieren kompakt nach oben rechts.
+
+### PLACE_DEFAULT {#PLACE-DEFAULT}
+```
+public static final int PLACE_DEFAULT
+```
+
+
+Standardplatzierung.
+
+### PLACE_HIERARCHY_BOTTOM_TO_CENTER {#PLACE-HIERARCHY-BOTTOM-TO-CENTER}
+```
+public static final int PLACE_HIERARCHY_BOTTOM_TO_CENTER
+```
+
+
+Hierarchie von unten nach Mitte platzieren.
+
+### PLACE_HIERARCHY_BOTTOM_TO_LEFT {#PLACE-HIERARCHY-BOTTOM-TO-LEFT}
+```
+public static final int PLACE_HIERARCHY_BOTTOM_TO_LEFT
+```
+
+
+Hierarchie von unten nach links platzieren.
+
+### PLACE_HIERARCHY_BOTTOM_TO_RIGHT {#PLACE-HIERARCHY-BOTTOM-TO-RIGHT}
+```
+public static final int PLACE_HIERARCHY_BOTTOM_TO_RIGHT
+```
+
+
+Hierarchie von unten nach rechts platzieren.
+
+### PLACE_HIERARCHY_LEFT_TO_RIGHT_BOTTOM {#PLACE-HIERARCHY-LEFT-TO-RIGHT-BOTTOM}
+```
+public static final int PLACE_HIERARCHY_LEFT_TO_RIGHT_BOTTOM
+```
+
+
+hierarchie von links nach rechts unten platzieren.
+
+### PLACE_HIERARCHY_LEFT_TO_RIGHT_MIDDLE {#PLACE-HIERARCHY-LEFT-TO-RIGHT-MIDDLE}
+```
+public static final int PLACE_HIERARCHY_LEFT_TO_RIGHT_MIDDLE
+```
+
+
+Hierarchie von links nach rechts mittig platzieren.
+
+### PLACE_HIERARCHY_LEFT_TO_RIGHT_TOP {#PLACE-HIERARCHY-LEFT-TO-RIGHT-TOP}
+```
+public static final int PLACE_HIERARCHY_LEFT_TO_RIGHT_TOP
+```
+
+
+Hierarchie von links nach rechts oben platzieren.
+
+### PLACE_HIERARCHY_RIGHT_TO_LEFT_BOTTOM {#PLACE-HIERARCHY-RIGHT-TO-LEFT-BOTTOM}
+```
+public static final int PLACE_HIERARCHY_RIGHT_TO_LEFT_BOTTOM
+```
+
+
+Hierarchie von rechts nach links unten platzieren.
+
+### PLACE_HIERARCHY_RIGHT_TO_LEFT_MIDDLE {#PLACE-HIERARCHY-RIGHT-TO-LEFT-MIDDLE}
+```
+public static final int PLACE_HIERARCHY_RIGHT_TO_LEFT_MIDDLE
+```
+
+
+Hierarchie von rechts nach links oben platzieren.
+
+### PLACE_HIERARCHY_RIGHT_TO_LEFT_TOP {#PLACE-HIERARCHY-RIGHT-TO-LEFT-TOP}
+```
+public static final int PLACE_HIERARCHY_RIGHT_TO_LEFT_TOP
+```
+
+
+Hierarchie von rechts nach links oben platzieren.
+
+### PLACE_HIERARCHY_TOP_TO_BOTTOM_CENTER {#PLACE-HIERARCHY-TOP-TO-BOTTOM-CENTER}
+```
+public static final int PLACE_HIERARCHY_TOP_TO_BOTTOM_CENTER
+```
+
+
+Hierarchie von oben nach unten mittig platzieren.
+
+### PLACE_HIERARCHY_TOP_TO_BOTTOM_LEFT {#PLACE-HIERARCHY-TOP-TO-BOTTOM-LEFT}
+```
+public static final int PLACE_HIERARCHY_TOP_TO_BOTTOM_LEFT
+```
+
+
+Hierarchie von oben nach unten links platzieren.
+
+### PLACE_HIERARCHY_TOP_TO_BOTTOM_RIGHT {#PLACE-HIERARCHY-TOP-TO-BOTTOM-RIGHT}
+```
+public static final int PLACE_HIERARCHY_TOP_TO_BOTTOM_RIGHT
+```
+
+
+Hierarchie von oben nach unten rechts platzieren.
+
+### PLACE_PARENT_DEFAULT {#PLACE-PARENT-DEFAULT}
+```
+public static final int PLACE_PARENT_DEFAULT
+```
+
+
+Standard-Elternelement platzieren.
+
+### PLACE_RADIAL {#PLACE-RADIAL}
+```
+public static final int PLACE_RADIAL
+```
+
+
+Radial platzieren.
+
+### PLACE_RIGHT_TO_LEFT {#PLACE-RIGHT-TO-LEFT}
+```
+public static final int PLACE_RIGHT_TO_LEFT
+```
+
+
+Von rechts nach links platzieren.
+
+### PLACE_TOP_TO_BOTTOM {#PLACE-TOP-TO-BOTTOM}
+```
+public static final int PLACE_TOP_TO_BOTTOM
+```
+
+
+Von oben nach unten platzieren.
+
+### PLACE_TO_RIGHT {#PLACE-TO-RIGHT}
+```
+public static final int PLACE_TO_RIGHT
+```
+
+
+Nach rechts platzieren.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/shapeplowcode/_index.md
+++ b/german/java/com.aspose.diagram/shapeplowcode/_index.md
@@ -1,0 +1,179 @@
+---
+title: ShapePlowCode
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt an, ob sich eine platzierbare Form entfernt, wenn Sie eine andere platzierbare Form in die Nähe der Form auf der Zeichenfläche ziehen.
+type: docs
+weight: 363
+url: /de/java/com.aspose.diagram/shapeplowcode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ShapePlowCode
+```
+
+Gibt an, ob sich eine platzierbare Form entfernt, wenn Sie eine andere platzierbare Form in die Nähe der Form auf der Zeichenfläche ziehen.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [ShapePlowCode(int value)](#ShapePlowCode-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Gibt an, ob sich eine platzierbare Form entfernt, wenn Sie eine andere platzierbare Form in die Nähe der Form auf der Zeichenfläche ziehen. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/shapeplowcode\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ShapePlowCode(int value) {#ShapePlowCode-int-}
+```
+public ShapePlowCode(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Gibt an, ob sich eine platzierbare Form entfernt, wenn Sie eine andere platzierbare Form in die Nähe der Form auf der Zeichenfläche ziehen.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/shapeplowcode\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/shapeplowcodevalue/_index.md
+++ b/german/java/com.aspose.diagram/shapeplowcodevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: ShapePlowCodeValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt an, ob sich eine platzierbare Form entfernt, wenn Sie eine andere platzierbare Form in die Nähe der Form auf der Zeichenfläche ziehen.
+type: docs
+weight: 364
+url: /de/java/com.aspose.diagram/shapeplowcodevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ShapePlowCodeValue
+```
+
+Gibt an, ob sich eine platzierbare Form entfernt, wenn Sie eine andere platzierbare Form in die Nähe der Form auf der Zeichenfläche ziehen.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [MOVE_SHAPE](#MOVE-SHAPE) | Form verschieben. |
+| [NOMOVE_SHAPE](#NOMOVE-SHAPE) | Form nicht verschieben. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+| [USE_PAGE_DEFAULT](#USE-PAGE-DEFAULT) | Verwenden Sie die Standardwerte der Seite. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### MOVE_SHAPE {#MOVE-SHAPE}
+```
+public static final int MOVE_SHAPE
+```
+
+
+Form verschieben.
+
+### NOMOVE_SHAPE {#NOMOVE-SHAPE}
+```
+public static final int NOMOVE_SHAPE
+```
+
+
+Form nicht verschieben.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### USE_PAGE_DEFAULT {#USE-PAGE-DEFAULT}
+```
+public static final int USE_PAGE_DEFAULT
+```
+
+
+Verwenden Sie die Standardwerte der Seite.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/shaperoutestyle/_index.md
+++ b/german/java/com.aspose.diagram/shaperoutestyle/_index.md
@@ -1,0 +1,179 @@
+---
+title: ShapeRouteStyle
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt den Routing‑Stil und die Richtung für einen Verbinder auf der Zeichenfläche an.
+type: docs
+weight: 365
+url: /de/java/com.aspose.diagram/shaperoutestyle/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ShapeRouteStyle
+```
+
+Gibt den Routing‑Stil und die Richtung für einen Verbinder auf der Zeichenfläche an.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [ShapeRouteStyle(int value)](#ShapeRouteStyle-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Gibt den Routing‑Stil und die Richtung für einen Verbinder auf der Zeichenfläche an. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/shaperoutestyle\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ShapeRouteStyle(int value) {#ShapeRouteStyle-int-}
+```
+public ShapeRouteStyle(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Gibt den Routing‑Stil und die Richtung für einen Verbinder auf der Zeichenfläche an.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/shaperoutestyle\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/shaperoutestylevalue/_index.md
+++ b/german/java/com.aspose.diagram/shaperoutestylevalue/_index.md
@@ -1,0 +1,345 @@
+---
+title: ShapeRouteStyleValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt den Routing‑Stil und die Richtung für einen Verbinder auf der Zeichenfläche an.
+type: docs
+weight: 366
+url: /de/java/com.aspose.diagram/shaperoutestylevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ShapeRouteStyleValue
+```
+
+Gibt den Routing‑Stil und die Richtung für einen Verbinder auf der Zeichenfläche an.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [CENTER_TO_CENTER](#CENTER-TO-CENTER) | Mitte zu Mitte. |
+| [FLOWCHART_BOTTOM_TO_TOP](#FLOWCHART-BOTTOM-TO-TOP) | Flussdiagramm. |
+| [FLOWCHART_LEFT_TO_RIGHT](#FLOWCHART-LEFT-TO-RIGHT) | Flussdiagramm. |
+| [FLOWCHART_RIGHT_TO_LEFT](#FLOWCHART-RIGHT-TO-LEFT) | Flussdiagramm. |
+| [FLOWCHART_TOP_TO_BOTTOM](#FLOWCHART-TOP-TO-BOTTOM) | Flussdiagramm. |
+| [NETWORK](#NETWORK) | Netzwerk |
+| [ORGANIZATION_CHART_BOTTOM_TO_TOP](#ORGANIZATION-CHART-BOTTOM-TO-TOP) | Organigramm. |
+| [ORGANIZATION_CHART_LEFT_TO_RIGHT](#ORGANIZATION-CHART-LEFT-TO-RIGHT) | Organigramm. |
+| [ORGANIZATION_CHART_RIGHT_TO_LEFT](#ORGANIZATION-CHART-RIGHT-TO-LEFT) | Organigramm. |
+| [ORGANIZATION_CHART_TOP_TO_BOTTOM](#ORGANIZATION-CHART-TOP-TO-BOTTOM) | Organigramm. |
+| [PAGE_DEFAULT](#PAGE-DEFAULT) | Seitenstandard. |
+| [RIGHT_ANGLE](#RIGHT-ANGLE) | Rechter Winkel. |
+| [SIMPLE_BOTTOM_TO_TOP](#SIMPLE-BOTTOM-TO-TOP) | Einfach. |
+| [SIMPLE_HORIZONTAL_VERTICAL](#SIMPLE-HORIZONTAL-VERTICAL) | Einfach horizontal-vertikal. |
+| [SIMPLE_LEFT_TO_RIGHT](#SIMPLE-LEFT-TO-RIGHT) | Einfach. |
+| [SIMPLE_RIGHT_TO_LEFT](#SIMPLE-RIGHT-TO-LEFT) | Einfach. |
+| [SIMPLE_TOP_TO_BOTTOM](#SIMPLE-TOP-TO-BOTTOM) | Einfach. |
+| [SIMPLE_VERTICAL_HORIZONTAL](#SIMPLE-VERTICAL-HORIZONTAL) | Einfach vertikal-horizontal. |
+| [STRAIGHT](#STRAIGHT) | Gerade. |
+| [TREE_BOTTOM_TO_TOP](#TREE-BOTTOM-TO-TOP) | Baum. |
+| [TREE_LEFT_TO_RIGHT](#TREE-LEFT-TO-RIGHT) | Baum. |
+| [TREE_RIGHT_TO_LEFT](#TREE-RIGHT-TO-LEFT) | Baum. |
+| [TREE_TOP_TO_BOTTOM](#TREE-TOP-TO-BOTTOM) | Baum. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CENTER_TO_CENTER {#CENTER-TO-CENTER}
+```
+public static final int CENTER_TO_CENTER
+```
+
+
+Mitte zu Mitte.
+
+### FLOWCHART_BOTTOM_TO_TOP {#FLOWCHART-BOTTOM-TO-TOP}
+```
+public static final int FLOWCHART_BOTTOM_TO_TOP
+```
+
+
+Flussdiagramm. Von unten nach oben.
+
+### FLOWCHART_LEFT_TO_RIGHT {#FLOWCHART-LEFT-TO-RIGHT}
+```
+public static final int FLOWCHART_LEFT_TO_RIGHT
+```
+
+
+Flussdiagramm. Von links nach rechts.
+
+### FLOWCHART_RIGHT_TO_LEFT {#FLOWCHART-RIGHT-TO-LEFT}
+```
+public static final int FLOWCHART_RIGHT_TO_LEFT
+```
+
+
+Flussdiagramm. Von rechts nach links.
+
+### FLOWCHART_TOP_TO_BOTTOM {#FLOWCHART-TOP-TO-BOTTOM}
+```
+public static final int FLOWCHART_TOP_TO_BOTTOM
+```
+
+
+Flussdiagramm. Von oben nach unten.
+
+### NETWORK {#NETWORK}
+```
+public static final int NETWORK
+```
+
+
+Netzwerk
+
+### ORGANIZATION_CHART_BOTTOM_TO_TOP {#ORGANIZATION-CHART-BOTTOM-TO-TOP}
+```
+public static final int ORGANIZATION_CHART_BOTTOM_TO_TOP
+```
+
+
+Organigramm. Von unten nach oben.
+
+### ORGANIZATION_CHART_LEFT_TO_RIGHT {#ORGANIZATION-CHART-LEFT-TO-RIGHT}
+```
+public static final int ORGANIZATION_CHART_LEFT_TO_RIGHT
+```
+
+
+Organigramm. Von links nach rechts.
+
+### ORGANIZATION_CHART_RIGHT_TO_LEFT {#ORGANIZATION-CHART-RIGHT-TO-LEFT}
+```
+public static final int ORGANIZATION_CHART_RIGHT_TO_LEFT
+```
+
+
+Organigramm. Von rechts nach links.
+
+### ORGANIZATION_CHART_TOP_TO_BOTTOM {#ORGANIZATION-CHART-TOP-TO-BOTTOM}
+```
+public static final int ORGANIZATION_CHART_TOP_TO_BOTTOM
+```
+
+
+Organigramm. Richtung von oben nach unten.
+
+### PAGE_DEFAULT {#PAGE-DEFAULT}
+```
+public static final int PAGE_DEFAULT
+```
+
+
+Seitenstandard.
+
+### RIGHT_ANGLE {#RIGHT-ANGLE}
+```
+public static final int RIGHT_ANGLE
+```
+
+
+Rechter Winkel.
+
+### SIMPLE_BOTTOM_TO_TOP {#SIMPLE-BOTTOM-TO-TOP}
+```
+public static final int SIMPLE_BOTTOM_TO_TOP
+```
+
+
+Einfach. Von unten nach oben.
+
+### SIMPLE_HORIZONTAL_VERTICAL {#SIMPLE-HORIZONTAL-VERTICAL}
+```
+public static final int SIMPLE_HORIZONTAL_VERTICAL
+```
+
+
+Einfach horizontal-vertikal.
+
+### SIMPLE_LEFT_TO_RIGHT {#SIMPLE-LEFT-TO-RIGHT}
+```
+public static final int SIMPLE_LEFT_TO_RIGHT
+```
+
+
+Einfach. Von links nach rechts.
+
+### SIMPLE_RIGHT_TO_LEFT {#SIMPLE-RIGHT-TO-LEFT}
+```
+public static final int SIMPLE_RIGHT_TO_LEFT
+```
+
+
+Einfach. Von rechts nach links.
+
+### SIMPLE_TOP_TO_BOTTOM {#SIMPLE-TOP-TO-BOTTOM}
+```
+public static final int SIMPLE_TOP_TO_BOTTOM
+```
+
+
+Einfach. Von oben nach unten.
+
+### SIMPLE_VERTICAL_HORIZONTAL {#SIMPLE-VERTICAL-HORIZONTAL}
+```
+public static final int SIMPLE_VERTICAL_HORIZONTAL
+```
+
+
+Einfach vertikal-horizontal.
+
+### STRAIGHT {#STRAIGHT}
+```
+public static final int STRAIGHT
+```
+
+
+Gerade.
+
+### TREE_BOTTOM_TO_TOP {#TREE-BOTTOM-TO-TOP}
+```
+public static final int TREE_BOTTOM_TO_TOP
+```
+
+
+Baum. Von unten nach oben.
+
+### TREE_LEFT_TO_RIGHT {#TREE-LEFT-TO-RIGHT}
+```
+public static final int TREE_LEFT_TO_RIGHT
+```
+
+
+Baum. Von links nach rechts
+
+### TREE_RIGHT_TO_LEFT {#TREE-RIGHT-TO-LEFT}
+```
+public static final int TREE_RIGHT_TO_LEFT
+```
+
+
+Baum. Von rechts nach links.
+
+### TREE_TOP_TO_BOTTOM {#TREE-TOP-TO-BOTTOM}
+```
+public static final int TREE_TOP_TO_BOTTOM
+```
+
+
+Baum. Von oben nach unten.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/shapeshdwshow/_index.md
+++ b/german/java/com.aspose.diagram/shapeshdwshow/_index.md
@@ -1,0 +1,179 @@
+---
+title: ShapeShdwShow
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt den Typ des Schattens für eine Form an.
+type: docs
+weight: 367
+url: /de/java/com.aspose.diagram/shapeshdwshow/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ShapeShdwShow
+```
+
+Gibt den Typ des Schattens für eine Form an.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [ShapeShdwShow(int value)](#ShapeShdwShow-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Gibt den Typ des Schattens für eine Form an. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe [getValue()](../../com.aspose.diagram/shapeshdwshow\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ShapeShdwShow(int value) {#ShapeShdwShow-int-}
+```
+public ShapeShdwShow(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Gibt den Typ des Schattens für eine Form an.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getValue()](../../com.aspose.diagram/shapeshdwshow\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/shapeshdwshowvalue/_index.md
+++ b/german/java/com.aspose.diagram/shapeshdwshowvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: ShapeShdwShowValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt den Typ des Schattens für eine Form an.
+type: docs
+weight: 368
+url: /de/java/com.aspose.diagram/shapeshdwshowvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ShapeShdwShowValue
+```
+
+Gibt den Typ des Schattens für eine Form an.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [ALWAYS_SHOW](#ALWAYS-SHOW) | Gibt an, dass das Schatteneffekt-Set immer angezeigt wird. |
+| [HAS_GEOM_SHOW](#HAS-GEOM-SHOW) | Gibt an, dass das Schatteneffekt-Set nur angezeigt wird, wenn die Form einen Geometry Section\_Type hat. |
+| [TOP_LEVEL_SHOW](#TOP-LEVEL-SHOW) | Gibt an, dass das Schatteneffekt-Set nur angezeigt wird, wenn die Form einen Geometry Section\_Type hat und die Form eine übergeordnete Form ist. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALWAYS_SHOW {#ALWAYS-SHOW}
+```
+public static final int ALWAYS_SHOW
+```
+
+
+Gibt an, dass das Schatteneffekt-Set immer angezeigt wird.
+
+### HAS_GEOM_SHOW {#HAS-GEOM-SHOW}
+```
+public static final int HAS_GEOM_SHOW
+```
+
+
+Gibt an, dass das Schatteneffekt-Set nur angezeigt wird, wenn die Form einen Geometry Section\_Type hat.
+
+### TOP_LEVEL_SHOW {#TOP-LEVEL-SHOW}
+```
+public static final int TOP_LEVEL_SHOW
+```
+
+
+Gibt an, dass das Schatteneffekt-Set nur angezeigt wird, wenn die Form einen Geometry Section\_Type hat und die Form eine übergeordnete Form ist.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/shapeshdwtype/_index.md
+++ b/german/java/com.aspose.diagram/shapeshdwtype/_index.md
@@ -1,0 +1,179 @@
+---
+title: ShapeShdwType
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt den Typ des Schattens für eine Form an.
+type: docs
+weight: 369
+url: /de/java/com.aspose.diagram/shapeshdwtype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ShapeShdwType
+```
+
+Gibt den Typ des Schattens für eine Form an.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [ShapeShdwType(int value)](#ShapeShdwType-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Gibt den Typ des Schattens für eine Form an. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe [getValue()](../../com.aspose.diagram/shapeshdwtype\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ShapeShdwType(int value) {#ShapeShdwType-int-}
+```
+public ShapeShdwType(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Gibt den Typ des Schattens für eine Form an.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getValue()](../../com.aspose.diagram/shapeshdwtype\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/shapeshdwtypevalue/_index.md
+++ b/german/java/com.aspose.diagram/shapeshdwtypevalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: ShapeShdwTypeValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt den Typ des Schattens für eine Form an.
+type: docs
+weight: 370
+url: /de/java/com.aspose.diagram/shapeshdwtypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ShapeShdwTypeValue
+```
+
+Gibt den Typ des Schattens für eine Form an.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [INNER](#INNER) | Innen |
+| [OBLIQUE](#OBLIQUE) | Schräg. |
+| [SIMPLE](#SIMPLE) | Einfach. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+| [USE_PAGE](#USE-PAGE) | Seitenstandard verwenden (der Standard). |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### INNER {#INNER}
+```
+public static final int INNER
+```
+
+
+Innen
+
+### OBLIQUE {#OBLIQUE}
+```
+public static final int OBLIQUE
+```
+
+
+Schräg.
+
+### SIMPLE {#SIMPLE}
+```
+public static final int SIMPLE
+```
+
+
+Einfach.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### USE_PAGE {#USE-PAGE}
+```
+public static final int USE_PAGE
+```
+
+
+Seitenstandard verwenden (der Standard).
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/shdwtype/_index.md
+++ b/german/java/com.aspose.diagram/shdwtype/_index.md
@@ -1,0 +1,179 @@
+---
+title: ShdwType
+second_title: Aspose.Diagram for Java API-Referenz
+description: Zeigt den Standard‑Schattentyp für eine Seite an.
+type: docs
+weight: 371
+url: /de/java/com.aspose.diagram/shdwtype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ShdwType
+```
+
+Zeigt den Standard‑Schattentyp für eine Seite an.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [ShdwType(int value)](#ShdwType-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Zeigt den Standard‑Schattentyp für eine Seite an. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/shdwtype\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ShdwType(int value) {#ShdwType-int-}
+```
+public ShdwType(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Zeigt den Standard‑Schattentyp für eine Seite an.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/shdwtype\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/shdwtypevalue/_index.md
+++ b/german/java/com.aspose.diagram/shdwtypevalue/_index.md
@@ -1,0 +1,156 @@
+---
+title: ShdwTypeValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Zeigt den Standard‑Schattentyp für eine Seite an.
+type: docs
+weight: 372
+url: /de/java/com.aspose.diagram/shdwtypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ShdwTypeValue
+```
+
+Zeigt den Standard‑Schattentyp für eine Seite an.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [OBLIQUE](#OBLIQUE) | Schräg. |
+| [SIMPLE](#SIMPLE) | Einfach. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### OBLIQUE {#OBLIQUE}
+```
+public static final int OBLIQUE
+```
+
+
+Schräg.
+
+### SIMPLE {#SIMPLE}
+```
+public static final int SIMPLE
+```
+
+
+Einfach.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/showdropbuttontype/_index.md
+++ b/german/java/com.aspose.diagram/showdropbuttontype/_index.md
@@ -1,0 +1,156 @@
+---
+title: ShowDropButtonType
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt an, wann die Drop‑Schaltfläche angezeigt wird
+type: docs
+weight: 373
+url: /de/java/com.aspose.diagram/showdropbuttontype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ShowDropButtonType
+```
+
+Gibt an, wann die Drop‑Schaltfläche angezeigt wird
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [ALWAYS](#ALWAYS) | Den Dropdown-Button immer anzeigen. |
+| [FOCUS](#FOCUS) | Zeige die Drop-Schaltfläche, wenn das Steuerelement den Fokus hat. |
+| [NEVER](#NEVER) | Zeige die Drop-Schaltfläche niemals. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALWAYS {#ALWAYS}
+```
+public static final int ALWAYS
+```
+
+
+Den Dropdown-Button immer anzeigen.
+
+### FOCUS {#FOCUS}
+```
+public static final int FOCUS
+```
+
+
+Zeige die Drop-Schaltfläche, wenn das Steuerelement den Fokus hat.
+
+### NEVER {#NEVER}
+```
+public static final int NEVER
+```
+
+
+Zeige die Drop-Schaltfläche niemals.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/smarttagdef/_index.md
+++ b/german/java/com.aspose.diagram/smarttagdef/_index.md
@@ -1,0 +1,337 @@
+---
+title: SmartTagDef
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält Elemente, die Informationen für jedes für eine Form oder Seite definierte SmartTag enthalten.
+type: docs
+weight: 374
+url: /de/java/com.aspose.diagram/smarttagdef/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class SmartTagDef
+```
+
+Enthält Elemente, die Informationen für jedes für eine Form oder Seite definierte SmartTag enthalten.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [SmartTagDef()](#SmartTagDef--) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getButtonFace()](#getButtonFace--) | Sie enthält die ID des Schaltflächenbildes, das auf der Smart‑Tag‑Schaltfläche angezeigt wird. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getDescription()](#getDescription--) | Das Description‑Element enthält eine Zeichenkette, die das Smart‑Tag beschreibt und als Tooltip angezeigt wird, wenn der Benutzer die Maus über das Tag hält. |
+| [getDisabled()](#getDisabled--) | Das Disabled‑Element bestimmt, ob das Smart‑Tag im Zeichenfenster angezeigt wird. |
+| [getDisplayMode()](#getDisplayMode--) | Das DisplayMode-Element bestimmt, ob das Smart-Tag erscheint, wenn der Benutzer die Maus über das Tag hält, wenn die Form ausgewählt ist oder die ganze Zeit. |
+| [getID()](#getID--) | Die eindeutige ID des Elements innerhalb seines übergeordneten Elements. |
+| [getName()](#getName--) | Der Name des Elements. |
+| [getNameU()](#getNameU--) | Der universelle Name des Elements. |
+| [getTagName()](#getTagName--) | Sie enthält den Namen des Smart‑Tags, der als Schlüssel verwendet wird, um das Smart‑Tag seinen Aktionen zuzuordnen. |
+| [getX()](#getX--) | Die x‑Koordinate in den lokalen Koordinaten der Form, um die die Smart‑Tag‑Schaltfläche platziert wird. |
+| [getXJustify()](#getXJustify--) | Der x‑Versatz des Smart‑Tag‑Buttons relativ zu dem durch die X‑ und Y‑Elemente definierten Punkt. |
+| [getY()](#getY--) | Die y‑Koordinate in den lokalen Koordinaten der Form, um die die Smart‑Tag‑Schaltfläche platziert wird. |
+| [getYJustify()](#getYJustify--) | Gibt den y‑Versatz des Smart‑Tag‑Buttons relativ zu dem durch die X‑ und Y‑Elemente definierten Punkt an. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/smarttagdef\#getDel--) |
+| [setID(int value)](#setID-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getID()](../../com.aspose.diagram/smarttagdef\#getID--) |
+| [setName(String value)](#setName-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getName()](../../com.aspose.diagram/smarttagdef\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getNameU()](../../com.aspose.diagram/smarttagdef\#getNameU--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SmartTagDef() {#SmartTagDef--}
+```
+public SmartTagDef()
+```
+
+
+Konstruktor.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getButtonFace() {#getButtonFace--}
+```
+public Str2Value getButtonFace()
+```
+
+
+Sie enthält die ID des Schaltflächenbildes, das auf der Smart‑Tag‑Schaltfläche angezeigt wird.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getDescription() {#getDescription--}
+```
+public Str2Value getDescription()
+```
+
+
+Das Description‑Element enthält eine Zeichenkette, die das Smart‑Tag beschreibt und als Tooltip angezeigt wird, wenn der Benutzer die Maus über das Tag hält.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getDisabled() {#getDisabled--}
+```
+public BoolValue getDisabled()
+```
+
+
+Das Disabled‑Element bestimmt, ob das Smart‑Tag im Zeichenfenster angezeigt wird.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getDisplayMode() {#getDisplayMode--}
+```
+public DisplayModeSmartTagDef getDisplayMode()
+```
+
+
+Das DisplayMode-Element bestimmt, ob das Smart-Tag erscheint, wenn der Benutzer die Maus über das Tag hält, wenn die Form ausgewählt ist oder die ganze Zeit.
+
+**Returns:**
+[DisplayModeSmartTagDef](../../com.aspose.diagram/displaymodesmarttagdef)
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+Die eindeutige ID des Elements innerhalb seines übergeordneten Elements.
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Der Name des Elements.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+Der universelle Name des Elements.
+
+**Returns:**
+java.lang.String
+### getTagName() {#getTagName--}
+```
+public Str2Value getTagName()
+```
+
+
+Sie enthält den Namen des Smart‑Tags, der als Schlüssel verwendet wird, um das Smart‑Tag seinen Aktionen zuzuordnen.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+Die x‑Koordinate in den lokalen Koordinaten der Form, um die die Smart‑Tag‑Schaltfläche platziert wird.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getXJustify() {#getXJustify--}
+```
+public XJustify getXJustify()
+```
+
+
+Der x‑Versatz des Smart‑Tag‑Buttons relativ zu dem durch die X‑ und Y‑Elemente definierten Punkt.
+
+**Returns:**
+[XJustify](../../com.aspose.diagram/xjustify)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+Die y‑Koordinate in den lokalen Koordinaten der Form, um die die Smart‑Tag‑Schaltfläche platziert wird.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getYJustify() {#getYJustify--}
+```
+public YJustify getYJustify()
+```
+
+
+Gibt den y‑Versatz des Smart‑Tag‑Buttons relativ zu dem durch die X‑ und Y‑Elemente definierten Punkt an.
+
+**Returns:**
+[YJustify](../../com.aspose.diagram/yjustify)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/smarttagdef\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getID()](../../com.aspose.diagram/smarttagdef\#getID--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getName()](../../com.aspose.diagram/smarttagdef\#getName--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getNameU()](../../com.aspose.diagram/smarttagdef\#getNameU--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/smarttagdefcollection/_index.md
+++ b/german/java/com.aspose.diagram/smarttagdefcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: SmartTagDefCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: SmartTagDef‑Sammlung.
+type: docs
+weight: 375
+url: /de/java/com.aspose.diagram/smarttagdefcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class SmartTagDefCollection extends Collection
+```
+
+SmartTagDef‑Sammlung.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [add(SmartTagDef item)](#add-com.aspose.diagram.SmartTagDef-) | Fügen Sie das SmartTagDef‑Objekt zur Sammlung hinzu. |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(SmartTagDef item)](#remove-com.aspose.diagram.SmartTagDef-) | Entfernen Sie das SmartTagDef‑Objekt aus der Sammlung. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(SmartTagDef item) {#add-com.aspose.diagram.SmartTagDef-}
+```
+public int add(SmartTagDef item)
+```
+
+
+Fügen Sie das SmartTagDef‑Objekt zur Sammlung hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [SmartTagDef](../../com.aspose.diagram/smarttagdef) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public SmartTagDef get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[SmartTagDef](../../com.aspose.diagram/smarttagdef) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(SmartTagDef item) {#remove-com.aspose.diagram.SmartTagDef-}
+```
+public void remove(SmartTagDef item)
+```
+
+
+Entfernen Sie das SmartTagDef‑Objekt aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [SmartTagDef](../../com.aspose.diagram/smarttagdef) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/smoothingmode/_index.md
+++ b/german/java/com.aspose.diagram/smoothingmode/_index.md
@@ -1,0 +1,183 @@
+---
+title: SmoothingMode
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt an, ob Glättungs‑Antialiasing auf Linien, Kurven und die Kanten gefüllter Flächen angewendet wird.
+type: docs
+weight: 376
+url: /de/java/com.aspose.diagram/smoothingmode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class SmoothingMode
+```
+
+Gibt an, ob Glättung (Antialiasing) auf Linien und Kurven sowie die Kanten von gefüllten Bereichen angewendet wird.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [ANTI_ALIAS](#ANTI-ALIAS) | Gibt antialiasiertes Rendering an. |
+| [DEFAULT](#DEFAULT) | Gibt keine Kantenglättung an. |
+| [HIGH_QUALITY](#HIGH-QUALITY) | Gibt antialiasiertes Rendering an. |
+| [HIGH_SPEED](#HIGH-SPEED) | Gibt keine Kantenglättung an. |
+| [INVALID](#INVALID) | Gibt einen ungültigen Modus an. |
+| [NONE](#NONE) | Gibt keine Kantenglättung an. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ANTI_ALIAS {#ANTI-ALIAS}
+```
+public static final int ANTI_ALIAS
+```
+
+
+Gibt antialiasiertes Rendering an.
+
+### DEFAULT {#DEFAULT}
+```
+public static final int DEFAULT
+```
+
+
+Gibt keine Kantenglättung an.
+
+### HIGH_QUALITY {#HIGH-QUALITY}
+```
+public static final int HIGH_QUALITY
+```
+
+
+Gibt antialiasiertes Rendering an.
+
+### HIGH_SPEED {#HIGH-SPEED}
+```
+public static final int HIGH_SPEED
+```
+
+
+Gibt keine Kantenglättung an.
+
+### INVALID {#INVALID}
+```
+public static final int INVALID
+```
+
+
+Gibt einen ungültigen Modus an.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Gibt keine Kantenglättung an.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/snapextensions/_index.md
+++ b/german/java/com.aspose.diagram/snapextensions/_index.md
@@ -1,0 +1,264 @@
+---
+title: SnapExtensions
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt an, ob eine bestimmte Snap‑Erweiterungseinstellung für das aktive Fenster aktiviert oder deaktiviert ist.
+type: docs
+weight: 377
+url: /de/java/com.aspose.diagram/snapextensions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class SnapExtensions
+```
+
+Gibt an, ob eine bestimmte Snap-Erweiterungseinstellung für das aktive Fenster aktiviert oder deaktiviert ist. Der Wert kann eine Summe der Werte sein.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [ALIGNMENT_BOX_EXTENSION](#ALIGNMENT-BOX-EXTENSION) | Einrasten an Ausrichtungsfeld-Erweiterung. |
+| [CENTER_AXES](#CENTER-AXES) | Einrasten an Mittelachsen-Erweiterung. |
+| [CURVE_EXTENSION](#CURVE-EXTENSION) | Einrasten an Kurven-Erweiterung. |
+| [CURVE_TANGENT](#CURVE-TANGENT) | Einrasten an Kurventangenten-Erweiterung. |
+| [ELLIPSE_CENTER](#ELLIPSE-CENTER) | Einrasten an Ellipsenmittelpunkt-Erweiterung. |
+| [ENDPOINT](#ENDPOINT) | Einrasten an Endpunkt-Erweiterung. |
+| [ENDPOINT_HORIZONTAL](#ENDPOINT-HORIZONTAL) | Einrasten an horizontalen Endpunkt-Erweiterung. |
+| [ENDPOINT_PERPENDICULAR](#ENDPOINT-PERPENDICULAR) | Einrasten an senkrechten Endpunkt-Erweiterung. |
+| [ENDPOINT_VERTICAL](#ENDPOINT-VERTICAL) | Einrasten an vertikalen Endpunkt-Erweiterung. |
+| [ISOMETRIC_ANGLES](#ISOMETRIC-ANGLES) | Einrasten an isometrische Winkel-Erweiterung. |
+| [LINEAR_EXTENSION](#LINEAR-EXTENSION) | Einrasten an lineare Erweiterung. |
+| [MIDPOINT](#MIDPOINT) | Einrasten an Mittelpunkt-Erweiterung. |
+| [MIDPOINT_PERPENDICULAR](#MIDPOINT-PERPENDICULAR) | Einrasten an senkrechte Mittelpunkt-Erweiterung. |
+| [NONE](#NONE) | Snap to nothing. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALIGNMENT_BOX_EXTENSION {#ALIGNMENT-BOX-EXTENSION}
+```
+public static final int ALIGNMENT_BOX_EXTENSION
+```
+
+
+Einrasten an Ausrichtungsfeld-Erweiterung.
+
+### CENTER_AXES {#CENTER-AXES}
+```
+public static final int CENTER_AXES
+```
+
+
+Einrasten an Mittelachsen-Erweiterung.
+
+### CURVE_EXTENSION {#CURVE-EXTENSION}
+```
+public static final int CURVE_EXTENSION
+```
+
+
+Einrasten an Kurven-Erweiterung.
+
+### CURVE_TANGENT {#CURVE-TANGENT}
+```
+public static final int CURVE_TANGENT
+```
+
+
+Einrasten an Kurventangenten-Erweiterung.
+
+### ELLIPSE_CENTER {#ELLIPSE-CENTER}
+```
+public static final int ELLIPSE_CENTER
+```
+
+
+Einrasten an Ellipsenmittelpunkt-Erweiterung.
+
+### ENDPOINT {#ENDPOINT}
+```
+public static final int ENDPOINT
+```
+
+
+Einrasten an Endpunkt-Erweiterung.
+
+### ENDPOINT_HORIZONTAL {#ENDPOINT-HORIZONTAL}
+```
+public static final int ENDPOINT_HORIZONTAL
+```
+
+
+Einrasten an horizontalen Endpunkt-Erweiterung.
+
+### ENDPOINT_PERPENDICULAR {#ENDPOINT-PERPENDICULAR}
+```
+public static final int ENDPOINT_PERPENDICULAR
+```
+
+
+Einrasten an senkrechten Endpunkt-Erweiterung.
+
+### ENDPOINT_VERTICAL {#ENDPOINT-VERTICAL}
+```
+public static final int ENDPOINT_VERTICAL
+```
+
+
+Einrasten an vertikalen Endpunkt-Erweiterung.
+
+### ISOMETRIC_ANGLES {#ISOMETRIC-ANGLES}
+```
+public static final int ISOMETRIC_ANGLES
+```
+
+
+Einrasten an isometrische Winkel-Erweiterung.
+
+### LINEAR_EXTENSION {#LINEAR-EXTENSION}
+```
+public static final int LINEAR_EXTENSION
+```
+
+
+Einrasten an lineare Erweiterung.
+
+### MIDPOINT {#MIDPOINT}
+```
+public static final int MIDPOINT
+```
+
+
+Einrasten an Mittelpunkt-Erweiterung.
+
+### MIDPOINT_PERPENDICULAR {#MIDPOINT-PERPENDICULAR}
+```
+public static final int MIDPOINT_PERPENDICULAR
+```
+
+
+Einrasten an senkrechte Mittelpunkt-Erweiterung.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Snap to nothing.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/snapextensionsvalue/_index.md
+++ b/german/java/com.aspose.diagram/snapextensionsvalue/_index.md
@@ -1,0 +1,264 @@
+---
+title: SnapExtensionsValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt an, ob eine bestimmte Snap‑Erweiterungseinstellung für das aktive Fenster aktiviert oder deaktiviert ist.
+type: docs
+weight: 378
+url: /de/java/com.aspose.diagram/snapextensionsvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class SnapExtensionsValue
+```
+
+Specifies whether a specific snap extension setting is enabled or disabled for the active window. The value can be a sum of the values in the following table.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [SNAP_TO_ALIGNMENT_BOX_EXTENSION](#SNAP-TO-ALIGNMENT-BOX-EXTENSION) | Einrasten an Ausrichtungsfeld-Erweiterung. |
+| [SNAP_TO_CENTER_AXIS_EXTENSION](#SNAP-TO-CENTER-AXIS-EXTENSION) | Einrasten an Mittelachsen-Erweiterung. |
+| [SNAP_TO_CURVE_EXTENSION](#SNAP-TO-CURVE-EXTENSION) | Einrasten an Kurven-Erweiterung. |
+| [SNAP_TO_CURVE_TANGENT_EXTENSION](#SNAP-TO-CURVE-TANGENT-EXTENSION) | Einrasten an Kurventangenten-Erweiterung. |
+| [SNAP_TO_ELLIPSE_CENTER_EXTENSION](#SNAP-TO-ELLIPSE-CENTER-EXTENSION) | Einrasten an Ellipsenmittelpunkt-Erweiterung. |
+| [SNAP_TO_END_POINT_EXTENSION](#SNAP-TO-END-POINT-EXTENSION) | Einrasten an Endpunkt-Erweiterung. |
+| [SNAP_TO_END_POINT_HORIZONTAL_EXTENSION](#SNAP-TO-END-POINT-HORIZONTAL-EXTENSION) | Einrasten an horizontalen Endpunkt-Erweiterung. |
+| [SNAP_TO_END_POINT_PERPENDICULAR_EXTENSION](#SNAP-TO-END-POINT-PERPENDICULAR-EXTENSION) | Einrasten an senkrechten Endpunkt-Erweiterung. |
+| [SNAP_TO_END_POINT_VERTICAL_EXTENSION](#SNAP-TO-END-POINT-VERTICAL-EXTENSION) | Einrasten an vertikalen Endpunkt-Erweiterung. |
+| [SNAP_TO_ISOMETRIC_ANGLES_EXTENSION](#SNAP-TO-ISOMETRIC-ANGLES-EXTENSION) | Einrasten an isometrische Winkel-Erweiterung. |
+| [SNAP_TO_LINEAR_EXTENSION](#SNAP-TO-LINEAR-EXTENSION) | Einrasten an lineare Erweiterung. |
+| [SNAP_TO_MID_POINT_EXTENSION](#SNAP-TO-MID-POINT-EXTENSION) | Einrasten an Mittelpunkt-Erweiterung. |
+| [SNAP_TO_MID_POINT_PERPENDICULAR_EXTENSION](#SNAP-TO-MID-POINT-PERPENDICULAR-EXTENSION) | Einrasten an senkrechte Mittelpunkt-Erweiterung. |
+| [SNAP_TO_NOTHING](#SNAP-TO-NOTHING) | Snap to nothing. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SNAP_TO_ALIGNMENT_BOX_EXTENSION {#SNAP-TO-ALIGNMENT-BOX-EXTENSION}
+```
+public static final int SNAP_TO_ALIGNMENT_BOX_EXTENSION
+```
+
+
+Einrasten an Ausrichtungsfeld-Erweiterung.
+
+### SNAP_TO_CENTER_AXIS_EXTENSION {#SNAP-TO-CENTER-AXIS-EXTENSION}
+```
+public static final int SNAP_TO_CENTER_AXIS_EXTENSION
+```
+
+
+Einrasten an Mittelachsen-Erweiterung.
+
+### SNAP_TO_CURVE_EXTENSION {#SNAP-TO-CURVE-EXTENSION}
+```
+public static final int SNAP_TO_CURVE_EXTENSION
+```
+
+
+Einrasten an Kurven-Erweiterung.
+
+### SNAP_TO_CURVE_TANGENT_EXTENSION {#SNAP-TO-CURVE-TANGENT-EXTENSION}
+```
+public static final int SNAP_TO_CURVE_TANGENT_EXTENSION
+```
+
+
+Einrasten an Kurventangenten-Erweiterung.
+
+### SNAP_TO_ELLIPSE_CENTER_EXTENSION {#SNAP-TO-ELLIPSE-CENTER-EXTENSION}
+```
+public static final int SNAP_TO_ELLIPSE_CENTER_EXTENSION
+```
+
+
+Einrasten an Ellipsenmittelpunkt-Erweiterung.
+
+### SNAP_TO_END_POINT_EXTENSION {#SNAP-TO-END-POINT-EXTENSION}
+```
+public static final int SNAP_TO_END_POINT_EXTENSION
+```
+
+
+Einrasten an Endpunkt-Erweiterung.
+
+### SNAP_TO_END_POINT_HORIZONTAL_EXTENSION {#SNAP-TO-END-POINT-HORIZONTAL-EXTENSION}
+```
+public static final int SNAP_TO_END_POINT_HORIZONTAL_EXTENSION
+```
+
+
+Einrasten an horizontalen Endpunkt-Erweiterung.
+
+### SNAP_TO_END_POINT_PERPENDICULAR_EXTENSION {#SNAP-TO-END-POINT-PERPENDICULAR-EXTENSION}
+```
+public static final int SNAP_TO_END_POINT_PERPENDICULAR_EXTENSION
+```
+
+
+Einrasten an senkrechten Endpunkt-Erweiterung.
+
+### SNAP_TO_END_POINT_VERTICAL_EXTENSION {#SNAP-TO-END-POINT-VERTICAL-EXTENSION}
+```
+public static final int SNAP_TO_END_POINT_VERTICAL_EXTENSION
+```
+
+
+Einrasten an vertikalen Endpunkt-Erweiterung.
+
+### SNAP_TO_ISOMETRIC_ANGLES_EXTENSION {#SNAP-TO-ISOMETRIC-ANGLES-EXTENSION}
+```
+public static final int SNAP_TO_ISOMETRIC_ANGLES_EXTENSION
+```
+
+
+Einrasten an isometrische Winkel-Erweiterung.
+
+### SNAP_TO_LINEAR_EXTENSION {#SNAP-TO-LINEAR-EXTENSION}
+```
+public static final int SNAP_TO_LINEAR_EXTENSION
+```
+
+
+Einrasten an lineare Erweiterung.
+
+### SNAP_TO_MID_POINT_EXTENSION {#SNAP-TO-MID-POINT-EXTENSION}
+```
+public static final int SNAP_TO_MID_POINT_EXTENSION
+```
+
+
+Einrasten an Mittelpunkt-Erweiterung.
+
+### SNAP_TO_MID_POINT_PERPENDICULAR_EXTENSION {#SNAP-TO-MID-POINT-PERPENDICULAR-EXTENSION}
+```
+public static final int SNAP_TO_MID_POINT_PERPENDICULAR_EXTENSION
+```
+
+
+Einrasten an senkrechte Mittelpunkt-Erweiterung.
+
+### SNAP_TO_NOTHING {#SNAP-TO-NOTHING}
+```
+public static final int SNAP_TO_NOTHING
+```
+
+
+Snap to nothing.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/snapsettings/_index.md
+++ b/german/java/com.aspose.diagram/snapsettings/_index.md
@@ -1,0 +1,246 @@
+---
+title: SnapSettings
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt die Objekte an, an die Formen einrasten, wenn das Einrasten im Fenster aktiv ist.
+type: docs
+weight: 379
+url: /de/java/com.aspose.diagram/snapsettings/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class SnapSettings
+```
+
+Specifies the objects that shapes snap to when snap is active in the window. The value may be a sum of the values.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [ALIGNMENT_BOX](#ALIGNMENT-BOX) | Snap to alignment box. |
+| [CONNECTION_POINTS](#CONNECTION-POINTS) | Snap to connection points. |
+| [DISABLED](#DISABLED) | Snap disabled. |
+| [EXTENSIONS](#EXTENSIONS) | Snap to shape extensions options. |
+| [GEOMETRY](#GEOMETRY) | Snap to the visible edges of shapes. |
+| [GRID](#GRID) | Snap to grid. |
+| [GUIDES](#GUIDES) | Snap to guides. |
+| [HANDLES](#HANDLES) | Snap to selection handles. |
+| [INTERSECTIONS](#INTERSECTIONS) | Snap to intersections. |
+| [NONE](#NONE) | Snap to nothing. |
+| [RULER_SUBDIVISIONS](#RULER-SUBDIVISIONS) | Snap to ruler subdivisions. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+| [VERTICES](#VERTICES) | Snap to vertices. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALIGNMENT_BOX {#ALIGNMENT-BOX}
+```
+public static final int ALIGNMENT_BOX
+```
+
+
+Snap to alignment box.
+
+### CONNECTION_POINTS {#CONNECTION-POINTS}
+```
+public static final int CONNECTION_POINTS
+```
+
+
+Snap to connection points.
+
+### DISABLED {#DISABLED}
+```
+public static final int DISABLED
+```
+
+
+Snap disabled.
+
+### EXTENSIONS {#EXTENSIONS}
+```
+public static final int EXTENSIONS
+```
+
+
+Snap to shape extensions options.
+
+### GEOMETRY {#GEOMETRY}
+```
+public static final int GEOMETRY
+```
+
+
+Snap to the visible edges of shapes.
+
+### GRID {#GRID}
+```
+public static final int GRID
+```
+
+
+Snap to grid.
+
+### GUIDES {#GUIDES}
+```
+public static final int GUIDES
+```
+
+
+Snap to guides.
+
+### HANDLES {#HANDLES}
+```
+public static final int HANDLES
+```
+
+
+Snap to selection handles.
+
+### INTERSECTIONS {#INTERSECTIONS}
+```
+public static final int INTERSECTIONS
+```
+
+
+Snap to intersections.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Snap to nothing.
+
+### RULER_SUBDIVISIONS {#RULER-SUBDIVISIONS}
+```
+public static final int RULER_SUBDIVISIONS
+```
+
+
+Snap to ruler subdivisions.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### VERTICES {#VERTICES}
+```
+public static final int VERTICES
+```
+
+
+Snap to vertices.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/snapsettingsvalue/_index.md
+++ b/german/java/com.aspose.diagram/snapsettingsvalue/_index.md
@@ -1,0 +1,246 @@
+---
+title: SnapSettingsValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt die Objekte an, an die Formen einrasten, wenn das Einrasten im Fenster aktiv ist
+type: docs
+weight: 380
+url: /de/java/com.aspose.diagram/snapsettingsvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class SnapSettingsValue
+```
+
+Gibt die Objekte an, an die Formen einrasten, wenn das Einrasten im Fenster aktiv ist
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [SNAP_DISABLED](#SNAP-DISABLED) | Snap disabled. |
+| [SNAP_TO_ALIGNMENT_BOX](#SNAP-TO-ALIGNMENT-BOX) | Snap to alignment box. |
+| [SNAP_TO_CONNECTION_POINTS](#SNAP-TO-CONNECTION-POINTS) | Snap to connection points. |
+| [SNAP_TO_GRID](#SNAP-TO-GRID) | Snap to grid. |
+| [SNAP_TO_GUIDES](#SNAP-TO-GUIDES) | Snap to guides. |
+| [SNAP_TO_INTERSECTIONS](#SNAP-TO-INTERSECTIONS) | Snap to intersections. |
+| [SNAP_TO_NOTHING](#SNAP-TO-NOTHING) | Snap to nothing. |
+| [SNAP_TO_RULER_SUBDIVISIONS](#SNAP-TO-RULER-SUBDIVISIONS) | Snap to ruler subdivisions. |
+| [SNAP_TO_SELECTION_HANDLES](#SNAP-TO-SELECTION-HANDLES) | Snap to selection handles. |
+| [SNAP_TO_SHAPE_EXTENSIONS_OPTIONS](#SNAP-TO-SHAPE-EXTENSIONS-OPTIONS) | Snap to shape extensions options. |
+| [SNAP_TO_THE_VISIBLE_EDGES_OF_SHAPES](#SNAP-TO-THE-VISIBLE-EDGES-OF-SHAPES) | Snap to the visible edges of shapes. |
+| [SNAP_TO_VERTICES](#SNAP-TO-VERTICES) | Snap to vertices. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SNAP_DISABLED {#SNAP-DISABLED}
+```
+public static final int SNAP_DISABLED
+```
+
+
+Snap disabled.
+
+### SNAP_TO_ALIGNMENT_BOX {#SNAP-TO-ALIGNMENT-BOX}
+```
+public static final int SNAP_TO_ALIGNMENT_BOX
+```
+
+
+Snap to alignment box.
+
+### SNAP_TO_CONNECTION_POINTS {#SNAP-TO-CONNECTION-POINTS}
+```
+public static final int SNAP_TO_CONNECTION_POINTS
+```
+
+
+Snap to connection points.
+
+### SNAP_TO_GRID {#SNAP-TO-GRID}
+```
+public static final int SNAP_TO_GRID
+```
+
+
+Snap to grid.
+
+### SNAP_TO_GUIDES {#SNAP-TO-GUIDES}
+```
+public static final int SNAP_TO_GUIDES
+```
+
+
+Snap to guides.
+
+### SNAP_TO_INTERSECTIONS {#SNAP-TO-INTERSECTIONS}
+```
+public static final int SNAP_TO_INTERSECTIONS
+```
+
+
+Snap to intersections.
+
+### SNAP_TO_NOTHING {#SNAP-TO-NOTHING}
+```
+public static final int SNAP_TO_NOTHING
+```
+
+
+Snap to nothing.
+
+### SNAP_TO_RULER_SUBDIVISIONS {#SNAP-TO-RULER-SUBDIVISIONS}
+```
+public static final int SNAP_TO_RULER_SUBDIVISIONS
+```
+
+
+Snap to ruler subdivisions.
+
+### SNAP_TO_SELECTION_HANDLES {#SNAP-TO-SELECTION-HANDLES}
+```
+public static final int SNAP_TO_SELECTION_HANDLES
+```
+
+
+Snap to selection handles.
+
+### SNAP_TO_SHAPE_EXTENSIONS_OPTIONS {#SNAP-TO-SHAPE-EXTENSIONS-OPTIONS}
+```
+public static final int SNAP_TO_SHAPE_EXTENSIONS_OPTIONS
+```
+
+
+Snap to shape extensions options.
+
+### SNAP_TO_THE_VISIBLE_EDGES_OF_SHAPES {#SNAP-TO-THE-VISIBLE-EDGES-OF-SHAPES}
+```
+public static final int SNAP_TO_THE_VISIBLE_EDGES_OF_SHAPES
+```
+
+
+Snap to the visible edges of shapes.
+
+### SNAP_TO_VERTICES {#SNAP-TO-VERTICES}
+```
+public static final int SNAP_TO_VERTICES
+```
+
+
+Snap to vertices.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/solutionxml/_index.md
+++ b/german/java/com.aspose.diagram/solutionxml/_index.md
@@ -1,0 +1,214 @@
+---
+title: SolutionXML
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält lösungspezifische, wohlgeformte XML-Daten, die in einem expliziten Namensraum vorangestellt sind und zusammen mit einem Dokument gespeichert werden.
+type: docs
+weight: 381
+url: /de/java/com.aspose.diagram/solutionxml/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class SolutionXML
+```
+
+Enthält lösungsspezifische, wohlgeformte XML‑Daten, die in einem expliziten Namensraum vorangestellt sind und zusammen mit einem Dokument gespeichert werden.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [SolutionXML(String name, String xmlValue)](#SolutionXML-java.lang.String-java.lang.String-) | Konstruktor. |
+| [SolutionXML()](#SolutionXML--) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | Ein eindeutiger Name zur Identifizierung des XML-Datensatzes. |
+| [getXmlValue()](#getXmlValue--) | Enthält lösungsspezifische, wohlgeformte XML‑Daten, die in einem expliziten Namensraum vorangestellt sind und zusammen mit einem Dokument gespeichert werden. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setName(String value)](#setName-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getName()](../../com.aspose.diagram/solutionxml\#getName--) |
+| [setXmlValue(String value)](#setXmlValue-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getXmlValue()](../../com.aspose.diagram/solutionxml\#getXmlValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SolutionXML(String name, String xmlValue) {#SolutionXML-java.lang.String-java.lang.String-}
+```
+public SolutionXML(String name, String xmlValue)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Name | java.lang.String |  |
+| xmlValue | java.lang.String |  |
+
+### SolutionXML() {#SolutionXML--}
+```
+public SolutionXML()
+```
+
+
+Konstruktor.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Ein eindeutiger Name zur Identifizierung des XML-Datensatzes.
+
+**Returns:**
+java.lang.String
+### getXmlValue() {#getXmlValue--}
+```
+public String getXmlValue()
+```
+
+
+Enthält lösungsspezifische, wohlgeformte XML‑Daten, die in einem expliziten Namensraum vorangestellt sind und zusammen mit einem Dokument gespeichert werden.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getName()](../../com.aspose.diagram/solutionxml\#getName--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setXmlValue(String value) {#setXmlValue-java.lang.String-}
+```
+public void setXmlValue(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getXmlValue()](../../com.aspose.diagram/solutionxml\#getXmlValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/solutionxmlcollection/_index.md
+++ b/german/java/com.aspose.diagram/solutionxmlcollection/_index.md
@@ -1,0 +1,234 @@
+---
+title: SolutionXMLCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: SolutionXML‑Sammlung.
+type: docs
+weight: 382
+url: /de/java/com.aspose.diagram/solutionxmlcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class SolutionXMLCollection extends Collection
+```
+
+SolutionXML‑Sammlung.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [add(SolutionXML solutionXml)](#add-com.aspose.diagram.SolutionXML-) | Fügen Sie das SolutionXML zur Sammlung hinzu. |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [get(String name)](#get-java.lang.String-) | Liefert das Element mit dem angegebenen Attributnamen. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(SolutionXML solutionXml)](#remove-com.aspose.diagram.SolutionXML-) | Entfernen Sie das SolutionXML aus der Sammlung. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(SolutionXML solutionXml) {#add-com.aspose.diagram.SolutionXML-}
+```
+public int add(SolutionXML solutionXml)
+```
+
+
+Fügen Sie das SolutionXML zur Sammlung hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| solutionXml | [SolutionXML](../../com.aspose.diagram/solutionxml) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public SolutionXML get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[SolutionXML](../../com.aspose.diagram/solutionxml) - 
+### get(String name) {#get-java.lang.String-}
+```
+public SolutionXML get(String name)
+```
+
+
+Liefert das Element mit dem angegebenen Attributnamen. Gibt null zurück, wenn ein Element nicht existiert.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Name | java.lang.String |  |
+
+**Returns:**
+[SolutionXML](../../com.aspose.diagram/solutionxml) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(SolutionXML solutionXml) {#remove-com.aspose.diagram.SolutionXML-}
+```
+public void remove(SolutionXML solutionXml)
+```
+
+
+Entfernen Sie das SolutionXML aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| solutionXml | [SolutionXML](../../com.aspose.diagram/solutionxml) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/spinbuttonactivexcontrol/_index.md
+++ b/german/java/com.aspose.diagram/spinbuttonactivexcontrol/_index.md
@@ -1,0 +1,547 @@
+---
+title: SpinButtonActiveXControl
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt das SpinButton-Steuerelement dar.
+type: docs
+weight: 383
+url: /de/java/com.aspose.diagram/spinbuttonactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class SpinButtonActiveXControl extends ActiveXControl
+```
+
+Stellt das SpinButton-Steuerelement dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBackOleColor()](#getBackOleColor--) | die OLE‑Farbe des Hintergrunds. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | die Binärdaten des Steuerelements. |
+| [getForeOleColor()](#getForeOleColor--) | die OLE‑Farbe des Vordergrunds. |
+| [getHeight()](#getHeight--) | die Höhe des Steuerelements in Punkt‑Einheiten. |
+| [getIMEMode()](#getIMEMode--) | der Standard‑Laufzeitmodus des Input Method Editors für das Steuerelement, wenn es den Fokus erhält. |
+| [getMax()](#getMax--) | der maximal zulässige Wert. |
+| [getMin()](#getMin--) | der minimal zulässige Wert. |
+| [getMouseIcon()](#getMouseIcon--) | ein benutzerdefiniertes Symbol, das als Mauszeiger für das Steuerelement angezeigt wird. |
+| [getMousePointer()](#getMousePointer--) | der Typ des als Mauszeiger für das Steuerelement angezeigten Symbols. |
+| [getOrientation()](#getOrientation--) | ob die SpinButton‑ oder ScrollBar‑Steuerung vertikal oder horizontal ausgerichtet ist. |
+| [getPosition()](#getPosition--) | der Wert. |
+| [getSmallChange()](#getSmallChange--) | der Betrag, um den sich die Eigenschaft Position ändert |
+| [getType()](#getType--) | Ermittelt den Typ des ActiveX-Steuerelements. |
+| [getWidth()](#getWidth--) | die Breite des Steuerelements in Punkt-Einheiten. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | Gibt an, ob das Steuerelement automatisch die Größe ändert, um seinen gesamten Inhalt anzuzeigen. |
+| [isEnabled()](#isEnabled--) | Gibt an, ob das Steuerelement den Fokus erhalten und auf benutzergenerierte Ereignisse reagieren kann. |
+| [isLocked()](#isLocked--) | Gibt an, ob Daten im Steuerelement für die Bearbeitung gesperrt sind. |
+| [isTransparent()](#isTransparent--) | Gibt an, ob das Steuerelement transparent ist. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setHeight(double value)](#setHeight-double-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setIMEMode(int value)](#setIMEMode-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) |
+| [setLocked(boolean value)](#setLocked-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) |
+| [setMax(int value)](#setMax-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getMax()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getMax--) |
+| [setMin(int value)](#setMin-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getMin()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getMin--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | Für die Beschreibung dieser Eigenschaft siehe bitte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setOrientation(int value)](#setOrientation-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getOrientation()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getOrientation--) |
+| [setPosition(int value)](#setPosition-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getPosition()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getPosition--) |
+| [setSmallChange(int value)](#setSmallChange-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getSmallChange()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getSmallChange--) |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) |
+| [setWidth(double value)](#setWidth-double-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+die OLE‑Farbe des Hintergrunds.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+die Binärdaten des Steuerelements.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+Die OLE-Farbe des Vordergrunds. Gilt nicht für das Image-Steuerelement.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+die Höhe des Steuerelements in Punkt‑Einheiten.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+der Standard‑Laufzeitmodus des Input Method Editors für das Steuerelement, wenn es den Fokus erhält.
+
+**Returns:**
+int
+### getMax() {#getMax--}
+```
+public int getMax()
+```
+
+
+der maximal zulässige Wert.
+
+**Returns:**
+int
+### getMin() {#getMin--}
+```
+public int getMin()
+```
+
+
+der minimal zulässige Wert.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+ein benutzerdefiniertes Symbol, das als Mauszeiger für das Steuerelement angezeigt wird.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+der Typ des als Mauszeiger für das Steuerelement angezeigten Symbols.
+
+**Returns:**
+int
+### getOrientation() {#getOrientation--}
+```
+public int getOrientation()
+```
+
+
+ob die SpinButton‑ oder ScrollBar‑Steuerung vertikal oder horizontal ausgerichtet ist.
+
+**Returns:**
+int
+### getPosition() {#getPosition--}
+```
+public int getPosition()
+```
+
+
+der Wert.
+
+**Returns:**
+int
+### getSmallChange() {#getSmallChange--}
+```
+public int getSmallChange()
+```
+
+
+der Betrag, um den sich die Eigenschaft Position ändert
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Ermittelt den Typ des ActiveX-Steuerelements.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+die Breite des Steuerelements in Punkt-Einheiten.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+Gibt an, ob das Steuerelement automatisch die Größe ändert, um seinen gesamten Inhalt anzuzeigen.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+Gibt an, ob das Steuerelement den Fokus erhalten und auf benutzergenerierte Ereignisse reagieren kann.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+Gibt an, ob Daten im Steuerelement für die Bearbeitung gesperrt sind.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+Gibt an, ob das Steuerelement transparent ist.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setMax(int value) {#setMax-int-}
+```
+public void setMax(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getMax()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getMax--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setMin(int value) {#setMin-int-}
+```
+public void setMin(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getMin()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getMin--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setOrientation(int value) {#setOrientation-int-}
+```
+public void setOrientation(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getOrientation()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getOrientation--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setPosition(int value) {#setPosition-int-}
+```
+public void setPosition(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getPosition()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getPosition--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setSmallChange(int value) {#setSmallChange-int-}
+```
+public void setSmallChange(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getSmallChange()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getSmallChange--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/splineknot/_index.md
+++ b/german/java/com.aspose.diagram/splineknot/_index.md
@@ -1,0 +1,274 @@
+---
+title: SplineKnot
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält x- und y-Koordinaten für einen Splinen-Steuerpunkt und einen Splinen-Knoten, die durch die X-, Y- und A-Elemente dargestellt werden.
+type: docs
+weight: 384
+url: /de/java/com.aspose.diagram/splineknot/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class SplineKnot extends Coordinate
+```
+
+Enthält X‑ und Y‑Koordinaten für den Kontrollpunkt einer Spline und den Knoten einer Spline, dargestellt durch die Elemente X, Y bzw. A.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [SplineKnot()](#SplineKnot--) | Erstellt eine Instanz der Klasse [SplineKnot](../../com.aspose.diagram/splineknot). |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | Einer der Knoten der Spline (außer dem letzten oder den ersten beiden). |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getIX()](#getIX--) | Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements. |
+| [getX()](#getX--) | Die x-Koordinate eines Steuerpunkts. |
+| [getY()](#getY--) | Die y-Koordinate eines Steuerpunkts. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getA()](../../com.aspose.diagram/splineknot\#getA--) |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/splineknot\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getIX()](../../com.aspose.diagram/splineknot\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getX()](../../com.aspose.diagram/splineknot\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getY()](../../com.aspose.diagram/splineknot\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SplineKnot() {#SplineKnot--}
+```
+public SplineKnot()
+```
+
+
+Erstellt eine Instanz der Klasse [SplineKnot](../../com.aspose.diagram/splineknot).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+Einer der Knoten der Spline (außer dem letzten oder den ersten beiden).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+Die x-Koordinate eines Steuerpunkts.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+Die y-Koordinate eines Steuerpunkts.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getA()](../../com.aspose.diagram/splineknot\#getA--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/splineknot\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getIX()](../../com.aspose.diagram/splineknot\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getX()](../../com.aspose.diagram/splineknot\#getX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getY()](../../com.aspose.diagram/splineknot\#getY--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/splineknotcollection/_index.md
+++ b/german/java/com.aspose.diagram/splineknotcollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: SplineKnotCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: SplineKnot‑Sammlung.
+type: docs
+weight: 385
+url: /de/java/com.aspose.diagram/splineknotcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class SplineKnotCollection extends Collection
+```
+
+SplineKnot‑Sammlung.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public SplineKnot get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[SplineKnot](../../com.aspose.diagram/splineknot) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/splinestart/_index.md
+++ b/german/java/com.aspose.diagram/splinestart/_index.md
@@ -1,0 +1,349 @@
+---
+title: SplineStart
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält x- und y-Koordinaten für den zweiten Steuerpunkt einer Spline, ihren zweiten Knoten, ihren ersten Knoten, den letzten Knoten und den Grad der Spline.
+type: docs
+weight: 386
+url: /de/java/com.aspose.diagram/splinestart/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class SplineStart extends Coordinate
+```
+
+Enthält x- und y-Koordinaten für den zweiten Steuerpunkt einer Spline, ihren zweiten Knoten, ihren ersten Knoten, den letzten Knoten und den Grad der Spline. Diese Informationen sind in den Elementen X, Y, A, B, C und D jeweils enthalten.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [SplineStart()](#SplineStart--) | Erstellt eine Instanz der Klasse [SplineStart](../../com.aspose.diagram/splinestart). |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | Der zweite Knoten der Spline. |
+| [getB()](#getB--) | Der erste Knoten einer Spline. |
+| [getC()](#getC--) | Der letzte Knoten der Spline. |
+| [getClass()](#getClass--) |  |
+| [getD()](#getD--) | Der Grad der Spline (eine ganze Zahl von 1 bis 25). |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getIX()](#getIX--) | Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements. |
+| [getX()](#getX--) | Die x-Koordinate des zweiten Steuerpunkts einer Spline. |
+| [getY()](#getY--) | Die y-Koordinate des zweiten Steuerpunkts einer Spline. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getA()](../../com.aspose.diagram/splinestart\#getA--) |
+| [setB(DoubleValue value)](#setB-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getB()](../../com.aspose.diagram/splinestart\#getB--) |
+| [setC(DoubleValue value)](#setC-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getC()](../../com.aspose.diagram/splinestart\#getC--) |
+| [setD(IntValue value)](#setD-com.aspose.diagram.IntValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getD()](../../com.aspose.diagram/splinestart\#getD--) |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/splinestart\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getIX()](../../com.aspose.diagram/splinestart\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getX()](../../com.aspose.diagram/splinestart\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getY()](../../com.aspose.diagram/splinestart\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SplineStart() {#SplineStart--}
+```
+public SplineStart()
+```
+
+
+Erstellt eine Instanz der Klasse [SplineStart](../../com.aspose.diagram/splinestart).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+Der zweite Knoten der Spline.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getB() {#getB--}
+```
+public DoubleValue getB()
+```
+
+
+Der erste Knoten einer Spline.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getC() {#getC--}
+```
+public DoubleValue getC()
+```
+
+
+Der letzte Knoten der Spline.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getD() {#getD--}
+```
+public IntValue getD()
+```
+
+
+Der Grad der Spline (eine ganze Zahl von 1 bis 25).
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+Die x-Koordinate des zweiten Steuerpunkts einer Spline.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+Die y-Koordinate des zweiten Steuerpunkts einer Spline.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getA()](../../com.aspose.diagram/splinestart\#getA--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setB(DoubleValue value) {#setB-com.aspose.diagram.DoubleValue-}
+```
+public void setB(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getB()](../../com.aspose.diagram/splinestart\#getB--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setC(DoubleValue value) {#setC-com.aspose.diagram.DoubleValue-}
+```
+public void setC(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getC()](../../com.aspose.diagram/splinestart\#getC--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setD(IntValue value) {#setD-com.aspose.diagram.IntValue-}
+```
+public void setD(IntValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getD()](../../com.aspose.diagram/splinestart\#getD--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/splinestart\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getIX()](../../com.aspose.diagram/splinestart\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getX()](../../com.aspose.diagram/splinestart\#getX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getY()](../../com.aspose.diagram/splinestart\#getY--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/splinestartcollection/_index.md
+++ b/german/java/com.aspose.diagram/splinestartcollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: SplineStartCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: SplineStart‑Sammlung.
+type: docs
+weight: 387
+url: /de/java/com.aspose.diagram/splinestartcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class SplineStartCollection extends Collection
+```
+
+SplineStart‑Sammlung.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public SplineStart get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[SplineStart](../../com.aspose.diagram/splinestart) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/str2value/_index.md
+++ b/german/java/com.aspose.diagram/str2value/_index.md
@@ -1,0 +1,244 @@
+---
+title: Str2Value
+second_title: Aspose.Diagram for Java API-Referenz
+description: String-Wert.
+type: docs
+weight: 388
+url: /de/java/com.aspose.diagram/str2value/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.StrValue](../../com.aspose.diagram/strvalue)
+```
+public class Str2Value extends StrValue
+```
+
+String-Wert.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [Str2Value(String value)](#Str2Value-java.lang.String-) | Konstruktor. |
+| [Str2Value(String value, UnitFormulaErrV ufev)](#Str2Value-java.lang.String-com.aspose.diagram.UnitFormulaErrV-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Attribute eines Elements. |
+| [getUfev()](#getUfev--) | Attribute eines Elements. |
+| [getValue()](#getValue--) | String-Wert. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getUfe()](../../com.aspose.diagram/strvalue\#getUfe--) |
+| [setUfev(UnitFormulaErrV value)](#setUfev-com.aspose.diagram.UnitFormulaErrV-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getUfev()](../../com.aspose.diagram/str2value\#getUfev--) |
+| [setValue(String value)](#setValue-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/strvalue\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Str2Value(String value) {#Str2Value-java.lang.String-}
+```
+public Str2Value(String value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### Str2Value(String value, UnitFormulaErrV ufev) {#Str2Value-java.lang.String-com.aspose.diagram.UnitFormulaErrV-}
+```
+public Str2Value(String value, UnitFormulaErrV ufev)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+| ufev | [UnitFormulaErrV](../../com.aspose.diagram/unitformulaerrv) |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Attribute eines Elements.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getUfev() {#getUfev--}
+```
+public UnitFormulaErrV getUfev()
+```
+
+
+Attribute eines Elements.
+
+**Returns:**
+[UnitFormulaErrV](../../com.aspose.diagram/unitformulaerrv)
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+String-Wert.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getUfe()](../../com.aspose.diagram/strvalue\#getUfe--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setUfev(UnitFormulaErrV value) {#setUfev-com.aspose.diagram.UnitFormulaErrV-}
+```
+public void setUfev(UnitFormulaErrV value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getUfev()](../../com.aspose.diagram/str2value\#getUfev--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [UnitFormulaErrV](../../com.aspose.diagram/unitformulaerrv) |  |
+
+### setValue(String value) {#setValue-java.lang.String-}
+```
+public void setValue(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/strvalue\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/streamprovideroptions/_index.md
+++ b/german/java/com.aspose.diagram/streamprovideroptions/_index.md
@@ -1,0 +1,186 @@
+---
+title: StreamProviderOptions
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt die Stream-Optionen dar.
+type: docs
+weight: 390
+url: /de/java/com.aspose.diagram/streamprovideroptions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class StreamProviderOptions
+```
+
+Stellt die Stream-Optionen dar.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [StreamProviderOptions()](#StreamProviderOptions--) |  |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDefaultPath()](#getDefaultPath--) | Der Standardpfad (URL), der in der erzeugten HTML-Datei für die referenzierte Quelle gespeichert wird. |
+| [getStream()](#getStream--) | Liest/Setzt den Ausgabestream zum Schreiben der gespeicherten Daten. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCustomPath(String value)](#setCustomPath-java.lang.String-) | Der vom Benutzer benutzerdefinierte Pfad (URL), der in der erzeugten HTML-Datei für die referenzierte Quelle gespeichert wird. |
+| [setStream(OutputStream value)](#setStream-java.io.OutputStream-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getStream()](../../com.aspose.diagram/streamprovideroptions\#getStream--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### StreamProviderOptions() {#StreamProviderOptions--}
+```
+public StreamProviderOptions()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultPath() {#getDefaultPath--}
+```
+public String getDefaultPath()
+```
+
+
+Der Standardpfad (URL), der in der erzeugten HTML-Datei für die referenzierte Quelle gespeichert wird. Zum Beispiel werden die Blattdaten in xxx\_files/sheet001.htm gespeichert, die im Haupt-HTML-File verwendete URL sollte etwa so aussehen: "src=\"xxx\_files/sheet001.htm\""
+
+**Returns:**
+java.lang.String
+### getStream() {#getStream--}
+```
+public OutputStream getStream()
+```
+
+
+Liest/Setzt den Ausgabestream zum Schreiben der gespeicherten Daten.
+
+**Returns:**
+java.io.OutputStream
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCustomPath(String value) {#setCustomPath-java.lang.String-}
+```
+public void setCustomPath(String value)
+```
+
+
+Der vom Benutzer benutzerdefinierte Pfad (URL), der in der erzeugten HTML-Datei für die referenzierte Quelle gespeichert wird. Wenn er nicht vom Benutzer definiert wird, wird DefaultPath verwendet. Zum Beispiel werden die Blattdaten vom Benutzer nach d:/sheet001.htm gespeichert, die im Haupt-HTML-File verwendete URL sollte "d:/sheet001.htm" oder ein anderer gültiger relativer Pfad sein, der vom Haupt-HTML-File aus erreichbar ist.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setStream(OutputStream value) {#setStream-java.io.OutputStream-}
+```
+public void setStream(OutputStream value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getStream()](../../com.aspose.diagram/streamprovideroptions\#getStream--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.io.OutputStream |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/strvalue/_index.md
+++ b/german/java/com.aspose.diagram/strvalue/_index.md
@@ -1,0 +1,234 @@
+---
+title: StrValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: String-Wert
+type: docs
+weight: 389
+url: /de/java/com.aspose.diagram/strvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class StrValue
+```
+
+String-Wert
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [StrValue(String value)](#StrValue-java.lang.String-) | Konstruktor. |
+| [StrValue(String value, UnitFormulaErr ufe)](#StrValue-java.lang.String-com.aspose.diagram.UnitFormulaErr-) | Konstruktor. |
+| [StrValue(String value, int unit)](#StrValue-java.lang.String-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Attribute eines Elements. |
+| [getValue()](#getValue--) | String-Wert. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getUfe()](../../com.aspose.diagram/strvalue\#getUfe--) |
+| [setValue(String value)](#setValue-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/strvalue\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### StrValue(String value) {#StrValue-java.lang.String-}
+```
+public StrValue(String value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### StrValue(String value, UnitFormulaErr ufe) {#StrValue-java.lang.String-com.aspose.diagram.UnitFormulaErr-}
+```
+public StrValue(String value, UnitFormulaErr ufe)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+| ufe | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### StrValue(String value, int unit) {#StrValue-java.lang.String-int-}
+```
+public StrValue(String value, int unit)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+| Einheit | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Attribute eines Elements.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+String-Wert.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getUfe()](../../com.aspose.diagram/strvalue\#getUfe--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(String value) {#setValue-java.lang.String-}
+```
+public void setValue(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/strvalue\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/style/_index.md
+++ b/german/java/com.aspose.diagram/style/_index.md
@@ -1,0 +1,204 @@
+---
+title: Style
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt die Zeichenformatierung an, die auf einen Textbereich im Textblock der Shapes angewendet wird.
+type: docs
+weight: 391
+url: /de/java/com.aspose.diagram/style/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Style
+```
+
+Gibt die Zeichenformatierung an, die auf einen Textbereich im Textblock der Form angewendet wird.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [Style(int value)](#Style-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Gibt die Zeichenformatierung an, die auf einen Textbereich im Textblock der Form angewendet wird. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getUfe()](../../com.aspose.diagram/style\#getUfe--) |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/style\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Style(int value) {#Style-int-}
+```
+public Style(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Gibt die Zeichenformatierung an, die auf einen Textbereich im Textblock der Form angewendet wird.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getUfe()](../../com.aspose.diagram/style\#getUfe--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/style\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/styleprop/_index.md
+++ b/german/java/com.aspose.diagram/styleprop/_index.md
@@ -1,0 +1,194 @@
+---
+title: StyleProp
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält Elemente, die das Stilverhalten steuern, z. b. ob ein Stil Textzeilen‑ und Füllattribute enthält.
+type: docs
+weight: 392
+url: /de/java/com.aspose.diagram/styleprop/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class StyleProp
+```
+
+Enthält Elemente, die das Stilverhalten steuern, z. B. ob ein Stil Text-, Linien- und Füllattribute enthält.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getEnableFillProps()](#getEnableFillProps--) | Gibt an, ob ein Stil Füllattribute enthält. |
+| [getEnableLineProps()](#getEnableLineProps--) | Gibt an, ob ein Stil Linieneigenschaften enthält |
+| [getEnableTextProps()](#getEnableTextProps--) | Gibt an, ob ein Stil Texteigenschaften enthält. |
+| [getHideForApply()](#getHideForApply--) | Gibt an, wo ein Stil in der Microsoft Visio-Benutzeroberfläche angezeigt wird. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/styleprop\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getEnableFillProps() {#getEnableFillProps--}
+```
+public BoolValue getEnableFillProps()
+```
+
+
+Gibt an, ob ein Stil Füllattribute enthält.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getEnableLineProps() {#getEnableLineProps--}
+```
+public BoolValue getEnableLineProps()
+```
+
+
+Gibt an, ob ein Stil Linieneigenschaften enthält
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getEnableTextProps() {#getEnableTextProps--}
+```
+public BoolValue getEnableTextProps()
+```
+
+
+Gibt an, ob ein Stil Texteigenschaften enthält.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getHideForApply() {#getHideForApply--}
+```
+public BoolValue getHideForApply()
+```
+
+
+Gibt an, wo ein Stil in der Microsoft Visio-Benutzeroberfläche angezeigt wird.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/styleprop\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/stylesheet/_index.md
+++ b/german/java/com.aspose.diagram/stylesheet/_index.md
@@ -1,0 +1,519 @@
+---
+title: StyleSheet
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt einen im Dokument definierten Stil dar.
+type: docs
+weight: 393
+url: /de/java/com.aspose.diagram/stylesheet/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class StyleSheet
+```
+
+Stellt einen im Dokument definierten Stil dar.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [StyleSheet()](#StyleSheet--) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getChars()](#getChars--) | Enthält eine Sammlung von Char-Elementen. |
+| [getClass()](#getClass--) |  |
+| [getConnectionABCDs()](#getConnectionABCDs--) | Enthält eine Sammlung von ConnectionABCD-Elementen. |
+| [getConnections()](#getConnections--) | Enthält eine Sammlung von Connection-Elementen. |
+| [getEvent()](#getEvent--) | Enthält Elemente, die Formeln angeben, die Formereignisse steuern. |
+| [getFill()](#getFill--) | Enthält die aktuellen Füllformatierungswerte für die Form und den Formschatten, einschließlich Muster, Vordergrundfarbe und Hintergrundfarbe. |
+| [getFillStyle()](#getFillStyle--) | StyleSheet-Element, von dem dieser Stil die Füllformatierung erbt. |
+| [getForeign()](#getForeign--) | Enthält Elemente, die die Breite und Höhe eines Objekts aus einem anderen Programm angeben, das in einem Microsoft Visio-Dokument verwendet wird. |
+| [getForeignData()](#getForeignData--) | Enthält einen MIME (Multipurpose Internet Mail Extensions) codierten BLOB von Bilddaten, wie Windows-Metadatei, Bitmap oder OLE-Daten. |
+| [getGroup()](#getGroup--) | Enthält Elemente, die steuern, wie Sie Formen zu einer Gruppe hinzufügen, Gruppenmitglieder verschieben und Gruppen auswählen. |
+| [getHelp()](#getHelp--) | Enthält Elemente, die das Hilfedatei-Thema und die Copyright-Informationen des Shape-Elements angeben. |
+| [getID()](#getID--) | Die eindeutige ID des Elements innerhalb seines übergeordneten Elements. |
+| [getImage()](#getImage--) | Enthält die Gamma-, Helligkeits-, Kontrast-, Unschärfe-, Schärfungs-, Rauschunterdrückungs- und Transparenzwerte für ein Bitmap. |
+| [getLayout()](#getLayout--) | Enthält Elemente, die die Platzierung von Formen und die Routing‑Einstellungen von Verbindern steuern. |
+| [getLine()](#getLine--) | Enthält Elemente, die Linienattribute für eine Form steuern, wie Muster, Stärke und Farbe. |
+| [getLineStyle()](#getLineStyle--) | StyleSheet-Element, von dem dieser Stil die Linienformatierung erbt. |
+| [getMisc()](#getMisc--) | Enthält Elemente, die das Hilfedatei-Thema und die Copyright-Informationen des Shape-Elements angeben. |
+| [getName()](#getName--) | Der Name des Elements. |
+| [getNameU()](#getNameU--) | Der universelle Name des Elements. |
+| [getPageLayout()](#getPageLayout--) | Enthält ein Diagram, das die Seitengestaltungseinstellungen für Formen und Verbinder steuert, wie z. B. den Abstand zwischen allen Formen auf der Seite, den Abstand zwischen allen Verbindern auf der Seite und den Routingsstil für alle Verbinder auf der Seite. |
+| [getParas()](#getParas--) | Enthält eine Sammlung von Para-Elementen. |
+| [getProtection()](#getProtection--) | Sperren hilft, unbeabsichtigte Änderungen an der Form zu verhindern, verhindert jedoch nicht, dass Microsoft Visio Werte unter anderen Umständen zurücksetzt. |
+| [getRulerGrid()](#getRulerGrid--) | Enthält Elemente, die die Einstellungen der Lineale und des Rasters der Seite festlegen. |
+| [getStyleProp()](#getStyleProp--) | Enthält Elemente, die das Stilverhalten steuern, z. B. ob ein Stil Text-, Linien- und Füllattribute enthält. |
+| [getTabsCollection()](#getTabsCollection--) | Enthält eine Sammlung von Tab-Elementen. |
+| [getTextBlock()](#getTextBlock--) | Enthält Elemente, die die Ausrichtung, Ränder und Standard-Tabstopp-Positionen des Textes im Textblock einer Form festlegen. |
+| [getTextStyle()](#getTextStyle--) | StyleSheet-Element, von dem dieser Stil die Textformatierung erbt. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setFillStyle(StyleSheet value)](#setFillStyle-com.aspose.diagram.StyleSheet-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getFillStyle()](../../com.aspose.diagram/stylesheet\#getFillStyle--) |
+| [setID(int value)](#setID-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getID()](../../com.aspose.diagram/stylesheet\#getID--) |
+| [setLineStyle(StyleSheet value)](#setLineStyle-com.aspose.diagram.StyleSheet-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getLineStyle()](../../com.aspose.diagram/stylesheet\#getLineStyle--) |
+| [setName(String value)](#setName-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getName()](../../com.aspose.diagram/stylesheet\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getNameU()](../../com.aspose.diagram/stylesheet\#getNameU--) |
+| [setTextStyle(StyleSheet value)](#setTextStyle-com.aspose.diagram.StyleSheet-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getTextStyle()](../../com.aspose.diagram/stylesheet\#getTextStyle--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### StyleSheet() {#StyleSheet--}
+```
+public StyleSheet()
+```
+
+
+Konstruktor.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getChars() {#getChars--}
+```
+public CharCollection getChars()
+```
+
+
+Enthält eine Sammlung von Char-Elementen.
+
+**Returns:**
+[CharCollection](../../com.aspose.diagram/charcollection)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConnectionABCDs() {#getConnectionABCDs--}
+```
+public ConnectionABCDCollection getConnectionABCDs()
+```
+
+
+Enthält eine Sammlung von ConnectionABCD-Elementen.
+
+**Returns:**
+[ConnectionABCDCollection](../../com.aspose.diagram/connectionabcdcollection)
+### getConnections() {#getConnections--}
+```
+public ConnectionCollection getConnections()
+```
+
+
+Enthält eine Sammlung von Connection-Elementen.
+
+**Returns:**
+[ConnectionCollection](../../com.aspose.diagram/connectioncollection)
+### getEvent() {#getEvent--}
+```
+public Event getEvent()
+```
+
+
+Enthält Elemente, die Formeln angeben, die Formereignisse steuern.
+
+**Returns:**
+[Event](../../com.aspose.diagram/event)
+### getFill() {#getFill--}
+```
+public Fill getFill()
+```
+
+
+Enthält die aktuellen Füllformatierungswerte für die Form und den Formschatten, einschließlich Muster, Vordergrundfarbe und Hintergrundfarbe.
+
+**Returns:**
+[Fill](../../com.aspose.diagram/fill)
+### getFillStyle() {#getFillStyle--}
+```
+public StyleSheet getFillStyle()
+```
+
+
+StyleSheet-Element, von dem dieser Stil die Füllformatierung erbt.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getForeign() {#getForeign--}
+```
+public Foreign getForeign()
+```
+
+
+Enthält Elemente, die die Breite und Höhe eines aus einem anderen Programm stammenden Objekts in einem Microsoft Visio-Dokument angeben. Außerdem enthält es Elemente, die den Abstand angeben, um den das Bild des Objekts innerhalb seiner Ränder versetzt ist.
+
+**Returns:**
+[Foreign](../../com.aspose.diagram/foreign)
+### getForeignData() {#getForeignData--}
+```
+public ForeignData getForeignData()
+```
+
+
+Enthält einen MIME (Multipurpose Internet Mail Extensions) codierten BLOB von Bilddaten, wie Windows-Metadatei, Bitmap oder OLE-Daten.
+
+**Returns:**
+[ForeignData](../../com.aspose.diagram/foreigndata)
+### getGroup() {#getGroup--}
+```
+public Group getGroup()
+```
+
+
+Enthält Elemente, die steuern, wie Sie Formen zu einer Gruppe hinzufügen, Gruppenmitglieder verschieben und Gruppen auswählen.
+
+**Returns:**
+[Group](../../com.aspose.diagram/group)
+### getHelp() {#getHelp--}
+```
+public Help getHelp()
+```
+
+
+Enthält Elemente, die das Hilfedatei-Thema und die Copyright-Informationen des Shape-Elements angeben.
+
+**Returns:**
+[Help](../../com.aspose.diagram/help)
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+Die eindeutige ID des Elements innerhalb seines übergeordneten Elements.
+
+**Returns:**
+int
+### getImage() {#getImage--}
+```
+public Image getImage()
+```
+
+
+Enthält die Gamma-, Helligkeits-, Kontrast-, Unschärfe-, Schärfungs-, Rauschunterdrückungs- und Transparenzwerte für ein Bitmap.
+
+**Returns:**
+[Image](../../com.aspose.diagram/image)
+### getLayout() {#getLayout--}
+```
+public Layout getLayout()
+```
+
+
+Enthält Elemente, die die Platzierung von Formen und die Routing‑Einstellungen von Verbindern steuern.
+
+**Returns:**
+[Layout](../../com.aspose.diagram/layout)
+### getLine() {#getLine--}
+```
+public Line getLine()
+```
+
+
+Enthält Elemente, die die Linieneigenschaften für eine Form steuern, wie Muster, Stärke und Farbe. Diese Elemente bestimmen, ob die Linienenden formatiert sind (zum Beispiel mit einer Pfeilspitze), die Größe der Linienendformate, der Radius des Rundungskreises, der auf die Linie angewendet wird, und den Linientyp (rund oder eckig).
+
+**Returns:**
+[Line](../../com.aspose.diagram/line)
+### getLineStyle() {#getLineStyle--}
+```
+public StyleSheet getLineStyle()
+```
+
+
+StyleSheet-Element, von dem dieser Stil die Linienformatierung erbt.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getMisc() {#getMisc--}
+```
+public Misc getMisc()
+```
+
+
+Enthält Elemente, die das Hilfedatei-Thema und die Copyright-Informationen des Shape-Elements angeben.
+
+**Returns:**
+[Misc](../../com.aspose.diagram/misc)
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Der Name des Elements.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+Der universelle Name des Elements.
+
+**Returns:**
+java.lang.String
+### getPageLayout() {#getPageLayout--}
+```
+public PageLayout getPageLayout()
+```
+
+
+Enthält ein Diagram, das die Seitengestaltungseinstellungen für Formen und Verbinder steuert, wie z. B. den Abstand zwischen allen Formen auf der Seite, den Abstand zwischen allen Verbindern auf der Seite und den Routingsstil für alle Verbinder auf der Seite.
+
+**Returns:**
+[PageLayout](../../com.aspose.diagram/pagelayout)
+### getParas() {#getParas--}
+```
+public ParaCollection getParas()
+```
+
+
+Enthält eine Sammlung von Para-Elementen.
+
+**Returns:**
+[ParaCollection](../../com.aspose.diagram/paracollection)
+### getProtection() {#getProtection--}
+```
+public Protection getProtection()
+```
+
+
+Das Sperren hilft, unbeabsichtigte Änderungen an der Form zu verhindern, verhindert jedoch nicht, dass Microsoft Visio Werte unter anderen Umständen zurücksetzt. Es schützt auch nicht vor Änderungen, die im ShapeSheet‑Fenster vorgenommen werden.
+
+**Returns:**
+[Protection](../../com.aspose.diagram/protection)
+### getRulerGrid() {#getRulerGrid--}
+```
+public RulerGrid getRulerGrid()
+```
+
+
+Enthält Elemente, die die Einstellungen der Lineale und des Rasters der Seite festlegen.
+
+**Returns:**
+[RulerGrid](../../com.aspose.diagram/rulergrid)
+### getStyleProp() {#getStyleProp--}
+```
+public StyleProp getStyleProp()
+```
+
+
+Enthält Elemente, die das Stilverhalten steuern, z. B. ob ein Stil Text-, Linien- und Füllattribute enthält.
+
+**Returns:**
+[StyleProp](../../com.aspose.diagram/styleprop)
+### getTabsCollection() {#getTabsCollection--}
+```
+public TabsCollection getTabsCollection()
+```
+
+
+Enthält eine Sammlung von Tab-Elementen.
+
+**Returns:**
+[TabsCollection](../../com.aspose.diagram/tabscollection)
+### getTextBlock() {#getTextBlock--}
+```
+public TextBlock getTextBlock()
+```
+
+
+Enthält Elemente, die die Ausrichtung, Ränder und Standard-Tabstopp-Positionen des Textes im Textblock einer Form festlegen.
+
+**Returns:**
+[TextBlock](../../com.aspose.diagram/textblock)
+### getTextStyle() {#getTextStyle--}
+```
+public StyleSheet getTextStyle()
+```
+
+
+StyleSheet-Element, von dem dieser Stil die Textformatierung erbt.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setFillStyle(StyleSheet value) {#setFillStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setFillStyle(StyleSheet value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getFillStyle()](../../com.aspose.diagram/stylesheet\#getFillStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getID()](../../com.aspose.diagram/stylesheet\#getID--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setLineStyle(StyleSheet value) {#setLineStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setLineStyle(StyleSheet value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getLineStyle()](../../com.aspose.diagram/stylesheet\#getLineStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getName()](../../com.aspose.diagram/stylesheet\#getName--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getNameU()](../../com.aspose.diagram/stylesheet\#getNameU--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setTextStyle(StyleSheet value) {#setTextStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setTextStyle(StyleSheet value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getTextStyle()](../../com.aspose.diagram/stylesheet\#getTextStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/stylesheetcollection/_index.md
+++ b/german/java/com.aspose.diagram/stylesheetcollection/_index.md
@@ -1,0 +1,234 @@
+---
+title: StyleSheetCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: Sammlung von StyleSheets.
+type: docs
+weight: 394
+url: /de/java/com.aspose.diagram/stylesheetcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class StyleSheetCollection extends Collection
+```
+
+Sammlung von StyleSheets.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [add(StyleSheet item)](#add-com.aspose.diagram.StyleSheet-) | StyleSheet zur Sammlung hinzufügen. |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [getStyleSheet(int ID)](#getStyleSheet-int-) | Liefert das Element mit der angegebenen ID. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(StyleSheet item)](#remove-com.aspose.diagram.StyleSheet-) | StyleSheet aus der Sammlung entfernen. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(StyleSheet item) {#add-com.aspose.diagram.StyleSheet-}
+```
+public int add(StyleSheet item)
+```
+
+
+StyleSheet zur Sammlung hinzufügen.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public StyleSheet get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### getStyleSheet(int ID) {#getStyleSheet-int-}
+```
+public StyleSheet getStyleSheet(int ID)
+```
+
+
+Liefert das Element mit der angegebenen ID.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| ID | int |  |
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet) - 
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(StyleSheet item) {#remove-com.aspose.diagram.StyleSheet-}
+```
+public void remove(StyleSheet item)
+```
+
+
+StyleSheet aus der Sammlung entfernen.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/stylevalue/_index.md
+++ b/german/java/com.aspose.diagram/stylevalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: StyleValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt die Zeichenformatierung an, die auf einen Textbereich im Textblock der Shapes angewendet wird.
+type: docs
+weight: 395
+url: /de/java/com.aspose.diagram/stylevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class StyleValue
+```
+
+Gibt die Zeichenformatierung an, die auf einen Textbereich im Textblock der Form angewendet wird.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [BOLD](#BOLD) | Fett. |
+| [ITALIC](#ITALIC) | Kursiv. |
+| [SMALL_CAPS](#SMALL-CAPS) | Kapitälchen. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+| [UNDERLINE](#UNDERLINE) | Unterstrichen. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOLD {#BOLD}
+```
+public static final int BOLD
+```
+
+
+Fett.
+
+### ITALIC {#ITALIC}
+```
+public static final int ITALIC
+```
+
+
+Kursiv.
+
+### SMALL_CAPS {#SMALL-CAPS}
+```
+public static final int SMALL_CAPS
+```
+
+
+Kapitälchen.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### UNDERLINE {#UNDERLINE}
+```
+public static final int UNDERLINE
+```
+
+
+Unterstrichen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/svgsaveoptions/_index.md
+++ b/german/java/com.aspose.diagram/svgsaveoptions/_index.md
@@ -1,0 +1,604 @@
+---
+title: SVGSaveOptions
+second_title: Aspose.Diagram for Java API-Referenz
+description: Ermöglicht das Angeben zusätzlicher Optionen beim Rendern von Diagrammseiten zu SVG.
+type: docs
+weight: 347
+url: /de/java/com.aspose.diagram/svgsaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.SaveOptions](../../com.aspose.diagram/saveoptions), [com.aspose.diagram.RenderingSaveOptions](../../com.aspose.diagram/renderingsaveoptions)
+```
+public class SVGSaveOptions extends RenderingSaveOptions
+```
+
+Ermöglicht das Angeben zusätzlicher Optionen beim Rendern von Diagrammseiten zu SVG.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [SVGSaveOptions()](#SVGSaveOptions--) | Initialisiert eine neue Instanz dieser Klasse, die verwendet werden kann, um ein Dokument im Format Aspose.Diagram.SaveFileFormat zu speichern. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | Erstellt ein Speicheroptionen-Objekt einer Klasse, die für das angegebene Speicherformat geeignet ist. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCustomImagePath()](#getCustomImagePath--) | Der benutzerdefinierte Pfad (URL), der in der erzeugten SVG-Datei für das Bild gespeichert wird. |
+| [getDefaultFont()](#getDefaultFont--) | Wenn Zeichen im Diagramm Unicode sind und nicht mit dem korrekten Schriftwert gesetzt werden oder die Schriftart nicht lokal installiert ist, können sie in PDF, Bild oder XPS als Block erscheinen. |
+| [getEmfRenderSetting()](#getEmfRenderSetting--) | Einstellung zum Rendern von Emf-Metadateien. |
+| [getEnlargePage()](#getEnlargePage--) | Gibt an, ob die Seite vergrößert werden soll. |
+| [getExportElementAsRectTag()](#getExportElementAsRectTag--) | Definiert, ob Rechteck-Elemente als <rect>-Tag exportiert werden sollen oder nicht. |
+| [getExportGuideShapes()](#getExportGuideShapes--) | Definiert, ob die Leitlinienformen exportiert werden sollen oder nicht. |
+| [getExportHiddenPage()](#getExportHiddenPage--) | Definiert, ob die versteckte Seite exportiert werden soll oder nicht. |
+| [getPageIndex()](#getPageIndex--) | Der nullbasierte Index der zu rendernden Seite. |
+| [getPageSize()](#getPageSize--) | die Seitengröße für die erzeugten Bilder. |
+| [getQuality()](#getQuality--) | Ein Wert, der die Qualität der erzeugten Bilder bestimmt und nur beim Speichern von Seiten im JPEG-Format angewendet wird. |
+| [getSVGFitToViewPort()](#getSVGFitToViewPort--) | Wenn diese Eigenschaft wahr ist, passt das erzeugte SVG zum Ansichtsfenster. |
+| [getSaveFormat()](#getSaveFormat--) | Gibt das Format an, in dem das Dokument gespeichert wird, wenn dieses SaveOptions‑Objekt verwendet wird. |
+| [getShapes()](#getShapes--) | Formen zum Rendern. |
+| [getWarningCallback()](#getWarningCallback--) | Warnungs-Callback. |
+| [hashCode()](#hashCode--) |  |
+| [isExportComments()](#isExportComments--) | Definiert, ob Kommentare exportiert werden sollen oder nicht. |
+| [isExportScaleInMatrix()](#isExportScaleInMatrix--) | Definiert, ob die Export-Skala in einer Matrix benötigt wird oder nicht. |
+| [isSavingCustomLinePattern()](#isSavingCustomLinePattern--) | Definiert, ob ein benutzerdefiniertes Linienmuster gespeichert wird. |
+| [isSavingImageSeparately()](#isSavingImageSeparately--) | Definiert, ob das Bild separat gespeichert wird. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCustomImagePath(String value)](#setCustomImagePath-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getCustomImagePath()](../../com.aspose.diagram/svgsaveoptions\#getCustomImagePath--) |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDefaultFont()](../../com.aspose.diagram/saveoptions\\#getDefaultFont--) |
+| [setEmfRenderSetting(int value)](#setEmfRenderSetting-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\\#getEmfRenderSetting--) |
+| [setEnlargePage(boolean value)](#setEnlargePage-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--) |
+| [setExportComments(boolean value)](#setExportComments-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--) |
+| [setExportElementAsRectTag(boolean value)](#setExportElementAsRectTag-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getExportElementAsRectTag()](../../com.aspose.diagram/svgsaveoptions\#getExportElementAsRectTag--) |
+| [setExportGuideShapes(boolean value)](#setExportGuideShapes-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--) |
+| [setExportHiddenPage(boolean value)](#setExportHiddenPage-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getExportHiddenPage()](../../com.aspose.diagram/svgsaveoptions\#getExportHiddenPage--) |
+| [setExportScaleInMatrix(boolean value)](#setExportScaleInMatrix-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isExportScaleInMatrix()](../../com.aspose.diagram/svgsaveoptions\#isExportScaleInMatrix--) |
+| [setPageIndex(int value)](#setPageIndex-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getPageIndex()](../../com.aspose.diagram/svgsaveoptions\#getPageIndex--) |
+| [setPageSize(PageSize value)](#setPageSize-com.aspose.diagram.PageSize-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--) |
+| [setQuality(int value)](#setQuality-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getQuality()](../../com.aspose.diagram/svgsaveoptions\#getQuality--) |
+| [setSVGFitToViewPort(boolean value)](#setSVGFitToViewPort-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getSVGFitToViewPort()](../../com.aspose.diagram/svgsaveoptions\#getSVGFitToViewPort--) |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getSaveFormat()](../../com.aspose.diagram/saveoptions\#getSaveFormat--) |
+| [setSavingCustomLinePattern(boolean value)](#setSavingCustomLinePattern-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isSavingCustomLinePattern()](../../com.aspose.diagram/svgsaveoptions\#isSavingCustomLinePattern--) |
+| [setSavingImageSeparately(boolean value)](#setSavingImageSeparately-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isSavingImageSeparately()](../../com.aspose.diagram/svgsaveoptions\#isSavingImageSeparately--) |
+| [setShapes(ShapeCollection value)](#setShapes-com.aspose.diagram.ShapeCollection-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--) |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SVGSaveOptions() {#SVGSaveOptions--}
+```
+public SVGSaveOptions()
+```
+
+
+Initialisiert eine neue Instanz dieser Klasse, die verwendet werden kann, um ein Dokument im Format Aspose.Diagram.SaveFileFormat zu speichern.
+
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+Erstellt ein Speicheroptionen-Objekt einer Klasse, die für das angegebene Speicherformat geeignet ist.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| saveFormat | int | Das Aspose.Diagram.SaveFileFormat, für das ein Save-Optionen-Objekt erstellt werden soll. |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCustomImagePath() {#getCustomImagePath--}
+```
+public String getCustomImagePath()
+```
+
+
+Der vom Benutzer benutzerdefinierte Pfad (URL), der in der erzeugten SVG-Datei für das Bild gespeichert wird. Wenn er nicht vom Benutzer definiert wird, wird das aktuelle Verzeichnis verwendet.
+
+**Returns:**
+java.lang.String
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+Wenn Zeichen im Diagramm Unicode sind und nicht mit dem korrekten Schriftwert gesetzt werden oder die Schriftart nicht lokal installiert ist, können sie im PDF, Bild oder XPS als Block erscheinen. Setzen Sie die DefaultFont, z. B. MingLiu oder MS Gothic, um diese Zeichen anzuzeigen.
+
+**Returns:**
+java.lang.String
+### getEmfRenderSetting() {#getEmfRenderSetting--}
+```
+public int getEmfRenderSetting()
+```
+
+
+Einstellung für das Rendern von EMF-Metadateien. EMF-Metadateien, die als "EMF+ Dual" identifiziert werden, können sowohl EMF+-Datensätze als auch EMF-Datensätze enthalten. Jeder Datensatztyp kann zum Rendern des Bildes verwendet werden, nur EMF+-Datensätze oder nur EMF-Datensätze. Wenn EmfPlusPrefer gesetzt ist, werden EMF+-Datensätze geparst, andernfalls werden nur EMF-Datensätze geparst. Der Standardwert ist EmfOnly"/>.
+
+**Returns:**
+int
+### getEnlargePage() {#getEnlargePage--}
+```
+public boolean getEnlargePage()
+```
+
+
+Gibt an, ob die Seite vergrößert werden soll. Wenn true – Seite vergrößern. Wenn false – Seite nicht vergrößern. Der Standardwert ist true.
+
+**Returns:**
+boolean
+### getExportElementAsRectTag() {#getExportElementAsRectTag--}
+```
+public boolean getExportElementAsRectTag()
+```
+
+
+Definiert, ob Rechteck-Elemente als rect-Tag exportiert werden sollen oder nicht. Der Standardwert ist false.
+
+**Returns:**
+boolean
+### getExportGuideShapes() {#getExportGuideShapes--}
+```
+public boolean getExportGuideShapes()
+```
+
+
+Definiert, ob Leitlinienformen exportiert werden sollen oder nicht. Standardwert ist true.
+
+**Returns:**
+boolean
+### getExportHiddenPage() {#getExportHiddenPage--}
+```
+public boolean getExportHiddenPage()
+```
+
+
+Definiert, ob versteckte Seiten exportiert werden sollen oder nicht. Standardwert ist true.
+
+**Returns:**
+boolean
+### getPageIndex() {#getPageIndex--}
+```
+public int getPageIndex()
+```
+
+
+Der nullbasierte Index der zu rendernden Seite. Standardwert ist 0.
+
+**Returns:**
+int
+### getPageSize() {#getPageSize--}
+```
+public PageSize getPageSize()
+```
+
+
+die Seitengröße für die erzeugten Bilder. Kann [PageSize](../../com.aspose.diagram/pagesize) oder null sein. Der Standardwert ist null. Wenn PageSize null ist, wird die Seitengröße für das erzeugte Bild aus dem Quell‑Diagramm übernommen.
+
+**Returns:**
+[PageSize](../../com.aspose.diagram/pagesize)
+### getQuality() {#getQuality--}
+```
+public int getQuality()
+```
+
+
+Ein Wert, der die Qualität der erzeugten Bilder bestimmt und nur beim Speichern von Seiten im JPEG-Format angewendet wird. Der Standardwert ist 100. Wirkt nur beim Speichern als JPEG. Der Wert muss zwischen 0 und 100 liegen. Der Standardwert ist 100.
+
+**Returns:**
+int
+### getSVGFitToViewPort() {#getSVGFitToViewPort--}
+```
+public boolean getSVGFitToViewPort()
+```
+
+
+Wenn diese Eigenschaft wahr ist, passt das erzeugte SVG zum Ansichtsfenster.
+
+**Returns:**
+boolean
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+Gibt das Format an, in dem das Dokument gespeichert wird, wenn dieses SaveOptions‑Objekt verwendet wird.
+
+**Returns:**
+int
+### getShapes() {#getShapes--}
+```
+public ShapeCollection getShapes()
+```
+
+
+Zu rendernde Shapes. Standardanzahl ist 0.
+
+**Returns:**
+[ShapeCollection](../../com.aspose.diagram/shapecollection)
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+Warnungs-Callback.
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExportComments() {#isExportComments--}
+```
+public boolean isExportComments()
+```
+
+
+Legt fest, ob Kommentare exportiert werden sollen oder nicht. Der Standardwert ist false.
+
+**Returns:**
+boolean
+### isExportScaleInMatrix() {#isExportScaleInMatrix--}
+```
+public boolean isExportScaleInMatrix()
+```
+
+
+Definiert, ob die Export‑Skala in einer Matrix benötigt wird oder nicht. Der Standardwert ist true.
+
+**Returns:**
+boolean
+### isSavingCustomLinePattern() {#isSavingCustomLinePattern--}
+```
+public boolean isSavingCustomLinePattern()
+```
+
+
+Definiert, ob ein benutzerdefiniertes Linienmuster gespeichert wird.
+
+**Returns:**
+boolean
+### isSavingImageSeparately() {#isSavingImageSeparately--}
+```
+public boolean isSavingImageSeparately()
+```
+
+
+Definiert, ob das Bild separat gespeichert wird.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCustomImagePath(String value) {#setCustomImagePath-java.lang.String-}
+```
+public void setCustomImagePath(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getCustomImagePath()](../../com.aspose.diagram/svgsaveoptions\#getCustomImagePath--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDefaultFont()](../../com.aspose.diagram/saveoptions\\#getDefaultFont--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setEmfRenderSetting(int value) {#setEmfRenderSetting-int-}
+```
+public void setEmfRenderSetting(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\\#getEmfRenderSetting--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setEnlargePage(boolean value) {#setEnlargePage-boolean-}
+```
+public void setEnlargePage(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setExportComments(boolean value) {#setExportComments-boolean-}
+```
+public void setExportComments(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setExportElementAsRectTag(boolean value) {#setExportElementAsRectTag-boolean-}
+```
+public void setExportElementAsRectTag(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getExportElementAsRectTag()](../../com.aspose.diagram/svgsaveoptions\#getExportElementAsRectTag--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setExportGuideShapes(boolean value) {#setExportGuideShapes-boolean-}
+```
+public void setExportGuideShapes(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setExportHiddenPage(boolean value) {#setExportHiddenPage-boolean-}
+```
+public void setExportHiddenPage(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getExportHiddenPage()](../../com.aspose.diagram/svgsaveoptions\#getExportHiddenPage--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setExportScaleInMatrix(boolean value) {#setExportScaleInMatrix-boolean-}
+```
+public void setExportScaleInMatrix(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isExportScaleInMatrix()](../../com.aspose.diagram/svgsaveoptions\#isExportScaleInMatrix--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setPageIndex(int value) {#setPageIndex-int-}
+```
+public void setPageIndex(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getPageIndex()](../../com.aspose.diagram/svgsaveoptions\#getPageIndex--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setPageSize(PageSize value) {#setPageSize-com.aspose.diagram.PageSize-}
+```
+public void setPageSize(PageSize value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [PageSize](../../com.aspose.diagram/pagesize) |  |
+
+### setQuality(int value) {#setQuality-int-}
+```
+public void setQuality(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getQuality()](../../com.aspose.diagram/svgsaveoptions\#getQuality--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setSVGFitToViewPort(boolean value) {#setSVGFitToViewPort-boolean-}
+```
+public void setSVGFitToViewPort(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getSVGFitToViewPort()](../../com.aspose.diagram/svgsaveoptions\#getSVGFitToViewPort--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getSaveFormat()](../../com.aspose.diagram/saveoptions\#getSaveFormat--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setSavingCustomLinePattern(boolean value) {#setSavingCustomLinePattern-boolean-}
+```
+public void setSavingCustomLinePattern(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isSavingCustomLinePattern()](../../com.aspose.diagram/svgsaveoptions\#isSavingCustomLinePattern--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setSavingImageSeparately(boolean value) {#setSavingImageSeparately-boolean-}
+```
+public void setSavingImageSeparately(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isSavingImageSeparately()](../../com.aspose.diagram/svgsaveoptions\#isSavingImageSeparately--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setShapes(ShapeCollection value) {#setShapes-com.aspose.diagram.ShapeCollection-}
+```
+public void setShapes(ShapeCollection value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [ShapeCollection](../../com.aspose.diagram/shapecollection) |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/tab/_index.md
+++ b/german/java/com.aspose.diagram/tab/_index.md
@@ -1,0 +1,261 @@
+---
+title: Tab
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält eine Sammlung von Tab-Elementen.
+type: docs
+weight: 396
+url: /de/java/com.aspose.diagram/tab/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Tab
+```
+
+Enthält eine Sammlung von Tab-Elementen.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAlignment()](#getAlignment--) | Gibt die Tab‑Ausrichtung an. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getIX()](#getIX--) | Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements. |
+| [getLeader()](#getLeader--) | Das Führungszeichen wurde angegeben. |
+| [getPosition()](#getPosition--) | Gibt die Position eines Tabstopps an. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAlignment(Alignment value)](#setAlignment-com.aspose.diagram.Alignment-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getAlignment()](../../com.aspose.diagram/tab\#getAlignment--) |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/tab\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getIX()](../../com.aspose.diagram/tab\#getIX--) |
+| [setLeader(StrValue value)](#setLeader-com.aspose.diagram.StrValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getLeader()](../../com.aspose.diagram/tab\#getLeader--) |
+| [setPosition(DoubleValue value)](#setPosition-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getPosition()](../../com.aspose.diagram/tab\#getPosition--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAlignment() {#getAlignment--}
+```
+public Alignment getAlignment()
+```
+
+
+Gibt die Tab‑Ausrichtung an.
+
+**Returns:**
+[Alignment](../../com.aspose.diagram/alignment)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements.
+
+**Returns:**
+int
+### getLeader() {#getLeader--}
+```
+public StrValue getLeader()
+```
+
+
+Das Führungszeichen wurde angegeben.
+
+**Returns:**
+[StrValue](../../com.aspose.diagram/strvalue)
+### getPosition() {#getPosition--}
+```
+public DoubleValue getPosition()
+```
+
+
+Gibt die Position eines Tabstopps an.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAlignment(Alignment value) {#setAlignment-com.aspose.diagram.Alignment-}
+```
+public void setAlignment(Alignment value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getAlignment()](../../com.aspose.diagram/tab\#getAlignment--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [Alignment](../../com.aspose.diagram/alignment) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/tab\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getIX()](../../com.aspose.diagram/tab\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setLeader(StrValue value) {#setLeader-com.aspose.diagram.StrValue-}
+```
+public void setLeader(StrValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getLeader()](../../com.aspose.diagram/tab\#getLeader--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [StrValue](../../com.aspose.diagram/strvalue) |  |
+
+### setPosition(DoubleValue value) {#setPosition-com.aspose.diagram.DoubleValue-}
+```
+public void setPosition(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getPosition()](../../com.aspose.diagram/tab\#getPosition--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/tabcollection/_index.md
+++ b/german/java/com.aspose.diagram/tabcollection/_index.md
@@ -1,0 +1,268 @@
+---
+title: TabCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält eine Sammlung von Tab-Elementen
+type: docs
+weight: 397
+url: /de/java/com.aspose.diagram/tabcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class TabCollection extends Collection
+```
+
+Enthält eine Sammlung von Tab-Elementen
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [add(Tab item)](#add-com.aspose.diagram.Tab-) | Füge das Tab-Objekt zur Sammlung hinzu. |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getIX()](#getIX--) | Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Tab item)](#remove-com.aspose.diagram.Tab-) | Entferne das Tab-Objekt aus der Sammlung. |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/tabcollection\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getIX()](../../com.aspose.diagram/tabcollection\#getIX--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Tab item) {#add-com.aspose.diagram.Tab-}
+```
+public int add(Tab item)
+```
+
+
+Füge das Tab-Objekt zur Sammlung hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [Tab](../../com.aspose.diagram/tab) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Tab get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[Tab](../../com.aspose.diagram/tab) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Tab item) {#remove-com.aspose.diagram.Tab-}
+```
+public void remove(Tab item)
+```
+
+
+Entferne das Tab-Objekt aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [Tab](../../com.aspose.diagram/tab) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/tabcollection\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getIX()](../../com.aspose.diagram/tabcollection\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/tabscollection/_index.md
+++ b/german/java/com.aspose.diagram/tabscollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: TabsCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält eine Sammlung von TabCollection-Elementen
+type: docs
+weight: 398
+url: /de/java/com.aspose.diagram/tabscollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class TabsCollection extends Collection
+```
+
+Enthält eine Sammlung von TabCollection-Elementen
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [add(TabCollection item)](#add-com.aspose.diagram.TabCollection-) | Füge das Tab-Objekt zur Sammlung hinzu. |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(TabCollection item)](#remove-com.aspose.diagram.TabCollection-) | Entferne das Tab-Objekt aus der Sammlung. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(TabCollection item) {#add-com.aspose.diagram.TabCollection-}
+```
+public int add(TabCollection item)
+```
+
+
+Füge das Tab-Objekt zur Sammlung hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [TabCollection](../../com.aspose.diagram/tabcollection) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public TabCollection get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[TabCollection](../../com.aspose.diagram/tabcollection) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(TabCollection item) {#remove-com.aspose.diagram.TabCollection-}
+```
+public void remove(TabCollection item)
+```
+
+
+Entferne das Tab-Objekt aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [TabCollection](../../com.aspose.diagram/tabcollection) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/text/_index.md
+++ b/german/java/com.aspose.diagram/text/_index.md
@@ -1,0 +1,160 @@
+---
+title: Text
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält den Text einer Form.
+type: docs
+weight: 399
+url: /de/java/com.aspose.diagram/text/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Text
+```
+
+Enthält den Text einer Form.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [Text()](#Text--) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getValue()](#getValue--) | FormatTxt-Sammlung, die den Text einer Form enthält. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Text() {#Text--}
+```
+public Text()
+```
+
+
+Konstruktor.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getValue() {#getValue--}
+```
+public FormatTxtCollection getValue()
+```
+
+
+FormatTxt-Sammlung, die den Text einer Form enthält.
+
+**Returns:**
+[FormatTxtCollection](../../com.aspose.diagram/formattxtcollection)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/textblock/_index.md
+++ b/german/java/com.aspose.diagram/textblock/_index.md
@@ -1,0 +1,386 @@
+---
+title: TextBlock
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält Elemente, die die Ausrichtungsränder und Standard‑Tabulatorpositionen des Textes in einem Form‑Textblock festlegen.
+type: docs
+weight: 400
+url: /de/java/com.aspose.diagram/textblock/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class TextBlock
+```
+
+Enthält Elemente, die die Ausrichtung, Ränder und Standard-Tabstopp-Positionen des Textes im Textblock einer Form festlegen.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBottomMargin()](#getBottomMargin--) | Bestimmt den Abstand zwischen der unteren Begrenzung des Textblocks und der letzten darin enthaltenen Textzeile. |
+| [getClass()](#getClass--) |  |
+| [getDefaultTabStop()](#getDefaultTabStop--) | Gibt das Intervall der Standard‑Tabulatoren in einem Textblock an. |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getLeftMargin()](#getLeftMargin--) | Gibt den Abstand zwischen der linken Begrenzung des Textblocks und dem darin enthaltenen Text an. |
+| [getRightMargin()](#getRightMargin--) | Gibt den Abstand zwischen der rechten Begrenzung des Textblocks und dem darin enthaltenen Text an. |
+| [getTextBkgnd()](#getTextBkgnd--) | Gibt die Hintergrundfarbe des Textes für eine Form an. |
+| [getTextBkgndTrans()](#getTextBkgndTrans--) | Gibt den Transparenzgrad für die Hintergrundfarbe des Textblocks einer Form an, von 0 (vollständig undurchsichtig) bis 1 (vollständig transparent). |
+| [getTextDirection()](#getTextDirection--) | Gibt die Richtung der Zeichen in einem Textblock an. |
+| [getTopMargin()](#getTopMargin--) | Gibt den Abstand zwischen der oberen Begrenzung des Textblocks und der ersten darin enthaltenen Textzeile an. |
+| [getVerticalAlign()](#getVerticalAlign--) | Gibt die vertikale Ausrichtung des Textes innerhalb des Textblocks an. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setBottomMargin(DoubleValue value)](#setBottomMargin-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getBottomMargin()](../../com.aspose.diagram/textblock\#getBottomMargin--) |
+| [setDefaultTabStop(DoubleValue value)](#setDefaultTabStop-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDefaultTabStop()](../../com.aspose.diagram/textblock\#getDefaultTabStop--) |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/textblock\#getDel--) |
+| [setLeftMargin(DoubleValue value)](#setLeftMargin-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getLeftMargin()](../../com.aspose.diagram/textblock\#getLeftMargin--) |
+| [setRightMargin(DoubleValue value)](#setRightMargin-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getRightMargin()](../../com.aspose.diagram/textblock\#getRightMargin--) |
+| [setTextBkgnd(ColorValue value)](#setTextBkgnd-com.aspose.diagram.ColorValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getTextBkgnd()](../../com.aspose.diagram/textblock\#getTextBkgnd--) |
+| [setTextBkgndTrans(DoubleValue value)](#setTextBkgndTrans-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getTextBkgndTrans()](../../com.aspose.diagram/textblock\#getTextBkgndTrans--) |
+| [setTextDirection(TextDirection value)](#setTextDirection-com.aspose.diagram.TextDirection-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getTextDirection()](../../com.aspose.diagram/textblock\#getTextDirection--) |
+| [setTopMargin(DoubleValue value)](#setTopMargin-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getTopMargin()](../../com.aspose.diagram/textblock\#getTopMargin--) |
+| [setVerticalAlign(VerticalAlign value)](#setVerticalAlign-com.aspose.diagram.VerticalAlign-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getVerticalAlign()](../../com.aspose.diagram/textblock\#getVerticalAlign--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBottomMargin() {#getBottomMargin--}
+```
+public DoubleValue getBottomMargin()
+```
+
+
+Bestimmt den Abstand zwischen dem unteren Rand des Textblocks und der letzten darin enthaltenen Textzeile. Der Standardwert beträgt 4 pt. Dieser Wert ist unabhängig vom Maßstab der Zeichnung. Wird die Zeichnung skaliert, bleibt der untere Rand unverändert.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultTabStop() {#getDefaultTabStop--}
+```
+public DoubleValue getDefaultTabStop()
+```
+
+
+Gibt das Intervall der Standard‑Tabulatoren in einem Textblock an.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getLeftMargin() {#getLeftMargin--}
+```
+public DoubleValue getLeftMargin()
+```
+
+
+Gibt den Abstand zwischen dem linken Rand des Textblocks und dem darin enthaltenen Text an. Dieser Wert ist unabhängig vom Maßstab der Zeichnung. Wird die Zeichnung skaliert, bleibt der linke Rand unverändert.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getRightMargin() {#getRightMargin--}
+```
+public DoubleValue getRightMargin()
+```
+
+
+Gibt den Abstand zwischen dem rechten Rand des Textblocks und dem darin enthaltenen Text an. Dieser Wert ist unabhängig vom Maßstab der Zeichnung. Wird die Zeichnung skaliert, bleibt der rechte Rand unverändert.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTextBkgnd() {#getTextBkgnd--}
+```
+public ColorValue getTextBkgnd()
+```
+
+
+Gibt die Hintergrundfarbe des Textes für eine Form an.
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getTextBkgndTrans() {#getTextBkgndTrans--}
+```
+public DoubleValue getTextBkgndTrans()
+```
+
+
+Gibt den Transparenzgrad für die Hintergrundfarbe des Textblocks einer Form an, von 0 (vollständig undurchsichtig) bis 1 (vollständig transparent).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTextDirection() {#getTextDirection--}
+```
+public TextDirection getTextDirection()
+```
+
+
+Gibt die Richtung der Zeichen in einem Textblock an.
+
+**Returns:**
+[TextDirection](../../com.aspose.diagram/textdirection)
+### getTopMargin() {#getTopMargin--}
+```
+public DoubleValue getTopMargin()
+```
+
+
+Gibt den Abstand zwischen der oberen Begrenzung des Textblocks und der ersten darin enthaltenen Textzeile an.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getVerticalAlign() {#getVerticalAlign--}
+```
+public VerticalAlign getVerticalAlign()
+```
+
+
+Gibt die vertikale Ausrichtung des Textes innerhalb des Textblocks an.
+
+**Returns:**
+[VerticalAlign](../../com.aspose.diagram/verticalalign)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setBottomMargin(DoubleValue value) {#setBottomMargin-com.aspose.diagram.DoubleValue-}
+```
+public void setBottomMargin(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getBottomMargin()](../../com.aspose.diagram/textblock\#getBottomMargin--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDefaultTabStop(DoubleValue value) {#setDefaultTabStop-com.aspose.diagram.DoubleValue-}
+```
+public void setDefaultTabStop(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDefaultTabStop()](../../com.aspose.diagram/textblock\#getDefaultTabStop--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/textblock\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setLeftMargin(DoubleValue value) {#setLeftMargin-com.aspose.diagram.DoubleValue-}
+```
+public void setLeftMargin(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getLeftMargin()](../../com.aspose.diagram/textblock\#getLeftMargin--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setRightMargin(DoubleValue value) {#setRightMargin-com.aspose.diagram.DoubleValue-}
+```
+public void setRightMargin(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getRightMargin()](../../com.aspose.diagram/textblock\#getRightMargin--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTextBkgnd(ColorValue value) {#setTextBkgnd-com.aspose.diagram.ColorValue-}
+```
+public void setTextBkgnd(ColorValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getTextBkgnd()](../../com.aspose.diagram/textblock\#getTextBkgnd--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setTextBkgndTrans(DoubleValue value) {#setTextBkgndTrans-com.aspose.diagram.DoubleValue-}
+```
+public void setTextBkgndTrans(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getTextBkgndTrans()](../../com.aspose.diagram/textblock\#getTextBkgndTrans--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTextDirection(TextDirection value) {#setTextDirection-com.aspose.diagram.TextDirection-}
+```
+public void setTextDirection(TextDirection value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getTextDirection()](../../com.aspose.diagram/textblock\#getTextDirection--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [TextDirection](../../com.aspose.diagram/textdirection) |  |
+
+### setTopMargin(DoubleValue value) {#setTopMargin-com.aspose.diagram.DoubleValue-}
+```
+public void setTopMargin(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getTopMargin()](../../com.aspose.diagram/textblock\#getTopMargin--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setVerticalAlign(VerticalAlign value) {#setVerticalAlign-com.aspose.diagram.VerticalAlign-}
+```
+public void setVerticalAlign(VerticalAlign value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getVerticalAlign()](../../com.aspose.diagram/textblock\#getVerticalAlign--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [VerticalAlign](../../com.aspose.diagram/verticalalign) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/textboxactivexcontrol/_index.md
+++ b/german/java/com.aspose.diagram/textboxactivexcontrol/_index.md
@@ -1,0 +1,922 @@
+---
+title: TextBoxActiveXControl
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt ein Textfeld-ActiveX-Steuerelement dar.
+type: docs
+weight: 401
+url: /de/java/com.aspose.diagram/textboxactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class TextBoxActiveXControl extends ActiveXControl
+```
+
+Stellt ein Textfeld-ActiveX-Steuerelement dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBackOleColor()](#getBackOleColor--) | die OLE‑Farbe des Hintergrunds. |
+| [getBorderOleColor()](#getBorderOleColor--) | die OLE‑Farbe des Hintergrunds. |
+| [getBorderStyle()](#getBorderStyle--) | der von dem Steuerelement verwendete Randtyp. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | die Binärdaten des Steuerelements. |
+| [getDropButtonStyle()](#getDropButtonStyle--) | Gibt das Symbol an, das auf dem Dropdown‑Button angezeigt wird. |
+| [getEnterFieldBehavior()](#getEnterFieldBehavior--) | Gibt das Auswahlverhalten beim Betreten des Steuerelements an. |
+| [getEnterKeyBehavior()](#getEnterKeyBehavior--) | Gibt das Verhalten der ENTER-Taste an. |
+| [getForeOleColor()](#getForeOleColor--) | die OLE‑Farbe des Vordergrunds. |
+| [getHeight()](#getHeight--) | die Höhe des Steuerelements in Punkt‑Einheiten. |
+| [getHideSelection()](#getHideSelection--) | Gibt an, ob ausgewählter Text im Steuerelement hervorgehoben wird, wenn das Steuerelement keinen Fokus hat. |
+| [getIMEMode()](#getIMEMode--) | der Standard‑Laufzeitmodus des Input Method Editors für das Steuerelement, wenn es den Fokus erhält. |
+| [getIntegralHeight()](#getIntegralHeight--) | Gibt an, ob das Steuerelement nur vollständige Textzeilen anzeigt, ohne Teilzeilen anzuzeigen. |
+| [getMaxLength()](#getMaxLength--) | die maximale Anzahl von Zeichen |
+| [getMouseIcon()](#getMouseIcon--) | ein benutzerdefiniertes Symbol, das als Mauszeiger für das Steuerelement angezeigt wird. |
+| [getMousePointer()](#getMousePointer--) | der Typ des als Mauszeiger für das Steuerelement angezeigten Symbols. |
+| [getPasswordChar()](#getPasswordChar--) | Ein Zeichen, das anstelle der eingegebenen Zeichen angezeigt wird. |
+| [getScrollBars()](#getScrollBars--) | Gibt an, ob das Steuerelement vertikale Bildlaufleisten, horizontale Bildlaufleisten, beides oder keine hat. |
+| [getShowDropButtonTypeWhen()](#getShowDropButtonTypeWhen--) | Gibt das Symbol an, das auf dem Dropdown‑Button angezeigt wird. |
+| [getSpecialEffect()](#getSpecialEffect--) | der Spezialeffekt des Steuerelements. |
+| [getTabKeyBehavior()](#getTabKeyBehavior--) | Gibt an, ob Tabulatorzeichen im Text des Steuerelements erlaubt sind. |
+| [getText()](#getText--) | Text des Steuerelements. |
+| [getType()](#getType--) | Ermittelt den Typ des ActiveX-Steuerelements. |
+| [getWidth()](#getWidth--) | die Breite des Steuerelements in Punkt-Einheiten. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | Gibt an, ob das Steuerelement automatisch die Größe ändert, um seinen gesamten Inhalt anzuzeigen. |
+| [isAutoTab()](#isAutoTab--) | Gibt an, ob der Fokus automatisch zum nächsten Steuerelement wechselt, wenn der Benutzer die maximale Zeichenanzahl eingibt. |
+| [isAutoWordSelected()](#isAutoWordSelected--) | Gibt die Basiseinheit an, die zum Erweitern einer Auswahl verwendet wird. |
+| [isDragBehaviorEnabled()](#isDragBehaviorEnabled--) | Gibt an, ob Ziehen und Ablegen für das Steuerelement aktiviert ist. |
+| [isEditable()](#isEditable--) | Gibt an, ob der Benutzer in das Steuerelement tippen kann. |
+| [isEnabled()](#isEnabled--) | Gibt an, ob das Steuerelement den Fokus erhalten und auf benutzergenerierte Ereignisse reagieren kann. |
+| [isLocked()](#isLocked--) | Gibt an, ob Daten im Steuerelement für die Bearbeitung gesperrt sind. |
+| [isMultiLine()](#isMultiLine--) | Gibt an, ob das Steuerelement mehr als eine Textzeile anzeigen kann. |
+| [isTransparent()](#isTransparent--) | Gibt an, ob das Steuerelement transparent ist. |
+| [isWordWrapped()](#isWordWrapped--) | Gibt an, ob der Inhalt des Steuerelements am Zeilenende automatisch umbrochen wird. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) |
+| [setAutoTab(boolean value)](#setAutoTab-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isAutoTab()](../../com.aspose.diagram/textboxactivexcontrol\#isAutoTab--) |
+| [setAutoWordSelected(boolean value)](#setAutoWordSelected-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isAutoWordSelected()](../../com.aspose.diagram/textboxactivexcontrol\#isAutoWordSelected--) |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setBorderOleColor(int value)](#setBorderOleColor-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getBorderOleColor()](../../com.aspose.diagram/textboxactivexcontrol\#getBorderOleColor--) |
+| [setBorderStyle(int value)](#setBorderStyle-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getBorderStyle()](../../com.aspose.diagram/textboxactivexcontrol\#getBorderStyle--) |
+| [setDragBehaviorEnabled(boolean value)](#setDragBehaviorEnabled-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isDragBehaviorEnabled()](../../com.aspose.diagram/textboxactivexcontrol\#isDragBehaviorEnabled--) |
+| [setDropButtonStyle(int value)](#setDropButtonStyle-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDropButtonStyle()](../../com.aspose.diagram/textboxactivexcontrol\#getDropButtonStyle--) |
+| [setEditable(boolean value)](#setEditable-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isEditable()](../../com.aspose.diagram/textboxactivexcontrol\#isEditable--) |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) |
+| [setEnterFieldBehavior(boolean value)](#setEnterFieldBehavior-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getEnterFieldBehavior()](../../com.aspose.diagram/textboxactivexcontrol\#getEnterFieldBehavior--) |
+| [setEnterKeyBehavior(boolean value)](#setEnterKeyBehavior-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getEnterKeyBehavior()](../../com.aspose.diagram/textboxactivexcontrol\#getEnterKeyBehavior--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setHeight(double value)](#setHeight-double-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setHideSelection(boolean value)](#setHideSelection-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getHideSelection()](../../com.aspose.diagram/textboxactivexcontrol\#getHideSelection--) |
+| [setIMEMode(int value)](#setIMEMode-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) |
+| [setIntegralHeight(boolean value)](#setIntegralHeight-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getIntegralHeight()](../../com.aspose.diagram/textboxactivexcontrol\#getIntegralHeight--) |
+| [setLocked(boolean value)](#setLocked-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) |
+| [setMaxLength(int value)](#setMaxLength-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getMaxLength()](../../com.aspose.diagram/textboxactivexcontrol\#getMaxLength--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | Für die Beschreibung dieser Eigenschaft siehe bitte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setMultiLine(boolean value)](#setMultiLine-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isMultiLine()](../../com.aspose.diagram/textboxactivexcontrol\#isMultiLine--) |
+| [setPasswordChar(char value)](#setPasswordChar-char-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getPasswordChar()](../../com.aspose.diagram/textboxactivexcontrol\#getPasswordChar--) |
+| [setScrollBars(int value)](#setScrollBars-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getScrollBars()](../../com.aspose.diagram/textboxactivexcontrol\#getScrollBars--) |
+| [setShowDropButtonTypeWhen(int value)](#setShowDropButtonTypeWhen-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getShowDropButtonTypeWhen()](../../com.aspose.diagram/textboxactivexcontrol\#getShowDropButtonTypeWhen--) |
+| [setSpecialEffect(int value)](#setSpecialEffect-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getSpecialEffect()](../../com.aspose.diagram/textboxactivexcontrol\#getSpecialEffect--) |
+| [setTabKeyBehavior(boolean value)](#setTabKeyBehavior-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getTabKeyBehavior()](../../com.aspose.diagram/textboxactivexcontrol\#getTabKeyBehavior--) |
+| [setText(String value)](#setText-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getText()](../../com.aspose.diagram/textboxactivexcontrol\#getText--) |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) |
+| [setWidth(double value)](#setWidth-double-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [setWordWrapped(boolean value)](#setWordWrapped-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isWordWrapped()](../../com.aspose.diagram/textboxactivexcontrol\#isWordWrapped--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+die OLE‑Farbe des Hintergrunds.
+
+**Returns:**
+int
+### getBorderOleColor() {#getBorderOleColor--}
+```
+public int getBorderOleColor()
+```
+
+
+die OLE‑Farbe des Hintergrunds.
+
+**Returns:**
+int
+### getBorderStyle() {#getBorderStyle--}
+```
+public int getBorderStyle()
+```
+
+
+der von dem Steuerelement verwendete Randtyp.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+die Binärdaten des Steuerelements.
+
+**Returns:**
+byte[]
+### getDropButtonStyle() {#getDropButtonStyle--}
+```
+public int getDropButtonStyle()
+```
+
+
+Gibt das Symbol an, das auf dem Dropdown‑Button angezeigt wird.
+
+**Returns:**
+int
+### getEnterFieldBehavior() {#getEnterFieldBehavior--}
+```
+public boolean getEnterFieldBehavior()
+```
+
+
+Gibt das Auswahlverhalten beim Betreten des Steuerelements an. True gibt an, dass die Auswahl unverändert bleibt seit dem letzten Mal, als das Steuerelement aktiv war. False gibt an, dass der gesamte Text im Steuerelement beim Betreten ausgewählt wird.
+
+**Returns:**
+boolean
+### getEnterKeyBehavior() {#getEnterKeyBehavior--}
+```
+public boolean getEnterKeyBehavior()
+```
+
+
+Gibt das Verhalten der EINGABETASTE an. Wahr gibt an, dass das Drücken der EINGABETASTE eine neue Zeile erzeugt. Falsch gibt an, dass das Drücken der EINGABETASTE den Fokus zum nächsten Objekt in der Tab-Reihenfolge verschiebt.
+
+**Returns:**
+boolean
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+Die OLE-Farbe des Vordergrunds. Gilt nicht für das Image-Steuerelement.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+die Höhe des Steuerelements in Punkt‑Einheiten.
+
+**Returns:**
+double
+### getHideSelection() {#getHideSelection--}
+```
+public boolean getHideSelection()
+```
+
+
+Gibt an, ob ausgewählter Text im Steuerelement hervorgehoben wird, wenn das Steuerelement keinen Fokus hat.
+
+**Returns:**
+boolean
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+der Standard‑Laufzeitmodus des Input Method Editors für das Steuerelement, wenn es den Fokus erhält.
+
+**Returns:**
+int
+### getIntegralHeight() {#getIntegralHeight--}
+```
+public boolean getIntegralHeight()
+```
+
+
+Gibt an, ob das Steuerelement nur vollständige Textzeilen anzeigt, ohne Teilzeilen anzuzeigen.
+
+**Returns:**
+boolean
+### getMaxLength() {#getMaxLength--}
+```
+public int getMaxLength()
+```
+
+
+die maximale Anzahl von Zeichen
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+ein benutzerdefiniertes Symbol, das als Mauszeiger für das Steuerelement angezeigt wird.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+der Typ des als Mauszeiger für das Steuerelement angezeigten Symbols.
+
+**Returns:**
+int
+### getPasswordChar() {#getPasswordChar--}
+```
+public char getPasswordChar()
+```
+
+
+Ein Zeichen, das anstelle der eingegebenen Zeichen angezeigt wird.
+
+**Returns:**
+char
+### getScrollBars() {#getScrollBars--}
+```
+public int getScrollBars()
+```
+
+
+Gibt an, ob das Steuerelement vertikale Bildlaufleisten, horizontale Bildlaufleisten, beides oder keine hat.
+
+**Returns:**
+int
+### getShowDropButtonTypeWhen() {#getShowDropButtonTypeWhen--}
+```
+public int getShowDropButtonTypeWhen()
+```
+
+
+Gibt das Symbol an, das auf dem Dropdown‑Button angezeigt wird.
+
+**Returns:**
+int
+### getSpecialEffect() {#getSpecialEffect--}
+```
+public int getSpecialEffect()
+```
+
+
+der Spezialeffekt des Steuerelements.
+
+**Returns:**
+int
+### getTabKeyBehavior() {#getTabKeyBehavior--}
+```
+public boolean getTabKeyBehavior()
+```
+
+
+Gibt an, ob Tabulatorzeichen im Text des Steuerelements erlaubt sind.
+
+**Returns:**
+boolean
+### getText() {#getText--}
+```
+public String getText()
+```
+
+
+Text des Steuerelements.
+
+**Returns:**
+java.lang.String
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Ermittelt den Typ des ActiveX-Steuerelements.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+die Breite des Steuerelements in Punkt-Einheiten.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+Gibt an, ob das Steuerelement automatisch die Größe ändert, um seinen gesamten Inhalt anzuzeigen.
+
+**Returns:**
+boolean
+### isAutoTab() {#isAutoTab--}
+```
+public boolean isAutoTab()
+```
+
+
+Gibt an, ob der Fokus automatisch zum nächsten Steuerelement wechselt, wenn der Benutzer die maximale Zeichenanzahl eingibt.
+
+**Returns:**
+boolean
+### isAutoWordSelected() {#isAutoWordSelected--}
+```
+public boolean isAutoWordSelected()
+```
+
+
+Gibt die Basiseinheit an, die zum Erweitern einer Auswahl verwendet wird. True gibt an, dass die Basiseinheit ein einzelnes Zeichen ist. false gibt an, dass die Basiseinheit ein ganzes Wort ist.
+
+**Returns:**
+boolean
+### isDragBehaviorEnabled() {#isDragBehaviorEnabled--}
+```
+public boolean isDragBehaviorEnabled()
+```
+
+
+Gibt an, ob Ziehen und Ablegen für das Steuerelement aktiviert ist.
+
+**Returns:**
+boolean
+### isEditable() {#isEditable--}
+```
+public boolean isEditable()
+```
+
+
+Gibt an, ob der Benutzer in das Steuerelement tippen kann.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+Gibt an, ob das Steuerelement den Fokus erhalten und auf benutzergenerierte Ereignisse reagieren kann.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+Gibt an, ob Daten im Steuerelement für die Bearbeitung gesperrt sind.
+
+**Returns:**
+boolean
+### isMultiLine() {#isMultiLine--}
+```
+public boolean isMultiLine()
+```
+
+
+Gibt an, ob das Steuerelement mehr als eine Textzeile anzeigen kann.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+Gibt an, ob das Steuerelement transparent ist.
+
+**Returns:**
+boolean
+### isWordWrapped() {#isWordWrapped--}
+```
+public boolean isWordWrapped()
+```
+
+
+Gibt an, ob der Inhalt des Steuerelements am Zeilenende automatisch umbrochen wird.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setAutoTab(boolean value) {#setAutoTab-boolean-}
+```
+public void setAutoTab(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isAutoTab()](../../com.aspose.diagram/textboxactivexcontrol\#isAutoTab--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setAutoWordSelected(boolean value) {#setAutoWordSelected-boolean-}
+```
+public void setAutoWordSelected(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isAutoWordSelected()](../../com.aspose.diagram/textboxactivexcontrol\#isAutoWordSelected--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setBorderOleColor(int value) {#setBorderOleColor-int-}
+```
+public void setBorderOleColor(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getBorderOleColor()](../../com.aspose.diagram/textboxactivexcontrol\#getBorderOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setBorderStyle(int value) {#setBorderStyle-int-}
+```
+public void setBorderStyle(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getBorderStyle()](../../com.aspose.diagram/textboxactivexcontrol\#getBorderStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setDragBehaviorEnabled(boolean value) {#setDragBehaviorEnabled-boolean-}
+```
+public void setDragBehaviorEnabled(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isDragBehaviorEnabled()](../../com.aspose.diagram/textboxactivexcontrol\#isDragBehaviorEnabled--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setDropButtonStyle(int value) {#setDropButtonStyle-int-}
+```
+public void setDropButtonStyle(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDropButtonStyle()](../../com.aspose.diagram/textboxactivexcontrol\#getDropButtonStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setEditable(boolean value) {#setEditable-boolean-}
+```
+public void setEditable(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isEditable()](../../com.aspose.diagram/textboxactivexcontrol\#isEditable--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setEnterFieldBehavior(boolean value) {#setEnterFieldBehavior-boolean-}
+```
+public void setEnterFieldBehavior(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getEnterFieldBehavior()](../../com.aspose.diagram/textboxactivexcontrol\#getEnterFieldBehavior--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setEnterKeyBehavior(boolean value) {#setEnterKeyBehavior-boolean-}
+```
+public void setEnterKeyBehavior(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getEnterKeyBehavior()](../../com.aspose.diagram/textboxactivexcontrol\#getEnterKeyBehavior--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double |  |
+
+### setHideSelection(boolean value) {#setHideSelection-boolean-}
+```
+public void setHideSelection(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getHideSelection()](../../com.aspose.diagram/textboxactivexcontrol\#getHideSelection--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setIntegralHeight(boolean value) {#setIntegralHeight-boolean-}
+```
+public void setIntegralHeight(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getIntegralHeight()](../../com.aspose.diagram/textboxactivexcontrol\#getIntegralHeight--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setMaxLength(int value) {#setMaxLength-int-}
+```
+public void setMaxLength(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getMaxLength()](../../com.aspose.diagram/textboxactivexcontrol\#getMaxLength--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setMultiLine(boolean value) {#setMultiLine-boolean-}
+```
+public void setMultiLine(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isMultiLine()](../../com.aspose.diagram/textboxactivexcontrol\#isMultiLine--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setPasswordChar(char value) {#setPasswordChar-char-}
+```
+public void setPasswordChar(char value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getPasswordChar()](../../com.aspose.diagram/textboxactivexcontrol\#getPasswordChar--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | char |  |
+
+### setScrollBars(int value) {#setScrollBars-int-}
+```
+public void setScrollBars(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getScrollBars()](../../com.aspose.diagram/textboxactivexcontrol\#getScrollBars--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setShowDropButtonTypeWhen(int value) {#setShowDropButtonTypeWhen-int-}
+```
+public void setShowDropButtonTypeWhen(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getShowDropButtonTypeWhen()](../../com.aspose.diagram/textboxactivexcontrol\#getShowDropButtonTypeWhen--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setSpecialEffect(int value) {#setSpecialEffect-int-}
+```
+public void setSpecialEffect(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getSpecialEffect()](../../com.aspose.diagram/textboxactivexcontrol\#getSpecialEffect--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setTabKeyBehavior(boolean value) {#setTabKeyBehavior-boolean-}
+```
+public void setTabKeyBehavior(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getTabKeyBehavior()](../../com.aspose.diagram/textboxactivexcontrol\#getTabKeyBehavior--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setText(String value) {#setText-java.lang.String-}
+```
+public void setText(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getText()](../../com.aspose.diagram/textboxactivexcontrol\#getText--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double |  |
+
+### setWordWrapped(boolean value) {#setWordWrapped-boolean-}
+```
+public void setWordWrapped(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isWordWrapped()](../../com.aspose.diagram/textboxactivexcontrol\#isWordWrapped--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/textcollection/_index.md
+++ b/german/java/com.aspose.diagram/textcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: TextCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält den Text einer Form.
+type: docs
+weight: 402
+url: /de/java/com.aspose.diagram/textcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class TextCollection extends Collection
+```
+
+Enthält den Text einer Form. Jeder Eintrag ist Text mit Zeichen-, Absatz- und Tabulator-Eigenschaften.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [add(Text item)](#add-com.aspose.diagram.Text-) | Fügen Sie das Text-Objekt zur Sammlung hinzu. |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Text item)](#remove-com.aspose.diagram.Text-) | Entfernen Sie das Text-Objekt aus der Sammlung. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Text item) {#add-com.aspose.diagram.Text-}
+```
+public int add(Text item)
+```
+
+
+Fügen Sie das Text-Objekt zur Sammlung hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [Text](../../com.aspose.diagram/text) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Text get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[Text](../../com.aspose.diagram/text) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Text item) {#remove-com.aspose.diagram.Text-}
+```
+public void remove(Text item)
+```
+
+
+Entfernen Sie das Text-Objekt aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [Text](../../com.aspose.diagram/text) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/textdirection/_index.md
+++ b/german/java/com.aspose.diagram/textdirection/_index.md
@@ -1,0 +1,204 @@
+---
+title: TextDirection
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt die Richtung der Zeichen in einem Textblock an.
+type: docs
+weight: 403
+url: /de/java/com.aspose.diagram/textdirection/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class TextDirection
+```
+
+Gibt die Richtung der Zeichen in einem Textblock an.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [TextDirection(int value)](#TextDirection-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Gibt die Richtung der Zeichen in einem Textblock an. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getUfe()](../../com.aspose.diagram/textdirection\#getUfe--) |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/textdirection\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### TextDirection(int value) {#TextDirection-int-}
+```
+public TextDirection(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Gibt die Richtung der Zeichen in einem Textblock an.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getUfe()](../../com.aspose.diagram/textdirection\#getUfe--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/textdirection\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/textdirectionvalue/_index.md
+++ b/german/java/com.aspose.diagram/textdirectionvalue/_index.md
@@ -1,0 +1,156 @@
+---
+title: TextDirectionValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt die Richtung der Zeichen in einem Textblock an.
+type: docs
+weight: 404
+url: /de/java/com.aspose.diagram/textdirectionvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class TextDirectionValue
+```
+
+Gibt die Richtung der Zeichen in einem Textblock an.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [HORIZONTAL](#HORIZONTAL) | Horizontal. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+| [VERTICAL](#VERTICAL) | Vertikal. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### HORIZONTAL {#HORIZONTAL}
+```
+public static final int HORIZONTAL
+```
+
+
+Horizontal.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### VERTICAL {#VERTICAL}
+```
+public static final int VERTICAL
+```
+
+
+Vertikal.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/textxform/_index.md
+++ b/german/java/com.aspose.diagram/textxform/_index.md
@@ -1,0 +1,336 @@
+---
+title: TextXForm
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält Elemente, die Positionsinformationen zu einem Textblock einer Form angeben.
+type: docs
+weight: 405
+url: /de/java/com.aspose.diagram/textxform/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class TextXForm
+```
+
+Enthält Elemente, die Positionsinformationen zum Textblock einer Form angeben.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getTxtAngle()](#getTxtAngle--) | Gibt den aktuellen Rotationswinkel des Textblocks in Bezug auf die x-Achse der Form an. |
+| [getTxtHeight()](#getTxtHeight--) | Gibt die Höhe des Textblocks an. |
+| [getTxtLocPinX()](#getTxtLocPinX--) | Gibt die x-Koordinate des Rotationszentrums des Textblocks in Bezug auf den Ursprung des Textblocks an. |
+| [getTxtLocPinY()](#getTxtLocPinY--) | Gibt die y-Koordinate des Rotationszentrums des Textblocks relativ zum Ursprung des Textblocks an. |
+| [getTxtPinX()](#getTxtPinX--) | Gibt die x-Koordinate des Rotationszentrums des Textblocks in Bezug auf den Ursprung der Form an. |
+| [getTxtPinY()](#getTxtPinY--) | Gibt die y-Koordinate des Rotationszentrums des Textblocks in Bezug auf den Ursprung der Form an. |
+| [getTxtWidth()](#getTxtWidth--) | Gibt die Breite des Textblocks an. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/textxform\#getDel--) |
+| [setTxtAngle(DoubleValue value)](#setTxtAngle-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getTxtAngle()](../../com.aspose.diagram/textxform\#getTxtAngle--) |
+| [setTxtHeight(DoubleValue value)](#setTxtHeight-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getTxtHeight()](../../com.aspose.diagram/textxform\#getTxtHeight--) |
+| [setTxtLocPinX(DoubleValue value)](#setTxtLocPinX-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getTxtLocPinX()](../../com.aspose.diagram/textxform\#getTxtLocPinX--) |
+| [setTxtLocPinY(DoubleValue value)](#setTxtLocPinY-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getTxtLocPinY()](../../com.aspose.diagram/textxform\#getTxtLocPinY--) |
+| [setTxtPinX(DoubleValue value)](#setTxtPinX-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getTxtPinX()](../../com.aspose.diagram/textxform\#getTxtPinX--) |
+| [setTxtPinY(DoubleValue value)](#setTxtPinY-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getTxtPinY()](../../com.aspose.diagram/textxform\#getTxtPinY--) |
+| [setTxtWidth(DoubleValue value)](#setTxtWidth-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getTxtWidth()](../../com.aspose.diagram/textxform\#getTxtWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getTxtAngle() {#getTxtAngle--}
+```
+public DoubleValue getTxtAngle()
+```
+
+
+Gibt den aktuellen Rotationswinkel des Textblocks in Bezug auf die x-Achse der Form an. Der Standardwert ist 0 Grad.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTxtHeight() {#getTxtHeight--}
+```
+public DoubleValue getTxtHeight()
+```
+
+
+Gibt die Höhe des Textblocks an. Die Standardformel, die der Höhe der Form entspricht, ist F="Height\*1".
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTxtLocPinX() {#getTxtLocPinX--}
+```
+public DoubleValue getTxtLocPinX()
+```
+
+
+Gibt die x-Koordinate des Rotationszentrums des Textblocks in Bezug auf den Ursprung des Textblocks an. Die Standardformel, die dem horizontalen Zentrum des Textblocks entspricht, ist F="TxtWidth\*0.5".
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTxtLocPinY() {#getTxtLocPinY--}
+```
+public DoubleValue getTxtLocPinY()
+```
+
+
+Gibt die y-Koordinate des Rotationszentrums des Textblocks relativ zum Ursprung des Textblocks an. Die Standardformel, die dem vertikalen Zentrum des Textblocks entspricht, ist F="TxtHeight\*0.5".
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTxtPinX() {#getTxtPinX--}
+```
+public DoubleValue getTxtPinX()
+```
+
+
+Gibt die x-Koordinate des Rotationszentrums des Textblocks in Bezug auf den Ursprung der Form an. Die Standardformel, die dem horizontalen Zentrum der Form entspricht, ist F="Width\*0.5".
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTxtPinY() {#getTxtPinY--}
+```
+public DoubleValue getTxtPinY()
+```
+
+
+Gibt die y-Koordinate des Rotationszentrums des Textblocks in Bezug auf den Ursprung der Form an. Die Standardformel, die dem vertikalen Zentrum der Form entspricht, ist F="Height\*0.5".
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTxtWidth() {#getTxtWidth--}
+```
+public DoubleValue getTxtWidth()
+```
+
+
+Gibt die Breite des Textblocks an. Die Standardformel, die der Breite der Form entspricht, ist F="Width\*1".
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/textxform\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setTxtAngle(DoubleValue value) {#setTxtAngle-com.aspose.diagram.DoubleValue-}
+```
+public void setTxtAngle(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getTxtAngle()](../../com.aspose.diagram/textxform\#getTxtAngle--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTxtHeight(DoubleValue value) {#setTxtHeight-com.aspose.diagram.DoubleValue-}
+```
+public void setTxtHeight(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getTxtHeight()](../../com.aspose.diagram/textxform\#getTxtHeight--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTxtLocPinX(DoubleValue value) {#setTxtLocPinX-com.aspose.diagram.DoubleValue-}
+```
+public void setTxtLocPinX(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getTxtLocPinX()](../../com.aspose.diagram/textxform\#getTxtLocPinX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTxtLocPinY(DoubleValue value) {#setTxtLocPinY-com.aspose.diagram.DoubleValue-}
+```
+public void setTxtLocPinY(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getTxtLocPinY()](../../com.aspose.diagram/textxform\#getTxtLocPinY--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTxtPinX(DoubleValue value) {#setTxtPinX-com.aspose.diagram.DoubleValue-}
+```
+public void setTxtPinX(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getTxtPinX()](../../com.aspose.diagram/textxform\#getTxtPinX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTxtPinY(DoubleValue value) {#setTxtPinY-com.aspose.diagram.DoubleValue-}
+```
+public void setTxtPinY(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getTxtPinY()](../../com.aspose.diagram/textxform\#getTxtPinY--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTxtWidth(DoubleValue value) {#setTxtWidth-com.aspose.diagram.DoubleValue-}
+```
+public void setTxtWidth(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getTxtWidth()](../../com.aspose.diagram/textxform\#getTxtWidth--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/threedformat/_index.md
+++ b/german/java/com.aspose.diagram/threedformat/_index.md
@@ -1,0 +1,625 @@
+---
+title: ThreeDFormat
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt die dreidimensionale Formatierung einer Form dar.
+type: docs
+weight: 406
+url: /de/java/com.aspose.diagram/threedformat/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ThreeDFormat
+```
+
+Stellt die dreidimensionale Formatierung einer Form dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object obj)](#equals-java.lang.Object-) |  |
+| [getBevelBottomHeight()](#getBevelBottomHeight--) | Gibt die Höhe der unteren Abschrägung bei einer 3D‑Form an. |
+| [getBevelBottomType()](#getBevelBottomType--) | Gibt den voreingestellten Abschrägungstyp für die untere Abschrägung bei einer 3D‑Form an |
+| [getBevelBottomWidth()](#getBevelBottomWidth--) | Gibt die Breite der unteren Abschrägung bei einer 3D‑Form an. |
+| [getBevelContourColor()](#getBevelContourColor--) | Gibt die Farbe der Kontur bei einer 3D‑Form an |
+| [getBevelContourSize()](#getBevelContourSize--) | Gibt die Dicke der Kontur bei einer 3D‑Form an |
+| [getBevelDepthColor()](#getBevelDepthColor--) | Gibt die Extrusionsfarbe bei einer 3D‑Form an |
+| [getBevelDepthSize()](#getBevelDepthSize--) | Gibt die Extrusionstiefe bei einer 3D‑Form an |
+| [getBevelLightingAngle()](#getBevelLightingAngle--) | Gibt die Richtung der Beleuchtung bei einer 3D‑Form an. |
+| [getBevelLightingType()](#getBevelLightingType--) | Gibt den voreingestellten Beleuchtungstyp bei einer 3D‑Form an |
+| [getBevelMaterialType()](#getBevelMaterialType--) | Gibt das voreingestellte Oberflächen‑Aussehen bei einer 3D‑Form an |
+| [getBevelTopHeight()](#getBevelTopHeight--) | Gibt die Höhe der oberen Abschrägung bei einer 3D‑Form an |
+| [getBevelTopType()](#getBevelTopType--) | Gibt den voreingestellten Abschrägungstyp für die obere Abschrägung bei einer 3D‑Form an |
+| [getBevelTopWidth()](#getBevelTopWidth--) | Gibt die Breite der oberen Abschrägung bei einer 3D‑Form an. |
+| [getClass()](#getClass--) |  |
+| [getDistanceFromGround()](#getDistanceFromGround--) | Gibt den Abstand an, den eine Form mit 3D‑Drehungseigenschaften hat |
+| [getKeepTextFlat()](#getKeepTextFlat--) | Gibt an, ob 3D‑Drehungseigenschaften auf den Text einer Form angewendet werden |
+| [getPerspective()](#getPerspective--) | Gibt den Blickwinkel für eine Form mit 3D‑Drehungseigenschaften an |
+| [getRotationType()](#getRotationType--) | Gibt den Projektionstyp der Effekt‑Eigenschaften einer Form an. |
+| [getRotationXAngle()](#getRotationXAngle--) | Gibt den gegen den Uhrzeigersinn gerichteten Rotationswinkel einer Form um die Y‑Achse an. |
+| [getRotationYAngle()](#getRotationYAngle--) | Gibt den gegen den Uhrzeigersinn gerichteten Rotationswinkel einer Form um die X‑Achse an |
+| [getRotationZAngle()](#getRotationZAngle--) | Gibt den gegen den Uhrzeigersinn gerichteten Rotationswinkel einer Form um die Z‑Achse an. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setBevelBottomHeight(DoubleValue value)](#setBevelBottomHeight-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getBevelBottomHeight()](../../com.aspose.diagram/threedformat\#getBevelBottomHeight--) |
+| [setBevelBottomType(BevelType value)](#setBevelBottomType-com.aspose.diagram.BevelType-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getBevelBottomType()](../../com.aspose.diagram/threedformat\#getBevelBottomType--) |
+| [setBevelBottomWidth(DoubleValue value)](#setBevelBottomWidth-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getBevelBottomWidth()](../../com.aspose.diagram/threedformat\#getBevelBottomWidth--) |
+| [setBevelContourColor(ColorValue value)](#setBevelContourColor-com.aspose.diagram.ColorValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getBevelContourColor()](../../com.aspose.diagram/threedformat\#getBevelContourColor--) |
+| [setBevelContourSize(DoubleValue value)](#setBevelContourSize-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getBevelContourSize()](../../com.aspose.diagram/threedformat\#getBevelContourSize--) |
+| [setBevelDepthColor(ColorValue value)](#setBevelDepthColor-com.aspose.diagram.ColorValue-) | Für die Beschreibung dieser Eigenschaft siehe [getBevelDepthColor()](../../com.aspose.diagram/threedformat\#getBevelDepthColor--) |
+| [setBevelDepthSize(DoubleValue value)](#setBevelDepthSize-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe [getBevelDepthSize()](../../com.aspose.diagram/threedformat\#getBevelDepthSize--) |
+| [setBevelLightingAngle(DoubleValue value)](#setBevelLightingAngle-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe [getBevelLightingAngle()](../../com.aspose.diagram/threedformat\#getBevelLightingAngle--) |
+| [setBevelLightingType(BevelLightingType value)](#setBevelLightingType-com.aspose.diagram.BevelLightingType-) | Für die Beschreibung dieser Eigenschaft siehe [getBevelLightingType()](../../com.aspose.diagram/threedformat\#getBevelLightingType--) |
+| [setBevelMaterialType(BevelMaterialType value)](#setBevelMaterialType-com.aspose.diagram.BevelMaterialType-) | Für die Beschreibung dieser Eigenschaft siehe [getBevelMaterialType()](../../com.aspose.diagram/threedformat\#getBevelMaterialType--) |
+| [setBevelTopHeight(DoubleValue value)](#setBevelTopHeight-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe [getBevelTopHeight()](../../com.aspose.diagram/threedformat\#getBevelTopHeight--) |
+| [setBevelTopType(BevelType value)](#setBevelTopType-com.aspose.diagram.BevelType-) | Für die Beschreibung dieser Eigenschaft siehe [getBevelTopType()](../../com.aspose.diagram/threedformat\#getBevelTopType--) |
+| [setBevelTopWidth(DoubleValue value)](#setBevelTopWidth-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe [getBevelTopWidth()](../../com.aspose.diagram/threedformat\#getBevelTopWidth--) |
+| [setDistanceFromGround(DoubleValue value)](#setDistanceFromGround-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe [getDistanceFromGround()](../../com.aspose.diagram/threedformat\#getDistanceFromGround--) |
+| [setKeepTextFlat(BoolValue value)](#setKeepTextFlat-com.aspose.diagram.BoolValue-) | Für die Beschreibung dieser Eigenschaft siehe [getKeepTextFlat()](../../com.aspose.diagram/threedformat\#getKeepTextFlat--) |
+| [setPerspective(DoubleValue value)](#setPerspective-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe [getPerspective()](../../com.aspose.diagram/threedformat\#getPerspective--) |
+| [setRotationType(RotationType value)](#setRotationType-com.aspose.diagram.RotationType-) | Für die Beschreibung dieser Eigenschaft siehe [getRotationType()](../../com.aspose.diagram/threedformat\#getRotationType--) |
+| [setRotationXAngle(DoubleValue value)](#setRotationXAngle-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe [getRotationXAngle()](../../com.aspose.diagram/threedformat\#getRotationXAngle--) |
+| [setRotationYAngle(DoubleValue value)](#setRotationYAngle-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe [getRotationYAngle()](../../com.aspose.diagram/threedformat\#getRotationYAngle--) |
+| [setRotationZAngle(DoubleValue value)](#setRotationZAngle-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe [getRotationZAngle()](../../com.aspose.diagram/threedformat\#getRotationZAngle--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| obj | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getBevelBottomHeight() {#getBevelBottomHeight--}
+```
+public DoubleValue getBevelBottomHeight()
+```
+
+
+Gibt die Höhe der unteren Abschrägung bei einer 3D‑Form an.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBevelBottomType() {#getBevelBottomType--}
+```
+public BevelType getBevelBottomType()
+```
+
+
+Gibt den voreingestellten Abschrägungstyp für die untere Abschrägung bei einer 3D‑Form an
+
+**Returns:**
+[BevelType](../../com.aspose.diagram/beveltype)
+### getBevelBottomWidth() {#getBevelBottomWidth--}
+```
+public DoubleValue getBevelBottomWidth()
+```
+
+
+Gibt die Breite der unteren Abschrägung bei einer 3D‑Form an.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBevelContourColor() {#getBevelContourColor--}
+```
+public ColorValue getBevelContourColor()
+```
+
+
+Gibt die Farbe der Kontur bei einer 3D‑Form an
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getBevelContourSize() {#getBevelContourSize--}
+```
+public DoubleValue getBevelContourSize()
+```
+
+
+Gibt die Dicke der Kontur bei einer 3D‑Form an
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBevelDepthColor() {#getBevelDepthColor--}
+```
+public ColorValue getBevelDepthColor()
+```
+
+
+Gibt die Extrusionsfarbe bei einer 3D‑Form an
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getBevelDepthSize() {#getBevelDepthSize--}
+```
+public DoubleValue getBevelDepthSize()
+```
+
+
+Gibt die Extrusionstiefe bei einer 3D‑Form an
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBevelLightingAngle() {#getBevelLightingAngle--}
+```
+public DoubleValue getBevelLightingAngle()
+```
+
+
+Gibt die Richtung der Beleuchtung bei einer 3D‑Form an.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBevelLightingType() {#getBevelLightingType--}
+```
+public BevelLightingType getBevelLightingType()
+```
+
+
+Gibt den voreingestellten Beleuchtungstyp bei einer 3D‑Form an
+
+**Returns:**
+[BevelLightingType](../../com.aspose.diagram/bevellightingtype)
+### getBevelMaterialType() {#getBevelMaterialType--}
+```
+public BevelMaterialType getBevelMaterialType()
+```
+
+
+Gibt das voreingestellte Oberflächen‑Aussehen bei einer 3D‑Form an
+
+**Returns:**
+[BevelMaterialType](../../com.aspose.diagram/bevelmaterialtype)
+### getBevelTopHeight() {#getBevelTopHeight--}
+```
+public DoubleValue getBevelTopHeight()
+```
+
+
+Gibt die Höhe der oberen Abschrägung bei einer 3D‑Form an
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBevelTopType() {#getBevelTopType--}
+```
+public BevelType getBevelTopType()
+```
+
+
+Gibt den voreingestellten Abschrägungstyp für die obere Abschrägung bei einer 3D‑Form an
+
+**Returns:**
+[BevelType](../../com.aspose.diagram/beveltype)
+### getBevelTopWidth() {#getBevelTopWidth--}
+```
+public DoubleValue getBevelTopWidth()
+```
+
+
+Gibt die Breite der oberen Abschrägung bei einer 3D‑Form an.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDistanceFromGround() {#getDistanceFromGround--}
+```
+public DoubleValue getDistanceFromGround()
+```
+
+
+Gibt den Abstand an, den eine Form mit 3D‑Drehungseigenschaften hat
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getKeepTextFlat() {#getKeepTextFlat--}
+```
+public BoolValue getKeepTextFlat()
+```
+
+
+Gibt an, ob 3D‑Drehungseigenschaften auf den Text einer Form angewendet werden
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getPerspective() {#getPerspective--}
+```
+public DoubleValue getPerspective()
+```
+
+
+Gibt den Blickwinkel für eine Form mit 3D‑Drehungseigenschaften an
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getRotationType() {#getRotationType--}
+```
+public RotationType getRotationType()
+```
+
+
+Gibt den Projektionstyp der Effekt‑Eigenschaften einer Form an.
+
+**Returns:**
+[RotationType](../../com.aspose.diagram/rotationtype)
+### getRotationXAngle() {#getRotationXAngle--}
+```
+public DoubleValue getRotationXAngle()
+```
+
+
+Gibt den gegen den Uhrzeigersinn gerichteten Rotationswinkel einer Form um die Y‑Achse an.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getRotationYAngle() {#getRotationYAngle--}
+```
+public DoubleValue getRotationYAngle()
+```
+
+
+Gibt den gegen den Uhrzeigersinn gerichteten Rotationswinkel einer Form um die X‑Achse an
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getRotationZAngle() {#getRotationZAngle--}
+```
+public DoubleValue getRotationZAngle()
+```
+
+
+Gibt den gegen den Uhrzeigersinn gerichteten Rotationswinkel einer Form um die Z‑Achse an.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setBevelBottomHeight(DoubleValue value) {#setBevelBottomHeight-com.aspose.diagram.DoubleValue-}
+```
+public void setBevelBottomHeight(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getBevelBottomHeight()](../../com.aspose.diagram/threedformat\#getBevelBottomHeight--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setBevelBottomType(BevelType value) {#setBevelBottomType-com.aspose.diagram.BevelType-}
+```
+public void setBevelBottomType(BevelType value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getBevelBottomType()](../../com.aspose.diagram/threedformat\#getBevelBottomType--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [BevelType](../../com.aspose.diagram/beveltype) |  |
+
+### setBevelBottomWidth(DoubleValue value) {#setBevelBottomWidth-com.aspose.diagram.DoubleValue-}
+```
+public void setBevelBottomWidth(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getBevelBottomWidth()](../../com.aspose.diagram/threedformat\#getBevelBottomWidth--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setBevelContourColor(ColorValue value) {#setBevelContourColor-com.aspose.diagram.ColorValue-}
+```
+public void setBevelContourColor(ColorValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getBevelContourColor()](../../com.aspose.diagram/threedformat\#getBevelContourColor--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setBevelContourSize(DoubleValue value) {#setBevelContourSize-com.aspose.diagram.DoubleValue-}
+```
+public void setBevelContourSize(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getBevelContourSize()](../../com.aspose.diagram/threedformat\#getBevelContourSize--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setBevelDepthColor(ColorValue value) {#setBevelDepthColor-com.aspose.diagram.ColorValue-}
+```
+public void setBevelDepthColor(ColorValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getBevelDepthColor()](../../com.aspose.diagram/threedformat\#getBevelDepthColor--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setBevelDepthSize(DoubleValue value) {#setBevelDepthSize-com.aspose.diagram.DoubleValue-}
+```
+public void setBevelDepthSize(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getBevelDepthSize()](../../com.aspose.diagram/threedformat\#getBevelDepthSize--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setBevelLightingAngle(DoubleValue value) {#setBevelLightingAngle-com.aspose.diagram.DoubleValue-}
+```
+public void setBevelLightingAngle(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getBevelLightingAngle()](../../com.aspose.diagram/threedformat\#getBevelLightingAngle--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setBevelLightingType(BevelLightingType value) {#setBevelLightingType-com.aspose.diagram.BevelLightingType-}
+```
+public void setBevelLightingType(BevelLightingType value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getBevelLightingType()](../../com.aspose.diagram/threedformat\#getBevelLightingType--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [BevelLightingType](../../com.aspose.diagram/bevellightingtype) |  |
+
+### setBevelMaterialType(BevelMaterialType value) {#setBevelMaterialType-com.aspose.diagram.BevelMaterialType-}
+```
+public void setBevelMaterialType(BevelMaterialType value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getBevelMaterialType()](../../com.aspose.diagram/threedformat\#getBevelMaterialType--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [BevelMaterialType](../../com.aspose.diagram/bevelmaterialtype) |  |
+
+### setBevelTopHeight(DoubleValue value) {#setBevelTopHeight-com.aspose.diagram.DoubleValue-}
+```
+public void setBevelTopHeight(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getBevelTopHeight()](../../com.aspose.diagram/threedformat\#getBevelTopHeight--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setBevelTopType(BevelType value) {#setBevelTopType-com.aspose.diagram.BevelType-}
+```
+public void setBevelTopType(BevelType value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getBevelTopType()](../../com.aspose.diagram/threedformat\#getBevelTopType--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [BevelType](../../com.aspose.diagram/beveltype) |  |
+
+### setBevelTopWidth(DoubleValue value) {#setBevelTopWidth-com.aspose.diagram.DoubleValue-}
+```
+public void setBevelTopWidth(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getBevelTopWidth()](../../com.aspose.diagram/threedformat\#getBevelTopWidth--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDistanceFromGround(DoubleValue value) {#setDistanceFromGround-com.aspose.diagram.DoubleValue-}
+```
+public void setDistanceFromGround(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getDistanceFromGround()](../../com.aspose.diagram/threedformat\#getDistanceFromGround--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setKeepTextFlat(BoolValue value) {#setKeepTextFlat-com.aspose.diagram.BoolValue-}
+```
+public void setKeepTextFlat(BoolValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getKeepTextFlat()](../../com.aspose.diagram/threedformat\#getKeepTextFlat--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setPerspective(DoubleValue value) {#setPerspective-com.aspose.diagram.DoubleValue-}
+```
+public void setPerspective(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getPerspective()](../../com.aspose.diagram/threedformat\#getPerspective--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setRotationType(RotationType value) {#setRotationType-com.aspose.diagram.RotationType-}
+```
+public void setRotationType(RotationType value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getRotationType()](../../com.aspose.diagram/threedformat\#getRotationType--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [RotationType](../../com.aspose.diagram/rotationtype) |  |
+
+### setRotationXAngle(DoubleValue value) {#setRotationXAngle-com.aspose.diagram.DoubleValue-}
+```
+public void setRotationXAngle(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getRotationXAngle()](../../com.aspose.diagram/threedformat\#getRotationXAngle--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setRotationYAngle(DoubleValue value) {#setRotationYAngle-com.aspose.diagram.DoubleValue-}
+```
+public void setRotationYAngle(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getRotationYAngle()](../../com.aspose.diagram/threedformat\#getRotationYAngle--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setRotationZAngle(DoubleValue value) {#setRotationZAngle-com.aspose.diagram.DoubleValue-}
+```
+public void setRotationZAngle(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getRotationZAngle()](../../com.aspose.diagram/threedformat\#getRotationZAngle--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/tiffcompression/_index.md
+++ b/german/java/com.aspose.diagram/tiffcompression/_index.md
@@ -1,0 +1,174 @@
+---
+title: TiffCompression
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt an, welche Art von Kompression beim Speichern von Seiten im TIFF-Format angewendet werden soll.
+type: docs
+weight: 407
+url: /de/java/com.aspose.diagram/tiffcompression/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class TiffCompression
+```
+
+Gibt an, welche Art von Kompression beim Speichern von Seiten im TIFF-Format angewendet werden soll.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [CCITT_3](#CCITT-3) | Gibt das CCITT3-Komprimierungsschema an. |
+| [CCITT_4](#CCITT-4) | Gibt das CCITT4-Komprimierungsschema an. |
+| [LZW](#LZW) | Gibt das LZW-Komprimierungsschema an. |
+| [NONE](#NONE) | Gibt keine Kompression an. |
+| [RLE](#RLE) | Gibt das RLE-Komprimierungsschema an. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CCITT_3 {#CCITT-3}
+```
+public static final int CCITT_3
+```
+
+
+Gibt das CCITT3-Komprimierungsschema an.
+
+### CCITT_4 {#CCITT-4}
+```
+public static final int CCITT_4
+```
+
+
+Gibt das CCITT4-Komprimierungsschema an.
+
+### LZW {#LZW}
+```
+public static final int LZW
+```
+
+
+Gibt das LZW-Komprimierungsschema an.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Gibt keine Kompression an.
+
+### RLE {#RLE}
+```
+public static final int RLE
+```
+
+
+Gibt das RLE-Komprimierungsschema an.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/timelinehelper/_index.md
+++ b/german/java/com.aspose.diagram/timelinehelper/_index.md
@@ -1,0 +1,512 @@
+---
+title: TimeLineHelper
+second_title: Aspose.Diagram for Java API-Referenz
+description: TimeLineHelper zum Festlegen der Eigenschaft einer Zeitlinienform.
+type: docs
+weight: 408
+url: /de/java/com.aspose.diagram/timelinehelper/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class TimeLineHelper
+```
+
+TimeLineHelper zum Festlegen der Eigenschaft einer Zeitlinienform.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [TimeLineHelper(Shape shape)](#TimeLineHelper-com.aspose.diagram.Shape-) | TimeLineHelper. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDoubleStringFromDateTime(DateTime dateTime)](#getDoubleStringFromDateTime-com.aspose.diagram.DateTime-) | Convert the date time to double value. |
+| [getTimePeriodFinish()](#getTimePeriodFinish--) | Time Period for finish of timeline shape |
+| [getTimePeriodStart()](#getTimePeriodStart--) | Time Period for start of timeline shape |
+| [getTimeScale()](#getTimeScale--) | scale of timeline shape |
+| [getWeekEnd(DateTime startDate, int weekStart)](#getWeekEnd-com.aspose.diagram.DateTime-int-) | getweekstart |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [refreshTimeLine()](#refreshTimeLine--) | Refresh time of timeline shapes |
+| [setArrowHead(int value)](#setArrowHead-int-) | ArrowHead of timeline shape |
+| [setAutoUpdate(boolean value)](#setAutoUpdate-boolean-) | whether to update data for markers (milestones, intervals) as they are moved on timeline |
+| [setBeginWeek(int value)](#setBeginWeek-int-) | Begin week of timeline shape |
+|  | [setDateFormatForBE(int value)](#setDateFormatForBE-int-) | DateFormat for start and finish of timeline shape /// |
+
+| ----------------------- | ------------------------------- |
+| **Value**\\u9286\\u20ac | **Format String**\\u9286\\u20ac |
+| 0                       | dddd, yyyy-M-d                  |
+| 1                       | yyyy-MM-dd                      |
+| 2                       | yy-MMM-d                        |
+| 3                       | yyyy/M/d                        |
+| 4                       | yy-MMM.                         | |
+|  | [setDateFormatForIntm(int value)](#setDateFormatForIntm-int-) | DateFormat for Intm of timeline shape /// |
+
+| ----------------------- | ------------------------------- |
+| **Value**\\u9286\\u20ac | **Format String**\\u9286\\u20ac |
+| 0                       | dddd, yyyy-M-d                  |
+| 1                       | yyyy-MM-dd                      |
+| 2                       | yy-MMM-d                        |
+| 3                       | yyyy/M/d                        |
+| 4                       | yy-MMM.                         | |
+| [setDateFormatStringForBE(String value)](#setDateFormatStringForBE-java.lang.String-) | DateFormat String for start and finish of timeline shape |
+| [setDateFormatStringForIntm(String value)](#setDateFormatStringForIntm-java.lang.String-) | DateFormat String for Intm of timeline shape |
+| [setDisplayBE(boolean value)](#setDisplayBE-boolean-) | whether to display Begin and End dates on timeline |
+| [setDisplayIntm(boolean value)](#setDisplayIntm-boolean-) | whether to display interim date/time ticks on timeline |
+| [setDisplayIntmDates(boolean value)](#setDisplayIntmDates-boolean-) | whether to display interim dates on interim ticks |
+| [setFiscalStart(DateTime value)](#setFiscalStart-com.aspose.diagram.DateTime-) | First day of fiscal year |
+| [setTimeLineType(int value)](#setTimeLineType-int-) | Begin week of timeline shape |
+| [setTimePeriodFinish(DateTime value)](#setTimePeriodFinish-com.aspose.diagram.DateTime-) |  |
+| [setTimePeriodStart(DateTime value)](#setTimePeriodStart-com.aspose.diagram.DateTime-) |  |
+| [setTimeScale(int value)](#setTimeScale-int-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### TimeLineHelper(Shape shape) {#TimeLineHelper-com.aspose.diagram.Shape-}
+```
+public TimeLineHelper(Shape shape)
+```
+
+
+TimeLineHelper.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| shape | [Shape](../../com.aspose.diagram/shape) |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDoubleStringFromDateTime(DateTime dateTime) {#getDoubleStringFromDateTime-com.aspose.diagram.DateTime-}
+```
+public static String getDoubleStringFromDateTime(DateTime dateTime)
+```
+
+
+Convert the date time to double value.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| dateTime | [DateTime](../../com.aspose.diagram/datetime) | Das Datum und die Uhrzeit. |
+
+**Returns:**
+java.lang.String -
+### getTimePeriodFinish() {#getTimePeriodFinish--}
+```
+public DateTime getTimePeriodFinish()
+```
+
+
+Time Period for finish of timeline shape
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### getTimePeriodStart() {#getTimePeriodStart--}
+```
+public DateTime getTimePeriodStart()
+```
+
+
+Time Period for start of timeline shape
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### getTimeScale() {#getTimeScale--}
+```
+public int getTimeScale()
+```
+
+
+scale of timeline shape
+
+**Returns:**
+int
+### getWeekEnd(DateTime startDate, int weekStart) {#getWeekEnd-com.aspose.diagram.DateTime-int-}
+```
+public static DateTime getWeekEnd(DateTime startDate, int weekStart)
+```
+
+
+getweekstart
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| startDate | [DateTime](../../com.aspose.diagram/datetime) |  |
+| Wochenstart | int | (0 Sonntag 1 Montag 2 Dienstag 3 Mittwoch 4 Donnerstag 5 Freitag 6 Samstag) |
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - 
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### refreshTimeLine() {#refreshTimeLine--}
+```
+public void refreshTimeLine()
+```
+
+
+Refresh time of timeline shapes
+
+### setArrowHead(int value) {#setArrowHead-int-}
+```
+public void setArrowHead(int value)
+```
+
+
+ArrowHead of timeline shape
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setAutoUpdate(boolean value) {#setAutoUpdate-boolean-}
+```
+public void setAutoUpdate(boolean value)
+```
+
+
+whether to update data for markers (milestones, intervals) as they are moved on timeline
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setBeginWeek(int value) {#setBeginWeek-int-}
+```
+public void setBeginWeek(int value)
+```
+
+
+Begin week of timeline shape
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setDateFormatForBE(int value) {#setDateFormatForBE-int-}
+```
+public void setDateFormatForBE(int value)
+```
+
+
+DateFormat for start and finish of timeline shape ///
+
+| ----------------------- | ------------------------------- |
+| **Value**\\u9286\\u20ac | **Format String**\\u9286\\u20ac |
+| 0                       | dddd, yyyy-M-d                  |
+| 1                       | yyyy-MM-dd                      |
+| 2                       | yy-MMM-d                        |
+| 3                       | yyyy/M/d                        |
+| 4                       | yy-MMM.-d                       |
+| 5                       | d MMMM yyyy                     |
+| 6                       | yy-M                            |
+| 7                       | MMM-yy                          |
+| 8                       | MMMM d, yyyy                    |
+| 9                       | MMM d, yyyy                     |
+| 10                      | M-d-yy                          |
+| 11                      | M-d                             |
+| 12                      | d MMMM, yyyy                    |
+| 13                      | d MMM, yyyy                     |
+| 14                      | d-M-yy                          |
+| 15                      | d-M                             |
+| 16                      | yy-M-d                          |
+| 17                      | yyyy-M-d                        |
+| 18                      | M-yy                            |
+| 19                      | M-yyyy                          |
+| 20                      | MMMM yyyy                       |
+| 21                      | MMMM yy                         |
+| 22                      | MMM yyyy                        |
+| 23                      | MMM yy                          |
+| 24                      | yy                              |
+| 25                      | yyyy                            |
+| 26                      | d                               |
+| 27                      | MMMM                            |
+| 28                      | MMM                             |
+| 29                      | M                               |
+| 30                      | MM/dd/yyyy                      |
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setDateFormatForIntm(int value) {#setDateFormatForIntm-int-}
+```
+public void setDateFormatForIntm(int value)
+```
+
+
+DateFormat for Intm of timeline shape ///
+
+| ----------------------- | ------------------------------- |
+| **Value**\\u9286\\u20ac | **Format String**\\u9286\\u20ac |
+| 0                       | dddd, yyyy-M-d                  |
+| 1                       | yyyy-MM-dd                      |
+| 2                       | yy-MMM-d                        |
+| 3                       | yyyy/M/d                        |
+| 4                       | yy-MMM.-d                       |
+| 5                       | d MMMM yyyy                     |
+| 6                       | yy-M                            |
+| 7                       | MMM-yy                          |
+| 8                       | MMMM d, yyyy                    |
+| 9                       | MMM d, yyyy                     |
+| 10                      | M-d-yy                          |
+| 11                      | M-d                             |
+| 12                      | d MMMM, yyyy                    |
+| 13                      | d MMM, yyyy                     |
+| 14                      | d-M-yy                          |
+| 15                      | d-M                             |
+| 16                      | yy-M-d                          |
+| 17                      | yyyy-M-d                        |
+| 18                      | M-yy                            |
+| 19                      | M-yyyy                          |
+| 20                      | MMMM yyyy                       |
+| 21                      | MMMM yy                         |
+| 22                      | MMM yyyy                        |
+| 23                      | MMM yy                          |
+| 24                      | yy                              |
+| 25                      | yyyy                            |
+| 26                      | d                               |
+| 27                      | MMMM                            |
+| 28                      | MMM                             |
+| 29                      | M                               |
+| 30                      | MM/dd/yyyy                      |
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setDateFormatStringForBE(String value) {#setDateFormatStringForBE-java.lang.String-}
+```
+public void setDateFormatStringForBE(String value)
+```
+
+
+DateFormat String for start and finish of timeline shape
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setDateFormatStringForIntm(String value) {#setDateFormatStringForIntm-java.lang.String-}
+```
+public void setDateFormatStringForIntm(String value)
+```
+
+
+DateFormat String for Intm of timeline shape
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setDisplayBE(boolean value) {#setDisplayBE-boolean-}
+```
+public void setDisplayBE(boolean value)
+```
+
+
+whether to display Begin and End dates on timeline
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setDisplayIntm(boolean value) {#setDisplayIntm-boolean-}
+```
+public void setDisplayIntm(boolean value)
+```
+
+
+whether to display interim date/time ticks on timeline
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setDisplayIntmDates(boolean value) {#setDisplayIntmDates-boolean-}
+```
+public void setDisplayIntmDates(boolean value)
+```
+
+
+whether to display interim dates on interim ticks
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setFiscalStart(DateTime value) {#setFiscalStart-com.aspose.diagram.DateTime-}
+```
+public void setFiscalStart(DateTime value)
+```
+
+
+First day of fiscal year
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setTimeLineType(int value) {#setTimeLineType-int-}
+```
+public void setTimeLineType(int value)
+```
+
+
+Begin week of timeline shape
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setTimePeriodFinish(DateTime value) {#setTimePeriodFinish-com.aspose.diagram.DateTime-}
+```
+public void setTimePeriodFinish(DateTime value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setTimePeriodStart(DateTime value) {#setTimePeriodStart-com.aspose.diagram.DateTime-}
+```
+public void setTimePeriodStart(DateTime value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setTimeScale(int value) {#setTimeScale-int-}
+```
+public void setTimeScale(int value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/togglebuttonactivexcontrol/_index.md
+++ b/german/java/com.aspose.diagram/togglebuttonactivexcontrol/_index.md
@@ -1,0 +1,604 @@
+---
+title: ToggleButtonActiveXControl
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt ein ToggleButton-ActiveX-Steuerelement dar.
+type: docs
+weight: 410
+url: /de/java/com.aspose.diagram/togglebuttonactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class ToggleButtonActiveXControl extends ActiveXControl
+```
+
+Stellt ein ToggleButton-ActiveX-Steuerelement dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAccelerator()](#getAccelerator--) | Die Beschleunigungstaste für das Steuerelement. |
+| [getBackOleColor()](#getBackOleColor--) | die OLE‑Farbe des Hintergrunds. |
+| [getCaption()](#getCaption--) | Der beschreibende Text, der auf einem Steuerelement erscheint. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | die Binärdaten des Steuerelements. |
+| [getForeOleColor()](#getForeOleColor--) | die OLE‑Farbe des Vordergrunds. |
+| [getHeight()](#getHeight--) | die Höhe des Steuerelements in Punkt‑Einheiten. |
+| [getIMEMode()](#getIMEMode--) | der Standard‑Laufzeitmodus des Input Method Editors für das Steuerelement, wenn es den Fokus erhält. |
+| [getMouseIcon()](#getMouseIcon--) | ein benutzerdefiniertes Symbol, das als Mauszeiger für das Steuerelement angezeigt wird. |
+| [getMousePointer()](#getMousePointer--) | der Typ des als Mauszeiger für das Steuerelement angezeigten Symbols. |
+| [getPicture()](#getPicture--) | Die Daten des Bildes. |
+| [getPicturePosition()](#getPicturePosition--) | Der Ort des Bildes des Steuerelements relativ zu seiner Beschriftung. |
+| [getSpecialEffect()](#getSpecialEffect--) | der Spezialeffekt des Steuerelements. |
+| [getType()](#getType--) | Ermittelt den Typ des ActiveX-Steuerelements. |
+| [getValue()](#getValue--) | Gibt an, ob das Steuerelement aktiviert ist oder nicht. |
+| [getWidth()](#getWidth--) | die Breite des Steuerelements in Punkt-Einheiten. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | Gibt an, ob das Steuerelement automatisch die Größe ändert, um seinen gesamten Inhalt anzuzeigen. |
+| [isEnabled()](#isEnabled--) | Gibt an, ob das Steuerelement den Fokus erhalten und auf benutzergenerierte Ereignisse reagieren kann. |
+| [isLocked()](#isLocked--) | Gibt an, ob Daten im Steuerelement für die Bearbeitung gesperrt sind. |
+| [isTransparent()](#isTransparent--) | Gibt an, ob das Steuerelement transparent ist. |
+| [isTripleState()](#isTripleState--) | Gibt an, wie das angegebene Steuerelement Nullwerte darstellt. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAccelerator(char value)](#setAccelerator-char-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getAccelerator()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getAccelerator--) |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setCaption(String value)](#setCaption-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getCaption()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getCaption--) |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setHeight(double value)](#setHeight-double-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setIMEMode(int value)](#setIMEMode-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) |
+| [setLocked(boolean value)](#setLocked-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | Für die Beschreibung dieser Eigenschaft siehe bitte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setPicture(byte[] value)](#setPicture-byte---) | Für die Beschreibung dieser Eigenschaft siehe bitte [getPicture()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getPicture--) |
+| [setPicturePosition(int value)](#setPicturePosition-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getPicturePosition()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getPicturePosition--) |
+| [setSpecialEffect(int value)](#setSpecialEffect-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getSpecialEffect()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getSpecialEffect--) |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) |
+| [setTripleState(boolean value)](#setTripleState-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isTripleState()](../../com.aspose.diagram/togglebuttonactivexcontrol\#isTripleState--) |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getValue--) |
+| [setWidth(double value)](#setWidth-double-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAccelerator() {#getAccelerator--}
+```
+public char getAccelerator()
+```
+
+
+Die Beschleunigungstaste für das Steuerelement.
+
+**Returns:**
+char
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+die OLE‑Farbe des Hintergrunds.
+
+**Returns:**
+int
+### getCaption() {#getCaption--}
+```
+public String getCaption()
+```
+
+
+Der beschreibende Text, der auf einem Steuerelement erscheint.
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+die Binärdaten des Steuerelements.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+Die OLE-Farbe des Vordergrunds. Gilt nicht für das Image-Steuerelement.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+die Höhe des Steuerelements in Punkt‑Einheiten.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+der Standard‑Laufzeitmodus des Input Method Editors für das Steuerelement, wenn es den Fokus erhält.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+ein benutzerdefiniertes Symbol, das als Mauszeiger für das Steuerelement angezeigt wird.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+der Typ des als Mauszeiger für das Steuerelement angezeigten Symbols.
+
+**Returns:**
+int
+### getPicture() {#getPicture--}
+```
+public byte[] getPicture()
+```
+
+
+Die Daten des Bildes.
+
+**Returns:**
+byte[]
+### getPicturePosition() {#getPicturePosition--}
+```
+public int getPicturePosition()
+```
+
+
+Der Ort des Bildes des Steuerelements relativ zu seiner Beschriftung.
+
+**Returns:**
+int
+### getSpecialEffect() {#getSpecialEffect--}
+```
+public int getSpecialEffect()
+```
+
+
+der Spezialeffekt des Steuerelements.
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Ermittelt den Typ des ActiveX-Steuerelements.
+
+**Returns:**
+int
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Gibt an, ob das Steuerelement aktiviert ist oder nicht.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+die Breite des Steuerelements in Punkt-Einheiten.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+Gibt an, ob das Steuerelement automatisch die Größe ändert, um seinen gesamten Inhalt anzuzeigen.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+Gibt an, ob das Steuerelement den Fokus erhalten und auf benutzergenerierte Ereignisse reagieren kann.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+Gibt an, ob Daten im Steuerelement für die Bearbeitung gesperrt sind.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+Gibt an, ob das Steuerelement transparent ist.
+
+**Returns:**
+boolean
+### isTripleState() {#isTripleState--}
+```
+public boolean isTripleState()
+```
+
+
+Gibt an, wie das angegebene Steuerelement Nullwerte darstellt.
+
+| ------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| Einstellung | Beschreibung                                                                                                                                     |
+| True    | Das Steuerelement durchläuft die Zustände für Ja-, Nein- und Nullwerte. Das Steuerelement erscheint abgedunkelt (grau), wenn seine Value‑Eigenschaft auf Null gesetzt ist. |
+| False   | (Standard) Das Steuerelement durchläuft die Zustände für Ja‑ und Nein‑Werte. Nullwerte werden angezeigt, als wären sie Nein‑Werte.                           |
+
+|
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAccelerator(char value) {#setAccelerator-char-}
+```
+public void setAccelerator(char value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getAccelerator()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getAccelerator--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | char |  |
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setCaption(String value) {#setCaption-java.lang.String-}
+```
+public void setCaption(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getCaption()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getCaption--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setPicture(byte[] value) {#setPicture-byte---}
+```
+public void setPicture(byte[] value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getPicture()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getPicture--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | byte[] |  |
+
+### setPicturePosition(int value) {#setPicturePosition-int-}
+```
+public void setPicturePosition(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getPicturePosition()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getPicturePosition--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setSpecialEffect(int value) {#setSpecialEffect-int-}
+```
+public void setSpecialEffect(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getSpecialEffect()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getSpecialEffect--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setTripleState(boolean value) {#setTripleState-boolean-}
+```
+public void setTripleState(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isTripleState()](../../com.aspose.diagram/togglebuttonactivexcontrol\#isTripleState--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/topartvalue/_index.md
+++ b/german/java/com.aspose.diagram/topartvalue/_index.md
@@ -1,0 +1,201 @@
+---
+title: ToPartValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Der Teil einer Form, zu dem eine Verbindung hergestellt wird.
+type: docs
+weight: 409
+url: /de/java/com.aspose.diagram/topartvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ToPartValue
+```
+
+Der Teil einer Form, zu dem eine Verbindung hergestellt wird.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [CONNECTION_POINT](#CONNECTION-POINT) | Verbindungspunkt. |
+| [GUIDE_INTERSECTION](#GUIDE-INTERSECTION) | Guide-Schnittpunkt. |
+| [GUIDE_X](#GUIDE-X) | GuideX. |
+| [GUIDE_Y](#GUIDE-Y) | GuideY. |
+| [NONE](#NONE) | Keine. |
+| [TO_ANGLE](#TO-ANGLE) | Zum Winkel. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+| [WHOLE_SHAPE](#WHOLE-SHAPE) | Gesamte Form. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CONNECTION_POINT {#CONNECTION-POINT}
+```
+public static final int CONNECTION_POINT
+```
+
+
+Verbindungspunkt.
+
+### GUIDE_INTERSECTION {#GUIDE-INTERSECTION}
+```
+public static final int GUIDE_INTERSECTION
+```
+
+
+Guide-Schnittpunkt.
+
+### GUIDE_X {#GUIDE-X}
+```
+public static final int GUIDE_X
+```
+
+
+GuideX.
+
+### GUIDE_Y {#GUIDE-Y}
+```
+public static final int GUIDE_Y
+```
+
+
+GuideY.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Keine.
+
+### TO_ANGLE {#TO-ANGLE}
+```
+public static final int TO_ANGLE
+```
+
+
+Zum Winkel.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### WHOLE_SHAPE {#WHOLE-SHAPE}
+```
+public static final int WHOLE_SHAPE
+```
+
+
+Gesamte Form.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/tp/_index.md
+++ b/german/java/com.aspose.diagram/tp/_index.md
@@ -1,0 +1,154 @@
+---
+title: Tp
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt den Beginn eines Tab-Eigenschaftslaufs an.
+type: docs
+weight: 411
+url: /de/java/com.aspose.diagram/tp/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.FormatTxt](../../com.aspose.diagram/formattxt)
+```
+public class Tp extends FormatTxt
+```
+
+Gibt den Beginn eines Tabs-Eigenschaftsabschnitts an. Der Abschnitt ist definiert bis zum Ende des Textes oder bis zum nächsten
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [Tp(int IX)](#Tp-int-) | Konstruktor |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getValue()](#getValue--) | Value |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Tp(int IX) {#Tp-int-}
+```
+public Tp(int IX)
+```
+
+
+Konstruktor
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| IX | int | Der nullbasierte Index des Elements innerhalb seines übergeordneten Elements. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+Value
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/txt/_index.md
+++ b/german/java/com.aspose.diagram/txt/_index.md
@@ -1,0 +1,179 @@
+---
+title: Txt
+second_title: Aspose.Diagram for Java API-Referenz
+description: Text der Form
+type: docs
+weight: 412
+url: /de/java/com.aspose.diagram/txt/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.FormatTxt](../../com.aspose.diagram/formattxt)
+```
+public class Txt extends FormatTxt
+```
+
+Text der Form
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [Txt(String value)](#Txt-java.lang.String-) | Konstruktor |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getText()](#getText--) | Enthält den Text einer Form. |
+| [getValue()](#getValue--) | Value |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setText(String value)](#setText-java.lang.String-) | For the description of this property, please see [getText()](../../com.aspose.diagram/txt\#getText--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Txt(String value) {#Txt-java.lang.String-}
+```
+public Txt(String value)
+```
+
+
+Konstruktor
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String | Text of the shape. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getText() {#getText--}
+```
+public String getText()
+```
+
+
+Enthält den Text einer Form.
+
+**Returns:**
+java.lang.String
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+Value
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setText(String value) {#setText-java.lang.String-}
+```
+public void setText(String value)
+```
+
+
+For the description of this property, please see [getText()](../../com.aspose.diagram/txt\#getText--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/typeconnection/_index.md
+++ b/german/java/com.aspose.diagram/typeconnection/_index.md
@@ -1,0 +1,190 @@
+---
+title: TypeConnection
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt verschiedene Typen basierend auf dem Element an, in dem es enthalten ist.
+type: docs
+weight: 413
+url: /de/java/com.aspose.diagram/typeconnection/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class TypeConnection
+```
+
+Gibt verschiedene Typen an, basierend auf dem Element, in dem es enthalten ist.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [TypeConnection(int value)](#TypeConnection-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Gibt verschiedene Typen an, basierend auf dem Element, in dem es enthalten ist. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/typeconnection\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### TypeConnection(int value) {#TypeConnection-int-}
+```
+public TypeConnection(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Gibt verschiedene Typen an, basierend auf dem Element, in dem es enthalten ist.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/typeconnection\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/typeconnectionvalue/_index.md
+++ b/german/java/com.aspose.diagram/typeconnectionvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: TypeConnectionValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt verschiedene Typen basierend auf dem Element an, in dem es enthalten ist.
+type: docs
+weight: 414
+url: /de/java/com.aspose.diagram/typeconnectionvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class TypeConnectionValue
+```
+
+Gibt verschiedene Typen an, basierend auf dem Element, in dem es enthalten ist.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [INWARD](#INWARD) | Nach innen. |
+| [INWARD_OUTWARD](#INWARD-OUTWARD) | Nach innen und nach außen. |
+| [OUTWARD](#OUTWARD) | Nach außen. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### INWARD {#INWARD}
+```
+public static final int INWARD
+```
+
+
+Nach innen.
+
+### INWARD_OUTWARD {#INWARD-OUTWARD}
+```
+public static final int INWARD_OUTWARD
+```
+
+
+Nach innen und nach außen.
+
+### OUTWARD {#OUTWARD}
+```
+public static final int OUTWARD
+```
+
+
+Nach außen.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/typefield/_index.md
+++ b/german/java/com.aspose.diagram/typefield/_index.md
@@ -1,0 +1,190 @@
+---
+title: TypeField
+second_title: Aspose.Diagram for Java API-Referenz
+description: Typ gibt einen Datentyp für den Textfeldwert an.
+type: docs
+weight: 415
+url: /de/java/com.aspose.diagram/typefield/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class TypeField
+```
+
+Typ gibt einen Datentyp für den Textfeldwert an.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [TypeField(int value)](#TypeField-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Typ gibt einen Datentyp für den Textfeldwert an. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/typefield\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### TypeField(int value) {#TypeField-int-}
+```
+public TypeField(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Typ gibt einen Datentyp für den Textfeldwert an.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/typefield\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/typefieldvalue/_index.md
+++ b/german/java/com.aspose.diagram/typefieldvalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: TypeFieldValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Typ gibt einen Datentyp für den Textfeldwert an.
+type: docs
+weight: 416
+url: /de/java/com.aspose.diagram/typefieldvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class TypeFieldValue
+```
+
+Typ gibt einen Datentyp für den Textfeldwert an.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [CURRENCY](#CURRENCY) | Währungswert. |
+| [DATE_TIME](#DATE-TIME) | Datum- oder Zeitwert. |
+| [DURATION](#DURATION) | Dauerwert. |
+| [NUMBER](#NUMBER) | Zahl. |
+| [STRING](#STRING) | Zeichenkette. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CURRENCY {#CURRENCY}
+```
+public static final int CURRENCY
+```
+
+
+Währungswert. Verwendet die aktuellen regionalen Systemeinstellungen.
+
+### DATE_TIME {#DATE-TIME}
+```
+public static final int DATE_TIME
+```
+
+
+Datum- oder Zeitwert. Zeigt Tage, Monate und Jahre oder Sekunden, Minuten und Stunden oder einen kombinierten Datum- und Zeitwert an.
+
+### DURATION {#DURATION}
+```
+public static final int DURATION
+```
+
+
+Dauerwert. Zeigt die verstrichene Zeit an.
+
+### NUMBER {#NUMBER}
+```
+public static final int NUMBER
+```
+
+
+Zahl. Enthält Datums-, Zeit-, Dauer- und Währungswerte sowie Skalare, Dimensionen und Winkel.
+
+### STRING {#STRING}
+```
+public static final int STRING
+```
+
+
+Zeichenkette.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/typeprop/_index.md
+++ b/german/java/com.aspose.diagram/typeprop/_index.md
@@ -1,0 +1,193 @@
+---
+title: TypeProp
+second_title: Aspose.Diagram for Java API-Referenz
+description: Typ gibt einen Datentyp für den benutzerdefinierten Eigenschaftswert an.
+type: docs
+weight: 417
+url: /de/java/com.aspose.diagram/typeprop/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class TypeProp
+```
+
+Typ gibt einen Datentyp für den benutzerdefinierten Eigenschaftswert an.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [TypeProp(int value)](#TypeProp-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Typ gibt einen Datentyp für den benutzerdefinierten Eigenschaftswert an. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getUfe()](../../com.aspose.diagram/typeprop\#getUfe--) |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/typeprop\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### TypeProp(int value) {#TypeProp-int-}
+```
+public TypeProp(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Typ gibt einen Datentyp für den benutzerdefinierten Eigenschaftswert an.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getUfe()](../../com.aspose.diagram/typeprop\#getUfe--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/typeprop\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/typepropvalue/_index.md
+++ b/german/java/com.aspose.diagram/typepropvalue/_index.md
@@ -1,0 +1,210 @@
+---
+title: TypePropValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Typ gibt einen Datentyp für den benutzerdefinierten Eigenschaftswert an.
+type: docs
+weight: 418
+url: /de/java/com.aspose.diagram/typepropvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class TypePropValue
+```
+
+Typ gibt einen Datentyp für den benutzerdefinierten Eigenschaftswert an.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [BOOLEAN](#BOOLEAN) | Boolesch. |
+| [CURRENCY](#CURRENCY) | Währungswert. |
+| [DATE_TIME](#DATE-TIME) | Datum- oder Zeitwert. |
+| [DURATION](#DURATION) | Dauerwert. |
+| [FIXED_LIST](#FIXED-LIST) | Feste Liste. |
+| [NUMBER](#NUMBER) | Zahl. |
+| [STRING](#STRING) | Zeichenkette. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+| [VARIABLE_LIST](#VARIABLE-LIST) | Variabelliste. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOOLEAN {#BOOLEAN}
+```
+public static final int BOOLEAN
+```
+
+
+Boolean. Zeigt FALSE und TRUE als Elemente an, die Benutzer aus einem Dropdown-Listenfeld im Dialogfeld Benutzerdefinierte Eigenschaften in der Visio-Anwendung auswählen können.
+
+### CURRENCY {#CURRENCY}
+```
+public static final int CURRENCY
+```
+
+
+Währungswert. Verwendet die aktuellen Regionseinstellungen des Systems.
+
+### DATE_TIME {#DATE-TIME}
+```
+public static final int DATE_TIME
+```
+
+
+Datum- oder Zeitwert. Zeigt Tage, Monate und Jahre oder Sekunden, Minuten und Stunden oder einen kombinierten Datum- und Zeitwert an.
+
+### DURATION {#DURATION}
+```
+public static final int DURATION
+```
+
+
+Dauerwert. Zeigt die verstrichene Zeit an.
+
+### FIXED_LIST {#FIXED-LIST}
+```
+public static final int FIXED_LIST
+```
+
+
+Feste Liste. Zeigt die Listenelemente in einem Dropdown-Combobox im Dialogfeld Benutzerdefinierte Eigenschaften an.
+
+### NUMBER {#NUMBER}
+```
+public static final int NUMBER
+```
+
+
+Zahl. Enthält Datums-, Zeit-, Dauer- und Währungswerte sowie Skalare, Dimensionen und Winkel.
+
+### STRING {#STRING}
+```
+public static final int STRING
+```
+
+
+Zeichenkette. Dies ist die Vorgabe.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### VARIABLE_LIST {#VARIABLE-LIST}
+```
+public static final int VARIABLE_LIST
+```
+
+
+Variabelliste. Zeigt die Listenelemente in einem Dropdown-Combobox im Dialogfeld Benutzerdefinierte Eigenschaften in Visio an. Benutzer können ein Listenelement auswählen oder ein neues Element eingeben, das zur aktuellen Liste im Format-Element hinzugefügt wird.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/typevalue/_index.md
+++ b/german/java/com.aspose.diagram/typevalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: TypeValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Optionale Aufzählung.
+type: docs
+weight: 419
+url: /de/java/com.aspose.diagram/typevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class TypeValue
+```
+
+Optionale Aufzählung. Der Typ einer Form.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [FOREIGN](#FOREIGN) | Fremd. |
+| [GROUP](#GROUP) | Gruppe. |
+| [GUIDE](#GUIDE) | Hilfslinie. |
+| [SHAPE](#SHAPE) | Form. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FOREIGN {#FOREIGN}
+```
+public static final int FOREIGN
+```
+
+
+Fremd.
+
+### GROUP {#GROUP}
+```
+public static final int GROUP
+```
+
+
+Gruppe.
+
+### GUIDE {#GUIDE}
+```
+public static final int GUIDE
+```
+
+
+Hilfslinie.
+
+### SHAPE {#SHAPE}
+```
+public static final int SHAPE
+```
+
+
+Form.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/uivisibility/_index.md
+++ b/german/java/com.aspose.diagram/uivisibility/_index.md
@@ -1,0 +1,179 @@
+---
+title: UIVisibility
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt die Tab‑Ausrichtung an.
+type: docs
+weight: 420
+url: /de/java/com.aspose.diagram/uivisibility/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class UIVisibility
+```
+
+Gibt die Tab‑Ausrichtung an.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [UIVisibility(int value)](#UIVisibility-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Gibt die uivisibility an. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft, bitte siehe [getValue()](../../com.aspose.diagram/uivisibility\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### UIVisibility(int value) {#UIVisibility-int-}
+```
+public UIVisibility(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Gibt die uivisibility an.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft, bitte siehe [getValue()](../../com.aspose.diagram/uivisibility\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/uivisibilityvalue/_index.md
+++ b/german/java/com.aspose.diagram/uivisibilityvalue/_index.md
@@ -1,0 +1,156 @@
+---
+title: UIVisibilityValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt die Tab‑Ausrichtung an.
+type: docs
+weight: 421
+url: /de/java/com.aspose.diagram/uivisibilityvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class UIVisibilityValue
+```
+
+Gibt die Tab‑Ausrichtung an.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [HIDDEN](#HIDDEN) | Versteckt. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+| [VISIBLE](#VISIBLE) | Sichtbar . |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### HIDDEN {#HIDDEN}
+```
+public static final int HIDDEN
+```
+
+
+Versteckt.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### VISIBLE {#VISIBLE}
+```
+public static final int VISIBLE
+```
+
+
+Sichtbar .
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/unitformulaerr/_index.md
+++ b/german/java/com.aspose.diagram/unitformulaerr/_index.md
@@ -1,0 +1,240 @@
+---
+title: UnitFormulaErr
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt Attribute eines Elements an.
+type: docs
+weight: 422
+url: /de/java/com.aspose.diagram/unitformulaerr/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class UnitFormulaErr
+```
+
+Gibt Attribute eines Elements an.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [UnitFormulaErr(int unit, String f, String err)](#UnitFormulaErr-int-java.lang.String-java.lang.String-) | Konstruktor. |
+| [UnitFormulaErr()](#UnitFormulaErr--) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getErr()](#getErr--) | Zeigt an, dass die Formel einen Fehler ergibt. |
+| [getF()](#getF--) | Stellt die Formel des Elements dar. |
+| [getUnit()](#getUnit--) | Maßeinheiten. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setErr(String value)](#setErr-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getErr()](../../com.aspose.diagram/unitformulaerr\#getErr--) |
+| [setF(String value)](#setF-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getF()](../../com.aspose.diagram/unitformulaerr\#getF--) |
+| [setUnit(int value)](#setUnit-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getUnit()](../../com.aspose.diagram/unitformulaerr\#getUnit--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### UnitFormulaErr(int unit, String f, String err) {#UnitFormulaErr-int-java.lang.String-java.lang.String-}
+```
+public UnitFormulaErr(int unit, String f, String err)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Einheit | int |  |
+| f | java.lang.String |  |
+| err | java.lang.String |  |
+
+### UnitFormulaErr() {#UnitFormulaErr--}
+```
+public UnitFormulaErr()
+```
+
+
+Konstruktor.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getErr() {#getErr--}
+```
+public String getErr()
+```
+
+
+Zeigt an, dass die Formel einen Fehler ergibt.
+
+**Returns:**
+java.lang.String
+### getF() {#getF--}
+```
+public String getF()
+```
+
+
+Stellt die Formel des Elements dar.
+
+**Returns:**
+java.lang.String
+### getUnit() {#getUnit--}
+```
+public int getUnit()
+```
+
+
+Maßeinheiten.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setErr(String value) {#setErr-java.lang.String-}
+```
+public void setErr(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getErr()](../../com.aspose.diagram/unitformulaerr\#getErr--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setF(String value) {#setF-java.lang.String-}
+```
+public void setF(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getF()](../../com.aspose.diagram/unitformulaerr\#getF--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setUnit(int value) {#setUnit-int-}
+```
+public void setUnit(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getUnit()](../../com.aspose.diagram/unitformulaerr\#getUnit--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/unitformulaerrv/_index.md
+++ b/german/java/com.aspose.diagram/unitformulaerrv/_index.md
@@ -1,0 +1,257 @@
+---
+title: UnitFormulaErrV
+second_title: Aspose.Diagram for Java API-Referenz
+description: Angegebene Attribute eines Elements.
+type: docs
+weight: 423
+url: /de/java/com.aspose.diagram/unitformulaerrv/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+```
+public class UnitFormulaErrV extends UnitFormulaErr
+```
+
+Angegebene Attribute eines Elements.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [UnitFormulaErrV(int unit, String f, String err, String v)](#UnitFormulaErrV-int-java.lang.String-java.lang.String-java.lang.String-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getErr()](#getErr--) | Zeigt an, dass die Formel einen Fehler ergibt. |
+| [getF()](#getF--) | Stellt die Formel des Elements dar. |
+| [getUnit()](#getUnit--) | Maßeinheiten. |
+| [getV()](#getV--) | Stellt die Nullzeichenkettenbedingung für einen Zeichenkettenzellenwert dar. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setErr(String value)](#setErr-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getErr()](../../com.aspose.diagram/unitformulaerr\#getErr--) |
+| [setF(String value)](#setF-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getF()](../../com.aspose.diagram/unitformulaerr\#getF--) |
+| [setUnit(int value)](#setUnit-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getUnit()](../../com.aspose.diagram/unitformulaerr\#getUnit--) |
+| [setV(String value)](#setV-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getV()](../../com.aspose.diagram/unitformulaerrv\#getV--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### UnitFormulaErrV(int unit, String f, String err, String v) {#UnitFormulaErrV-int-java.lang.String-java.lang.String-java.lang.String-}
+```
+public UnitFormulaErrV(int unit, String f, String err, String v)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Einheit | int |  |
+| f | java.lang.String |  |
+| err | java.lang.String |  |
+| v | java.lang.String |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getErr() {#getErr--}
+```
+public String getErr()
+```
+
+
+Zeigt an, dass die Formel einen Fehler ergibt.
+
+**Returns:**
+java.lang.String
+### getF() {#getF--}
+```
+public String getF()
+```
+
+
+Stellt die Formel des Elements dar.
+
+**Returns:**
+java.lang.String
+### getUnit() {#getUnit--}
+```
+public int getUnit()
+```
+
+
+Maßeinheiten.
+
+**Returns:**
+int
+### getV() {#getV--}
+```
+public String getV()
+```
+
+
+Stellt die Nullzeichenkettenbedingung für einen Zeichenkettenzellenwert dar. In manchen Fällen ist es hilfreich, zwischen einem leeren Zeichenkettenzellen-Nullwert und einem Null-Zeichenkettenzellenwert zu unterscheiden. Dieses Attribut wird verwendet, um zwischen diesen Formen eines leeren Wertes zu unterscheiden.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setErr(String value) {#setErr-java.lang.String-}
+```
+public void setErr(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getErr()](../../com.aspose.diagram/unitformulaerr\#getErr--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setF(String value) {#setF-java.lang.String-}
+```
+public void setF(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getF()](../../com.aspose.diagram/unitformulaerr\#getF--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setUnit(int value) {#setUnit-int-}
+```
+public void setUnit(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getUnit()](../../com.aspose.diagram/unitformulaerr\#getUnit--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setV(String value) {#setV-java.lang.String-}
+```
+public void setV(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getV()](../../com.aspose.diagram/unitformulaerrv\#getV--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/unknowncontrol/_index.md
+++ b/german/java/com.aspose.diagram/unknowncontrol/_index.md
@@ -1,0 +1,449 @@
+---
+title: UnknownControl
+second_title: Aspose.Diagram for Java API-Referenz
+description: Unbekannte Steuerung.
+type: docs
+weight: 424
+url: /de/java/com.aspose.diagram/unknowncontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class UnknownControl extends ActiveXControl
+```
+
+Unbekannte Steuerung.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBackOleColor()](#getBackOleColor--) | die OLE‑Farbe des Hintergrunds. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | die Binärdaten des Steuerelements. |
+| [getForeOleColor()](#getForeOleColor--) | die OLE‑Farbe des Vordergrunds. |
+| [getHeight()](#getHeight--) | die Höhe des Steuerelements in Punkt‑Einheiten. |
+| [getIMEMode()](#getIMEMode--) | der Standard‑Laufzeitmodus des Input Method Editors für das Steuerelement, wenn es den Fokus erhält. |
+| [getMouseIcon()](#getMouseIcon--) | ein benutzerdefiniertes Symbol, das als Mauszeiger für das Steuerelement angezeigt wird. |
+| [getMousePointer()](#getMousePointer--) | der Typ des als Mauszeiger für das Steuerelement angezeigten Symbols. |
+| [getPersistenceType()](#getPersistenceType--) | Ermittelt die Persistenzmethode, um ein ActiveX-Steuerelement zu speichern. |
+| [getRelationshipData(String relId)](#getRelationshipData-java.lang.String-) | Ermittelt die Beziehungsdaten. |
+| [getType()](#getType--) | Ermittelt den Typ des ActiveX-Steuerelements. |
+| [getWidth()](#getWidth--) | die Breite des Steuerelements in Punkt-Einheiten. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | Gibt an, ob das Steuerelement automatisch die Größe ändert, um seinen gesamten Inhalt anzuzeigen. |
+| [isEnabled()](#isEnabled--) | Gibt an, ob das Steuerelement den Fokus erhalten und auf benutzergenerierte Ereignisse reagieren kann. |
+| [isLocked()](#isLocked--) | Gibt an, ob Daten im Steuerelement für die Bearbeitung gesperrt sind. |
+| [isTransparent()](#isTransparent--) | Gibt an, ob das Steuerelement transparent ist. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setHeight(double value)](#setHeight-double-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setIMEMode(int value)](#setIMEMode-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) |
+| [setLocked(boolean value)](#setLocked-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | Für die Beschreibung dieser Eigenschaft siehe bitte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | Für die Beschreibung dieser Eigenschaft siehe bitte [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) |
+| [setWidth(double value)](#setWidth-double-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+die OLE‑Farbe des Hintergrunds.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+die Binärdaten des Steuerelements.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+Die OLE-Farbe des Vordergrunds. Gilt nicht für das Image-Steuerelement.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+die Höhe des Steuerelements in Punkt‑Einheiten.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+der Standard‑Laufzeitmodus des Input Method Editors für das Steuerelement, wenn es den Fokus erhält.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+ein benutzerdefiniertes Symbol, das als Mauszeiger für das Steuerelement angezeigt wird.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+der Typ des als Mauszeiger für das Steuerelement angezeigten Symbols.
+
+**Returns:**
+int
+### getPersistenceType() {#getPersistenceType--}
+```
+public int getPersistenceType()
+```
+
+
+Ermittelt die Persistenzmethode, um ein ActiveX-Steuerelement zu speichern.
+
+**Returns:**
+int
+### getRelationshipData(String relId) {#getRelationshipData-java.lang.String-}
+```
+public byte[] getRelationshipData(String relId)
+```
+
+
+Ermittelt die Beziehungsdaten.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| relId | java.lang.String | Die Beziehungs-ID. |
+
+**Returns:**
+byte[] - gibt die Beziehungsdaten zurück.
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Ermittelt den Typ des ActiveX-Steuerelements.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+die Breite des Steuerelements in Punkt-Einheiten.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+Gibt an, ob das Steuerelement automatisch die Größe ändert, um seinen gesamten Inhalt anzuzeigen.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+Gibt an, ob das Steuerelement den Fokus erhalten und auf benutzergenerierte Ereignisse reagieren kann.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+Gibt an, ob Daten im Steuerelement für die Bearbeitung gesperrt sind.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+Gibt an, ob das Steuerelement transparent ist.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/user/_index.md
+++ b/german/java/com.aspose.diagram/user/_index.md
@@ -1,0 +1,299 @@
+---
+title: Benutzer
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält einen Arbeitsbereich zum Eingeben von Formeln in benutzerspezifischen Elementen, auf die von anderen Elementen und Add‑On‑Tools verwiesen wird.
+type: docs
+weight: 425
+url: /de/java/com.aspose.diagram/user/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class User
+```
+
+Enthält einen Arbeitsbereich zum Eingeben von Formeln in benutzerspezifischen Elementen, auf die von anderen Elementen und Add‑On‑Tools verwiesen wird.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [User()](#User--) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getID()](#getID--) | Die eindeutige ID des Elements innerhalb seines übergeordneten Elements. |
+| [getName()](#getName--) | Der Name des Elements. |
+| [getNameU()](#getNameU--) | Der universelle Name des Elements. |
+| [getPrompt()](#getPrompt--) | Sie gibt einen beschreibenden Hinweis oder Kommentar für das benutzerdefinierte Element an. |
+| [getValue()](#getValue--) | Enthält lösungsspezifische, wohlgeformte XML‑Daten, die in einem expliziten Namensraum vorangestellt sind und zusammen mit einem Dokument gespeichert werden. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/user\#getDel--) |
+| [setID(int value)](#setID-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getID()](../../com.aspose.diagram/user\#getID--) |
+| [setName(String value)](#setName-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getName()](../../com.aspose.diagram/user\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getNameU()](../../com.aspose.diagram/user\#getNameU--) |
+| [setPrompt(Str2Value value)](#setPrompt-com.aspose.diagram.Str2Value-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getPrompt()](../../com.aspose.diagram/user\#getPrompt--) |
+| [setValue(Value value)](#setValue-com.aspose.diagram.Value-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/user\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### User() {#User--}
+```
+public User()
+```
+
+
+Konstruktor.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+Die eindeutige ID des Elements innerhalb seines übergeordneten Elements.
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Der Name des Elements.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+Der universelle Name des Elements.
+
+**Returns:**
+java.lang.String
+### getPrompt() {#getPrompt--}
+```
+public Str2Value getPrompt()
+```
+
+
+Sie gibt einen beschreibenden Hinweis oder Kommentar für das benutzerdefinierte Element an.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getValue() {#getValue--}
+```
+public Value getValue()
+```
+
+
+Enthält lösungsspezifische, wohlgeformte XML‑Daten, die in einem expliziten Namensraum vorangestellt sind und zusammen mit einem Dokument gespeichert werden.
+
+**Returns:**
+[Value](../../com.aspose.diagram/value)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/user\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getID()](../../com.aspose.diagram/user\#getID--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getName()](../../com.aspose.diagram/user\#getName--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getNameU()](../../com.aspose.diagram/user\#getNameU--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setPrompt(Str2Value value) {#setPrompt-com.aspose.diagram.Str2Value-}
+```
+public void setPrompt(Str2Value value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getPrompt()](../../com.aspose.diagram/user\#getPrompt--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [Str2Value](../../com.aspose.diagram/str2value) |  |
+
+### setValue(Value value) {#setValue-com.aspose.diagram.Value-}
+```
+public void setValue(Value value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/user\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [Value](../../com.aspose.diagram/value) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/usercollection/_index.md
+++ b/german/java/com.aspose.diagram/usercollection/_index.md
@@ -1,0 +1,250 @@
+---
+title: UserCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: Benutzersammlung.
+type: docs
+weight: 426
+url: /de/java/com.aspose.diagram/usercollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class UserCollection extends Collection
+```
+
+Benutzersammlung.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [add(User item)](#add-com.aspose.diagram.User-) | Füge das User-Objekt zur Sammlung hinzu. |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [getUser(int ID)](#getUser-int-) | Liefert das Element mit der angegebenen ID. |
+| [getUser(String name)](#getUser-java.lang.String-) | Liefert das Element mit der angegebenen ID. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(User item)](#remove-com.aspose.diagram.User-) | Entferne das User-Objekt aus der Sammlung. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(User item) {#add-com.aspose.diagram.User-}
+```
+public int add(User item)
+```
+
+
+Füge das User-Objekt zur Sammlung hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [User](../../com.aspose.diagram/user) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public User get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[User](../../com.aspose.diagram/user) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### getUser(int ID) {#getUser-int-}
+```
+public User getUser(int ID)
+```
+
+
+Liefert das Element mit der angegebenen ID.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| ID | int |  |
+
+**Returns:**
+[User](../../com.aspose.diagram/user) - 
+### getUser(String name) {#getUser-java.lang.String-}
+```
+public User getUser(String name)
+```
+
+
+Liefert das Element mit der angegebenen ID.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Name | java.lang.String |  |
+
+**Returns:**
+[User](../../com.aspose.diagram/user) - 
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(User item) {#remove-com.aspose.diagram.User-}
+```
+public void remove(User item)
+```
+
+
+Entferne das User-Objekt aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| item | [User](../../com.aspose.diagram/user) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/validation/_index.md
+++ b/german/java/com.aspose.diagram/validation/_index.md
@@ -1,0 +1,158 @@
+---
+title: Validierung
+second_title: Aspose.Diagram for Java API-Referenz
+description: Speichert Informationen zur Diagrammvalidierung für das Dokument.
+type: docs
+weight: 427
+url: /de/java/com.aspose.diagram/validation/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Validation
+```
+
+Speichert Informationen zur Diagrammvalidierung für das Dokument.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getIssues()](#getIssues--) | Enthält alle Issue-Elemente für das Dokument. |
+| [getRuleSets()](#getRuleSets--) | Enthält ein RuleSet-Element für jedes Validierungsregelset im Dokument. |
+| [getValidationProperties()](#getValidationProperties--) | Kapselt Eigenschaften, die sich auf die Validierung des Dokuments beziehen. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getIssues() {#getIssues--}
+```
+public IssueCollection getIssues()
+```
+
+
+Enthält alle Issue-Elemente für das Dokument.
+
+**Returns:**
+[IssueCollection](../../com.aspose.diagram/issuecollection)
+### getRuleSets() {#getRuleSets--}
+```
+public RuleSetCollection getRuleSets()
+```
+
+
+Enthält ein RuleSet-Element für jedes Validierungsregelset im Dokument.
+
+**Returns:**
+[RuleSetCollection](../../com.aspose.diagram/rulesetcollection)
+### getValidationProperties() {#getValidationProperties--}
+```
+public ValidationProperties getValidationProperties()
+```
+
+
+Kapselt Eigenschaften, die sich auf die Validierung des Dokuments beziehen.
+
+**Returns:**
+[ValidationProperties](../../com.aspose.diagram/validationproperties)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/validationproperties/_index.md
+++ b/german/java/com.aspose.diagram/validationproperties/_index.md
@@ -1,0 +1,194 @@
+---
+title: ValidationProperties
+second_title: Aspose.Diagram for Java API-Referenz
+description: Kapselt Eigenschaften, die sich auf die Validierung des Dokuments beziehen.
+type: docs
+weight: 428
+url: /de/java/com.aspose.diagram/validationproperties/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ValidationProperties
+```
+
+Kapselt Eigenschaften, die sich auf die Validierung des Dokuments beziehen.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [ValidationProperties(DateTime lastValidated, int showIgnored)](#ValidationProperties-com.aspose.diagram.DateTime-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getLastValidated()](#getLastValidated--) | Datum und Uhrzeit, zu der das Dokument zuletzt validiert wurde |
+| [getShowIgnored()](#getShowIgnored--) | Ob ignorierte Validierungsprobleme im Fenster 'Probleme' angezeigt werden sollen. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setLastValidated(DateTime value)](#setLastValidated-com.aspose.diagram.DateTime-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getLastValidated()](../../com.aspose.diagram/validationproperties\#getLastValidated--) |
+| [setShowIgnored(int value)](#setShowIgnored-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getShowIgnored()](../../com.aspose.diagram/validationproperties\#getShowIgnored--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ValidationProperties(DateTime lastValidated, int showIgnored) {#ValidationProperties-com.aspose.diagram.DateTime-int-}
+```
+public ValidationProperties(DateTime lastValidated, int showIgnored)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| lastValidated | [DateTime](../../com.aspose.diagram/datetime) |  |
+| showIgnored | int |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLastValidated() {#getLastValidated--}
+```
+public DateTime getLastValidated()
+```
+
+
+Datum und Uhrzeit, zu der das Dokument zuletzt validiert wurde
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### getShowIgnored() {#getShowIgnored--}
+```
+public int getShowIgnored()
+```
+
+
+Ob ignorierte Validierungsprobleme im Fenster 'Probleme' angezeigt werden sollen.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setLastValidated(DateTime value) {#setLastValidated-com.aspose.diagram.DateTime-}
+```
+public void setLastValidated(DateTime value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getLastValidated()](../../com.aspose.diagram/validationproperties\#getLastValidated--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setShowIgnored(int value) {#setShowIgnored-int-}
+```
+public void setShowIgnored(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getShowIgnored()](../../com.aspose.diagram/validationproperties\#getShowIgnored--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/value/_index.md
+++ b/german/java/com.aspose.diagram/value/_index.md
@@ -1,0 +1,211 @@
+---
+title: Value
+second_title: Aspose.Diagram for Java API-Referenz
+description: Wert.
+type: docs
+weight: 429
+url: /de/java/com.aspose.diagram/value/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Value
+```
+
+Wert.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object obj)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getSolutionXML()](#getSolutionXML--) | Enthält lösungsspezifische, wohlgeformte XML‑Daten, die in einem expliziten Namensraum vorangestellt sind und zusammen mit einem Dokument gespeichert werden. |
+| [getUfev()](#getUfev--) | Angegebene Attribute eines Elements. |
+| [getVal()](#getVal--) | Textwert |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setSolutionXML(SolutionXML value)](#setSolutionXML-com.aspose.diagram.SolutionXML-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getSolutionXML()](../../com.aspose.diagram/value\#getSolutionXML--) |
+| [setUfev(UnitFormulaErrV value)](#setUfev-com.aspose.diagram.UnitFormulaErrV-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getUfev()](../../com.aspose.diagram/value\#getUfev--) |
+| [setVal(String value)](#setVal-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getVal()](../../com.aspose.diagram/value\#getVal--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| obj | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getSolutionXML() {#getSolutionXML--}
+```
+public SolutionXML getSolutionXML()
+```
+
+
+Enthält lösungsspezifische, wohlgeformte XML‑Daten, die in einem expliziten Namensraum vorangestellt sind und zusammen mit einem Dokument gespeichert werden.
+
+**Returns:**
+[SolutionXML](../../com.aspose.diagram/solutionxml)
+### getUfev() {#getUfev--}
+```
+public UnitFormulaErrV getUfev()
+```
+
+
+Angegebene Attribute eines Elements.
+
+**Returns:**
+[UnitFormulaErrV](../../com.aspose.diagram/unitformulaerrv)
+### getVal() {#getVal--}
+```
+public String getVal()
+```
+
+
+Textwert
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setSolutionXML(SolutionXML value) {#setSolutionXML-com.aspose.diagram.SolutionXML-}
+```
+public void setSolutionXML(SolutionXML value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getSolutionXML()](../../com.aspose.diagram/value\#getSolutionXML--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [SolutionXML](../../com.aspose.diagram/solutionxml) |  |
+
+### setUfev(UnitFormulaErrV value) {#setUfev-com.aspose.diagram.UnitFormulaErrV-}
+```
+public void setUfev(UnitFormulaErrV value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getUfev()](../../com.aspose.diagram/value\#getUfev--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [UnitFormulaErrV](../../com.aspose.diagram/unitformulaerrv) |  |
+
+### setVal(String value) {#setVal-java.lang.String-}
+```
+public void setVal(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getVal()](../../com.aspose.diagram/value\#getVal--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/vbamodule/_index.md
+++ b/german/java/com.aspose.diagram/vbamodule/_index.md
@@ -1,0 +1,186 @@
+---
+title: VbaModule
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt ein Modul dar, das im VBA‑Projekt enthalten ist.
+type: docs
+weight: 430
+url: /de/java/com.aspose.diagram/vbamodule/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class VbaModule
+```
+
+Stellt ein Modul dar, das im VBA‑Projekt enthalten ist.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCodes()](#getCodes--) | die Codes des Moduls. |
+| [getName()](#getName--) | der Name des Moduls. |
+| [getType()](#getType--) | Gets the type of module. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCodes(String value)](#setCodes-java.lang.String-) | For the description of this property, please see [getCodes()](../../com.aspose.diagram/vbamodule\#getCodes--) |
+| [setName(String value)](#setName-java.lang.String-) | For the description of this property, please see [getName()](../../com.aspose.diagram/vbamodule\#getName--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCodes() {#getCodes--}
+```
+public String getCodes()
+```
+
+
+die Codes des Moduls.
+
+**Returns:**
+java.lang.String
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+der Name des Moduls.
+
+**Returns:**
+java.lang.String
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Gets the type of module.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCodes(String value) {#setCodes-java.lang.String-}
+```
+public void setCodes(String value)
+```
+
+
+For the description of this property, please see [getCodes()](../../com.aspose.diagram/vbamodule\#getCodes--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+For the description of this property, please see [getName()](../../com.aspose.diagram/vbamodule\#getName--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/vbamodulecollection/_index.md
+++ b/german/java/com.aspose.diagram/vbamodulecollection/_index.md
@@ -1,0 +1,311 @@
+---
+title: VbaModuleCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: Represents the list of
+type: docs
+weight: 431
+url: /de/java/com.aspose.diagram/vbamodulecollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.CollectionBase](../../com.aspose.diagram/collectionbase)
+```
+public class VbaModuleCollection extends CollectionBase
+```
+
+Represents the list of [VbaModule](../../com.aspose.diagram/vbamodule)
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [add(Page page)](#add-com.aspose.diagram.Page-) | Adds module for a page. |
+| [add(int type, String name)](#add-int-java.lang.String-) | Adds module. |
+| [add(Object o)](#add-java.lang.Object-) | Fügt ein Element zur CollectionBase-Instanz hinzu. |
+| [clear()](#clear--) | Entfernt alle Objekte aus der CollectionBase-Instanz. |
+| [contains(Object o)](#contains-java.lang.Object-) | Gibt zurück, ob die Instanz dieses Objekt enthält |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gets [VbaModule](../../com.aspose.diagram/vbamodule) in the list by the index. |
+| [get(String name)](#get-java.lang.String-) | Erhält [VbaModule](../../com.aspose.diagram/vbamodule) in der Liste nach dem Namen. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ermittelt die Anzahl der in der CollectionBase-Instanz enthaltenen Elemente. |
+| [hashCode()](#hashCode--) |  |
+| [indexOf(Object o)](#indexOf-java.lang.Object-) | Bestimmt den Index eines bestimmten Elements in der CollectionBase-Instanz. |
+| [iterator()](#iterator--) | Gibt einen Enumerator zurück, der die CollectionBase-Instanz durchläuft. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Page page)](#remove-com.aspose.diagram.Page-) | Entfernt das Modul für eine Seite. |
+| [remove(String name)](#remove-java.lang.String-) | Entferne das Modul nach dem Namen |
+| [removeAt(int index)](#removeAt-int-) | Entfernt das Element am angegebenen Index. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Page page) {#add-com.aspose.diagram.Page-}
+```
+public int add(Page page)
+```
+
+
+Adds module for a page.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| page | [Page](../../com.aspose.diagram/page) | Die Seite |
+
+**Returns:**
+int -
+### add(int type, String name) {#add-int-java.lang.String-}
+```
+public int add(int type, String name)
+```
+
+
+Adds module.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Typ | int | Der Typ des Moduls. |
+| Name | java.lang.String | Der Name des Moduls. |
+
+**Returns:**
+int -
+### add(Object o) {#add-java.lang.Object-}
+```
+public int add(Object o)
+```
+
+
+Fügt ein Element zur CollectionBase-Instanz hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| o | java.lang.Object | Das Objekt, das zur CollectionBase-Instanz hinzugefügt werden soll. |
+
+**Returns:**
+int - Die Position, in die das neue Element eingefügt wurde.
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Objekte aus der CollectionBase-Instanz.
+
+### contains(Object o) {#contains-java.lang.Object-}
+```
+public boolean contains(Object o)
+```
+
+
+Gibt zurück, ob die Instanz dieses Objekt enthält
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| o | java.lang.Object | Testobjekt |
+
+**Returns:**
+boolean - Gibt an, ob die Instanz dieses Objekt enthält
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public VbaModule get(int index)
+```
+
+
+Gets [VbaModule](../../com.aspose.diagram/vbamodule) in the list by the index.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Der Index. |
+
+**Returns:**
+[VbaModule](../../com.aspose.diagram/vbamodule) - 
+### get(String name) {#get-java.lang.String-}
+```
+public VbaModule get(String name)
+```
+
+
+Erhält [VbaModule](../../com.aspose.diagram/vbamodule) in der Liste nach dem Namen.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Name | java.lang.String | Der Name des Moduls. |
+
+**Returns:**
+[VbaModule](../../com.aspose.diagram/vbamodule) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ermittelt die Anzahl der in der CollectionBase-Instanz enthaltenen Elemente.
+
+**Returns:**
+int - Die Anzahl der im CollectionBase-Instanz enthaltenen Elemente.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### indexOf(Object o) {#indexOf-java.lang.Object-}
+```
+public int indexOf(Object o)
+```
+
+
+Bestimmt den Index eines bestimmten Elements in der CollectionBase-Instanz.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| o | java.lang.Object | Bestimmt den Index eines bestimmten Elements in der CollectionBase-Instanz. |
+
+**Returns:**
+int - Der Index des Werts, falls in der Liste gefunden; sonst -1.
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Gibt einen Enumerator zurück, der die CollectionBase-Instanz durchläuft.
+
+**Returns:**
+java.util.Iterator - Ein Iterator für die CollectionBase-Instanz.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Page page) {#remove-com.aspose.diagram.Page-}
+```
+public void remove(Page page)
+```
+
+
+Entfernt das Modul für eine Seite.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| page | [Page](../../com.aspose.diagram/page) | Die Seite |
+
+### remove(String name) {#remove-java.lang.String-}
+```
+public void remove(String name)
+```
+
+
+Entferne das Modul nach dem Namen
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Name | java.lang.String |  |
+
+### removeAt(int index) {#removeAt-int-}
+```
+public void removeAt(int index)
+```
+
+
+Entfernt das Element am angegebenen Index.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Der nullbasierte Index des zu entfernenden Elements. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/vbamoduletype/_index.md
+++ b/german/java/com.aspose.diagram/vbamoduletype/_index.md
@@ -1,0 +1,165 @@
+---
+title: VbaModuleType
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt den Typ des VBA‑Moduls dar.
+type: docs
+weight: 432
+url: /de/java/com.aspose.diagram/vbamoduletype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class VbaModuleType
+```
+
+Stellt den Typ des VBA‑Moduls dar.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [CLASS](#CLASS) | Stellt ein Klassenmodul dar. |
+| [DESIGNER](#DESIGNER) | Stellt ein Designer‑Modul dar. |
+| [DOCUMENT](#DOCUMENT) | Stellt ein Dokumentmodul dar. |
+| [PROCEDURAL](#PROCEDURAL) | Stellt ein prozedurales Modul dar. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CLASS {#CLASS}
+```
+public static final int CLASS
+```
+
+
+Stellt ein Klassenmodul dar.
+
+### DESIGNER {#DESIGNER}
+```
+public static final int DESIGNER
+```
+
+
+Stellt ein Designer‑Modul dar.
+
+### DOCUMENT {#DOCUMENT}
+```
+public static final int DOCUMENT
+```
+
+
+Stellt ein Dokumentmodul dar.
+
+### PROCEDURAL {#PROCEDURAL}
+```
+public static final int PROCEDURAL
+```
+
+
+Stellt ein prozedurales Modul dar.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/vbaproject/_index.md
+++ b/german/java/com.aspose.diagram/vbaproject/_index.md
@@ -1,0 +1,183 @@
+---
+title: VbaProject
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt das VBA‑Projekt dar.
+type: docs
+weight: 433
+url: /de/java/com.aspose.diagram/vbaproject/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class VbaProject
+```
+
+Stellt das VBA‑Projekt dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getModules()](#getModules--) | Ruft alle [VbaModule](../../com.aspose.diagram/vbamodule) Objekte ab. |
+| [getName()](#getName--) | der Name des VBA-Projekts. |
+| [getReferences()](#getReferences--) | Ruft alle Verweise des VBA-Projekts ab. |
+| [hashCode()](#hashCode--) |  |
+| [isSigned()](#isSigned--) | Gibt an, ob VBAcode signiert ist oder nicht. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setName(String value)](#setName-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe [getName()](../../com.aspose.diagram/vbaproject\#getName--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getModules() {#getModules--}
+```
+public VbaModuleCollection getModules()
+```
+
+
+Ruft alle [VbaModule](../../com.aspose.diagram/vbamodule) Objekte ab.
+
+**Returns:**
+[VbaModuleCollection](../../com.aspose.diagram/vbamodulecollection)
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+der Name des VBA-Projekts.
+
+**Returns:**
+java.lang.String
+### getReferences() {#getReferences--}
+```
+public VbaProjectReferenceCollection getReferences()
+```
+
+
+Ruft alle Verweise des VBA-Projekts ab.
+
+**Returns:**
+[VbaProjectReferenceCollection](../../com.aspose.diagram/vbaprojectreferencecollection)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isSigned() {#isSigned--}
+```
+public boolean isSigned()
+```
+
+
+Gibt an, ob VBAcode signiert ist oder nicht.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getName()](../../com.aspose.diagram/vbaproject\#getName--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/vbaprojectreference/_index.md
+++ b/german/java/com.aspose.diagram/vbaprojectreference/_index.md
@@ -1,0 +1,261 @@
+---
+title: VbaProjectReference
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt die Referenz des VBA‑Projekts dar.
+type: docs
+weight: 434
+url: /de/java/com.aspose.diagram/vbaprojectreference/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class VbaProjectReference
+```
+
+Stellt die Referenz des VBA‑Projekts dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getExtendedLibid()](#getExtendedLibid--) | die erweiterte Libid der Referenz. |
+| [getLibid()](#getLibid--) | die Libid der Referenz. |
+| [getName()](#getName--) | der Name der Referenz. |
+| [getRelativeLibid()](#getRelativeLibid--) | der referenzierte VBA-Projekt\u9225\u6a9a-Bezeichner mit einem relativen Pfad. |
+| [getTwiddledlibid()](#getTwiddledlibid--) | die veränderte Libid der Referenz. |
+| [getType()](#getType--) | Gibt den Typ dieser Referenz zurück. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setExtendedLibid(String value)](#setExtendedLibid-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getExtendedLibid()](../../com.aspose.diagram/vbaprojectreference\#getExtendedLibid--) |
+| [setLibid(String value)](#setLibid-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getLibid()](../../com.aspose.diagram/vbaprojectreference\#getLibid--) |
+| [setName(String value)](#setName-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getName()](../../com.aspose.diagram/vbaprojectreference\#getName--) |
+| [setRelativeLibid(String value)](#setRelativeLibid-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getRelativeLibid()](../../com.aspose.diagram/vbaprojectreference\#getRelativeLibid--) |
+| [setTwiddledlibid(String value)](#setTwiddledlibid-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getTwiddledlibid()](../../com.aspose.diagram/vbaprojectreference\#getTwiddledlibid--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getExtendedLibid() {#getExtendedLibid--}
+```
+public String getExtendedLibid()
+```
+
+
+die erweiterte Libid der Referenz. Nur für Steuerungsreferenz.
+
+**Returns:**
+java.lang.String
+### getLibid() {#getLibid--}
+```
+public String getLibid()
+```
+
+
+die Libid der Referenz.
+
+**Returns:**
+java.lang.String
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+der Name der Referenz.
+
+**Returns:**
+java.lang.String
+### getRelativeLibid() {#getRelativeLibid--}
+```
+public String getRelativeLibid()
+```
+
+
+der referenzierte VBA-Projekt\u9225\u6a9a-Bezeichner mit einem relativen Pfad. Nur für Projektreferenz.
+
+**Returns:**
+java.lang.String
+### getTwiddledlibid() {#getTwiddledlibid--}
+```
+public String getTwiddledlibid()
+```
+
+
+die veränderte Libid der Referenz. Nur für Steuerungsreferenz.
+
+**Returns:**
+java.lang.String
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Gibt den Typ dieser Referenz zurück.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setExtendedLibid(String value) {#setExtendedLibid-java.lang.String-}
+```
+public void setExtendedLibid(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getExtendedLibid()](../../com.aspose.diagram/vbaprojectreference\#getExtendedLibid--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setLibid(String value) {#setLibid-java.lang.String-}
+```
+public void setLibid(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getLibid()](../../com.aspose.diagram/vbaprojectreference\#getLibid--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getName()](../../com.aspose.diagram/vbaprojectreference\#getName--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setRelativeLibid(String value) {#setRelativeLibid-java.lang.String-}
+```
+public void setRelativeLibid(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getRelativeLibid()](../../com.aspose.diagram/vbaprojectreference\#getRelativeLibid--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setTwiddledlibid(String value) {#setTwiddledlibid-java.lang.String-}
+```
+public void setTwiddledlibid(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getTwiddledlibid()](../../com.aspose.diagram/vbaprojectreference\#getTwiddledlibid--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/vbaprojectreferencecollection/_index.md
+++ b/german/java/com.aspose.diagram/vbaprojectreferencecollection/_index.md
@@ -1,0 +1,288 @@
+---
+title: VbaProjectReferenceCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt alle Referenzen des VBA‑Projekts dar.
+type: docs
+weight: 435
+url: /de/java/com.aspose.diagram/vbaprojectreferencecollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.CollectionBase](../../com.aspose.diagram/collectionbase)
+```
+public class VbaProjectReferenceCollection extends CollectionBase
+```
+
+Stellt alle Referenzen des VBA‑Projekts dar.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [add(Object o)](#add-java.lang.Object-) | Fügt ein Element zur CollectionBase-Instanz hinzu. |
+| [addControlRefrernce(String name, String libid, String twiddledlibid, String extendedLibid)](#addControlRefrernce-java.lang.String-java.lang.String-java.lang.String-java.lang.String-) | Add a reference to a twiddled type library and its extended type library. |
+| [addProjectRefrernce(String name, String absoluteLibid, String relativeLibid)](#addProjectRefrernce-java.lang.String-java.lang.String-java.lang.String-) | Add a reference to an external VBA project. |
+| [addRegisteredReference(String name, String libid)](#addRegisteredReference-java.lang.String-java.lang.String-) | Add a reference to an Automation type library. |
+| [clear()](#clear--) | Entfernt alle Objekte aus der CollectionBase-Instanz. |
+| [contains(Object o)](#contains-java.lang.Object-) | Gibt zurück, ob die Instanz dieses Objekt enthält |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int i)](#get-int-) | Get the reference in the list by the index. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ermittelt die Anzahl der in der CollectionBase-Instanz enthaltenen Elemente. |
+| [hashCode()](#hashCode--) |  |
+| [indexOf(Object o)](#indexOf-java.lang.Object-) | Bestimmt den Index eines bestimmten Elements in der CollectionBase-Instanz. |
+| [iterator()](#iterator--) | Gibt einen Enumerator zurück, der die CollectionBase-Instanz durchläuft. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [removeAt(int index)](#removeAt-int-) | Entfernt das Element am angegebenen Index. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Object o) {#add-java.lang.Object-}
+```
+public int add(Object o)
+```
+
+
+Fügt ein Element zur CollectionBase-Instanz hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| o | java.lang.Object | Das Objekt, das zur CollectionBase-Instanz hinzugefügt werden soll. |
+
+**Returns:**
+int - Die Position, in die das neue Element eingefügt wurde.
+### addControlRefrernce(String name, String libid, String twiddledlibid, String extendedLibid) {#addControlRefrernce-java.lang.String-java.lang.String-java.lang.String-java.lang.String-}
+```
+public int addControlRefrernce(String name, String libid, String twiddledlibid, String extendedLibid)
+```
+
+
+Add a reference to a twiddled type library and its extended type library.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Name | java.lang.String | The name of reference. |
+| libid | java.lang.String | The identifier of an Automation type library. |
+| twiddledlibid | java.lang.String | The identifier of a twiddled type library |
+| extendedLibid | java.lang.String | Der Bezeichner einer erweiterten Typbibliothek |
+
+**Returns:**
+int -
+### addProjectRefrernce(String name, String absoluteLibid, String relativeLibid) {#addProjectRefrernce-java.lang.String-java.lang.String-java.lang.String-}
+```
+public int addProjectRefrernce(String name, String absoluteLibid, String relativeLibid)
+```
+
+
+Add a reference to an external VBA project.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Name | java.lang.String | The name of reference. |
+| absoluteLibid | java.lang.String | Der referenzierte VBA\u9225\u6a9a-Bezeichner mit einem absoluten Pfad. |
+| relativeLibid | java.lang.String | Der referenzierte VBA\u9225\u6a9a-Bezeichner mit einem relativen Pfad. |
+
+**Returns:**
+int -
+### addRegisteredReference(String name, String libid) {#addRegisteredReference-java.lang.String-java.lang.String-}
+```
+public int addRegisteredReference(String name, String libid)
+```
+
+
+Add a reference to an Automation type library.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Name | java.lang.String | The name of reference. |
+| libid | java.lang.String | The identifier of an Automation type library. |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Objekte aus der CollectionBase-Instanz.
+
+### contains(Object o) {#contains-java.lang.Object-}
+```
+public boolean contains(Object o)
+```
+
+
+Gibt zurück, ob die Instanz dieses Objekt enthält
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| o | java.lang.Object | Testobjekt |
+
+**Returns:**
+boolean - Gibt an, ob die Instanz dieses Objekt enthält
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int i) {#get-int-}
+```
+public VbaProjectReference get(int i)
+```
+
+
+Get the reference in the list by the index.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| i | int | Der Index. |
+
+**Returns:**
+[VbaProjectReference](../../com.aspose.diagram/vbaprojectreference) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ermittelt die Anzahl der in der CollectionBase-Instanz enthaltenen Elemente.
+
+**Returns:**
+int - Die Anzahl der im CollectionBase-Instanz enthaltenen Elemente.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### indexOf(Object o) {#indexOf-java.lang.Object-}
+```
+public int indexOf(Object o)
+```
+
+
+Bestimmt den Index eines bestimmten Elements in der CollectionBase-Instanz.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| o | java.lang.Object | Bestimmt den Index eines bestimmten Elements in der CollectionBase-Instanz. |
+
+**Returns:**
+int - Der Index des Werts, falls in der Liste gefunden; sonst -1.
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Gibt einen Enumerator zurück, der die CollectionBase-Instanz durchläuft.
+
+**Returns:**
+java.util.Iterator - Ein Iterator für die CollectionBase-Instanz.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### removeAt(int index) {#removeAt-int-}
+```
+public void removeAt(int index)
+```
+
+
+Entfernt das Element am angegebenen Index.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Der nullbasierte Index des zu entfernenden Elements. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/vbaprojectreferencetype/_index.md
+++ b/german/java/com.aspose.diagram/vbaprojectreferencetype/_index.md
@@ -1,0 +1,156 @@
+---
+title: VbaProjectReferenceType
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt den Typ der VBA‑Projekt‑Referenz dar.
+type: docs
+weight: 436
+url: /de/java/com.aspose.diagram/vbaprojectreferencetype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class VbaProjectReferenceType
+```
+
+Stellt den Typ der VBA‑Projekt‑Referenz dar.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [CONTROL](#CONTROL) | Gibt eine Referenz zu einer veränderten Typbibliothek und ihrer erweiterten Typbibliothek an. |
+| [PROJECT](#PROJECT) | Gibt eine Referenz zu einem externen VBA-Projekt an. |
+| [REGISTERED](#REGISTERED) | Gibt eine Referenz zu einer Automation-Typbibliothek an. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CONTROL {#CONTROL}
+```
+public static final int CONTROL
+```
+
+
+Gibt eine Referenz zu einer veränderten Typbibliothek und ihrer erweiterten Typbibliothek an.
+
+### PROJECT {#PROJECT}
+```
+public static final int PROJECT
+```
+
+
+Gibt eine Referenz zu einem externen VBA-Projekt an.
+
+### REGISTERED {#REGISTERED}
+```
+public static final int REGISTERED
+```
+
+
+Gibt eine Referenz zu einer Automation-Typbibliothek an.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/verticalalign/_index.md
+++ b/german/java/com.aspose.diagram/verticalalign/_index.md
@@ -1,0 +1,204 @@
+---
+title: VerticalAlign
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt die vertikale Ausrichtung des Textes innerhalb des Textblocks an.
+type: docs
+weight: 437
+url: /de/java/com.aspose.diagram/verticalalign/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class VerticalAlign
+```
+
+Gibt die vertikale Ausrichtung des Textes innerhalb des Textblocks an.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [VerticalAlign(int value)](#VerticalAlign-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Gibt die vertikale Ausrichtung des Textes innerhalb des Textblocks an. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | Für die Beschreibung dieser Eigenschaft, siehe bitte [getUfe()](../../com.aspose.diagram/verticalalign\#getUfe--) |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft, siehe bitte [getValue()](../../com.aspose.diagram/verticalalign\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### VerticalAlign(int value) {#VerticalAlign-int-}
+```
+public VerticalAlign(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Gibt die vertikale Ausrichtung des Textes innerhalb des Textblocks an.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft, siehe bitte [getUfe()](../../com.aspose.diagram/verticalalign\#getUfe--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft, siehe bitte [getValue()](../../com.aspose.diagram/verticalalign\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/verticalalignvalue/_index.md
+++ b/german/java/com.aspose.diagram/verticalalignvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: VerticalAlignValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt die vertikale Ausrichtung des Textes innerhalb des Textblocks an.
+type: docs
+weight: 438
+url: /de/java/com.aspose.diagram/verticalalignvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class VerticalAlignValue
+```
+
+Gibt die vertikale Ausrichtung des Textes innerhalb des Textblocks an.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [BOTTOM](#BOTTOM) | Unten. |
+| [MIDDLE](#MIDDLE) | Mitte. |
+| [TOP](#TOP) | Oben. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOTTOM {#BOTTOM}
+```
+public static final int BOTTOM
+```
+
+
+Unten.
+
+### MIDDLE {#MIDDLE}
+```
+public static final int MIDDLE
+```
+
+
+Mitte.
+
+### TOP {#TOP}
+```
+public static final int TOP
+```
+
+
+Oben.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/visruletargetsvalue/_index.md
+++ b/german/java/com.aspose.diagram/visruletargetsvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: VisRuleTargetsValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt Inhalte an, die das Ziel der Validierungsregel definieren, die an die Eigenschaft ValidationRule.TargetType übergeben und von ihr zurückgegeben wird.
+type: docs
+weight: 439
+url: /de/java/com.aspose.diagram/visruletargetsvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class VisRuleTargetsValue
+```
+
+Gibt Inhalte an, die das Ziel der Validierungsregel definieren; wird an die Eigenschaft ValidationRule.TargetType übergeben und von ihr zurückgegeben.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+| [VIS_RULE_TARGET_DOCUMENT](#VIS-RULE-TARGET-DOCUMENT) | Die Regel gilt für Formen im Dokument. |
+| [VIS_RULE_TARGET_PAGE](#VIS-RULE-TARGET-PAGE) | Die Regel gilt für Seiten im Dokument. |
+| [VIS_RULE_TARGET_SHAPE](#VIS-RULE-TARGET-SHAPE) | Die Regel gilt für das Dokument selbst. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### VIS_RULE_TARGET_DOCUMENT {#VIS-RULE-TARGET-DOCUMENT}
+```
+public static final int VIS_RULE_TARGET_DOCUMENT
+```
+
+
+Die Regel gilt für Formen im Dokument.
+
+### VIS_RULE_TARGET_PAGE {#VIS-RULE-TARGET-PAGE}
+```
+public static final int VIS_RULE_TARGET_PAGE
+```
+
+
+Die Regel gilt für Seiten im Dokument.
+
+### VIS_RULE_TARGET_SHAPE {#VIS-RULE-TARGET-SHAPE}
+```
+public static final int VIS_RULE_TARGET_SHAPE
+```
+
+
+Die Regel gilt für das Dokument selbst.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/walkpreference/_index.md
+++ b/german/java/com.aspose.diagram/walkpreference/_index.md
@@ -1,0 +1,179 @@
+---
+title: WalkPreference
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt an, ob ein Endpunkt einer 1-D-Form zu einem horizontalen oder vertikalen Verbindungspunkt auf der Form, an die sie mit dynamischem Klebstoff geklebt ist, bewegt wird, wenn die Form in eine mehrdeutige Position verschoben wird.
+type: docs
+weight: 440
+url: /de/java/com.aspose.diagram/walkpreference/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class WalkPreference
+```
+
+Gibt an, ob ein Endpunkt einer 1‑D‑Form zu einem horizontalen oder vertikalen Verbindungspunkt der Form, an die sie geklebt ist, mit dynamischem Kleben verschoben wird, wenn die Form in eine mehrdeutige Position bewegt wird.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [WalkPreference(int value)](#WalkPreference-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Gibt an, ob ein Endpunkt einer 1‑D‑Form zu einem horizontalen oder vertikalen Verbindungspunkt der Form, an die sie geklebt ist, mit dynamischem Kleben verschoben wird, wenn die Form in eine mehrdeutige Position bewegt wird. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/walkpreference\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### WalkPreference(int value) {#WalkPreference-int-}
+```
+public WalkPreference(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Gibt an, ob ein Endpunkt einer 1‑D‑Form zu einem horizontalen oder vertikalen Verbindungspunkt der Form, an die sie geklebt ist, mit dynamischem Kleben verschoben wird, wenn die Form in eine mehrdeutige Position bewegt wird.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/walkpreference\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/walkpreferencevalue/_index.md
+++ b/german/java/com.aspose.diagram/walkpreferencevalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: WalkPreferenceValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt an, ob ein Endpunkt einer 1-D-Form zu einem horizontalen oder vertikalen Verbindungspunkt auf der Form, an die sie mit dynamischem Klebstoff geklebt ist, bewegt wird, wenn die Form in eine mehrdeutige Position verschoben wird.
+type: docs
+weight: 441
+url: /de/java/com.aspose.diagram/walkpreferencevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class WalkPreferenceValue
+```
+
+Gibt an, ob ein Endpunkt einer 1‑D‑Form zu einem horizontalen oder vertikalen Verbindungspunkt der Form, an die sie geklebt ist, mit dynamischem Kleben verschoben wird, wenn die Form in eine mehrdeutige Position bewegt wird.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [SIDE_TO_SIDE_CONNECTIONS](#SIDE-TO-SIDE-CONNECTIONS) | Der Standard. |
+| [SIDE_TO_TOP_OR_SIDE_TO_BOTTOM_CONNECTIONS](#SIDE-TO-TOP-OR-SIDE-TO-BOTTOM-CONNECTIONS) | Der Anfangspunkt der 1-D-Form bewegt sich zu einem horizontalen Verbindungspunkt, und der Endpunkt bewegt sich zu einem vertikalen Verbindungspunkt (Verbindungen von Seite zu oben oder von Seite zu unten). |
+| [TOP_TO_BOTTOM_CONNECTIONS](#TOP-TO-BOTTOM-CONNECTIONS) | Beide Endpunkte der 1-D-Form bewegen sich zu vertikalen Verbindungspunkten (Verbindungen von oben nach unten). |
+| [TOP_TO_SIDE_OR_BOTTOM_TO_SIDE_CONNECTIONS](#TOP-TO-SIDE-OR-BOTTOM-TO-SIDE-CONNECTIONS) | Der Anfangspunkt der 1-D-Form bewegt sich zu einem vertikalen Verbindungspunkt, und der Endpunkt bewegt sich zu einem horizontalen Verbindungspunkt (Verbindungen von oben zu Seite oder von unten zu Seite). |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SIDE_TO_SIDE_CONNECTIONS {#SIDE-TO-SIDE-CONNECTIONS}
+```
+public static final int SIDE_TO_SIDE_CONNECTIONS
+```
+
+
+Der Standard. Beide Endpunkte der 1-D-Form bewegen sich zu horizontalen Verbindungspunkten (Verbindungen von Seite zu Seite).
+
+### SIDE_TO_TOP_OR_SIDE_TO_BOTTOM_CONNECTIONS {#SIDE-TO-TOP-OR-SIDE-TO-BOTTOM-CONNECTIONS}
+```
+public static final int SIDE_TO_TOP_OR_SIDE_TO_BOTTOM_CONNECTIONS
+```
+
+
+Der Anfangspunkt der 1-D-Form bewegt sich zu einem horizontalen Verbindungspunkt, und der Endpunkt bewegt sich zu einem vertikalen Verbindungspunkt (Verbindungen von Seite zu oben oder von Seite zu unten).
+
+### TOP_TO_BOTTOM_CONNECTIONS {#TOP-TO-BOTTOM-CONNECTIONS}
+```
+public static final int TOP_TO_BOTTOM_CONNECTIONS
+```
+
+
+Beide Endpunkte der 1-D-Form bewegen sich zu vertikalen Verbindungspunkten (Verbindungen von oben nach unten).
+
+### TOP_TO_SIDE_OR_BOTTOM_TO_SIDE_CONNECTIONS {#TOP-TO-SIDE-OR-BOTTOM-TO-SIDE-CONNECTIONS}
+```
+public static final int TOP_TO_SIDE_OR_BOTTOM_TO_SIDE_CONNECTIONS
+```
+
+
+Der Anfangspunkt der 1-D-Form bewegt sich zu einem vertikalen Verbindungspunkt, und der Endpunkt bewegt sich zu einem horizontalen Verbindungspunkt (Verbindungen von oben zu Seite oder von unten zu Seite).
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/warninginfo/_index.md
+++ b/german/java/com.aspose.diagram/warninginfo/_index.md
@@ -1,0 +1,166 @@
+---
+title: WarningInfo
+second_title: Aspose.Diagram for Java API-Referenz
+description: Warnungsinfo
+type: docs
+weight: 442
+url: /de/java/com.aspose.diagram/warninginfo/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class WarningInfo
+```
+
+Warnungsinfo
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [WarningInfo(int warningType, String description)](#WarningInfo-int-java.lang.String-) | Erstelle Warnungsinformationen. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDescription()](#getDescription--) | Hole die Beschreibung der Warnungsinformationen. |
+| [getWarningType()](#getWarningType--) | Hole den Warnungstyp. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### WarningInfo(int warningType, String description) {#WarningInfo-int-java.lang.String-}
+```
+public WarningInfo(int warningType, String description)
+```
+
+
+Erstelle Warnungsinformationen.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| warningType | int | Warnungstyp |
+| Beschreibung | java.lang.String | Warnungsbeschreibung |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDescription() {#getDescription--}
+```
+public String getDescription()
+```
+
+
+Hole die Beschreibung der Warnungsinformationen.
+
+**Returns:**
+java.lang.String
+### getWarningType() {#getWarningType--}
+```
+public int getWarningType()
+```
+
+
+Hole den Warnungstyp.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/warningtype/_index.md
+++ b/german/java/com.aspose.diagram/warningtype/_index.md
@@ -1,0 +1,138 @@
+---
+title: Warnungstyp
+second_title: Aspose.Diagram for Java API-Referenz
+description: Warnungstyp
+type: docs
+weight: 443
+url: /de/java/com.aspose.diagram/warningtype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class WarningType
+```
+
+Warnungstyp
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [FONT_SUBSTITUTION](#FONT-SUBSTITUTION) | Schriftersatz-Warnungstyp, wenn eine Schriftart nicht gefunden wurde; dieser Warnungstyp kann abgerufen werden. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FONT_SUBSTITUTION {#FONT-SUBSTITUTION}
+```
+public static final int FONT_SUBSTITUTION
+```
+
+
+Schriftersatz-Warnungstyp, wenn eine Schriftart nicht gefunden wurde; dieser Warnungstyp kann abgerufen werden.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/window/_index.md
+++ b/german/java/com.aspose.diagram/window/_index.md
@@ -1,0 +1,899 @@
+---
+title: Window
+second_title: Aspose.Diagram for Java API-Referenz
+description: Stellt ein offenes Fenster in einer Microsoft‑Visio‑Instanz dar.
+type: docs
+weight: 444
+url: /de/java/com.aspose.diagram/window/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Window
+```
+
+Stellt ein offenes Fenster in einer Microsoft Visio-Instanz dar. Dieses Element enthält die Informationen, die erforderlich sind, um ein Benutzeroberflächenfenster im Anwendungsarbeitsbereich exakt wiederherzustellen, wenn die DatadiagramML-Datei zunächst von Visio geöffnet wird.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [Window()](#Window--) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getContainer()](#getContainer--) | ID des Containers: Seite, Blatt oder Master. |
+| [getContainerType()](#getContainerType--) | Kann einen der folgenden Werte haben: Document, Page oder Master. |
+| [getDocument()](#getDocument--) | Dateipfad des in diesem Fenster angezeigten Dokuments. |
+| [getDynamicGridEnabled()](#getDynamicGridEnabled--) | Gibt an, ob die dynamische Rasterfunktion für ein Dokument oder Fenster aktiviert ist. |
+| [getGlueSettings()](#getGlueSettings--) | Gibt die Objekte an, an die Formen geklebt werden, wenn Kleben im Dokument aktiviert ist. |
+| [getID()](#getID--) | Die eindeutige ID des Elements innerhalb seines übergeordneten Elements. |
+| [getMaster()](#getMaster--) | Master-ID, wenn dieses Fenster einen Master anzeigt. |
+| [getPage()](#getPage--) | Seiten-ID, wenn dieses Fenster eine Seite anzeigt. |
+| [getParentWindow()](#getParentWindow--) | ID des Fensters, in dem dieses Stencil-Fenster enthalten ist. |
+| [getReadOnly()](#getReadOnly--) | Nur-Lese-Flag, wenn dieses Stencil kein Dokument-Stencil ist. |
+| [getSheet()](#getSheet--) | ID des Blatts im Container. |
+| [getShowConnectionPoints()](#getShowConnectionPoints--) | Gibt an, ob Verbindungspunkte in einem Fenster angezeigt werden. |
+| [getShowGrid()](#getShowGrid--) | Gibt an, ob ein Raster im Zeichenfenster angezeigt wird. |
+| [getShowGuides()](#getShowGuides--) | Gibt an, ob Hilfslinien im Zeichenfenster angezeigt werden. |
+| [getShowPageBreaks()](#getShowPageBreaks--) | Gibt an, ob Seitenumbrüche in einem Fenster angezeigt werden. |
+| [getShowRulers()](#getShowRulers--) | Gibt an, ob Lineale im Zeichenfenster angezeigt werden. |
+| [getSnapAngles()](#getSnapAngles--) | Enthält eine Sammlung von SnapAngle-Elementen. |
+| [getSnapExtensions()](#getSnapExtensions--) | Gibt an, ob eine bestimmte Snap‑Erweiterungseinstellung für das aktive Fenster aktiviert oder deaktiviert ist. |
+| [getSnapSettings()](#getSnapSettings--) | Gibt die Objekte an, an die Formen einrasten, wenn das Einrasten im Fenster aktiv ist. |
+| [getStencilGroup()](#getStencilGroup--) | Gibt die Gruppe zusammengeführter Stencil-Fenster an, deren Mitglied dieses Fenster ist. |
+| [getStencilGroupPos()](#getStencilGroupPos--) | Enthält eine ganze Zahl, die die relative Position eines Stencils innerhalb einer Gruppe in einem Fenster angibt. |
+| [getTabSplitterPos()](#getTabSplitterPos--) | Gibt die Breite der Seitenregister-Steuerung eines Zeichenfensters an (als Bruchteil der Gesamtheit der Breite des Zeichenfensters). |
+| [getViewCenterX()](#getViewCenterX--) | Optionaler Double. |
+| [getViewCenterY()](#getViewCenterY--) | Optionaler Double. |
+| [getViewScale()](#getViewScale--) | Optionaler Double. |
+| [getWindowHeight()](#getWindowHeight--) | Höhe des Fensterrechtecks. |
+| [getWindowLeft()](#getWindowLeft--) | Linke Koordinate des Fensterrechtecks. |
+| [getWindowState()](#getWindowState--) | Dieses Attribut kann die Summe der folgenden Werte sein. |
+| [getWindowTop()](#getWindowTop--) | Obere Koordinate des Fensterrechtecks. |
+| [getWindowType()](#getWindowType--) | Ein aufzählbarer Wert, der einer der folgenden sein kann: Drawing, Sheet, Stencil oder Icon. Ein Window-Element mit WindowType='Stencil' muss nach seinem übergeordneten Zeichenfenster (WindowType='Drawing') und vor allen anderen Zeichenfenster-Elementen erscheinen. |
+| [getWindowWidth()](#getWindowWidth--) | Breite des Fensterrechtecks. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setContainer(int value)](#setContainer-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getContainer()](../../com.aspose.diagram/window\#getContainer--) |
+| [setContainerType(int value)](#setContainerType-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getContainerType()](../../com.aspose.diagram/window\#getContainerType--) |
+| [setDocument(String value)](#setDocument-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDocument()](../../com.aspose.diagram/window\#getDocument--) |
+| [setDynamicGridEnabled(int value)](#setDynamicGridEnabled-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDynamicGridEnabled()](../../com.aspose.diagram/window\#getDynamicGridEnabled--) |
+| [setGlueSettings(int value)](#setGlueSettings-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getGlueSettings()](../../com.aspose.diagram/window\#getGlueSettings--) |
+| [setID(int value)](#setID-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getID()](../../com.aspose.diagram/window\#getID--) |
+| [setMaster(Master value)](#setMaster-com.aspose.diagram.Master-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getMaster()](../../com.aspose.diagram/window\#getMaster--) |
+| [setPage(Page value)](#setPage-com.aspose.diagram.Page-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getPage()](../../com.aspose.diagram/window\#getPage--) |
+| [setParentWindow(int value)](#setParentWindow-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getParentWindow()](../../com.aspose.diagram/window\#getParentWindow--) |
+| [setReadOnly(int value)](#setReadOnly-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getReadOnly()](../../com.aspose.diagram/window\#getReadOnly--) |
+| [setSheet(int value)](#setSheet-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getSheet()](../../com.aspose.diagram/window\#getSheet--) |
+| [setShowConnectionPoints(int value)](#setShowConnectionPoints-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getShowConnectionPoints()](../../com.aspose.diagram/window\#getShowConnectionPoints--) |
+| [setShowGrid(int value)](#setShowGrid-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getShowGrid()](../../com.aspose.diagram/window\#getShowGrid--) |
+| [setShowGuides(int value)](#setShowGuides-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getShowGuides()](../../com.aspose.diagram/window\#getShowGuides--) |
+| [setShowPageBreaks(int value)](#setShowPageBreaks-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getShowPageBreaks()](../../com.aspose.diagram/window\#getShowPageBreaks--) |
+| [setShowRulers(int value)](#setShowRulers-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getShowRulers()](../../com.aspose.diagram/window\#getShowRulers--) |
+| [setSnapExtensions(int value)](#setSnapExtensions-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getSnapExtensions()](../../com.aspose.diagram/window\#getSnapExtensions--) |
+| [setSnapSettings(int value)](#setSnapSettings-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getSnapSettings()](../../com.aspose.diagram/window\#getSnapSettings--) |
+| [setStencilGroup(String value)](#setStencilGroup-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getStencilGroup()](../../com.aspose.diagram/window\#getStencilGroup--) |
+| [setStencilGroupPos(int value)](#setStencilGroupPos-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getStencilGroupPos()](../../com.aspose.diagram/window\#getStencilGroupPos--) |
+| [setTabSplitterPos(double value)](#setTabSplitterPos-double-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getTabSplitterPos()](../../com.aspose.diagram/window\#getTabSplitterPos--) |
+| [setViewCenterX(double value)](#setViewCenterX-double-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getViewCenterX()](../../com.aspose.diagram/window\#getViewCenterX--) |
+| [setViewCenterY(double value)](#setViewCenterY-double-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getViewCenterY()](../../com.aspose.diagram/window\#getViewCenterY--) |
+| [setViewScale(double value)](#setViewScale-double-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getViewScale()](../../com.aspose.diagram/window\#getViewScale--) |
+| [setWindowHeight(long value)](#setWindowHeight-long-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getWindowHeight()](../../com.aspose.diagram/window\#getWindowHeight--) |
+| [setWindowLeft(int value)](#setWindowLeft-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getWindowLeft()](../../com.aspose.diagram/window\#getWindowLeft--) |
+| [setWindowState(int value)](#setWindowState-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getWindowState()](../../com.aspose.diagram/window\#getWindowState--) |
+| [setWindowTop(int value)](#setWindowTop-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getWindowTop()](../../com.aspose.diagram/window\#getWindowTop--) |
+| [setWindowType(int value)](#setWindowType-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getWindowType()](../../com.aspose.diagram/window\#getWindowType--) |
+| [setWindowWidth(long value)](#setWindowWidth-long-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getWindowWidth()](../../com.aspose.diagram/window\#getWindowWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Window() {#Window--}
+```
+public Window()
+```
+
+
+Konstruktor.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getContainer() {#getContainer--}
+```
+public int getContainer()
+```
+
+
+ID des Containers: Seite, Blatt oder Master. Nur relevant und erforderlich, wenn ContainerType angegeben ist.
+
+**Returns:**
+int
+### getContainerType() {#getContainerType--}
+```
+public int getContainerType()
+```
+
+
+Kann einer der folgenden Werte sein: Dokument, Seite oder Master. Nur relevant, wenn WindowType als Zeichnung oder Blatt angegeben ist.
+
+**Returns:**
+int
+### getDocument() {#getDocument--}
+```
+public String getDocument()
+```
+
+
+Dateipfad des im Fenster angezeigten Dokuments. Dieses Attribut ist relevant für Fenster, deren WindowType als Stencil angegeben ist.
+
+**Returns:**
+java.lang.String
+### getDynamicGridEnabled() {#getDynamicGridEnabled--}
+```
+public int getDynamicGridEnabled()
+```
+
+
+Gibt an, ob die dynamische Rasterfunktion für ein Dokument oder Fenster aktiviert ist.
+
+**Returns:**
+int
+### getGlueSettings() {#getGlueSettings--}
+```
+public int getGlueSettings()
+```
+
+
+Gibt die Objekte an, an die Formen geklebt werden, wenn Kleben im Dokument aktiviert ist.
+
+**Returns:**
+int
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+Die eindeutige ID des Elements innerhalb seines übergeordneten Elements.
+
+**Returns:**
+int
+### getMaster() {#getMaster--}
+```
+public Master getMaster()
+```
+
+
+Master-ID, wenn dieses Fenster einen Master anzeigt.
+
+**Returns:**
+[Master](../../com.aspose.diagram/master)
+### getPage() {#getPage--}
+```
+public Page getPage()
+```
+
+
+Seiten-ID, wenn dieses Fenster eine Seite anzeigt. Nur relevant, wenn WindowType als Drawing angegeben ist und ContainerType als Page angegeben ist.
+
+**Returns:**
+[Page](../../com.aspose.diagram/page)
+### getParentWindow() {#getParentWindow--}
+```
+public int getParentWindow()
+```
+
+
+ID des Fensters, in dem dieses Stencil-Fenster enthalten ist. Nur relevant, wenn WindowType als Stencil angegeben ist.
+
+**Returns:**
+int
+### getReadOnly() {#getReadOnly--}
+```
+public int getReadOnly()
+```
+
+
+Nur-Lese-Flag, wenn dieses Stencil kein Dokument-Stencil ist.
+
+**Returns:**
+int
+### getSheet() {#getSheet--}
+```
+public int getSheet()
+```
+
+
+ID des Blatts im Container. Nur relevant, wenn Container als Sheet angegeben ist.
+
+**Returns:**
+int
+### getShowConnectionPoints() {#getShowConnectionPoints--}
+```
+public int getShowConnectionPoints()
+```
+
+
+Gibt an, ob Verbindungspunkte in einem Fenster angezeigt werden.
+
+**Returns:**
+int
+### getShowGrid() {#getShowGrid--}
+```
+public int getShowGrid()
+```
+
+
+Gibt an, ob ein Raster im Zeichenfenster angezeigt wird.
+
+**Returns:**
+int
+### getShowGuides() {#getShowGuides--}
+```
+public int getShowGuides()
+```
+
+
+Gibt an, ob Hilfslinien im Zeichenfenster angezeigt werden.
+
+**Returns:**
+int
+### getShowPageBreaks() {#getShowPageBreaks--}
+```
+public int getShowPageBreaks()
+```
+
+
+Gibt an, ob Seitenumbrüche in einem Fenster angezeigt werden.
+
+**Returns:**
+int
+### getShowRulers() {#getShowRulers--}
+```
+public int getShowRulers()
+```
+
+
+Gibt an, ob Lineale im Zeichenfenster angezeigt werden.
+
+**Returns:**
+int
+### getSnapAngles() {#getSnapAngles--}
+```
+public FloatPointNumCollection getSnapAngles()
+```
+
+
+Enthält eine Sammlung von SnapAngle-Elementen.
+
+**Returns:**
+[FloatPointNumCollection](../../com.aspose.diagram/floatpointnumcollection)
+### getSnapExtensions() {#getSnapExtensions--}
+```
+public int getSnapExtensions()
+```
+
+
+Specifies whether a specific snap extension setting is enabled or disabled for the active window. The value can be a sum of the values in the following table.
+
+**Returns:**
+int
+### getSnapSettings() {#getSnapSettings--}
+```
+public int getSnapSettings()
+```
+
+
+Gibt die Objekte an, an denen Formen einrasten, wenn das Einrasten im Fenster aktiv ist. Der Wert kann die Summe der Werte in der folgenden Tabelle sein.
+
+**Returns:**
+int
+### getStencilGroup() {#getStencilGroup--}
+```
+public String getStencilGroup()
+```
+
+
+Gibt die Gruppe zusammengeführter Stencil-Fenster an, deren Mitglied dieses Fenster ist. Dieses Attribut ist nur für Window-Elemente relevant, deren WindowType-Attribut Stencil ist, und nur, wenn das Stencil-Fenster Teil einer zusammengeführten Gruppe von Stencil-Fenstern ist. Alle Stencil-Fenster, die Teil derselben zusammengeführten Gruppe sind, haben denselben StencilGroup-Elementwert.
+
+**Returns:**
+java.lang.String
+### getStencilGroupPos() {#getStencilGroupPos--}
+```
+public int getStencilGroupPos()
+```
+
+
+Enthält eine ganze Zahl, die die relative Position eines Stencils innerhalb einer Gruppe in einem Fenster angibt.
+
+**Returns:**
+int
+### getTabSplitterPos() {#getTabSplitterPos--}
+```
+public double getTabSplitterPos()
+```
+
+
+Gibt die Breite der Seitenregister-Steuerung eines Zeichenfensters an (als Bruchteil der Gesamtheit der Breite des Zeichenfensters).
+
+**Returns:**
+double
+### getViewCenterX() {#getViewCenterX--}
+```
+public double getViewCenterX()
+```
+
+
+Optionaler Double.
+
+**Returns:**
+double
+### getViewCenterY() {#getViewCenterY--}
+```
+public double getViewCenterY()
+```
+
+
+Optionaler Double.
+
+**Returns:**
+double
+### getViewScale() {#getViewScale--}
+```
+public double getViewScale()
+```
+
+
+Optionaler Double.
+
+**Returns:**
+double
+### getWindowHeight() {#getWindowHeight--}
+```
+public long getWindowHeight()
+```
+
+
+Höhe des Fensterrechtecks.
+
+**Returns:**
+long
+### getWindowLeft() {#getWindowLeft--}
+```
+public int getWindowLeft()
+```
+
+
+Linke Koordinate des Fensterrechtecks.
+
+**Returns:**
+int
+### getWindowState() {#getWindowState--}
+```
+public int getWindowState()
+```
+
+
+Dieses Attribut kann die Summe der folgenden Werte sein.
+
+**Returns:**
+int
+### getWindowTop() {#getWindowTop--}
+```
+public int getWindowTop()
+```
+
+
+Obere Koordinate des Fensterrechtecks.
+
+**Returns:**
+int
+### getWindowType() {#getWindowType--}
+```
+public int getWindowType()
+```
+
+
+Ein aufzählbarer Wert, der einer der folgenden sein kann: Drawing, Sheet, Stencil oder Icon. Ein Window-Element mit WindowType='Stencil' muss nach seinem übergeordneten Zeichenfenster (WindowType='Drawing') und vor allen anderen Zeichenfenster-Elementen erscheinen.
+
+**Returns:**
+int
+### getWindowWidth() {#getWindowWidth--}
+```
+public long getWindowWidth()
+```
+
+
+Breite des Fensterrechtecks.
+
+**Returns:**
+long
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setContainer(int value) {#setContainer-int-}
+```
+public void setContainer(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getContainer()](../../com.aspose.diagram/window\#getContainer--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setContainerType(int value) {#setContainerType-int-}
+```
+public void setContainerType(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getContainerType()](../../com.aspose.diagram/window\#getContainerType--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setDocument(String value) {#setDocument-java.lang.String-}
+```
+public void setDocument(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDocument()](../../com.aspose.diagram/window\#getDocument--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setDynamicGridEnabled(int value) {#setDynamicGridEnabled-int-}
+```
+public void setDynamicGridEnabled(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDynamicGridEnabled()](../../com.aspose.diagram/window\#getDynamicGridEnabled--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setGlueSettings(int value) {#setGlueSettings-int-}
+```
+public void setGlueSettings(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getGlueSettings()](../../com.aspose.diagram/window\#getGlueSettings--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getID()](../../com.aspose.diagram/window\#getID--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setMaster(Master value) {#setMaster-com.aspose.diagram.Master-}
+```
+public void setMaster(Master value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getMaster()](../../com.aspose.diagram/window\#getMaster--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [Master](../../com.aspose.diagram/master) |  |
+
+### setPage(Page value) {#setPage-com.aspose.diagram.Page-}
+```
+public void setPage(Page value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getPage()](../../com.aspose.diagram/window\#getPage--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [Page](../../com.aspose.diagram/page) |  |
+
+### setParentWindow(int value) {#setParentWindow-int-}
+```
+public void setParentWindow(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getParentWindow()](../../com.aspose.diagram/window\#getParentWindow--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setReadOnly(int value) {#setReadOnly-int-}
+```
+public void setReadOnly(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getReadOnly()](../../com.aspose.diagram/window\#getReadOnly--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setSheet(int value) {#setSheet-int-}
+```
+public void setSheet(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getSheet()](../../com.aspose.diagram/window\#getSheet--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setShowConnectionPoints(int value) {#setShowConnectionPoints-int-}
+```
+public void setShowConnectionPoints(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getShowConnectionPoints()](../../com.aspose.diagram/window\#getShowConnectionPoints--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setShowGrid(int value) {#setShowGrid-int-}
+```
+public void setShowGrid(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getShowGrid()](../../com.aspose.diagram/window\#getShowGrid--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setShowGuides(int value) {#setShowGuides-int-}
+```
+public void setShowGuides(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getShowGuides()](../../com.aspose.diagram/window\#getShowGuides--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setShowPageBreaks(int value) {#setShowPageBreaks-int-}
+```
+public void setShowPageBreaks(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getShowPageBreaks()](../../com.aspose.diagram/window\#getShowPageBreaks--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setShowRulers(int value) {#setShowRulers-int-}
+```
+public void setShowRulers(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getShowRulers()](../../com.aspose.diagram/window\#getShowRulers--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setSnapExtensions(int value) {#setSnapExtensions-int-}
+```
+public void setSnapExtensions(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getSnapExtensions()](../../com.aspose.diagram/window\#getSnapExtensions--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setSnapSettings(int value) {#setSnapSettings-int-}
+```
+public void setSnapSettings(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getSnapSettings()](../../com.aspose.diagram/window\#getSnapSettings--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setStencilGroup(String value) {#setStencilGroup-java.lang.String-}
+```
+public void setStencilGroup(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getStencilGroup()](../../com.aspose.diagram/window\#getStencilGroup--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setStencilGroupPos(int value) {#setStencilGroupPos-int-}
+```
+public void setStencilGroupPos(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getStencilGroupPos()](../../com.aspose.diagram/window\#getStencilGroupPos--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setTabSplitterPos(double value) {#setTabSplitterPos-double-}
+```
+public void setTabSplitterPos(double value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getTabSplitterPos()](../../com.aspose.diagram/window\#getTabSplitterPos--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double |  |
+
+### setViewCenterX(double value) {#setViewCenterX-double-}
+```
+public void setViewCenterX(double value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getViewCenterX()](../../com.aspose.diagram/window\#getViewCenterX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double |  |
+
+### setViewCenterY(double value) {#setViewCenterY-double-}
+```
+public void setViewCenterY(double value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getViewCenterY()](../../com.aspose.diagram/window\#getViewCenterY--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double |  |
+
+### setViewScale(double value) {#setViewScale-double-}
+```
+public void setViewScale(double value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getViewScale()](../../com.aspose.diagram/window\#getViewScale--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | double |  |
+
+### setWindowHeight(long value) {#setWindowHeight-long-}
+```
+public void setWindowHeight(long value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getWindowHeight()](../../com.aspose.diagram/window\#getWindowHeight--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | long |  |
+
+### setWindowLeft(int value) {#setWindowLeft-int-}
+```
+public void setWindowLeft(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getWindowLeft()](../../com.aspose.diagram/window\#getWindowLeft--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setWindowState(int value) {#setWindowState-int-}
+```
+public void setWindowState(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getWindowState()](../../com.aspose.diagram/window\#getWindowState--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setWindowTop(int value) {#setWindowTop-int-}
+```
+public void setWindowTop(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getWindowTop()](../../com.aspose.diagram/window\#getWindowTop--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setWindowType(int value) {#setWindowType-int-}
+```
+public void setWindowType(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getWindowType()](../../com.aspose.diagram/window\#getWindowType--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setWindowWidth(long value) {#setWindowWidth-long-}
+```
+public void setWindowWidth(long value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getWindowWidth()](../../com.aspose.diagram/window\#getWindowWidth--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | long |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/windowcollection/_index.md
+++ b/german/java/com.aspose.diagram/windowcollection/_index.md
@@ -1,0 +1,268 @@
+---
+title: WindowCollection
+second_title: Aspose.Diagram for Java API-Referenz
+description: Fenstersammlung.
+type: docs
+weight: 445
+url: /de/java/com.aspose.diagram/windowcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class WindowCollection extends Collection
+```
+
+Fenstersammlung.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [add(Window window)](#add-com.aspose.diagram.Window-) | Füge das Fenster zur Sammlung hinzu. |
+| [clear()](#clear--) | Entfernt alle Elemente aus der Sammlung. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gibt das Element am angegebenen Index zurück. |
+| [getClass()](#getClass--) |  |
+| [getClientHeight()](#getClientHeight--) | Optionaler int. |
+| [getClientWidth()](#getClientWidth--) | Optionaler int. |
+| [getCount()](#getCount--) | Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existiert ein Element in der Sammlung. |
+| [iterator()](#iterator--) | Unterstützt eine einfache Iteration über eine nicht generische Sammlung. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Window window)](#remove-com.aspose.diagram.Window-) | Entferne das Fenster aus der Sammlung. |
+| [setClientHeight(int value)](#setClientHeight-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getClientHeight()](../../com.aspose.diagram/windowcollection\#getClientHeight--) |
+| [setClientWidth(int value)](#setClientWidth-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getClientWidth()](../../com.aspose.diagram/windowcollection\#getClientWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Window window) {#add-com.aspose.diagram.Window-}
+```
+public int add(Window window)
+```
+
+
+Füge das Fenster zur Sammlung hinzu.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| window | [Window](../../com.aspose.diagram/window) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Entfernt alle Elemente aus der Sammlung.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Window get(int index)
+```
+
+
+Gibt das Element am angegebenen Index zurück.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int |  |
+
+**Returns:**
+[Window](../../com.aspose.diagram/window) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getClientHeight() {#getClientHeight--}
+```
+public int getClientHeight()
+```
+
+
+Optionaler int.
+
+**Returns:**
+int
+### getClientWidth() {#getClientWidth--}
+```
+public int getClientWidth()
+```
+
+
+Optionaler int.
+
+**Returns:**
+int
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gibt die tatsächlich in der Sammlung enthaltene Elementanzahl zurück.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existiert ein Element in der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Index | int | Index des Elements. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Unterstützt eine einfache Iteration über eine nicht generische Sammlung.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Window window) {#remove-com.aspose.diagram.Window-}
+```
+public void remove(Window window)
+```
+
+
+Entferne das Fenster aus der Sammlung.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| window | [Window](../../com.aspose.diagram/window) |  |
+
+### setClientHeight(int value) {#setClientHeight-int-}
+```
+public void setClientHeight(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getClientHeight()](../../com.aspose.diagram/windowcollection\#getClientHeight--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setClientWidth(int value) {#setClientWidth-int-}
+```
+public void setClientWidth(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getClientWidth()](../../com.aspose.diagram/windowcollection\#getClientWidth--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/windowstatevalue/_index.md
+++ b/german/java/com.aspose.diagram/windowstatevalue/_index.md
@@ -1,0 +1,264 @@
+---
+title: WindowStateValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Eine ganze Zahl, die Bit‑Flags angibt.
+type: docs
+weight: 446
+url: /de/java/com.aspose.diagram/windowstatevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class WindowStateValue
+```
+
+Eine Ganzzahl, die Bit‑Flags angibt. Dieses Attribut kann die Summe der folgenden Werte sein.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [ACTIVE](#ACTIVE) | Aktiv. |
+| [ANCHOR_BOTTOM](#ANCHOR-BOTTOM) | Unten verankern. |
+| [ANCHOR_LEFT](#ANCHOR-LEFT) | Links verankern. |
+| [ANCHOR_MERGED](#ANCHOR-MERGED) | Zusammengeführt verankern. |
+| [ANCHOR_RIGHT](#ANCHOR-RIGHT) | Rechts verankern. |
+| [ANCHOR_TOP](#ANCHOR-TOP) | Oben verankern. |
+| [DOCKED_BOTTOM](#DOCKED-BOTTOM) | Unten angedockt. |
+| [DOCKED_LEFT](#DOCKED-LEFT) | Links angedockt. |
+| [DOCKED_RIGHT](#DOCKED-RIGHT) | Rechts angedockt. |
+| [DOCKED_TOP](#DOCKED-TOP) | Oben angedockt. |
+| [DOUBLEING](#DOUBLEING) | Verdoppeln. |
+| [MAXIMIZED](#MAXIMIZED) | Maximiert. |
+| [MINIMIZED](#MINIMIZED) | Minimiert. |
+| [RESTORED](#RESTORED) | Wiederhergestellt. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ACTIVE {#ACTIVE}
+```
+public static final int ACTIVE
+```
+
+
+Aktiv.
+
+### ANCHOR_BOTTOM {#ANCHOR-BOTTOM}
+```
+public static final int ANCHOR_BOTTOM
+```
+
+
+Unten verankern.
+
+### ANCHOR_LEFT {#ANCHOR-LEFT}
+```
+public static final int ANCHOR_LEFT
+```
+
+
+Links verankern.
+
+### ANCHOR_MERGED {#ANCHOR-MERGED}
+```
+public static final int ANCHOR_MERGED
+```
+
+
+Zusammengeführt verankern.
+
+### ANCHOR_RIGHT {#ANCHOR-RIGHT}
+```
+public static final int ANCHOR_RIGHT
+```
+
+
+Rechts verankern.
+
+### ANCHOR_TOP {#ANCHOR-TOP}
+```
+public static final int ANCHOR_TOP
+```
+
+
+Oben verankern.
+
+### DOCKED_BOTTOM {#DOCKED-BOTTOM}
+```
+public static final int DOCKED_BOTTOM
+```
+
+
+Unten angedockt.
+
+### DOCKED_LEFT {#DOCKED-LEFT}
+```
+public static final int DOCKED_LEFT
+```
+
+
+Links angedockt.
+
+### DOCKED_RIGHT {#DOCKED-RIGHT}
+```
+public static final int DOCKED_RIGHT
+```
+
+
+Rechts angedockt.
+
+### DOCKED_TOP {#DOCKED-TOP}
+```
+public static final int DOCKED_TOP
+```
+
+
+Oben angedockt.
+
+### DOUBLEING {#DOUBLEING}
+```
+public static final int DOUBLEING
+```
+
+
+Verdoppeln.
+
+### MAXIMIZED {#MAXIMIZED}
+```
+public static final int MAXIMIZED
+```
+
+
+Maximiert.
+
+### MINIMIZED {#MINIMIZED}
+```
+public static final int MINIMIZED
+```
+
+
+Minimiert.
+
+### RESTORED {#RESTORED}
+```
+public static final int RESTORED
+```
+
+
+Wiederhergestellt.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/windowtypevalue/_index.md
+++ b/german/java/com.aspose.diagram/windowtypevalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: WindowTypeValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Ein enumerierter Wert, der einer der folgenden sein kann: Drawing Sheet Stencil oder Icon.
+type: docs
+weight: 447
+url: /de/java/com.aspose.diagram/windowtypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class WindowTypeValue
+```
+
+Ein enumerierter Wert, der einer der folgenden sein kann: Drawing, Sheet, Stencil oder Icon. Ein Window-Element mit WindowType='Stencil' muss nach seinem übergeordneten Zeichenfenster (WindowType='Drawing') und vor allen anderen Zeichenfenster-Elementen erscheinen.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [DRAWING](#DRAWING) | Drawing |
+| [ICON](#ICON) | Icon. |
+| [SHEET](#SHEET) | Sheet |
+| [STENCIL](#STENCIL) | Stencil. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DRAWING {#DRAWING}
+```
+public static final int DRAWING
+```
+
+
+Drawing
+
+### ICON {#ICON}
+```
+public static final int ICON
+```
+
+
+Icon.
+
+### SHEET {#SHEET}
+```
+public static final int SHEET
+```
+
+
+Sheet
+
+### STENCIL {#STENCIL}
+```
+public static final int STENCIL
+```
+
+
+Stencil.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/xamlsaveoptions/_index.md
+++ b/german/java/com.aspose.diagram/xamlsaveoptions/_index.md
@@ -1,0 +1,329 @@
+---
+title: XAMLSaveOptions
+second_title: Aspose.Diagram for Java API-Referenz
+description: Ermöglicht das Angeben zusätzlicher Optionen beim Rendern von Diagrammseiten zu XAML.
+type: docs
+weight: 448
+url: /de/java/com.aspose.diagram/xamlsaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.SaveOptions](../../com.aspose.diagram/saveoptions)
+```
+public class XAMLSaveOptions extends SaveOptions
+```
+
+Ermöglicht das Angeben zusätzlicher Optionen beim Rendern von Diagrammseiten zu XAML.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [XAMLSaveOptions()](#XAMLSaveOptions--) | Initialisiert eine neue Instanz dieser Klasse, die verwendet werden kann, um ein Dokument im Format Aspose.Diagram.SaveFileFormat zu speichern. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | Erstellt ein Speicheroptionen-Objekt einer Klasse, die für das angegebene Speicherformat geeignet ist. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDefaultFont()](#getDefaultFont--) | Wenn Zeichen im Diagramm Unicode sind und nicht mit dem korrekten Schriftwert gesetzt werden oder die Schriftart nicht lokal installiert ist, können sie in PDF, Bild oder XPS als Block erscheinen. |
+| [getPageCount()](#getPageCount--) | die Anzahl der Seiten, die in XAML gerendert werden sollen. |
+| [getPageIndex()](#getPageIndex--) | der nullbasierte Index der ersten zu rendernden Seite. |
+| [getSaveForegroundPagesOnly()](#getSaveForegroundPagesOnly--) | Gibt an, ob alle Seiten als Bild gespeichert werden oder nur der Vordergrund. |
+| [getSaveFormat()](#getSaveFormat--) | Gibt das Format an, in dem die gerenderten Diagrammseiten gespeichert werden, wenn dieses Speicheroptionen-Objekt verwendet wird. |
+| [getStreamProvider()](#getStreamProvider--) | der IStreamProvider zum Exportieren von Objekten. |
+| [getWarningCallback()](#getWarningCallback--) | Warnungs-Callback. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDefaultFont()](../../com.aspose.diagram/saveoptions\\#getDefaultFont--) |
+| [setPageCount(int value)](#setPageCount-int-) | Für die Beschreibung dieser Eigenschaft siehe [getPageCount()](../../com.aspose.diagram/xamlsaveoptions\#getPageCount--) |
+| [setPageIndex(int value)](#setPageIndex-int-) | Für die Beschreibung dieser Eigenschaft siehe [getPageIndex()](../../com.aspose.diagram/xamlsaveoptions\#getPageIndex--) |
+| [setSaveForegroundPagesOnly(boolean value)](#setSaveForegroundPagesOnly-boolean-) | Für die Beschreibung dieser Eigenschaft siehe [getSaveForegroundPagesOnly()](../../com.aspose.diagram/xamlsaveoptions\#getSaveForegroundPagesOnly--) |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | Für die Beschreibung dieser Eigenschaft siehe [getSaveFormat()](../../com.aspose.diagram/xamlsaveoptions\#getSaveFormat--) |
+| [setStreamProvider(IStreamProvider value)](#setStreamProvider-com.aspose.diagram.IStreamProvider-) | Für die Beschreibung dieser Eigenschaft siehe [getStreamProvider()](../../com.aspose.diagram/xamlsaveoptions\#getStreamProvider--) |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### XAMLSaveOptions() {#XAMLSaveOptions--}
+```
+public XAMLSaveOptions()
+```
+
+
+Initialisiert eine neue Instanz dieser Klasse, die verwendet werden kann, um ein Dokument im Format Aspose.Diagram.SaveFileFormat zu speichern.
+
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+Erstellt ein Speicheroptionen-Objekt einer Klasse, die für das angegebene Speicherformat geeignet ist.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| saveFormat | int | Das Aspose.Diagram.SaveFileFormat, für das ein Save-Optionen-Objekt erstellt werden soll. |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+Wenn Zeichen im Diagramm Unicode sind und nicht mit dem korrekten Schriftwert gesetzt werden oder die Schriftart nicht lokal installiert ist, können sie im PDF, Bild oder XPS als Block erscheinen. Setzen Sie die DefaultFont, z. B. MingLiu oder MS Gothic, um diese Zeichen anzuzeigen.
+
+**Returns:**
+java.lang.String
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+Die Anzahl der Seiten, die in XAML gerendert werden sollen. Standard ist MaxValue, was bedeutet, dass alle Seiten des Diagramms gerendert werden.
+
+**Returns:**
+int
+### getPageIndex() {#getPageIndex--}
+```
+public int getPageIndex()
+```
+
+
+Der nullbasierte Index der ersten zu rendernden Seite. Standard ist 0.
+
+**Returns:**
+int
+### getSaveForegroundPagesOnly() {#getSaveForegroundPagesOnly--}
+```
+public boolean getSaveForegroundPagesOnly()
+```
+
+
+Legt fest, ob alle Seiten im Bild gespeichert werden oder nur der Vordergrund. Wenn true – werden nur Vordergrundseiten gerendert (mit Hintergrund, falls vorhanden). Wenn false – werden Vordergrundseiten gerendert (mit Hintergrund, falls vorhanden) und danach leere Hintergrundseiten. Kann nur true zurückgeben, wenn PageCount > 1. Der Standardwert ist false.
+
+**Returns:**
+boolean
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+Gibt das Format an, in dem die gerenderten Diagrammseiten gespeichert werden, wenn dieses Speicheroptionsobjekt verwendet wird. Kann nur Aspose.Diagram.SaveFileFormat sein.
+
+**Returns:**
+int
+### getStreamProvider() {#getStreamProvider--}
+```
+public IStreamProvider getStreamProvider()
+```
+
+
+der IStreamProvider zum Exportieren von Objekten.
+
+**Returns:**
+[IStreamProvider](../../com.aspose.diagram/istreamprovider)
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+Warnungs-Callback.
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDefaultFont()](../../com.aspose.diagram/saveoptions\\#getDefaultFont--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setPageCount(int value) {#setPageCount-int-}
+```
+public void setPageCount(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getPageCount()](../../com.aspose.diagram/xamlsaveoptions\#getPageCount--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setPageIndex(int value) {#setPageIndex-int-}
+```
+public void setPageIndex(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getPageIndex()](../../com.aspose.diagram/xamlsaveoptions\#getPageIndex--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setSaveForegroundPagesOnly(boolean value) {#setSaveForegroundPagesOnly-boolean-}
+```
+public void setSaveForegroundPagesOnly(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getSaveForegroundPagesOnly()](../../com.aspose.diagram/xamlsaveoptions\#getSaveForegroundPagesOnly--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getSaveFormat()](../../com.aspose.diagram/xamlsaveoptions\#getSaveFormat--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setStreamProvider(IStreamProvider value) {#setStreamProvider-com.aspose.diagram.IStreamProvider-}
+```
+public void setStreamProvider(IStreamProvider value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe [getStreamProvider()](../../com.aspose.diagram/xamlsaveoptions\#getStreamProvider--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [IStreamProvider](../../com.aspose.diagram/istreamprovider) |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/xform/_index.md
+++ b/german/java/com.aspose.diagram/xform/_index.md
@@ -1,0 +1,436 @@
+---
+title: XForm
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält Elemente, die Linieneigenschaften für eine Form steuern, wie Mustergewicht und Farbe.
+type: docs
+weight: 449
+url: /de/java/com.aspose.diagram/xform/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class XForm
+```
+
+Enthält Elemente, die die Linieneigenschaften für eine Form steuern, wie Muster, Stärke und Farbe. Diese Elemente bestimmen, ob die Linienenden formatiert sind (zum Beispiel mit einer Pfeilspitze), die Größe der Linienendformate, der Radius des Rundungskreises, der auf die Linie angewendet wird, und den Linientyp (rund oder eckig).
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAngle()](#getAngle--) | Stellt den aktuellen Drehwinkel der Form in Relation zu ihrem übergeordneten Element dar. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getFlipX()](#getFlipX--) | Gibt an, ob die Form horizontal gespiegelt wurde |
+| [getFlipY()](#getFlipY--) | Gibt an, ob die Form vertikal gespiegelt wurde. |
+| [getHeight()](#getHeight--) | Gibt die Höhe der Form in Zeichen­einheiten an. |
+| [getLocPinX()](#getLocPinX--) | Gibt die x‑Koordinate des Pins der Form (Drehzentrum) relativ zum Ursprung der Form an. |
+| [getLocPinY()](#getLocPinY--) | Gibt die y‑Koordinate des Pins der Form (Drehzentrum) relativ zum Ursprung der Form an. |
+| [getPinPos()](#getPinPos--) | Gibt die Pin‑Position der Form an |
+| [getPinX()](#getPinX--) | Gibt die x‑Koordinate des Pins der Form (Drehzentrum) relativ zum Ursprung ihres übergeordneten Elements an. |
+| [getPinY()](#getPinY--) | Gibt die y‑Koordinate des Pins der Form (Drehzentrum) relativ zum Ursprung ihres übergeordneten Elements an. |
+| [getResizeMode()](#getResizeMode--) | Gibt die aktuelle Einstellung für das Größenänderungsverhalten der Form an, wenn sie in einer Gruppe enthalten ist. |
+| [getWidth()](#getWidth--) | Enthält die Breite der zugehörigen Form in Zeichen­einheiten. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAngle(DoubleValue value)](#setAngle-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getAngle()](../../com.aspose.diagram/xform\#getAngle--) |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/xform\#getDel--) |
+| [setFlipX(BoolValue value)](#setFlipX-com.aspose.diagram.BoolValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getFlipX()](../../com.aspose.diagram/xform\#getFlipX--) |
+| [setFlipY(BoolValue value)](#setFlipY-com.aspose.diagram.BoolValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getFlipY()](../../com.aspose.diagram/xform\#getFlipY--) |
+| [setHeight(DoubleValue value)](#setHeight-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getHeight()](../../com.aspose.diagram/xform\#getHeight--) |
+| [setLocPinX(DoubleValue value)](#setLocPinX-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getLocPinX()](../../com.aspose.diagram/xform\#getLocPinX--) |
+| [setLocPinY(DoubleValue value)](#setLocPinY-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getLocPinY()](../../com.aspose.diagram/xform\#getLocPinY--) |
+| [setPinPos(int value)](#setPinPos-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getPinPos()](../../com.aspose.diagram/xform\#getPinPos--) |
+| [setPinX(DoubleValue value)](#setPinX-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getPinX()](../../com.aspose.diagram/xform\#getPinX--) |
+| [setPinY(DoubleValue value)](#setPinY-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getPinY()](../../com.aspose.diagram/xform\#getPinY--) |
+| [setResizeMode(ResizeMode value)](#setResizeMode-com.aspose.diagram.ResizeMode-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getResizeMode()](../../com.aspose.diagram/xform\#getResizeMode--) |
+| [setWidth(DoubleValue value)](#setWidth-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getWidth()](../../com.aspose.diagram/xform\#getWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAngle() {#getAngle--}
+```
+public DoubleValue getAngle()
+```
+
+
+Stellt den aktuellen Drehwinkel der Form in Relation zu ihrem übergeordneten Element dar.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getFlipX() {#getFlipX--}
+```
+public BoolValue getFlipX()
+```
+
+
+Gibt an, ob die Form horizontal gespiegelt wurde
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getFlipY() {#getFlipY--}
+```
+public BoolValue getFlipY()
+```
+
+
+Gibt an, ob die Form vertikal gespiegelt wurde.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getHeight() {#getHeight--}
+```
+public DoubleValue getHeight()
+```
+
+
+Gibt die Höhe der Form in Zeichen­einheiten an.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLocPinX() {#getLocPinX--}
+```
+public DoubleValue getLocPinX()
+```
+
+
+Gibt die x‑Koordinate des Pins der Form (Drehzentrum) relativ zum Ursprung der Form an. Die Standardformel zur Bestimmung von LocPinX lautet: F='Width\* 0.5'.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLocPinY() {#getLocPinY--}
+```
+public DoubleValue getLocPinY()
+```
+
+
+Gibt die y‑Koordinate des Pins der Form (Drehzentrum) relativ zum Ursprung der Form an. Die Standardformel zur Bestimmung von LocPinY lautet: F='Height \* 0.5'.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getPinPos() {#getPinPos--}
+```
+public int getPinPos()
+```
+
+
+Gibt die Pin‑Position der Form an
+
+**Returns:**
+int
+### getPinX() {#getPinX--}
+```
+public DoubleValue getPinX()
+```
+
+
+Gibt die x‑Koordinate des Pins der Form (Drehzentrum) relativ zum Ursprung ihres übergeordneten Elements an.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getPinY() {#getPinY--}
+```
+public DoubleValue getPinY()
+```
+
+
+Gibt die y‑Koordinate des Pins der Form (Drehzentrum) relativ zum Ursprung ihres übergeordneten Elements an.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getResizeMode() {#getResizeMode--}
+```
+public ResizeMode getResizeMode()
+```
+
+
+Gibt die aktuelle Einstellung für das Größenänderungsverhalten der Form an, wenn sie in einer Gruppe enthalten ist.
+
+**Returns:**
+[ResizeMode](../../com.aspose.diagram/resizemode)
+### getWidth() {#getWidth--}
+```
+public DoubleValue getWidth()
+```
+
+
+Enthält die Breite der zugehörigen Form in Zeichen­einheiten.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAngle(DoubleValue value) {#setAngle-com.aspose.diagram.DoubleValue-}
+```
+public void setAngle(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getAngle()](../../com.aspose.diagram/xform\#getAngle--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/xform\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setFlipX(BoolValue value) {#setFlipX-com.aspose.diagram.BoolValue-}
+```
+public void setFlipX(BoolValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getFlipX()](../../com.aspose.diagram/xform\#getFlipX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setFlipY(BoolValue value) {#setFlipY-com.aspose.diagram.BoolValue-}
+```
+public void setFlipY(BoolValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getFlipY()](../../com.aspose.diagram/xform\#getFlipY--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setHeight(DoubleValue value) {#setHeight-com.aspose.diagram.DoubleValue-}
+```
+public void setHeight(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getHeight()](../../com.aspose.diagram/xform\#getHeight--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setLocPinX(DoubleValue value) {#setLocPinX-com.aspose.diagram.DoubleValue-}
+```
+public void setLocPinX(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getLocPinX()](../../com.aspose.diagram/xform\#getLocPinX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setLocPinY(DoubleValue value) {#setLocPinY-com.aspose.diagram.DoubleValue-}
+```
+public void setLocPinY(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getLocPinY()](../../com.aspose.diagram/xform\#getLocPinY--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setPinPos(int value) {#setPinPos-int-}
+```
+public void setPinPos(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getPinPos()](../../com.aspose.diagram/xform\#getPinPos--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setPinX(DoubleValue value) {#setPinX-com.aspose.diagram.DoubleValue-}
+```
+public void setPinX(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getPinX()](../../com.aspose.diagram/xform\#getPinX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setPinY(DoubleValue value) {#setPinY-com.aspose.diagram.DoubleValue-}
+```
+public void setPinY(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getPinY()](../../com.aspose.diagram/xform\#getPinY--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setResizeMode(ResizeMode value) {#setResizeMode-com.aspose.diagram.ResizeMode-}
+```
+public void setResizeMode(ResizeMode value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getResizeMode()](../../com.aspose.diagram/xform\#getResizeMode--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [ResizeMode](../../com.aspose.diagram/resizemode) |  |
+
+### setWidth(DoubleValue value) {#setWidth-com.aspose.diagram.DoubleValue-}
+```
+public void setWidth(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getWidth()](../../com.aspose.diagram/xform\#getWidth--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/xform1d/_index.md
+++ b/german/java/com.aspose.diagram/xform1d/_index.md
@@ -1,0 +1,261 @@
+---
+title: XForm1D
+second_title: Aspose.Diagram for Java API-Referenz
+description: Enthält x- und y-Koordinaten des Anfangs- und Endpunkts einer 1‑D‑Form.
+type: docs
+weight: 450
+url: /de/java/com.aspose.diagram/xform1d/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class XForm1D
+```
+
+Enthält die x- und y-Koordinaten des Anfangs- und Endpunkts einer 1‑D‑Form. Dieses Element erscheint nur bei 1‑D‑Formen.
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [deepClone()](#deepClone--) | Erstellt eine tiefe Kopie dieser Instanz. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBeginX()](#getBeginX--) | Stellt die x‑Koordinate des Anfangspunkts der 1‑D‑Form in Bezug auf den Ursprung ihres übergeordneten Elements dar. |
+| [getBeginY()](#getBeginY--) | Stellt die y‑Koordinate des Anfangspunkts der 1‑D‑Form in Bezug auf den Ursprung ihres übergeordneten Elements dar. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Ein Flag, das angibt, ob das Element lokal gelöscht wurde. |
+| [getEndX()](#getEndX--) | Stellt die x‑Koordinate des Endpunkts einer 1‑D‑Form in Bezug auf den Ursprung ihres übergeordneten Elements dar. |
+| [getEndY()](#getEndY--) | Stellt die y‑Koordinate des Endpunkts einer 1‑D‑Form in Bezug auf den Ursprung ihres übergeordneten Elements dar. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setBeginX(DoubleValue value)](#setBeginX-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getBeginX()](../../com.aspose.diagram/xform1d\#getBeginX--) |
+| [setBeginY(DoubleValue value)](#setBeginY-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getBeginY()](../../com.aspose.diagram/xform1d\#getBeginY--) |
+| [setDel(int value)](#setDel-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/xform1d\#getDel--) |
+| [setEndX(DoubleValue value)](#setEndX-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getEndX()](../../com.aspose.diagram/xform1d\#getEndX--) |
+| [setEndY(DoubleValue value)](#setEndY-com.aspose.diagram.DoubleValue-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getEndY()](../../com.aspose.diagram/xform1d\#getEndY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Erstellt eine tiefe Kopie dieser Instanz.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBeginX() {#getBeginX--}
+```
+public DoubleValue getBeginX()
+```
+
+
+Stellt die x‑Koordinate des Anfangspunkts der 1‑D‑Form in Bezug auf den Ursprung ihres übergeordneten Elements dar.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBeginY() {#getBeginY--}
+```
+public DoubleValue getBeginY()
+```
+
+
+Stellt die y‑Koordinate des Anfangspunkts der 1‑D‑Form in Bezug auf den Ursprung ihres übergeordneten Elements dar.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Ein Flag, das angibt, ob das Element lokal gelöscht wurde. Ein Wert von 1 bedeutet, dass das Element lokal gelöscht wurde.
+
+**Returns:**
+int
+### getEndX() {#getEndX--}
+```
+public DoubleValue getEndX()
+```
+
+
+Stellt die x‑Koordinate des Endpunkts einer 1‑D‑Form in Bezug auf den Ursprung ihres übergeordneten Elements dar.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getEndY() {#getEndY--}
+```
+public DoubleValue getEndY()
+```
+
+
+Stellt die y‑Koordinate des Endpunkts einer 1‑D‑Form in Bezug auf den Ursprung ihres übergeordneten Elements dar.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setBeginX(DoubleValue value) {#setBeginX-com.aspose.diagram.DoubleValue-}
+```
+public void setBeginX(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getBeginX()](../../com.aspose.diagram/xform1d\#getBeginX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setBeginY(DoubleValue value) {#setBeginY-com.aspose.diagram.DoubleValue-}
+```
+public void setBeginY(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getBeginY()](../../com.aspose.diagram/xform1d\#getBeginY--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDel()](../../com.aspose.diagram/xform1d\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setEndX(DoubleValue value) {#setEndX-com.aspose.diagram.DoubleValue-}
+```
+public void setEndX(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getEndX()](../../com.aspose.diagram/xform1d\#getEndX--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setEndY(DoubleValue value) {#setEndY-com.aspose.diagram.DoubleValue-}
+```
+public void setEndY(DoubleValue value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getEndY()](../../com.aspose.diagram/xform1d\#getEndY--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/xjustify/_index.md
+++ b/german/java/com.aspose.diagram/xjustify/_index.md
@@ -1,0 +1,179 @@
+---
+title: XJustify
+second_title: Aspose.Diagram for Java API-Referenz
+description: Der x‑Versatz des Smart‑Tag‑Buttons relativ zu dem durch die X‑ und Y‑Elemente definierten Punkt.
+type: docs
+weight: 451
+url: /de/java/com.aspose.diagram/xjustify/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class XJustify
+```
+
+Der x‑Versatz des Smart‑Tag‑Buttons relativ zu dem durch die X‑ und Y‑Elemente definierten Punkt.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [XJustify(int value)](#XJustify-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Der x‑Versatz des Smart‑Tag‑Buttons relativ zu dem durch die X‑ und Y‑Elemente definierten Punkt. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/xjustify\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### XJustify(int value) {#XJustify-int-}
+```
+public XJustify(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Der x‑Versatz des Smart‑Tag‑Buttons relativ zu dem durch die X‑ und Y‑Elemente definierten Punkt.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/xjustify\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/xjustifyvalue/_index.md
+++ b/german/java/com.aspose.diagram/xjustifyvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: XJustifyValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Der x‑Versatz des Smart‑Tag‑Buttons relativ zu dem durch die X‑ und Y‑Elemente definierten Punkt.
+type: docs
+weight: 452
+url: /de/java/com.aspose.diagram/xjustifyvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class XJustifyValue
+```
+
+Der x‑Versatz des Smart‑Tag‑Buttons relativ zu dem durch die X‑ und Y‑Elemente definierten Punkt.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [CENTERED](#CENTERED) | Zentriert. |
+| [LEFT_JUSTIFIED](#LEFT-JUSTIFIED) | Linksbündig (Standard). |
+| [RIGHT_JUSTIFIED](#RIGHT-JUSTIFIED) | Rechtsbündig. |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CENTERED {#CENTERED}
+```
+public static final int CENTERED
+```
+
+
+Zentriert.
+
+### LEFT_JUSTIFIED {#LEFT-JUSTIFIED}
+```
+public static final int LEFT_JUSTIFIED
+```
+
+
+Linksbündig (Standard).
+
+### RIGHT_JUSTIFIED {#RIGHT-JUSTIFIED}
+```
+public static final int RIGHT_JUSTIFIED
+```
+
+
+Rechtsbündig.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/xpssaveoptions/_index.md
+++ b/german/java/com.aspose.diagram/xpssaveoptions/_index.md
@@ -1,0 +1,329 @@
+---
+title: XPSSaveOptions
+second_title: Aspose.Diagram for Java API-Referenz
+description: Ermöglicht das Angeben zusätzlicher Optionen beim Rendern von Diagrammseiten zu XPS.
+type: docs
+weight: 453
+url: /de/java/com.aspose.diagram/xpssaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.SaveOptions](../../com.aspose.diagram/saveoptions)
+```
+public class XPSSaveOptions extends SaveOptions
+```
+
+Ermöglicht das Angeben zusätzlicher Optionen beim Rendern von Diagrammseiten zu XPS.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [XPSSaveOptions()](#XPSSaveOptions--) | Initialisiert eine neue Instanz dieser Klasse, die verwendet werden kann, um ein Dokument im Format Aspose.Diagram.SaveFileFormat zu speichern. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | Erstellt ein Speicheroptionen-Objekt einer Klasse, die für das angegebene Speicherformat geeignet ist. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDefaultFont()](#getDefaultFont--) | Wenn Zeichen im Diagramm Unicode sind und nicht mit dem korrekten Schriftwert gesetzt werden oder die Schriftart nicht lokal installiert ist, können sie in PDF, Bild oder XPS als Block erscheinen. |
+| [getExportHiddenPage()](#getExportHiddenPage--) | Definiert, ob die versteckte Seite exportiert werden soll oder nicht. |
+| [getPageCount()](#getPageCount--) | die Anzahl der Seiten, die in XPS gerendert werden sollen. |
+| [getPageIndex()](#getPageIndex--) | der nullbasierte Index der ersten zu rendernden Seite. |
+| [getSaveForegroundPagesOnly()](#getSaveForegroundPagesOnly--) | Gibt an, ob alle Seiten als Bild gespeichert werden oder nur der Vordergrund. |
+| [getSaveFormat()](#getSaveFormat--) | Gibt das Format an, in dem die gerenderten Diagrammseiten gespeichert werden, wenn dieses Speicheroptionen-Objekt verwendet wird. |
+| [getWarningCallback()](#getWarningCallback--) | Warnungs-Callback. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getDefaultFont()](../../com.aspose.diagram/saveoptions\\#getDefaultFont--) |
+| [setExportHiddenPage(boolean value)](#setExportHiddenPage-boolean-) | Für die Beschreibung dieser Eigenschaft, bitte siehe [getExportHiddenPage()](../../com.aspose.diagram/xpssaveoptions\#getExportHiddenPage--) |
+| [setPageCount(int value)](#setPageCount-int-) | Für die Beschreibung dieser Eigenschaft, bitte siehe [getPageCount()](../../com.aspose.diagram/xpssaveoptions\#getPageCount--) |
+| [setPageIndex(int value)](#setPageIndex-int-) | Für die Beschreibung dieser Eigenschaft, bitte siehe [getPageIndex()](../../com.aspose.diagram/xpssaveoptions\#getPageIndex--) |
+| [setSaveForegroundPagesOnly(boolean value)](#setSaveForegroundPagesOnly-boolean-) | Für die Beschreibung dieser Eigenschaft, bitte siehe [getSaveForegroundPagesOnly()](../../com.aspose.diagram/xpssaveoptions\#getSaveForegroundPagesOnly--) |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | Für die Beschreibung dieser Eigenschaft, bitte siehe [getSaveFormat()](../../com.aspose.diagram/xpssaveoptions\#getSaveFormat--) |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### XPSSaveOptions() {#XPSSaveOptions--}
+```
+public XPSSaveOptions()
+```
+
+
+Initialisiert eine neue Instanz dieser Klasse, die verwendet werden kann, um ein Dokument im Format Aspose.Diagram.SaveFileFormat zu speichern.
+
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+Erstellt ein Speicheroptionen-Objekt einer Klasse, die für das angegebene Speicherformat geeignet ist.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| saveFormat | int | Das Aspose.Diagram.SaveFileFormat, für das ein Save-Optionen-Objekt erstellt werden soll. |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+Wenn Zeichen im Diagramm Unicode sind und nicht mit dem korrekten Schriftwert gesetzt werden oder die Schriftart nicht lokal installiert ist, können sie im PDF, Bild oder XPS als Block erscheinen. Setzen Sie die DefaultFont, z. B. MingLiu oder MS Gothic, um diese Zeichen anzuzeigen.
+
+**Returns:**
+java.lang.String
+### getExportHiddenPage() {#getExportHiddenPage--}
+```
+public boolean getExportHiddenPage()
+```
+
+
+Definiert, ob versteckte Seiten exportiert werden sollen oder nicht. Standardwert ist true.
+
+**Returns:**
+boolean
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+die Anzahl der Seiten, die in XPS gerendert werden sollen. Standard ist MaxValue, was bedeutet, dass alle Seiten des Diagramms gerendert werden.
+
+**Returns:**
+int
+### getPageIndex() {#getPageIndex--}
+```
+public int getPageIndex()
+```
+
+
+Der nullbasierte Index der ersten zu rendernden Seite. Standard ist 0.
+
+**Returns:**
+int
+### getSaveForegroundPagesOnly() {#getSaveForegroundPagesOnly--}
+```
+public boolean getSaveForegroundPagesOnly()
+```
+
+
+Legt fest, ob alle Seiten im Bild gespeichert werden oder nur der Vordergrund. Wenn true – werden nur Vordergrundseiten gerendert (mit Hintergrund, falls vorhanden). Wenn false – werden Vordergrundseiten gerendert (mit Hintergrund, falls vorhanden) und danach leere Hintergrundseiten. Kann nur true zurückgeben, wenn PageCount > 1. Der Standardwert ist false.
+
+**Returns:**
+boolean
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+Gibt das Format an, in dem die gerenderten Diagrammseiten gespeichert werden, wenn dieses Speicheroptionsobjekt verwendet wird. Kann nur Aspose.Diagram.SaveFileFormat sein.
+
+**Returns:**
+int
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+Warnungs-Callback.
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getDefaultFont()](../../com.aspose.diagram/saveoptions\\#getDefaultFont--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.String |  |
+
+### setExportHiddenPage(boolean value) {#setExportHiddenPage-boolean-}
+```
+public void setExportHiddenPage(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft, bitte siehe [getExportHiddenPage()](../../com.aspose.diagram/xpssaveoptions\#getExportHiddenPage--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setPageCount(int value) {#setPageCount-int-}
+```
+public void setPageCount(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft, bitte siehe [getPageCount()](../../com.aspose.diagram/xpssaveoptions\#getPageCount--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setPageIndex(int value) {#setPageIndex-int-}
+```
+public void setPageIndex(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft, bitte siehe [getPageIndex()](../../com.aspose.diagram/xpssaveoptions\#getPageIndex--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setSaveForegroundPagesOnly(boolean value) {#setSaveForegroundPagesOnly-boolean-}
+```
+public void setSaveForegroundPagesOnly(boolean value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft, bitte siehe [getSaveForegroundPagesOnly()](../../com.aspose.diagram/xpssaveoptions\#getSaveForegroundPagesOnly--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | boolean |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft, bitte siehe [getSaveFormat()](../../com.aspose.diagram/xpssaveoptions\#getSaveFormat--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/yjustify/_index.md
+++ b/german/java/com.aspose.diagram/yjustify/_index.md
@@ -1,0 +1,179 @@
+---
+title: YJustify
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt den y‑Versatz des Smart‑Tag‑Buttons relativ zu dem durch die X‑ und Y‑Elemente definierten Punkt an.
+type: docs
+weight: 454
+url: /de/java/com.aspose.diagram/yjustify/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class YJustify
+```
+
+Gibt den y‑Versatz des Smart‑Tag‑Buttons relativ zu dem durch die X‑ und Y‑Elemente definierten Punkt an.
+## Konstruktoren
+
+| Konstruktor | Beschreibung |
+| --- | --- |
+| [YJustify(int value)](#YJustify-int-) | Konstruktor. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Sind Objekte gleich. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Gibt Attribute eines Elements an. |
+| [getValue()](#getValue--) | Gibt den y‑Versatz des Smart‑Tag‑Buttons relativ zu dem durch die X‑ und Y‑Elemente definierten Punkt an. |
+| [hashCode()](#hashCode--) | Dient als Hash‑Funktion für einen bestimmten Typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/yjustify\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### YJustify(int value) {#YJustify-int-}
+```
+public YJustify(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Sind Objekte gleich.
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Gibt Attribute eines Elements an.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Gibt den y‑Versatz des Smart‑Tag‑Buttons relativ zu dem durch die X‑ und Y‑Elemente definierten Punkt an.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Dient als Hash‑Funktion für einen bestimmten Typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Für die Beschreibung dieser Eigenschaft siehe bitte [getValue()](../../com.aspose.diagram/yjustify\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| Wert | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/german/java/com.aspose.diagram/yjustifyvalue/_index.md
+++ b/german/java/com.aspose.diagram/yjustifyvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: YJustifyValue
+second_title: Aspose.Diagram for Java API-Referenz
+description: Gibt den y‑Versatz des Smart‑Tag‑Buttons relativ zu dem durch die X‑ und Y‑Elemente definierten Punkt an.
+type: docs
+weight: 455
+url: /de/java/com.aspose.diagram/yjustifyvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class YJustifyValue
+```
+
+Gibt den y‑Versatz des Smart‑Tag‑Buttons relativ zu dem durch die X‑ und Y‑Elemente definierten Punkt an.
+## Felder
+
+| Feld | Beschreibung |
+| --- | --- |
+| [BOTTOM_JUSTIFIED](#BOTTOM-JUSTIFIED) | Unten ausgerichtet. |
+| [CENTERED](#CENTERED) | Zentriert. |
+| [TOP_JUSTIFIED](#TOP-JUSTIFIED) | Oben ausgerichtet (Standard). |
+| [UNDEFINED](#UNDEFINED) | Undefiniert. |
+## Methoden
+
+| Methode | Beschreibung |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOTTOM_JUSTIFIED {#BOTTOM-JUSTIFIED}
+```
+public static final int BOTTOM_JUSTIFIED
+```
+
+
+Unten ausgerichtet.
+
+### CENTERED {#CENTERED}
+```
+public static final int CENTERED
+```
+
+
+Zentriert.
+
+### TOP_JUSTIFIED {#TOP-JUSTIFIED}
+```
+public static final int TOP_JUSTIFIED
+```
+
+
+Oben ausgerichtet (Standard).
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefiniert.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beschreibung |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+


### PR DESCRIPTION
Automated translation of the JAVA API Reference to **German** (`de`) generated by RDA.

- Pages translated: 451/451
- Errors: 0
- Source: `english/java`
- Output: `german/java`

🤖 Generated by RDA