### PR TITLE
[auto] Translate JAVA API Reference to Italian

### DIFF
--- a/italian/java/_index.md
+++ b/italian/java/_index.md
@@ -1,0 +1,13 @@
+---
+title: Aspose.Diagram per Java
+type: docs
+weight: 11
+url: /it/java/
+description: Le API di riferimento di Aspose.Diagram per Java contengono esempi, frammenti di codice e documentazione API. Fornisce pacchetti, classi, interfacce e altri dettagli dell'API.
+is_root: true
+---
+
+## Packages
+| Pacchetto | Descrizione |
+| --- | --- |
+| [com.aspose.diagram](./com.aspose.diagram) | Il pacchetto com.aspose.diagram fornisce classi per generare, convertire, modificare, renderizzare e stampare documenti Microsoft Visio senza utilizzare Microsoft Visio. |

--- a/italian/java/com.aspose.diagram/_index.md
+++ b/italian/java/com.aspose.diagram/_index.md
@@ -1,0 +1,471 @@
+---
+title: com.aspose.diagram
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Il pacchetto com.aspose.diagram fornisce classi per generare, convertire, modificare, renderizzare e stampare documenti Microsoft Visio senza utilizzare Microsoft Visio.
+type: docs
+weight: 10
+url: /it/java/com.aspose.diagram/
+---
+
+
+Il pacchetto com.aspose.diagram fornisce classi per generare, convertire, modificare, renderizzare e stampare documenti Microsoft Visio senza utilizzare Microsoft Visio.
+
+
+## Classi
+
+| Classe | Descrizione |
+| --- | --- |
+| [AbstractInterruptMonitor](../com.aspose.diagram/abstractinterruptmonitor) | Monitor per le richieste di interruzione in tutte le operazioni che richiedono molto tempo. |
+| [Act](../com.aspose.diagram/act) | Definisce nomi di comandi personalizzati che appaiono nel menu contestuale di un oggetto e specifica le azioni che i comandi eseguono. |
+| [ActCollection](../com.aspose.diagram/actcollection) | Collezione Act. |
+| [ActiveXControl](../com.aspose.diagram/activexcontrol) | Rappresenta il controllo ActiveX. |
+| [ActiveXControlBase](../com.aspose.diagram/activexcontrolbase) | Rappresenta il controllo ActiveX. |
+| [ActiveXPersistenceType](../com.aspose.diagram/activexpersistencetype) | Rappresenta il metodo di persistenza per mantenere un controllo ActiveX. |
+| [Align](../com.aspose.diagram/align) | Indica l'allineamento di una forma rispetto alla guida o al punto guida a cui la forma è incollata. |
+| [AlignNameValue](../com.aspose.diagram/alignnamevalue) | int opzionale. |
+| [Alignment](../com.aspose.diagram/alignment) | Specifica l'allineamento della scheda. |
+| [AlignmentValue](../com.aspose.diagram/alignmentvalue) | Specifica l'allineamento della scheda. |
+| [Annotation](../com.aspose.diagram/annotation) | Contiene elementi che includono informazioni sui commenti inseriti in una pagina del documento. |
+| [AnnotationCollection](../com.aspose.diagram/annotationcollection) | Collezione di annotazioni. |
+| [ArcTo](../com.aspose.diagram/arcto) | Contiene le coordinate x e y e l'arco di un arco circolare rappresentati rispettivamente dagli elementi X, Y e A. |
+| [ArcToCollection](../com.aspose.diagram/arctocollection) | Collezione ArcTo. |
+| [ArrowSize](../com.aspose.diagram/arrowsize) | Specifica la dimensione della punta della freccia della linea. |
+| [ArrowSizeValue](../com.aspose.diagram/arrowsizevalue) | Specifica la dimensione della punta della freccia della linea. |
+| [AsposeDiagramPrintDocument](../com.aspose.diagram/asposediagramprintdocument) | È la propria versione della classe .NET PrintDocument che può essere passata a un modulo PrintPreviewDialog per stampare e visualizzare in anteprima un diagramma. |
+| [AutoLinkComparison](../com.aspose.diagram/autolinkcomparison) | Definisce una regola che confronta una colonna nell'elemento DataRecordset padre con un elemento dati di forma dell'ultima azione di collegamento automatico riuscita eseguita nell'interfaccia utente. |
+| [AutoSpaceOptions](../com.aspose.diagram/autospaceoptions) | Rappresenta le opzioni di spaziatura automatica. |
+| [BOOL](../com.aspose.diagram/bool) | Booleano. |
+| [Bevel](../com.aspose.diagram/bevel) | Rappresenta una smussatura di una forma |
+| [BevelLightingType](../com.aspose.diagram/bevellightingtype) | Specifica il tipo di ombra per una forma. |
+| [BevelLightingTypeValue](../com.aspose.diagram/bevellightingtypevalue) | Rappresenta una luce predefinita a destra che può essere applicata a una forma |
+| [BevelMaterialType](../com.aspose.diagram/bevelmaterialtype) | Specifica il tipo di ombra per una forma. |
+| [BevelMaterialTypeValue](../com.aspose.diagram/bevelmaterialtypevalue) | Descrive l'aspetto della superficie di una forma. |
+| [BevelPresetType](../com.aspose.diagram/bevelpresettype) | Rappresenta un preset per un tipo di smussatura che può essere applicato a una forma in 3D. |
+| [BevelType](../com.aspose.diagram/beveltype) | Specifica il tipo di ombra per una forma. |
+| [BevelTypeValue](../com.aspose.diagram/beveltypevalue) | Rappresenta un preset per un tipo di smussatura che può essere applicato a una forma in 3D. |
+| [BoolValue](../com.aspose.diagram/boolvalue) | Valore booleano. |
+| [Bullet](../com.aspose.diagram/bullet) | Determina lo stile del punto elenco. |
+| [BulletValue](../com.aspose.diagram/bulletvalue) | Determina lo stile del punto elenco. |
+| [Calendar](../com.aspose.diagram/calendar) | Determina il calendario utilizzato per le proprietà personalizzate, i campi di testo e le formule degli elementi. |
+| [CalendarValue](../com.aspose.diagram/calendarvalue) | Determina il calendario utilizzato per le proprietà personalizzate, i campi di testo e le formule degli elementi. |
+| [Case](../com.aspose.diagram/case) | Determina il maiuscolo/minuscolo del testo di una forma. |
+| [CaseValue](../com.aspose.diagram/casevalue) | Determina il maiuscolo/minuscolo del testo di una forma. |
+| [Char](../com.aspose.diagram/char) | Contiene gli attributi di formattazione per il testo della forma, come carattere, colore, stile del testo, maiuscolo/minuscolo, posizione relativa alla linea di base e dimensione in punti. |
+| [CharCollection](../com.aspose.diagram/charcollection) | Raccolta di caratteri. |
+| [CheckBoxActiveXControl](../com.aspose.diagram/checkboxactivexcontrol) | Rappresenta un controllo ActiveX CheckBox. |
+| [CheckValueType](../com.aspose.diagram/checkvaluetype) | Rappresenta il tipo di valore di spunta della casella di controllo. |
+| [Collection](../com.aspose.diagram/collection) | È la classe base per le raccolte. |
+| [CollectionBase](../com.aspose.diagram/collectionbase) | Fornisce la classe base astratta per una raccolta tipizzata fortemente. |
+| [Color](../com.aspose.diagram/color) | Rappresenta un colore ARGB (alpha, rosso, verde, blu). |
+| [ColorEntry](../com.aspose.diagram/colorentry) | Contiene una voce della tabella dei colori. |
+| [ColorEntryCollection](../com.aspose.diagram/colorentrycollection) | Contiene la tabella dei colori del documento. |
+| [ColorValue](../com.aspose.diagram/colorvalue) | Rappresenta il valore del colore |
+| [ComboBoxActiveXControl](../com.aspose.diagram/comboboxactivexcontrol) | Rappresenta un controllo ActiveX ComboBox. |
+| [CommandButtonActiveXControl](../com.aspose.diagram/commandbuttonactivexcontrol) | Rappresenta un pulsante di comando. |
+| [CompositingQuality](../com.aspose.diagram/compositingquality) | Specifica il livello di qualità da utilizzare durante il compositing. |
+| [CompoundType](../com.aspose.diagram/compoundtype) | Specifica la dimensione della punta della freccia della linea. |
+| [CompoundTypeValue](../com.aspose.diagram/compoundtypevalue) | Rappresenta lo stile di disegno delle linee. |
+| [CompressionType](../com.aspose.diagram/compressiontype) | Questo attributo ha senso solo se i dati esterni sono un oggetto esterno basato su raster, come un file DIB, JPG, PNG, TIFF o GIF. |
+| [ConFixedCode](../com.aspose.diagram/confixedcode) | Determina quando un connettore viene ricalcolato. |
+| [ConFixedCodeValue](../com.aspose.diagram/confixedcodevalue) | Determina quando un connettore viene ricalcolato. |
+| [ConLineJumpCode](../com.aspose.diagram/conlinejumpcode) | Determina se un connettore salta quando due connettori si incrociano. |
+| [ConLineJumpCodeValue](../com.aspose.diagram/conlinejumpcodevalue) | Determina se un connettore salta quando due connettori si incrociano. |
+| [ConLineJumpDirX](../com.aspose.diagram/conlinejumpdirx) | Determina la direzione del salto di linea per i salti di linea che si verificano su un segmento orizzontale di un connettore dinamico. |
+| [ConLineJumpDirXValue](../com.aspose.diagram/conlinejumpdirxvalue) | Determina la direzione del salto di linea per i salti di linea che si verificano su un segmento orizzontale di un connettore dinamico. |
+| [ConLineJumpDirY](../com.aspose.diagram/conlinejumpdiry) | Determina la direzione del salto di linea per i salti di linea che si verificano su un segmento verticale di un connettore dinamico. |
+| [ConLineJumpDirYValue](../com.aspose.diagram/conlinejumpdiryvalue) | Determina la direzione del salto di linea per i salti di linea che si verificano su un segmento verticale di un connettore dinamico. |
+| [ConLineJumpStyle](../com.aspose.diagram/conlinejumpstyle) | Determina lo stile del salto di linea per i salti di linea su un connettore dinamico. |
+| [ConLineJumpStyleValue](../com.aspose.diagram/conlinejumpstylevalue) | Determina lo stile del salto di linea per i salti di linea su un connettore dinamico. |
+| [ConLineRouteExt](../com.aspose.diagram/conlinerouteext) | Determina l'aspetto di un connettore. |
+| [ConLineRouteExtValue](../com.aspose.diagram/conlinerouteextvalue) | Determina l'aspetto di un connettore. |
+| [ConType](../com.aspose.diagram/contype) | Specifica il tipo di comportamento che la coordinata x o y della maniglia di controllo mostra dopo che la maniglia è stata spostata. |
+| [ConValue](../com.aspose.diagram/convalue) | Specifica il tipo di comportamento che la coordinata x o y della maniglia di controllo mostra dopo che la maniglia è stata spostata. |
+| [Connect](../com.aspose.diagram/connect) | Rappresenta una connessione tra due forme in un disegno, come una linea e una casella in un organigramma. |
+| [ConnectCollection](../com.aspose.diagram/connectcollection) | Raccolta Connect. |
+| [ConnectedShapesFlags](../com.aspose.diagram/connectedshapesflags) | Filtra l'array di ID forma restituiti in base alla direzionalità dei connettori. |
+| [Connection](../com.aspose.diagram/connection) | Contiene elementi per un punto di connessione definito per la forma. |
+| [ConnectionABCD](../com.aspose.diagram/connectionabcd) | L'elemento ConnectionABCD è una versione obsoleta dell'elemento Connection e esiste solo per compatibilità retroattiva. |
+| [ConnectionABCDCollection](../com.aspose.diagram/connectionabcdcollection) | Raccolta ConnectionABCD. |
+| [ConnectionCollection](../com.aspose.diagram/connectioncollection) | Raccolta Connection. |
+| [ConnectionPointPlace](../com.aspose.diagram/connectionpointplace) | Specifica la posizione sulla forma dove il connettore sarà collegato. |
+| [ConnectorRule](../com.aspose.diagram/connectorrule) | Rappresenta la regola del connettore tra due forme con un connettore, includendo quale punto di connessione di quale forma parte, la forma finale e il suo punto di connessione. |
+| [ConnectorsTypeValue](../com.aspose.diagram/connectorstypevalue) | Può essere uno dei seguenti valori: RightAngle, StraightLines o CurvedLines. |
+| [ContainerTypeValue](../com.aspose.diagram/containertypevalue) | Può essere uno dei seguenti valori: Document, Page o Master. |
+| [ContextTypeValue](../com.aspose.diagram/contexttypevalue) | Specifica le proprietà del gruppo o della forma da utilizzare per il confronto. |
+| [Control](../com.aspose.diagram/control) | Contiene elementi per le coordinate x e y di ogni maniglia di controllo definita per una forma, e elementi che specificano il modo in cui la maniglia di controllo dovrebbe comportarsi. |
+| [ControlBorderType](../com.aspose.diagram/controlbordertype) | Rappresenta il tipo di bordo del controllo ActiveX. |
+| [ControlCaptionAlignmentType](../com.aspose.diagram/controlcaptionalignmenttype) | Rappresenta la posizione della didascalia rispetto al controllo. |
+| [ControlCollection](../com.aspose.diagram/controlcollection) | Raccolta Control. |
+| [ControlListStyle](../com.aspose.diagram/controlliststyle) | Rappresenta l'aspetto visivo dell'elenco in un ListBox o ComboBox. |
+| [ControlMatchEntryType](../com.aspose.diagram/controlmatchentrytype) | Rappresenta come un ListBox o ComboBox ricerca la sua lista mentre l'utente digita. |
+| [ControlMousePointerType](../com.aspose.diagram/controlmousepointertype) | Rappresenta il tipo di icona visualizzata come puntatore del mouse per il controllo. |
+| [ControlPictureAlignmentType](../com.aspose.diagram/controlpicturealignmenttype) | Rappresenta l'allineamento dell'immagine all'interno del Form o dell'Image. |
+| [ControlPicturePositionType](../com.aspose.diagram/controlpicturepositiontype) | Rappresenta la posizione dell'immagine del controllo rispetto alla sua didascalia. |
+| [ControlPictureSizeMode](../com.aspose.diagram/controlpicturesizemode) | Rappresenta come visualizzare l'immagine. |
+| [ControlScrollBarType](../com.aspose.diagram/controlscrollbartype) | Rappresenta il tipo di barra di scorrimento. |
+| [ControlScrollOrientation](../com.aspose.diagram/controlscrollorientation) | Rappresenta il tipo di orientamento dello scorrimento. |
+| [ControlSpecialEffectType](../com.aspose.diagram/controlspecialeffecttype) | Rappresenta il tipo di effetto speciale. |
+| [ControlType](../com.aspose.diagram/controltype) | Rappresenta tutti i tipi di controllo ActiveX. |
+| [Coordinate](../com.aspose.diagram/coordinate) | Classe astratta per le coordinate x e y. |
+| [CoordinateCollection](../com.aspose.diagram/coordinatecollection) | Raccolta di coordinate. |
+| [CountryCode](../com.aspose.diagram/countrycode) | Rappresenta gli identificatori dei paesi del diagramma. |
+| [Cp](../com.aspose.diagram/cp) | Segna l'inizio di una sequenza di proprietà del carattere formattata secondo l'elemento Char corrispondente. |
+| [CustomProp](../com.aspose.diagram/customprop) | Struttura CustomProp. |
+| [CustomPropCollection](../com.aspose.diagram/custompropcollection) | Raccolta CustomProps. |
+| [CustomValue](../com.aspose.diagram/customvalue) | Valore della proprietà. |
+| [DataColumn](../com.aspose.diagram/datacolumn) | Definisce come una colonna dati appare nella finestra Dati esterni nell'interfaccia utente di Visio e qualifica i dati nella colonna definendo il suo tipo di dato e la formattazione. |
+| [DataColumnCollection](../com.aspose.diagram/datacolumncollection) | Raccolta DataColumn. |
+| [DataConnection](../com.aspose.diagram/dataconnection) | Astrazione della comunicazione tra uno o più elementi DataRecordset e una fonte dati non XML. |
+| [DataConnectionCollection](../com.aspose.diagram/dataconnectioncollection) | Raccolta DataConnection. |
+| [DataConnectionType](../com.aspose.diagram/dataconnectiontype) | Consente di configurare le opzioni per le connessioni al database. |
+| [DataRecordSet](../com.aspose.diagram/datarecordset) | Memorizza, formatta, aggiorna e espone i dati interrogati da un database in Microsoft Visio. |
+| [DataRecordSetCollection](../com.aspose.diagram/datarecordsetcollection) | Raccolta DataRecordSet. |
+| [DateTime](../com.aspose.diagram/datetime) | Rappresenta un istante nel tempo, tipicamente espresso come data e ora del giorno. |
+| [DateValue](../com.aspose.diagram/datevalue) | Valore di data e ora. |
+| [Diagram](../com.aspose.diagram/diagram) | Elemento radice della gerarchia degli oggetti Visio. |
+| [DiagramException](../com.aspose.diagram/diagramexception) | Classe base per tutte le eccezioni di Aspose.Diagram |
+| [DiagramSaveOptions](../com.aspose.diagram/diagramsaveoptions) | Può essere usato per specificare opzioni aggiuntive durante il salvataggio di un diagramma nel formato Visio (VDX\\VSX). |
+| [DisplayMode](../com.aspose.diagram/displaymode) | Quando è contenuto in un elemento Group, l'elemento DisplayMode specifica come viene visualizzata una forma di gruppo e i suoi membri. |
+| [DisplayModeSmartTagDef](../com.aspose.diagram/displaymodesmarttagdef) | L'elemento DisplayMode determina se il tag intelligente appare quando l'utente ferma il mouse sul tag, quando la forma è selezionata, o in ogni momento. |
+| [DisplayModeSmartTagDefValue](../com.aspose.diagram/displaymodesmarttagdefvalue) | L'elemento DisplayMode determina se il tag intelligente appare quando l'utente ferma il mouse sul tag, quando la forma è selezionata, o in ogni momento. |
+| [DisplayModeValue](../com.aspose.diagram/displaymodevalue) | Quando è contenuto in un elemento Group, l'elemento DisplayMode specifica come viene visualizzata una forma di gruppo e i suoi membri. |
+| [DocProps](../com.aspose.diagram/docprops) | Contiene elementi che controllano la qualità dell'anteprima del documento, l'ambito e il formato di output. |
+| [DocumentProperties](../com.aspose.diagram/documentproperties) | Contiene elementi di proprietà del documento come il titolo del documento, l'autore e così via. |
+| [DocumentSettings](../com.aspose.diagram/documentsettings) | Contiene elementi che specificano le impostazioni del documento. |
+| [DocumentSheet](../com.aspose.diagram/documentsheet) | Specifica la struttura ShapeSheet di un documento. |
+| [DoubleValue](../com.aspose.diagram/doublevalue) | Valore double |
+| [DrawingResizeType](../com.aspose.diagram/drawingresizetype) | Determina se la pagina di disegno si ridimensiona automaticamente per adattarsi al diagramma. |
+| [DrawingResizeTypeValue](../com.aspose.diagram/drawingresizetypevalue) | Determina se la pagina di disegno si ridimensiona automaticamente per adattarsi al diagramma. |
+| [DrawingScaleType](../com.aspose.diagram/drawingscaletype) | Specifica il tipo di scala di disegno da utilizzare per una pagina. |
+| [DrawingScaleTypeValue](../com.aspose.diagram/drawingscaletypevalue) | Specifica il tipo di scala di disegno da utilizzare per una pagina. |
+| [DrawingSizeType](../com.aspose.diagram/drawingsizetype) | Specifica le dimensioni di disegno di una pagina. |
+| [DrawingSizeTypeValue](../com.aspose.diagram/drawingsizetypevalue) | Specifica le dimensioni di disegno di una pagina. |
+| [DropButtonStyle](../com.aspose.diagram/dropbuttonstyle) | Rappresenta il simbolo visualizzato sul pulsante a discesa. |
+| [DynFeedback](../com.aspose.diagram/dynfeedback) | Specifica il tipo di feedback visivo fornito agli utenti quando trascinano un connettore. |
+| [DynFeedbackValue](../com.aspose.diagram/dynfeedbackvalue) | Specifica il tipo di feedback visivo fornito agli utenti quando trascinano un connettore. |
+| [Ellipse](../com.aspose.diagram/ellipse) | Contiene elementi che specificano le coordinate x e y del punto centrale dell'ellisse e due punti sull'ellisse. |
+| [EllipseCollection](../com.aspose.diagram/ellipsecollection) | Raccolta di ellissi. |
+| [EllipticalArcTo](../com.aspose.diagram/ellipticalarcto) | Contiene elementi che specificano informazioni su un arco ellittico. |
+| [EllipticalArcToCollection](../com.aspose.diagram/ellipticalarctocollection) | Raccolta EllipticalArcTo. |
+| [EmfRenderSetting](../com.aspose.diagram/emfrendersetting) | Impostazione per il rendering del metafile Emf. |
+| [Encoding](../com.aspose.diagram/encoding) | Rappresenta una codifica dei caratteri. |
+| [Event](../com.aspose.diagram/event) | Contiene elementi che specificano formule che controllano gli eventi della forma. |
+| [EventItem](../com.aspose.diagram/eventitem) | Incapsula un codice evento. |
+| [EventItemCollection](../com.aspose.diagram/eventitemcollection) | Raccolta EventItem. |
+| [Field](../com.aspose.diagram/field) | Contiene elementi che specificano funzioni e formule inserite nel testo della forma. |
+| [FieldCollection](../com.aspose.diagram/fieldcollection) | Raccolta di campi. |
+| [FileFontSource](../com.aspose.diagram/filefontsource) | Rappresenta il singolo file di font TrueType memorizzato nel file system. |
+| [FileFormatInfo](../com.aspose.diagram/fileformatinfo) | Contiene i dati restituiti dai metodi di rilevamento del formato file di [FileFormatUtil](../com.aspose.diagram/fileformatutil). |
+| [FileFormatType](../com.aspose.diagram/fileformattype) | Enumera i tipi di formato file dei fogli di calcolo |
+| [FileFormatUtil](../com.aspose.diagram/fileformatutil) | Fornisce metodi di utilità per convertire le enumerazioni di formato file in stringhe o estensioni di file e viceversa. |
+| [Fill](../com.aspose.diagram/fill) | Contiene i valori di formattazione di riempimento attuali per la forma e l'ombra della forma, inclusi modello, colore di primo piano e colore di sfondo. |
+| [FillType](../com.aspose.diagram/filltype) | Tipo di formato di riempimento. |
+| [Fld](../com.aspose.diagram/fld) | Indica un punto di inserimento del campo di testo per l'elemento Field corrispondente. |
+| [FloatPointNumCollection](../com.aspose.diagram/floatpointnumcollection) | Contiene una raccolta di numeri di punti doppi |
+| [FolderFontSource](../com.aspose.diagram/folderfontsource) | Rappresenta la cartella che contiene i file di font TrueType. |
+| [Font](../com.aspose.diagram/font) | Contiene informazioni su un font. |
+| [FontCollection](../com.aspose.diagram/fontcollection) | Contiene una raccolta di elementi Font. |
+| [FontConfigs](../com.aspose.diagram/fontconfigs) | Specifica le impostazioni del font |
+| [FontSourceBase](../com.aspose.diagram/fontsourcebase) | Questa è una classe base astratta per le classi che consentono all'utente di specificare varie font source |
+| [FontSourceType](../com.aspose.diagram/fontsourcetype) | Specifica il tipo di una font source. |
+| [Foreign](../com.aspose.diagram/foreign) | Contiene elementi che specificano la larghezza e l'altezza di un oggetto proveniente da un altro programma utilizzato in un documento Microsoft Visio. |
+| [ForeignData](../com.aspose.diagram/foreigndata) | Contiene un BLOB codificato MIME (Multipurpose Internet Mail Extensions) di dati immagine, come metafile Windows, bitmap o dati OLE. |
+| [ForeignType](../com.aspose.diagram/foreigntype) | Tipo di dati. |
+| [FormatTxt](../com.aspose.diagram/formattxt) | Classe astratta per la formattazione del testo |
+| [FormatTxtCollection](../com.aspose.diagram/formattxtcollection) | Raccolta FormatTxt che contiene il testo di una forma. |
+| [FromPartValue](../com.aspose.diagram/frompartvalue) | La parte di una forma da cui origina una connessione. |
+| [Geom](../com.aspose.diagram/geom) | Contiene elementi che specificano le coordinate dei vertici per le linee e gli archi che compongono la forma. |
+| [GeomCollection](../com.aspose.diagram/geomcollection) | Raccolta Geom. |
+| [GlowEffect](../com.aspose.diagram/gloweffect) | Questa classe specifica un effetto bagliore, in cui un contorno sfocato di colore viene aggiunto al di fuori dei bordi dell'oggetto. |
+| [GlueSettings](../com.aspose.diagram/gluesettings) | I valori dei bit indicano che una specifica impostazione di incollaggio è attiva o disattiva. |
+| [GlueSettingsValue](../com.aspose.diagram/gluesettingsvalue) | Specifica gli oggetti a cui le forme si incollano quando la colla è abilitata nel documento. |
+| [GlueType](../com.aspose.diagram/gluetype) | Specifica se è consentita la colla dinamica (forma‑a‑forma) quando si collega a una forma. |
+| [GlueTypeValue](../com.aspose.diagram/gluetypevalue) | Specifica se è consentita la colla dinamica (forma‑a‑forma) quando si collega a una forma. |
+| [GluedShapesFlags](../com.aspose.diagram/gluedshapesflags) | Specifica le costanti che identificano quali forme restituire, in base alla dimensionalità e alla direzionalità dei punti di connessione incollati a una forma particolare; passate al metodo Shape.GluedShapes. |
+| [GradientDirectionType](../com.aspose.diagram/gradientdirectiontype) | Rappresenta tutti i tipi di direzione del gradiente. |
+| [GradientFill](../com.aspose.diagram/gradientfill) | Rappresenta il riempimento a gradiente. |
+| [GradientFillDir](../com.aspose.diagram/gradientfilldir) | Specifica il tipo di gradiente di colore di riempimento di una forma |
+| [GradientFillType](../com.aspose.diagram/gradientfilltype) | Rappresenta tutti i tipi di riempimento a gradiente. |
+| [GradientStop](../com.aspose.diagram/gradientstop) | Rappresenta il punto di arresto del gradiente. |
+| [GradientStopCollection](../com.aspose.diagram/gradientstopcollection) | Rappresenta la raccolta dei punti di arresto del gradiente. |
+| [GradientStyleType](../com.aspose.diagram/gradientstyletype) | Rappresenta lo stile di sfumatura del gradiente. |
+| [GridDensity](../com.aspose.diagram/griddensity) | Specifica il tipo di griglia orizzontale/verticale da utilizzare per una pagina. |
+| [GridDensityValue](../com.aspose.diagram/griddensityvalue) | Specifica il tipo di griglia orizzontale/verticale da utilizzare per una pagina. |
+| [Group](../com.aspose.diagram/group) | Contiene gli elementi che controllano come aggiungere forme a un gruppo, spostare i membri di un gruppo e selezionare i gruppi. |
+| [HTMLSaveOptions](../com.aspose.diagram/htmlsaveoptions) | Consente di specificare opzioni aggiuntive durante il rendering delle pagine del diagramma in HTML. |
+| [HeaderFooter](../com.aspose.diagram/headerfooter) | Contiene gli elementi per l'intestazione e il piè di pagina di un documento. |
+| [HeaderFooterFont](../com.aspose.diagram/headerfooterfont) | Specifica il carattere utilizzato per il testo dell'intestazione e del piè di pagina. |
+| [Help](../com.aspose.diagram/help) | Contiene gli elementi che specificano l'argomento del file di aiuto dell'elemento Shape e le informazioni sul copyright. |
+| [HorzAlign](../com.aspose.diagram/horzalign) | Specifica l'allineamento orizzontale del testo nel blocco di testo della forma. |
+| [HorzAlignValue](../com.aspose.diagram/horzalignvalue) | Specifica l'allineamento orizzontale del testo nel blocco di testo della forma. |
+| [Hyperlink](../com.aspose.diagram/hyperlink) | Contiene gli elementi per creare più collegamenti tra una forma o una pagina di disegno e un'altra pagina di disegno, un altro file o un sito Web. |
+| [HyperlinkCollection](../com.aspose.diagram/hyperlinkcollection) | Raccolta di collegamenti ipertestuali. |
+| [IconSizeValue](../com.aspose.diagram/iconsizevalue) | int opzionale. |
+| [Image](../com.aspose.diagram/image) | Contiene i valori di gamma, luminosità, contrasto, sfocatura, nitidezza, riduzione del rumore e trasparenza per un bitmap. |
+| [ImageActiveXControl](../com.aspose.diagram/imageactivexcontrol) | Rappresenta il controllo immagine. |
+| [ImageColorMode](../com.aspose.diagram/imagecolormode) | Specifica la modalità colore per le immagini generate delle pagine del documento. |
+| [ImageFormat](../com.aspose.diagram/imageformat) | Specifica il formato file dell'immagine. |
+| [ImageSaveOptions](../com.aspose.diagram/imagesaveoptions) | Consente di specificare opzioni aggiuntive durante il rendering delle pagine del diagramma in immagini. |
+| [IndividualFontConfigs](../com.aspose.diagram/individualfontconfigs) | Configurazioni dei caratteri per ogni oggetto [Diagram](../com.aspose.diagram/diagram). |
+| [InfiniteLine](../com.aspose.diagram/infiniteline) | Contiene elementi che specificano le coordinate x e y di due punti su una linea infinita. |
+| [InfiniteLineCollection](../com.aspose.diagram/infinitelinecollection) | Raccolta InfiniteLine. |
+| [InputMethodEditorMode](../com.aspose.diagram/inputmethodeditormode) | Rappresenta la modalità di esecuzione predefinita dell'Input Method Editor. |
+| [IntValue](../com.aspose.diagram/intvalue) | Valore intero |
+| [InterpolationMode](../com.aspose.diagram/interpolationmode) | L'enumerazione InterpolationMode specifica l'algoritmo utilizzato quando le immagini vengono scalate o ruotate. |
+| [InterruptMonitor](../com.aspose.diagram/interruptmonitor) | Rappresenta tutti gli operatori relativi all'interruzione. |
+| [Issue](../com.aspose.diagram/issue) | Rappresenta un singolo problema di convalida nel documento. |
+| [IssueCollection](../com.aspose.diagram/issuecollection) | Raccolta Issue. |
+| [IssueTarget](../com.aspose.diagram/issuetarget) | A seconda dell'obiettivo del problema di convalida padre, specifica la pagina o sia la pagina che la forma a cui il problema di convalida padre è associato. |
+| [LabelActiveXControl](../com.aspose.diagram/labelactivexcontrol) | Rappresenta il controllo ActiveX label. |
+| [Layer](../com.aspose.diagram/layer) | Contiene elementi che definiscono un singolo livello e le sue proprietà per una pagina. |
+| [LayerCollection](../com.aspose.diagram/layercollection) | Raccolta Layer. |
+| [LayerMem](../com.aspose.diagram/layermem) | Contiene l'elemento LayerMember, che specifica ogni livello a cui la forma è assegnata. |
+| [Layout](../com.aspose.diagram/layout) | Contiene elementi che controllano il posizionamento delle forme e le impostazioni di instradamento dei connettori. |
+| [LayoutDirection](../com.aspose.diagram/layoutdirection) | Utilizzato per impostare la direzione del layout. |
+| [LayoutOptions](../com.aspose.diagram/layoutoptions) | Utilizzato per specificare lo stile e le opzioni aggiuntive del layout delle forme per eseguire il Re-Layout di pagina(pagine). |
+| [LayoutStyle](../com.aspose.diagram/layoutstyle) | Utilizzato per specificare lo stile del layout. |
+| [License](../com.aspose.diagram/license) | Fornisce metodi per licenziare il componente. |
+| [LightRigDirectionType](../com.aspose.diagram/lightrigdirectiontype) | Rappresenta il tipo di direzione del rig luminoso. |
+| [Line](../com.aspose.diagram/line) | Contiene elementi che specificano informazioni generali di posizionamento su una forma. |
+| [LineAdjustFrom](../com.aspose.diagram/lineadjustfrom) | Specifica quali connettori dinamici separare se si sovrappongono. |
+| [LineAdjustFromValue](../com.aspose.diagram/lineadjustfromvalue) | Specifica quali connettori dinamici separare se si sovrappongono. |
+| [LineAdjustTo](../com.aspose.diagram/lineadjustto) | Specifica quali connettori dinamici allineare uno sopra l'altro se si sovrappongono. |
+| [LineAdjustToValue](../com.aspose.diagram/lineadjusttovalue) | Specifica quali connettori dinamici allineare uno sopra l'altro se si sovrappongono. |
+| [LineJumpCode](../com.aspose.diagram/linejumpcode) | Determina i connettori dinamici a cui si desidera aggiungere salti. |
+| [LineJumpCodeValue](../com.aspose.diagram/linejumpcodevalue) | Determina i connettori dinamici a cui si desidera aggiungere salti. |
+| [LineJumpStyle](../com.aspose.diagram/linejumpstyle) | Specifica lo stile di salto di linea per tutti i connettori sulla pagina di disegno che non hanno uno stile di salto di linea locale. |
+| [LineJumpStyleValue](../com.aspose.diagram/linejumpstylevalue) | Specifica lo stile di salto di linea per tutti i connettori sulla pagina di disegno che non hanno uno stile di salto di linea locale. |
+| [LineRouteExt](../com.aspose.diagram/linerouteext) | Specifica l'aspetto predefinito per tutti i connettori su una pagina. |
+| [LineRouteExtValue](../com.aspose.diagram/linerouteextvalue) | Specifica l'aspetto predefinito per tutti i connettori su una pagina. |
+| [LineTo](../com.aspose.diagram/lineto) | Contiene le coordinate x e y del vertice finale di un segmento di linea retta. |
+| [LineToCollection](../com.aspose.diagram/linetocollection) | Raccolta LineTo. |
+| [ListBoxActiveXControl](../com.aspose.diagram/listboxactivexcontrol) | Rappresenta un controllo ActiveX ListBox. |
+| [LoadFileFormat](../com.aspose.diagram/loadfileformat) | Enumerazione per la selezione del formato di caricamento del diagramma. |
+| [LoadOptions](../com.aspose.diagram/loadoptions) | Consente di specificare opzioni aggiuntive durante il caricamento di un diagramma in un oggetto Diagram. |
+| [LocalizeFont](../com.aspose.diagram/localizefont) | Specifica se il testo della forma deve essere localizzato (tradotto in un'altra lingua). |
+| [LocalizeFontValue](../com.aspose.diagram/localizefontvalue) | Specifica se il testo della forma deve essere localizzato (tradotto in un'altra lingua). |
+| [Margin](../com.aspose.diagram/margin) | Specifica il margine. |
+| [Master](../com.aspose.diagram/master) | Contiene gli elementi che definiscono un master per il documento. |
+| [MasterCollection](../com.aspose.diagram/mastercollection) | Raccolta Master. |
+| [MasterShortcut](../com.aspose.diagram/mastershortcut) | Specifica una scorciatoia master definita nel documento. |
+| [MasterShortcutCollection](../com.aspose.diagram/mastershortcutcollection) | Raccolta MasterShortcut. |
+| [MeasureConst](../com.aspose.diagram/measureconst) | Unità di\\ misura. |
+| [MemoryFontSource](../com.aspose.diagram/memoryfontsource) | Rappresenta il singolo file di font TrueType memorizzato in memoria. |
+| [MilestoneHelper](../com.aspose.diagram/milestonehelper) | MilestoneHelper per impostare la proprietà della forma milestone. |
+| [Misc](../com.aspose.diagram/misc) | Contiene vari elementi di forme e gruppi, come quelli che controllano l'evidenziazione della selezione e la visibilità. |
+| [MoveTo](../com.aspose.diagram/moveto) | Contiene le coordinate x e y del primo vertice di una forma, oppure le coordinate x e y del primo vertice dopo un'interruzione in un percorso. |
+| [MoveToCollection](../com.aspose.diagram/movetocollection) | Raccolta MoveTo. |
+| [NURBSTo](../com.aspose.diagram/nurbsto) | Contiene le coordinate x e y, la posizione del penultimo nodo, la posizione dell'ultimo peso, la posizione del primo nodo, la posizione del primo peso e la formula per una B-spline razionale non uniforme (NURBS). |
+| [NURBSToCollection](../com.aspose.diagram/nurbstocollection) | Raccolta NURBSTo. |
+| [ObjType](../com.aspose.diagram/objtype) | Specifica se gli oggetti sono posizionabili o instradabili nei diagrammi quando si utilizza Microsoft Visio per disporre le forme sulla pagina di disegno. |
+| [ObjTypeValue](../com.aspose.diagram/objtypevalue) | Specifica se gli oggetti sono posizionabili o instradabili nei diagrammi quando si utilizza Microsoft Visio per disporre le forme sulla pagina di disegno. |
+| [ObjectKind](../com.aspose.diagram/objectkind) | Indica il tipo di campo di testo. |
+| [ObjectKindValue](../com.aspose.diagram/objectkindvalue) | Indica il tipo di campo di testo. |
+| [ObjectType](../com.aspose.diagram/objecttype) | Se l'attributo ForeignType è "Object", l'elemento ForeignData deve inoltre avere un attributo ObjectType. |
+| [OptionsValue](../com.aspose.diagram/optionsvalue) | Intero senza segno opzionale. |
+| [OutputFormat](../com.aspose.diagram/outputformat) | Specifica il formato di output per un disegno. |
+| [OutputFormatValue](../com.aspose.diagram/outputformatvalue) | Specifica il formato di output per un disegno. |
+| [Page](../com.aspose.diagram/page) | Contiene gli elementi che definiscono una pagina nel documento. |
+| [PageCollection](../com.aspose.diagram/pagecollection) | Raccolta di pagine. |
+| [PageEndSavingArgs](../com.aspose.diagram/pageendsavingargs) | Informazioni per una pagina terminano il processo di salvataggio. |
+| [PageLayout](../com.aspose.diagram/pagelayout) | Contiene celle che controllano le impostazioni di layout della pagina per forme e connettori, come la spaziatura tra tutte le forme sulla pagina, la spaziatura tra tutti i connettori sulla pagina e lo stile di instradamento per tutti i connettori sulla pagina. |
+| [PageLineJumpDirX](../com.aspose.diagram/pagelinejumpdirx) | Specifica la direzione dei salti di linea sui segmenti orizzontali dei connettori dinamici nella pagina di disegno per i quali non è stata applicata una direzione locale del salto. |
+| [PageLineJumpDirXValue](../com.aspose.diagram/pagelinejumpdirxvalue) | Specifica la direzione dei salti di linea sui segmenti orizzontali dei connettori dinamici nella pagina di disegno per i quali non è stata applicata una direzione locale del salto. |
+| [PageLineJumpDirY](../com.aspose.diagram/pagelinejumpdiry) | Specifica la direzione dei salti di linea sui connettori dinamici verticali nella pagina di disegno per i quali non è stata applicata una direzione locale del salto. |
+| [PageLineJumpDirYValue](../com.aspose.diagram/pagelinejumpdiryvalue) | Specifica la direzione dei salti di linea sui connettori dinamici verticali nella pagina di disegno per i quali non è stata applicata una direzione locale del salto. |
+| [PageProps](../com.aspose.diagram/pageprops) | Contiene celle che controllano gli attributi della pagina, come larghezza, altezza e scala della pagina. |
+| [PageSavingArgs](../com.aspose.diagram/pagesavingargs) | Informazioni per il processo di salvataggio di una pagina. |
+| [PageSheet](../com.aspose.diagram/pagesheet) | Contiene elementi che definiscono il foglio di pagina per un elemento Pagina o Master. |
+| [PageSize](../com.aspose.diagram/pagesize) | Contiene informazioni sulla dimensione della pagina per le immagini generate. |
+| [PageStartSavingArgs](../com.aspose.diagram/pagestartsavingargs) | Informazioni per una pagina avviano il processo di salvataggio. |
+| [PaperSizeFormat](../com.aspose.diagram/papersizeformat) | Enumerazione per la selezione del formato di dimensione carta da salvare. |
+| [Para](../com.aspose.diagram/para) | Contiene gli elementi di formattazione del paragrafo per il testo della forma, come rientri, interlinea, elenchi puntati e allineamento orizzontale dei paragrafi. |
+| [ParaCollection](../com.aspose.diagram/paracollection) | Raccolta di paragrafi. |
+| [PdfCompliance](../com.aspose.diagram/pdfcompliance) | Specifica il livello di conformità PDF per il file di output. |
+| [PdfDigitalSignatureHashAlgorithm](../com.aspose.diagram/pdfdigitalsignaturehashalgorithm) | Specifica l'algoritmo di hash digitale utilizzato dalla firma digitale. |
+| [PdfEncryptionAlgorithm](../com.aspose.diagram/pdfencryptionalgorithm) | Specifica l'algoritmo di crittografia da utilizzare per cifrare un documento PDF. |
+| [PdfEncryptionDetails](../com.aspose.diagram/pdfencryptiondetails) | Contiene i dettagli per una crittografia PDF. |
+| [PdfPermissions](../com.aspose.diagram/pdfpermissions) | Specifica i permessi dell'utente per il documento PDF. |
+| [PdfSaveOptions](../com.aspose.diagram/pdfsaveoptions) | Consente di specificare opzioni aggiuntive durante il rendering delle pagine del diagramma in PDF. |
+| [PdfTextCompression](../com.aspose.diagram/pdftextcompression) | Specifica un tipo di compressione applicato a tutti i contenuti nel file PDF, eccetto le immagini. |
+| [PinPosValue](../com.aspose.diagram/pinposvalue) | Specifica la posizione del perno per la forma. |
+| [PixelOffsetMode](../com.aspose.diagram/pixeloffsetmode) | Specifica come i pixel sono spostati durante il rendering. |
+| [PlaceDepth](../com.aspose.diagram/placedepth) | Per un disegno disposto automaticamente, specifica il metodo con cui il disegno viene analizzato prima di creare il layout e determina il tipo di layout. |
+| [PlaceDepthValue](../com.aspose.diagram/placedepthvalue) | Per un disegno disposto automaticamente, specifica il metodo con cui il disegno viene analizzato prima di creare il layout e determina il tipo di layout. |
+| [PlaceFlip](../com.aspose.diagram/placeflip) | Specifica come le forme posizionabili vengono capovolte e/o ruotate su una pagina quando le forme sono disposte usando il comando Lay Out Shapes in Microsoft Visio. |
+| [PlaceFlipValue](../com.aspose.diagram/placeflipvalue) | Specifica come le forme posizionabili vengono capovolte e/o ruotate su una pagina quando le forme sono disposte usando il comando Lay Out Shapes in Microsoft Visio. |
+| [PlaceStyle](../com.aspose.diagram/placestyle) | Specifica come le forme vengono posizionate sulla pagina quando le forme sono disposte dopo che l'utente seleziona Lay Out Shapes (menu Forma). |
+| [PlaceStyleValue](../com.aspose.diagram/placestylevalue) | Specifica come le forme vengono posizionate sulla pagina quando le forme sono disposte dopo che l'utente seleziona Lay Out Shapes (menu Forma). |
+| [PolylineTo](../com.aspose.diagram/polylineto) | Contiene le coordinate x e y dell'ultimo punto di una polilinea e la formula della polilinea. |
+| [PolylineToCollection](../com.aspose.diagram/polylinetocollection) | Raccolta PolylineTo. |
+| [Pos](../com.aspose.diagram/pos) | Specifica la posizione del testo della forma rispetto alla linea di base. |
+| [PosValue](../com.aspose.diagram/posvalue) | Specifica la posizione del testo della forma rispetto alla linea di base. |
+| [Pp](../com.aspose.diagram/pp) | Specifica l'inizio di un blocco di proprietà del paragrafo. |
+| [PresetCameraType](../com.aspose.diagram/presetcameratype) | Rappresenta diversi metodi algoritmici per impostare tutte le proprietà della fotocamera, inclusa la posizione. |
+| [PresetColorMatricsValue](../com.aspose.diagram/presetcolormatricsvalue) | Utilizzato per impostare la proprietà colore dello stile del tema della Forma |
+| [PresetQuickStyleValue](../com.aspose.diagram/presetquickstylevalue) | Specifica il valore dello stile rapido del tema |
+| [PresetShadowType](../com.aspose.diagram/presetshadowtype) | Rappresenta il tipo di ombra predefinito. |
+| [PresetStyleMatricsValue](../com.aspose.diagram/presetstylematricsvalue) | Utilizzato per impostare la proprietà dello stile del tema della Forma |
+| [PresetThemeValue](../com.aspose.diagram/presetthemevalue) | Specifica il valore del tema |
+| [PresetThemeVariantValue](../com.aspose.diagram/presetthemevariantvalue) | Specifica il valore della variante del tema |
+| [PreviewScope](../com.aspose.diagram/previewscope) | Specifica se il documento include un'anteprima e, in tal caso, se l'anteprima mostra solo la prima pagina o tutte le pagine del documento. |
+| [PreviewScopeValue](../com.aspose.diagram/previewscopevalue) | Specifica se il documento include un'anteprima e, in tal caso, se l'anteprima mostra solo la prima pagina o tutte le pagine del documento. |
+| [PrintPageOrientation](../com.aspose.diagram/printpageorientation) | Determina se la pagina viene stampata in orientamento verticale o orizzontale. |
+| [PrintPageOrientationValue](../com.aspose.diagram/printpageorientationvalue) | Determina se la pagina viene stampata in orientamento verticale o orizzontale. |
+| [PrintProps](../com.aspose.diagram/printprops) | Contiene elementi che controllano come la pagina di disegno è formattata (appare) sulla pagina della stampante. |
+| [PrintSaveOptions](../com.aspose.diagram/printsaveoptions) | Consente di specificare opzioni aggiuntive durante la stampa del diagramma. |
+| [Prop](../com.aspose.diagram/prop) | Contiene elementi per definire proprietà personalizzate ed elementi per associare dati a una forma. |
+| [PropCollection](../com.aspose.diagram/propcollection) | Raccolta Prop. |
+| [PropType](../com.aspose.diagram/proptype) | Tipo di proprietà. |
+| [Protection](../com.aspose.diagram/protection) | Il blocco aiuta a prevenire modifiche involontarie alla forma ma non impedisce a Microsoft Visio di ripristinare i valori in altre circostanze. |
+| [RadioButtonActiveXControl](../com.aspose.diagram/radiobuttonactivexcontrol) | Rappresenta un controllo ActiveX RadioButton. |
+| [RectangleAlignmentType](../com.aspose.diagram/rectanglealignmenttype) | Rappresenta come posizionare due rettangoli l'uno rispetto all'altro. |
+| [ReflectionEffectType](../com.aspose.diagram/reflectioneffecttype) |  |
+| [RelCubBezTo](../com.aspose.diagram/relcubbezto) | Contiene le coordinate x e y per i punti di un RelCubBezTo. |
+| [RelCubBezToCollection](../com.aspose.diagram/relcubbeztocollection) | Raccolta RelCubBezTo. |
+| [RelEllipticalArcTo](../com.aspose.diagram/relellipticalarcto) | Contiene elementi che specificano informazioni su un arco ellittico. Le coordinate sono specificate come coordinate relative. |
+| [RelEllipticalArcToCollection](../com.aspose.diagram/relellipticalarctocollection) | Raccolta RelEllipticalArcTo. |
+| [RelLineTo](../com.aspose.diagram/rellineto) | Contiene le coordinate x e y del vertice finale di un segmento di linea retta. |
+| [RelLineToCollection](../com.aspose.diagram/rellinetocollection) | Raccolta RelLineTo. |
+| [RelMoveTo](../com.aspose.diagram/relmoveto) | Contiene le coordinate x e y del primo vertice di una forma, o contiene le coordinate x e y del primo vertice dopo un'interruzione in un percorso. Le coordinate sono specificate come coordinate relative. |
+| [RelMoveToCollection](../com.aspose.diagram/relmovetocollection) | Raccolta RelMoveTo. |
+| [RelQuadBezTo](../com.aspose.diagram/relquadbezto) | Contiene le coordinate x e y per i punti di un RelQuadBezTo. |
+| [RelQuadBezToCollection](../com.aspose.diagram/relquadbeztocollection) | Raccolta RelQuadBezTo. |
+| [RemoveHiddenInfoItem](../com.aspose.diagram/removehiddeninfoitem) | Specifica la rimozione delle informazioni nascoste per il diagramma. |
+| [RenderingSaveOptions](../com.aspose.diagram/renderingsaveoptions) | Questa è una classe base astratta per le classi che consentono all'utente di specificare opzioni aggiuntive quando si salva un diagramma in un formato specifico. |
+| [ResizeMode](../com.aspose.diagram/resizemode) | Specifica l'impostazione corrente del comportamento di ridimensionamento per la forma quando è contenuta in un gruppo. |
+| [ResizeModeValue](../com.aspose.diagram/resizemodevalue) | Specifica l'impostazione corrente del comportamento di ridimensionamento per la forma quando è contenuta in un gruppo. |
+| [Reviewer](../com.aspose.diagram/reviewer) | Contiene elementi che includono informazioni identificative su un revisore di documento. |
+| [ReviewerCollection](../com.aspose.diagram/reviewercollection) | Raccolta Reviewer. |
+| [RotationType](../com.aspose.diagram/rotationtype) | Specifica il tipo di ombra per una forma. |
+| [RotationTypeValue](../com.aspose.diagram/rotationtypevalue) | Specifica il tipo di proiezione delle proprietà di effetto di una forma. |
+| [RouteStyle](../com.aspose.diagram/routestyle) | Specifica lo stile di instradamento e la direzione per tutti i connettori dinamici nella pagina di disegno che non hanno uno stile di instradamento locale. |
+| [RouteStyleValue](../com.aspose.diagram/routestylevalue) | Specifica lo stile di instradamento e la direzione per tutti i connettori dinamici nella pagina di disegno che non hanno uno stile di instradamento locale. |
+| [Row](../com.aspose.diagram/row) | Indica una riga nel set di record dei dati. |
+| [RowCollection](../com.aspose.diagram/rowcollection) | Raccolta Row. |
+| [Rule](../com.aspose.diagram/rule) | Rappresenta una singola regola di convalida in un set di regole di convalida del diagramma. |
+| [RuleCollection](../com.aspose.diagram/rulecollection) | Raccolta Rule. |
+| [RuleInfo](../com.aspose.diagram/ruleinfo) | Specifica le informazioni sulla regola di convalida a cui si riferisce il problema di convalida padre. |
+| [RuleSet](../com.aspose.diagram/ruleset) | Rappresenta un set di regole di convalida del diagramma. |
+| [RuleSetCollection](../com.aspose.diagram/rulesetcollection) | Raccolta RuleSet. |
+| [RuleValue](../com.aspose.diagram/rulevalue) | Valore della regola. |
+| [RulerDensity](../com.aspose.diagram/rulerdensity) | Specifica le suddivisioni orizzontali sul righello per la pagina. |
+| [RulerDensityValue](../com.aspose.diagram/rulerdensityvalue) | Specifica le suddivisioni orizzontali sul righello per la pagina. |
+| [RulerGrid](../com.aspose.diagram/rulergrid) | Contiene elementi che specificano le impostazioni dei righelli e della griglia della pagina. |
+| [SVGSaveOptions](../com.aspose.diagram/svgsaveoptions) | Consente di specificare opzioni aggiuntive durante il rendering delle pagine del diagramma in SVG. |
+| [SaveFileFormat](../com.aspose.diagram/savefileformat) | Enumerazione per la selezione del formato di salvataggio del diagramma. |
+| [SaveOptions](../com.aspose.diagram/saveoptions) | Questa è una classe base astratta per le classi che consentono all'utente di specificare opzioni aggiuntive quando si salva un diagramma in un formato specifico. |
+| [Scratch](../com.aspose.diagram/scratch) | Contiene un'area di lavoro per inserire e testare formule a cui fanno riferimento altri elementi. |
+| [ScratchCollection](../com.aspose.diagram/scratchcollection) | Raccolta Scratch. |
+| [ScrollBarActiveXControl](../com.aspose.diagram/scrollbaractivexcontrol) | Rappresenta il controllo ScrollBar. |
+| [SelectMode](../com.aspose.diagram/selectmode) | Specifica come l'utente seleziona una forma di gruppo e i suoi membri. |
+| [SelectModeValue](../com.aspose.diagram/selectmodevalue) | Specifica come l'utente seleziona una forma di gruppo e i suoi membri. |
+| [Shape](../com.aspose.diagram/shape) | Contiene elementi che definiscono una forma in un elemento Master, Pagina o forma di gruppo. |
+| [ShapeCollection](../com.aspose.diagram/shapecollection) | Raccolta di forme. |
+| [ShapeFixedCode](../com.aspose.diagram/shapefixedcode) | Specifica il comportamento di posizionamento per una forma posizionabile. |
+| [ShapeFixedCodeValue](../com.aspose.diagram/shapefixedcodevalue) | Specifica il comportamento di posizionamento per una forma posizionabile. |
+| [ShapePlaceFlip](../com.aspose.diagram/shapeplaceflip) | Specifica come una forma posizionabile si capovolge e/o ruota nella pagina quando l'utente seleziona Disposizione forme (menu Forme). |
+| [ShapePlaceFlipValue](../com.aspose.diagram/shapeplaceflipvalue) | Specifica come una forma posizionabile si capovolge e/o ruota nella pagina quando l'utente seleziona Disposizione forme (menu Forme). |
+| [ShapePlaceStyle](../com.aspose.diagram/shapeplacestyle) | Determina lo stile di posizionamento per i figli. |
+| [ShapePlaceStyleValue](../com.aspose.diagram/shapeplacestylevalue) | Determina lo stile di posizionamento per i figli. |
+| [ShapePlowCode](../com.aspose.diagram/shapeplowcode) | Specifica se una forma posizionabile si allontana quando trascini un'altra forma posizionabile vicino alla forma nella pagina di disegno. |
+| [ShapePlowCodeValue](../com.aspose.diagram/shapeplowcodevalue) | Specifica se una forma posizionabile si allontana quando trascini un'altra forma posizionabile vicino alla forma nella pagina di disegno. |
+| [ShapeRouteStyle](../com.aspose.diagram/shaperoutestyle) | Specifica lo stile di instradamento e la direzione per un connettore nella pagina di disegno. |
+| [ShapeRouteStyleValue](../com.aspose.diagram/shaperoutestylevalue) | Specifica lo stile di instradamento e la direzione per un connettore nella pagina di disegno. |
+| [ShapeShdwShow](../com.aspose.diagram/shapeshdwshow) | Specifica il tipo di ombra per una forma. |
+| [ShapeShdwShowValue](../com.aspose.diagram/shapeshdwshowvalue) | Specifica il tipo di ombra per una forma. |
+| [ShapeShdwType](../com.aspose.diagram/shapeshdwtype) | Specifica il tipo di ombra per una forma. |
+| [ShapeShdwTypeValue](../com.aspose.diagram/shapeshdwtypevalue) | Specifica il tipo di ombra per una forma. |
+| [ShdwType](../com.aspose.diagram/shdwtype) | Indica il tipo di ombra predefinito per una pagina. |
+| [ShdwTypeValue](../com.aspose.diagram/shdwtypevalue) | Indica il tipo di ombra predefinito per una pagina. |
+| [ShowDropButtonType](../com.aspose.diagram/showdropbuttontype) | Specifica quando mostrare il pulsante di rilascio |
+| [SmartTagDef](../com.aspose.diagram/smarttagdef) | Contiene elementi che includono informazioni per ogni smart tag definito per una forma o una pagina. |
+| [SmartTagDefCollection](../com.aspose.diagram/smarttagdefcollection) | Raccolta SmartTagDef. |
+| [SmoothingMode](../com.aspose.diagram/smoothingmode) | Specifica se l'anti-aliasing (smussatura) è applicato a linee e curve e ai bordi delle aree riempite. |
+| [SnapExtensions](../com.aspose.diagram/snapextensions) | Specifica se un'impostazione specifica di estensione snap è abilitata o disabilitata per la finestra attiva. |
+| [SnapExtensionsValue](../com.aspose.diagram/snapextensionsvalue) | Specifica se un'impostazione specifica di estensione snap è abilitata o disabilitata per la finestra attiva. |
+| [SnapSettings](../com.aspose.diagram/snapsettings) | Specifica gli oggetti a cui le forme si agganciano quando lo snap è attivo nella finestra. |
+| [SnapSettingsValue](../com.aspose.diagram/snapsettingsvalue) | Specifica gli oggetti a cui le forme si agganciano quando lo snap è attivo nella finestra |
+| [SolutionXML](../com.aspose.diagram/solutionxml) | Contiene dati XML ben formati specifici della soluzione, con prefisso in uno spazio dei nomi esplicito e memorizzati con un documento. |
+| [SolutionXMLCollection](../com.aspose.diagram/solutionxmlcollection) | Raccolta SolutionXML. |
+| [SpinButtonActiveXControl](../com.aspose.diagram/spinbuttonactivexcontrol) | Rappresenta il controllo SpinButton. |
+| [SplineKnot](../com.aspose.diagram/splineknot) | Contiene le coordinate x e y per il punto di controllo di una spline e per un nodo della spline, rappresentati rispettivamente dagli elementi X, Y e A. |
+| [SplineKnotCollection](../com.aspose.diagram/splineknotcollection) | Raccolta SplineKnot. |
+| [SplineStart](../com.aspose.diagram/splinestart) | Contiene le coordinate x e y per il secondo punto di controllo di una spline, il suo secondo nodo, il suo primo nodo, l'ultimo nodo e il grado della spline. |
+| [SplineStartCollection](../com.aspose.diagram/splinestartcollection) | Raccolta SplineStart. |
+| [Str2Value](../com.aspose.diagram/str2value) | Valore stringa. |
+| [StrValue](../com.aspose.diagram/strvalue) | Valore stringa |
+| [StreamProviderOptions](../com.aspose.diagram/streamprovideroptions) | Rappresenta le opzioni di flusso. |
+| [Style](../com.aspose.diagram/style) | Specifica la formattazione dei caratteri applicata a un intervallo di testo nel blocco di testo della forma. |
+| [StyleProp](../com.aspose.diagram/styleprop) | Contiene elementi che controllano il comportamento dello stile, ad esempio se uno stile include attributi di testo, linea e riempimento. |
+| [StyleSheet](../com.aspose.diagram/stylesheet) | Rappresenta uno stile definito in un documento. |
+| [StyleSheetCollection](../com.aspose.diagram/stylesheetcollection) | Raccolta di fogli di stile. |
+| [StyleValue](../com.aspose.diagram/stylevalue) | Specifica la formattazione dei caratteri applicata a un intervallo di testo nel blocco di testo della forma. |
+| [Tab](../com.aspose.diagram/tab) | Contiene una raccolta di elementi Tab. |
+| [TabCollection](../com.aspose.diagram/tabcollection) | Contiene una raccolta di elementi Tab |
+| [TabsCollection](../com.aspose.diagram/tabscollection) | Contiene una raccolta di elementi TabCollection |
+| [Text](../com.aspose.diagram/text) | Contiene il testo di una forma. |
+| [TextBlock](../com.aspose.diagram/textblock) | Contiene elementi che specificano l'allineamento, i margini e le posizioni predefinite delle tabulazioni del testo nel blocco di testo di una forma. |
+| [TextBoxActiveXControl](../com.aspose.diagram/textboxactivexcontrol) | Rappresenta un controllo ActiveX casella di testo. |
+| [TextCollection](../com.aspose.diagram/textcollection) | Contiene il testo di una forma. |
+| [TextDirection](../com.aspose.diagram/textdirection) | Specifica la direzione dei caratteri in un blocco di testo. |
+| [TextDirectionValue](../com.aspose.diagram/textdirectionvalue) | Specifica la direzione dei caratteri in un blocco di testo. |
+| [TextXForm](../com.aspose.diagram/textxform) | Contiene elementi che specificano le informazioni di posizionamento del blocco di testo di una forma. |
+| [ThreeDFormat](../com.aspose.diagram/threedformat) | Rappresenta la formattazione tridimensionale di una forma. |
+| [TiffCompression](../com.aspose.diagram/tiffcompression) | Specifica quale tipo di compressione applicare durante il salvataggio delle pagine nel formato TIFF. |
+| [TimeLineHelper](../com.aspose.diagram/timelinehelper) | TimeLineHelper per impostare la proprietà della forma della timeline. |
+| [ToPartValue](../com.aspose.diagram/topartvalue) | La parte di una forma a cui viene effettuata una connessione. |
+| [ToggleButtonActiveXControl](../com.aspose.diagram/togglebuttonactivexcontrol) | Rappresenta un controllo ActiveX ToggleButton. |
+| [Tp](../com.aspose.diagram/tp) | Specifica l'inizio di una sequenza di proprietà delle tabulazioni. |
+| [Txt](../com.aspose.diagram/txt) | Testo della forma |
+| [TypeConnection](../com.aspose.diagram/typeconnection) | Specifica vari tipi, in base all'elemento in cui è contenuto. |
+| [TypeConnectionValue](../com.aspose.diagram/typeconnectionvalue) | Specifica vari tipi, in base all'elemento in cui è contenuto. |
+| [TypeField](../com.aspose.diagram/typefield) | Tipo specifica un tipo di dati per il valore del campo di testo. |
+| [TypeFieldValue](../com.aspose.diagram/typefieldvalue) | Tipo specifica un tipo di dati per il valore del campo di testo. |
+| [TypeProp](../com.aspose.diagram/typeprop) | Tipo specifica un tipo di dati per il valore della proprietà personalizzata. |
+| [TypePropValue](../com.aspose.diagram/typepropvalue) | Tipo specifica un tipo di dati per il valore della proprietà personalizzata. |
+| [TypeValue](../com.aspose.diagram/typevalue) | Enumerazione opzionale. |
+| [UIVisibility](../com.aspose.diagram/uivisibility) | Specifica l'allineamento della scheda. |
+| [UIVisibilityValue](../com.aspose.diagram/uivisibilityvalue) | Specifica l'allineamento della scheda. |
+| [UnitFormulaErr](../com.aspose.diagram/unitformulaerr) | Specifica gli attributi di un elemento. |
+| [UnitFormulaErrV](../com.aspose.diagram/unitformulaerrv) | Attributi specificati di un elemento. |
+| [UnknownControl](../com.aspose.diagram/unknowncontrol) | Controllo sconosciuto. |
+| [User](../com.aspose.diagram/user) | Contiene un'area di lavoro per l'inserimento di formule in elementi specifici dell'utente a cui fanno riferimento altri elementi e strumenti aggiuntivi. |
+| [UserCollection](../com.aspose.diagram/usercollection) | Raccolta utenti. |
+| [Validation](../com.aspose.diagram/validation) | Memorizza informazioni sulla convalida del diagramma per il documento. |
+| [ValidationProperties](../com.aspose.diagram/validationproperties) | Incapsula le proprietà relative alla convalida per il documento. |
+| [Value](../com.aspose.diagram/value) | Valore. |
+| [VbaModule](../com.aspose.diagram/vbamodule) | Rappresenta il modulo contenuto nel progetto VBA. |
+| [VbaModuleCollection](../com.aspose.diagram/vbamodulecollection) | Rappresenta l'elenco di [VbaModule](../com.aspose.diagram/vbamodule) |
+| [VbaModuleType](../com.aspose.diagram/vbamoduletype) | Rappresenta il tipo di modulo VBA. |
+| [VbaProject](../com.aspose.diagram/vbaproject) | Rappresenta il progetto VBA. |
+| [VbaProjectReference](../com.aspose.diagram/vbaprojectreference) | Rappresenta il riferimento del progetto VBA. |
+| [VbaProjectReferenceCollection](../com.aspose.diagram/vbaprojectreferencecollection) | Rappresenta tutti i riferimenti del progetto VBA. |
+| [VbaProjectReferenceType](../com.aspose.diagram/vbaprojectreferencetype) | Rappresenta il tipo di riferimento del progetto VBA. |
+| [VerticalAlign](../com.aspose.diagram/verticalalign) | Specifica l'allineamento verticale del testo all'interno del blocco di testo. |
+| [VerticalAlignValue](../com.aspose.diagram/verticalalignvalue) | Specifica l'allineamento verticale del testo all'interno del blocco di testo. |
+| [VisRuleTargetsValue](../com.aspose.diagram/visruletargetsvalue) | Specifica i contenuti che definiscono l'obiettivo della regola di convalida; passati a e restituiti dalla proprietà ValidationRule.TargetType. |
+| [WalkPreference](../com.aspose.diagram/walkpreference) | Specifica se un'estremità di una forma 1-D si sposta verso un punto di connessione orizzontale o verticale sulla forma a cui è incollata, utilizzando la colla dinamica, quando la forma viene spostata in una posizione ambigua. |
+| [WalkPreferenceValue](../com.aspose.diagram/walkpreferencevalue) | Specifica se un'estremità di una forma 1-D si sposta verso un punto di connessione orizzontale o verticale sulla forma a cui è incollata, utilizzando la colla dinamica, quando la forma viene spostata in una posizione ambigua. |
+| [WarningInfo](../com.aspose.diagram/warninginfo) | Informazioni di avviso |
+| [WarningType](../com.aspose.diagram/warningtype) | WarningType |
+| [Window](../com.aspose.diagram/window) | Rappresenta una finestra aperta in un'istanza di Microsoft Visio. |
+| [WindowCollection](../com.aspose.diagram/windowcollection) | Raccolta finestre. |
+| [WindowStateValue](../com.aspose.diagram/windowstatevalue) | Un intero che specifica i flag di bit. |
+| [WindowTypeValue](../com.aspose.diagram/windowtypevalue) | Un valore enumerato che può essere uno dei seguenti: Drawing, Sheet, Stencil o Icon. |
+| [XAMLSaveOptions](../com.aspose.diagram/xamlsaveoptions) | Consente di specificare opzioni aggiuntive durante il rendering delle pagine del diagramma in XAML. |
+| [XForm](../com.aspose.diagram/xform) | Contiene elementi che controllano gli attributi di linea per una forma, come modello, spessore e colore. |
+| [XForm1D](../com.aspose.diagram/xform1d) | Contiene le coordinate x e y del punto iniziale e del punto finale di una forma 1-D. |
+| [XJustify](../com.aspose.diagram/xjustify) | L'offset x del pulsante smart tag rispetto al punto definito dagli elementi X e Y. |
+| [XJustifyValue](../com.aspose.diagram/xjustifyvalue) | L'offset x del pulsante smart tag rispetto al punto definito dagli elementi X e Y. |
+| [XPSSaveOptions](../com.aspose.diagram/xpssaveoptions) | Consente di specificare opzioni aggiuntive durante il rendering delle pagine del diagramma in XPS. |
+| [YJustify](../com.aspose.diagram/yjustify) | Specifica l'offset y del pulsante smart tag rispetto al punto definito dagli elementi X e Y. |
+| [YJustifyValue](../com.aspose.diagram/yjustifyvalue) | Specifica l'offset y del pulsante smart tag rispetto al punto definito dagli elementi X e Y. |
+
+## Interfacce
+
+| Interfaccia | Descrizione |
+| --- | --- |
+| [IPageSavingCallback](../com.aspose.diagram/ipagesavingcallback) | Controlla/Indica l'avanzamento del processo di salvataggio della pagina. |
+| [IStreamProvider](../com.aspose.diagram/istreamprovider) | Rappresenta il provider di stream esportato. |
+| [IWarningCallback](../com.aspose.diagram/iwarningcallback) | Interfaccia di callback di avviso. |

--- a/italian/java/com.aspose.diagram/abstractinterruptmonitor/_index.md
+++ b/italian/java/com.aspose.diagram/abstractinterruptmonitor/_index.md
@@ -1,0 +1,147 @@
+---
+title: AbstractInterruptMonitor
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Monitor per le richieste di interruzione in tutte le operazioni che richiedono molto tempo.
+type: docs
+weight: 10
+url: /it/java/com.aspose.diagram/abstractinterruptmonitor/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public abstract class AbstractInterruptMonitor
+```
+
+Monitor per le richieste di interruzione in tutte le operazioni che richiedono molto tempo.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [AbstractInterruptMonitor()](#AbstractInterruptMonitor--) |  |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [isInterruptionRequested()](#isInterruptionRequested--) | Indica se è richiesta un'interruzione per l'operazione corrente. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AbstractInterruptMonitor() {#AbstractInterruptMonitor--}
+```
+public AbstractInterruptMonitor()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isInterruptionRequested() {#isInterruptionRequested--}
+```
+public abstract boolean isInterruptionRequested()
+```
+
+
+Indica se è richiesta un'interruzione per l'operazione corrente. Se vero, l'operazione corrente verrà interrotta.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/act/_index.md
+++ b/italian/java/com.aspose.diagram/act/_index.md
@@ -1,0 +1,395 @@
+---
+title: Act
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Definisce i nomi dei comandi personalizzati che appaiono nel menu di scelta rapida di un oggetto e specifica le azioni che i comandi eseguono.
+type: docs
+weight: 11
+url: /it/java/com.aspose.diagram/act/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Act
+```
+
+Definisce nomi di comandi personalizzati che appaiono nel menu contestuale di un oggetto e specifica le azioni che i comandi eseguono.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [Act()](#Act--) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAction()](#getAction--) | Contiene la formula da eseguire quando l'utente fa clic sul nome del comando definito nell'elemento Menu corrispondente. |
+| [getBeginGroup()](#getBeginGroup--) | Indica se un separatore è inserito nel menu sopra questa azione. |
+| [getButtonFace()](#getButtonFace--) | Identifica l'icona che appare accanto a un elemento nel menu di scelta rapida. |
+| [getChecked()](#getChecked--) | Determina se un segno di spunta è visualizzato accanto al nome del comando nel menu di scelta rapida di una forma. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getDisabled()](#getDisabled--) | L'elemento Disabled determina se il nome del comando è visualizzato nel menu di scelta rapida. |
+| [getFlyoutChild()](#getFlyoutChild--) | Determina se la riga di azione è un menu a comparsa figlio dell'ultima riga sopra di essa che non è un figlio a comparsa. |
+| [getID()](#getID--) | L'ID univoco dell'elemento all'interno del suo elemento genitore. |
+| [getIX()](#getIX--) | L'indice basato su zero dell'elemento all'interno del suo elemento genitore. |
+| [getInvisible()](#getInvisible--) | L'elemento Invisible indica se l'azione è visibile sullo smart tag o sul menu di scelta rapida. |
+| [getMenu()](#getMenu--) | Specifica il nome del comando che appare nel menu di scelta rapida per una forma o una pagina. |
+| [getName()](#getName--) | Il nome dell'elemento. |
+| [getNameU()](#getNameU--) | Il nome universale dell'elemento. |
+| [getReadOnly()](#getReadOnly--) | Determina se l'azione su uno smart tag o sul menu di scelta rapida è in sola lettura. |
+| [getSortKey()](#getSortKey--) | Specifica un numero che determina l'ordine delle azioni che appaiono in un menu di scelta rapida o smart tag. |
+| [getTagName()](#getTagName--) | Contiene il nome del tag intelligente a cui è associata l'azione. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/act\#getDel--) |
+| [setID(int value)](#setID-int-) | Per la descrizione di questa proprietà, vedere [getID()](../../com.aspose.diagram/act\#getID--) |
+| [setIX(int value)](#setIX-int-) | Per la descrizione di questa proprietà, vedere [getIX()](../../com.aspose.diagram/act\#getIX--) |
+| [setName(String value)](#setName-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getName()](../../com.aspose.diagram/act\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getNameU()](../../com.aspose.diagram/act\#getNameU--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Act() {#Act--}
+```
+public Act()
+```
+
+
+Costruttore.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAction() {#getAction--}
+```
+public DoubleValue getAction()
+```
+
+
+Contiene la formula da eseguire quando l'utente fa clic sul nome del comando definito nell'elemento Menu corrispondente.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBeginGroup() {#getBeginGroup--}
+```
+public BoolValue getBeginGroup()
+```
+
+
+Indica se un separatore è inserito nel menu sopra questa azione.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getButtonFace() {#getButtonFace--}
+```
+public Str2Value getButtonFace()
+```
+
+
+Identifica l'icona che appare accanto a un elemento nel menu di scelta rapida.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getChecked() {#getChecked--}
+```
+public BoolValue getChecked()
+```
+
+
+Determina se un segno di spunta è visualizzato accanto al nome del comando nel menu di scelta rapida di una forma.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getDisabled() {#getDisabled--}
+```
+public BoolValue getDisabled()
+```
+
+
+L'elemento Disabled determina se il nome del comando è visualizzato nel menu di scelta rapida.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getFlyoutChild() {#getFlyoutChild--}
+```
+public BoolValue getFlyoutChild()
+```
+
+
+Determina se la riga di azione è un menu a comparsa figlio dell'ultima riga sopra di essa che non è un figlio a comparsa.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+L'ID univoco dell'elemento all'interno del suo elemento genitore.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+L'indice basato su zero dell'elemento all'interno del suo elemento genitore.
+
+**Returns:**
+int
+### getInvisible() {#getInvisible--}
+```
+public BoolValue getInvisible()
+```
+
+
+L'elemento Invisible indica se l'azione è visibile sullo smart tag o sul menu di scelta rapida.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getMenu() {#getMenu--}
+```
+public Str2Value getMenu()
+```
+
+
+Specifica il nome del comando che appare nel menu di scelta rapida per una forma o una pagina.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Il nome dell'elemento.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+Il nome universale dell'elemento.
+
+**Returns:**
+java.lang.String
+### getReadOnly() {#getReadOnly--}
+```
+public BoolValue getReadOnly()
+```
+
+
+Determina se l'azione su uno smart tag o sul menu di scelta rapida è in sola lettura.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getSortKey() {#getSortKey--}
+```
+public Str2Value getSortKey()
+```
+
+
+Specifica un numero che determina l'ordine delle azioni che appaiono in un menu di scelta rapida o smart tag.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getTagName() {#getTagName--}
+```
+public Str2Value getTagName()
+```
+
+
+Contiene il nome del tag intelligente a cui è associata l'azione.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/act\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getID()](../../com.aspose.diagram/act\#getID--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getIX()](../../com.aspose.diagram/act\#getIX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getName()](../../com.aspose.diagram/act\#getName--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getNameU()](../../com.aspose.diagram/act\#getNameU--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/actcollection/_index.md
+++ b/italian/java/com.aspose.diagram/actcollection/_index.md
@@ -1,0 +1,234 @@
+---
+title: ActCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Collezione Act.
+type: docs
+weight: 12
+url: /it/java/com.aspose.diagram/actcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ActCollection extends Collection
+```
+
+Collezione Act.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [add(Act item)](#add-com.aspose.diagram.Act-) | Aggiungi l'oggetto Act nella collezione. |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getAct(int ID)](#getAct-int-) | Restituisce l'elemento con l'ID specificato. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Act item)](#remove-com.aspose.diagram.Act-) | Rimuovi l'oggetto Act dalla collezione. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Act item) {#add-com.aspose.diagram.Act-}
+```
+public int add(Act item)
+```
+
+
+Aggiungi l'oggetto Act nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [Act](../../com.aspose.diagram/act) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Act get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[Act](../../com.aspose.diagram/act) - 
+### getAct(int ID) {#getAct-int-}
+```
+public Act getAct(int ID)
+```
+
+
+Restituisce l'elemento con l'ID specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| ID | int |  |
+
+**Returns:**
+[Act](../../com.aspose.diagram/act) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Act item) {#remove-com.aspose.diagram.Act-}
+```
+public void remove(Act item)
+```
+
+
+Rimuovi l'oggetto Act dalla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [Act](../../com.aspose.diagram/act) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/activexcontrol/_index.md
+++ b/italian/java/com.aspose.diagram/activexcontrol/_index.md
@@ -1,0 +1,422 @@
+---
+title: ActiveXControl
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta il controllo ActiveX.
+type: docs
+weight: 13
+url: /it/java/com.aspose.diagram/activexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase)
+```
+public abstract class ActiveXControl extends ActiveXControlBase
+```
+
+Rappresenta il controllo ActiveX.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBackOleColor()](#getBackOleColor--) | il colore OLE dello sfondo. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | i dati binari del controllo. |
+| [getForeOleColor()](#getForeOleColor--) | il colore OLE del primo piano. |
+| [getHeight()](#getHeight--) | l'altezza del controllo in unità di punti. |
+| [getIMEMode()](#getIMEMode--) | la modalità di esecuzione predefinita dell'Input Method Editor per il controllo quando riceve il fuoco. |
+| [getMouseIcon()](#getMouseIcon--) | un'icona personalizzata da visualizzare come puntatore del mouse per il controllo. |
+| [getMousePointer()](#getMousePointer--) | il tipo di icona visualizzata come puntatore del mouse per il controllo. |
+| [getType()](#getType--) | Ottiene il tipo del controllo ActiveX. |
+| [getWidth()](#getWidth--) | la larghezza del controllo in unità di punti. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | Indica se il controllo ridimensionerà automaticamente per visualizzare tutto il contenuto. |
+| [isEnabled()](#isEnabled--) | Indica se il controllo può ricevere il focus e rispondere agli eventi generati dall'utente. |
+| [isLocked()](#isLocked--) | Indica se i dati nel controllo sono bloccati per la modifica. |
+| [isTransparent()](#isTransparent--) | Indica se il controllo è trasparente. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | Per la descrizione di questa proprietà, vedere [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | Per la descrizione di questa proprietà, vedere [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | Per la descrizione di questa proprietà, vedere [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | Per la descrizione di questa proprietà, vedere [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setHeight(double value)](#setHeight-double-) | Per la descrizione di questa proprietà, vedere [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setIMEMode(int value)](#setIMEMode-int-) | Per la descrizione di questa proprietà, vedere [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) |
+| [setLocked(boolean value)](#setLocked-boolean-) | Per la descrizione di questa proprietà, vedere [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | Per la descrizione di questa proprietà, vedere [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | Per la descrizione di questa proprietà, vedere [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | Per la descrizione di questa proprietà, vedere [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) |
+| [setWidth(double value)](#setWidth-double-) | Per la descrizione di questa proprietà, vedere [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+il colore OLE dello sfondo.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+i dati binari del controllo.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+Il colore OLE del primo piano. Non si applica al controllo Image.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+l'altezza del controllo in unità di punti.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+la modalità di esecuzione predefinita dell'Input Method Editor per il controllo quando riceve il fuoco.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+un'icona personalizzata da visualizzare come puntatore del mouse per il controllo.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+il tipo di icona visualizzata come puntatore del mouse per il controllo.
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public abstract int getType()
+```
+
+
+Ottiene il tipo del controllo ActiveX.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+la larghezza del controllo in unità di punti.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+Indica se il controllo ridimensionerà automaticamente per visualizzare tutto il contenuto.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+Indica se il controllo può ricevere il focus e rispondere agli eventi generati dall'utente.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+Indica se i dati nel controllo sono bloccati per la modifica.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+Indica se il controllo è trasparente.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/activexcontrolbase/_index.md
+++ b/italian/java/com.aspose.diagram/activexcontrolbase/_index.md
@@ -1,0 +1,297 @@
+---
+title: ActiveXControlBase
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta il controllo ActiveX.
+type: docs
+weight: 14
+url: /it/java/com.aspose.diagram/activexcontrolbase/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public abstract class ActiveXControlBase
+```
+
+Rappresenta il controllo ActiveX.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBackOleColor()](#getBackOleColor--) | il colore OLE dello sfondo. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | i dati binari del controllo. |
+| [getForeOleColor()](#getForeOleColor--) | il colore OLE del primo piano. |
+| [getHeight()](#getHeight--) | l'altezza del controllo in unità di punti. |
+| [getMouseIcon()](#getMouseIcon--) | un'icona personalizzata da visualizzare come puntatore del mouse per il controllo. |
+| [getMousePointer()](#getMousePointer--) | il tipo di icona visualizzata come puntatore del mouse per il controllo. |
+| [getType()](#getType--) | Ottiene il tipo del controllo ActiveX. |
+| [getWidth()](#getWidth--) | la larghezza del controllo in unità di punti. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | Per la descrizione di questa proprietà, vedere [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | Per la descrizione di questa proprietà, vedere [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setHeight(double value)](#setHeight-double-) | Per la descrizione di questa proprietà, vedere [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | Per la descrizione di questa proprietà, vedere [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | Per la descrizione di questa proprietà, vedere [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setWidth(double value)](#setWidth-double-) | Per la descrizione di questa proprietà, vedere [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+il colore OLE dello sfondo.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+i dati binari del controllo.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+Il colore OLE del primo piano. Non si applica al controllo Image.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+l'altezza del controllo in unità di punti.
+
+**Returns:**
+double
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+un'icona personalizzata da visualizzare come puntatore del mouse per il controllo.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+il tipo di icona visualizzata come puntatore del mouse per il controllo.
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public abstract int getType()
+```
+
+
+Ottiene il tipo del controllo ActiveX.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+la larghezza del controllo in unità di punti.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/activexpersistencetype/_index.md
+++ b/italian/java/com.aspose.diagram/activexpersistencetype/_index.md
@@ -1,0 +1,165 @@
+---
+title: ActiveXPersistenceType
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta il metodo di persistenza per mantenere un controllo ActiveX.
+type: docs
+weight: 15
+url: /it/java/com.aspose.diagram/activexpersistencetype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ActiveXPersistenceType
+```
+
+Rappresenta il metodo di persistenza per mantenere un controllo ActiveX.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [PROPERTY_BAG](#PROPERTY-BAG) | I dati sono memorizzati come dati XML. |
+| [STORAGE](#STORAGE) | I dati sono memorizzati come dati binari di archiviazione. |
+| [STREAM](#STREAM) | I dati sono memorizzati come dati binari di flusso. |
+| [STREAM_INIT](#STREAM-INIT) | I dati sono memorizzati come dati binari di streaminit. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PROPERTY_BAG {#PROPERTY-BAG}
+```
+public static final int PROPERTY_BAG
+```
+
+
+I dati sono memorizzati come dati XML.
+
+### STORAGE {#STORAGE}
+```
+public static final int STORAGE
+```
+
+
+I dati sono memorizzati come dati binari di archiviazione.
+
+### STREAM {#STREAM}
+```
+public static final int STREAM
+```
+
+
+I dati sono memorizzati come dati binari di flusso.
+
+### STREAM_INIT {#STREAM-INIT}
+```
+public static final int STREAM_INIT
+```
+
+
+I dati sono memorizzati come dati binari di streaminit.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/align/_index.md
+++ b/italian/java/com.aspose.diagram/align/_index.md
@@ -1,0 +1,227 @@
+---
+title: Align
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Indica l'allineamento di una forma rispetto alla guida o al punto guida a cui la forma è incollata.
+type: docs
+weight: 16
+url: /it/java/com.aspose.diagram/align/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Align
+```
+
+Indica l'allineamento di una forma rispetto alla guida o al punto guida a cui la forma è incollata. L'elemento Align appare solo per le forme che sono incollate a guide o punti guida.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAlignBottom()](#getAlignBottom--) | Determina la posizione verticale, rispetto all'origine del suo genitore, di una guida orizzontale o di un punto guida a cui è allineato il bordo inferiore della forma. |
+| [getAlignCenter()](#getAlignCenter--) | Determina la posizione orizzontale, rispetto all'origine del suo genitore, di una guida verticale o di un punto guida a cui è allineato il centro orizzontale della forma. |
+| [getAlignLeft()](#getAlignLeft--) | Determina la posizione orizzontale, rispetto all'origine del suo genitore, di una guida verticale o di un punto guida a cui è allineato il bordo sinistro della forma. |
+| [getAlignMiddle()](#getAlignMiddle--) | Determina la posizione verticale, relativa all'origine del suo genitore, di una guida orizzontale o punto guida a cui è allineato il centro verticale della forma. |
+| [getAlignRight()](#getAlignRight--) | Determina la posizione orizzontale, relativa all'origine del suo genitore, di una guida verticale o punto guida a cui è allineato il bordo destro della forma. |
+| [getAlignTop()](#getAlignTop--) | Determina la posizione verticale, relativa all'origine del suo genitore, di una guida orizzontale o punto guida a cui è allineato il bordo superiore della forma. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, consultare [getDel()](../../com.aspose.diagram/align\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAlignBottom() {#getAlignBottom--}
+```
+public DoubleValue getAlignBottom()
+```
+
+
+Determina la posizione verticale, rispetto all'origine del suo genitore, di una guida orizzontale o di un punto guida a cui è allineato il bordo inferiore della forma.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getAlignCenter() {#getAlignCenter--}
+```
+public DoubleValue getAlignCenter()
+```
+
+
+Determina la posizione orizzontale, rispetto all'origine del suo genitore, di una guida verticale o di un punto guida a cui è allineato il centro orizzontale della forma.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getAlignLeft() {#getAlignLeft--}
+```
+public DoubleValue getAlignLeft()
+```
+
+
+Determina la posizione orizzontale, rispetto all'origine del suo genitore, di una guida verticale o di un punto guida a cui è allineato il bordo sinistro della forma.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getAlignMiddle() {#getAlignMiddle--}
+```
+public DoubleValue getAlignMiddle()
+```
+
+
+Determina la posizione verticale, relativa all'origine del suo genitore, di una guida orizzontale o punto guida a cui è allineato il centro verticale della forma.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getAlignRight() {#getAlignRight--}
+```
+public DoubleValue getAlignRight()
+```
+
+
+Determina la posizione orizzontale, relativa all'origine del suo genitore, di una guida verticale o punto guida a cui è allineato il bordo destro della forma.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getAlignTop() {#getAlignTop--}
+```
+public DoubleValue getAlignTop()
+```
+
+
+Determina la posizione verticale, relativa all'origine del suo genitore, di una guida orizzontale o punto guida a cui è allineato il bordo superiore della forma.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getDel()](../../com.aspose.diagram/align\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/alignment/_index.md
+++ b/italian/java/com.aspose.diagram/alignment/_index.md
@@ -1,0 +1,179 @@
+---
+title: Alignment
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica l'allineamento della scheda.
+type: docs
+weight: 18
+url: /it/java/com.aspose.diagram/alignment/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Alignment
+```
+
+Specifica l'allineamento della scheda.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [Alignment(int value)](#Alignment-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Specifica l'allineamento della scheda. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, consultare [getValue()](../../com.aspose.diagram/alignment\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Alignment(int value) {#Alignment-int-}
+```
+public Alignment(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specifica l'allineamento della scheda.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getValue()](../../com.aspose.diagram/alignment\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/alignmentvalue/_index.md
+++ b/italian/java/com.aspose.diagram/alignmentvalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: AlignmentValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica l'allineamento della scheda.
+type: docs
+weight: 19
+url: /it/java/com.aspose.diagram/alignmentvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class AlignmentValue
+```
+
+Specifica l'allineamento della scheda.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [CENTER](#CENTER) | Centro. |
+| [DECIMAL](#DECIMAL) | Decimale. |
+| [LEFT](#LEFT) | Sinistra. |
+| [RIGHT](#RIGHT) | Destra. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CENTER {#CENTER}
+```
+public static final int CENTER
+```
+
+
+Centro.
+
+### DECIMAL {#DECIMAL}
+```
+public static final int DECIMAL
+```
+
+
+Decimale.
+
+### LEFT {#LEFT}
+```
+public static final int LEFT
+```
+
+
+Sinistra.
+
+### RIGHT {#RIGHT}
+```
+public static final int RIGHT
+```
+
+
+Destra.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/alignnamevalue/_index.md
+++ b/italian/java/com.aspose.diagram/alignnamevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: AlignNameValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: int opzionale.
+type: docs
+weight: 17
+url: /it/java/com.aspose.diagram/alignnamevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class AlignNameValue
+```
+
+int opzionale. Specifica se il testo del master nella finestra stencil è allineato a sinistra, a destra o al centro.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [ALIGN_TEXT_CENTER](#ALIGN-TEXT-CENTER) | Allinea il testo al centro. |
+| [ALIGN_TEXT_LEFT](#ALIGN-TEXT-LEFT) | Allinea il testo a sinistra. |
+| [ALIGN_TEXT_RIGHT](#ALIGN-TEXT-RIGHT) | Allinea il testo a destra. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALIGN_TEXT_CENTER {#ALIGN-TEXT-CENTER}
+```
+public static final int ALIGN_TEXT_CENTER
+```
+
+
+Allinea il testo al centro.
+
+### ALIGN_TEXT_LEFT {#ALIGN-TEXT-LEFT}
+```
+public static final int ALIGN_TEXT_LEFT
+```
+
+
+Allinea il testo a sinistra.
+
+### ALIGN_TEXT_RIGHT {#ALIGN-TEXT-RIGHT}
+```
+public static final int ALIGN_TEXT_RIGHT
+```
+
+
+Allinea il testo a destra.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/annotation/_index.md
+++ b/italian/java/com.aspose.diagram/annotation/_index.md
@@ -1,0 +1,288 @@
+---
+title: Annotazione
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene elementi che includono informazioni sui commenti inseriti in una pagina del documento.
+type: docs
+weight: 20
+url: /it/java/com.aspose.diagram/annotation/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Annotation
+```
+
+Contiene elementi che includono informazioni sui commenti inseriti in una pagina del documento.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getComment()](#getComment--) | Contiene il testo del commento in formato stringa per una forma. |
+| [getDate()](#getDate--) | specifica quando è stato creato un commento |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getEditDate()](#getEditDate--) | Specifica quando un commento è stato modificato l'ultima volta |
+| [getIX()](#getIX--) | L'indice basato su zero dell'elemento all'interno del suo elemento genitore. |
+| [getLangID()](#getLangID--) | Indica l'ID locale (LCID) della lingua in cui è stata inserita la formula della cella, il testo, la proprietà personalizzata o il commento. |
+| [getMarkerIndex()](#getMarkerIndex--) | Specifica il numero di indice assegnato a un marcatore di commento. |
+| [getReviewerID()](#getReviewerID--) | Contiene il numero ID del revisore che aggiunge markup al documento. |
+| [getShapeID()](#getShapeID--) | L'ID della forma del commento. |
+| [getX()](#getX--) | La coordinata x del marcatore di commento nelle coordinate della pagina. |
+| [getY()](#getY--) | La coordinata y del marcatore di commento nelle coordinate della pagina. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/annotation\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Per la descrizione di questa proprietà, vedere [getIX()](../../com.aspose.diagram/annotation\#getIX--) |
+| [setShapeID(int value)](#setShapeID-int-) | Per la descrizione di questa proprietà, vedere [getShapeID()](../../com.aspose.diagram/annotation\#getShapeID--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getComment() {#getComment--}
+```
+public Str2Value getComment()
+```
+
+
+Contiene il testo del commento in formato stringa per una forma.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getDate() {#getDate--}
+```
+public DateValue getDate()
+```
+
+
+specifica quando è stato creato un commento
+
+**Returns:**
+[DateValue](../../com.aspose.diagram/datevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getEditDate() {#getEditDate--}
+```
+public DateValue getEditDate()
+```
+
+
+Specifica quando un commento è stato modificato l'ultima volta
+
+**Returns:**
+[DateValue](../../com.aspose.diagram/datevalue)
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+L'indice basato su zero dell'elemento all'interno del suo elemento genitore.
+
+**Returns:**
+int
+### getLangID() {#getLangID--}
+```
+public IntValue getLangID()
+```
+
+
+Indica l'ID locale (LCID) della lingua in cui è stata inserita la formula della cella, il testo, la proprietà personalizzata o il commento.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getMarkerIndex() {#getMarkerIndex--}
+```
+public IntValue getMarkerIndex()
+```
+
+
+Specifica il numero di indice assegnato a un marcatore di commento.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getReviewerID() {#getReviewerID--}
+```
+public IntValue getReviewerID()
+```
+
+
+Contiene il numero ID del revisore che aggiunge markup al documento.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getShapeID() {#getShapeID--}
+```
+public int getShapeID()
+```
+
+
+L'ID della forma del commento.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+La coordinata x del marcatore di commento nelle coordinate della pagina.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+La coordinata y del marcatore di commento nelle coordinate della pagina.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/annotation\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getIX()](../../com.aspose.diagram/annotation\#getIX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setShapeID(int value) {#setShapeID-int-}
+```
+public void setShapeID(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getShapeID()](../../com.aspose.diagram/annotation\#getShapeID--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/annotationcollection/_index.md
+++ b/italian/java/com.aspose.diagram/annotationcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: AnnotationCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Collezione di annotazioni.
+type: docs
+weight: 21
+url: /it/java/com.aspose.diagram/annotationcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class AnnotationCollection extends Collection
+```
+
+Collezione di annotazioni.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [add(Annotation item)](#add-com.aspose.diagram.Annotation-) | Aggiungi l'oggetto Annotation nella collezione. |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Annotation item)](#remove-com.aspose.diagram.Annotation-) | Rimuovi l'oggetto Annotation dalla collezione. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Annotation item) {#add-com.aspose.diagram.Annotation-}
+```
+public int add(Annotation item)
+```
+
+
+Aggiungi l'oggetto Annotation nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [Annotation](../../com.aspose.diagram/annotation) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Annotation get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[Annotation](../../com.aspose.diagram/annotation) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Annotation item) {#remove-com.aspose.diagram.Annotation-}
+```
+public void remove(Annotation item)
+```
+
+
+Rimuovi l'oggetto Annotation dalla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [Annotation](../../com.aspose.diagram/annotation) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/arcto/_index.md
+++ b/italian/java/com.aspose.diagram/arcto/_index.md
@@ -1,0 +1,274 @@
+---
+title: ArcTo
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene le coordinate x e y e la curvatura di un arco circolare rappresentati rispettivamente dagli elementi X Y e A.
+type: docs
+weight: 22
+url: /it/java/com.aspose.diagram/arcto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class ArcTo extends Coordinate
+```
+
+Contiene le coordinate x e y e l'arco di un arco circolare rappresentati rispettivamente dagli elementi X, Y e A.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [ArcTo()](#ArcTo--) | Crea un'istanza della classe [ArcTo](../../com.aspose.diagram/arcto). |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | La distanza dal punto medio dell'arco al punto medio della sua corda. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getIX()](#getIX--) | L'indice basato su zero dell'elemento all'interno del suo elemento genitore. |
+| [getX()](#getX--) | La coordinata x del vertice finale di un arco. |
+| [getY()](#getY--) | La coordinata y del vertice finale di un arco. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getA()](../../com.aspose.diagram/arcto\#getA--) |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/arcto\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Per la descrizione di questa proprietà, vedere [getIX()](../../com.aspose.diagram/arcto\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getX()](../../com.aspose.diagram/arcto\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getY()](../../com.aspose.diagram/arcto\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ArcTo() {#ArcTo--}
+```
+public ArcTo()
+```
+
+
+Crea un'istanza della classe [ArcTo](../../com.aspose.diagram/arcto).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+La distanza dal punto medio dell'arco al punto medio della sua corda.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+L'indice basato su zero dell'elemento all'interno del suo elemento genitore.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+La coordinata x del vertice finale di un arco.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+La coordinata y del vertice finale di un arco.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getA()](../../com.aspose.diagram/arcto\#getA--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/arcto\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getIX()](../../com.aspose.diagram/arcto\#getIX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getX()](../../com.aspose.diagram/arcto\#getX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getY()](../../com.aspose.diagram/arcto\#getY--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/arctocollection/_index.md
+++ b/italian/java/com.aspose.diagram/arctocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: ArcToCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Collezione ArcTo.
+type: docs
+weight: 23
+url: /it/java/com.aspose.diagram/arctocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ArcToCollection extends Collection
+```
+
+Collezione ArcTo.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public ArcTo get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[ArcTo](../../com.aspose.diagram/arcto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/arrowsize/_index.md
+++ b/italian/java/com.aspose.diagram/arrowsize/_index.md
@@ -1,0 +1,204 @@
+---
+title: ArrowSize
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica la dimensione della punta della freccia della linea.
+type: docs
+weight: 24
+url: /it/java/com.aspose.diagram/arrowsize/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ArrowSize
+```
+
+Specifica la dimensione della punta della freccia della linea.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [ArrowSize(int value)](#ArrowSize-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Specifica la dimensione della punta della freccia della linea. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [isThemed()](#isThemed--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setThemed(boolean value)](#setThemed-boolean-) | Per la descrizione di questa proprietà, vedere [isThemed()](../../com.aspose.diagram/arrowsize\#isThemed--) |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/arrowsize\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ArrowSize(int value) {#ArrowSize-int-}
+```
+public ArrowSize(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specifica la dimensione della punta della freccia della linea.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### isThemed() {#isThemed--}
+```
+public boolean isThemed()
+```
+
+
+
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setThemed(boolean value) {#setThemed-boolean-}
+```
+public void setThemed(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isThemed()](../../com.aspose.diagram/arrowsize\#isThemed--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/arrowsize\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/arrowsizevalue/_index.md
+++ b/italian/java/com.aspose.diagram/arrowsizevalue/_index.md
@@ -1,0 +1,201 @@
+---
+title: ArrowSizeValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica la dimensione della punta della freccia della linea.
+type: docs
+weight: 25
+url: /it/java/com.aspose.diagram/arrowsizevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ArrowSizeValue
+```
+
+Specifica la dimensione della punta della freccia della linea.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [COLOSSAL](#COLOSSAL) | Colossale. |
+| [EXTRA_LARGE](#EXTRA-LARGE) | ExtraLarge. |
+| [JUMBO](#JUMBO) | Jumbo. |
+| [LARGE](#LARGE) | Grande. |
+| [MEDIUM](#MEDIUM) | Medio. |
+| [SMALL](#SMALL) | Piccolo. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+| [VERY_SMALL](#VERY-SMALL) | MoltoPiccolo. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### COLOSSAL {#COLOSSAL}
+```
+public static final int COLOSSAL
+```
+
+
+Colossale.
+
+### EXTRA_LARGE {#EXTRA-LARGE}
+```
+public static final int EXTRA_LARGE
+```
+
+
+ExtraLarge.
+
+### JUMBO {#JUMBO}
+```
+public static final int JUMBO
+```
+
+
+Jumbo.
+
+### LARGE {#LARGE}
+```
+public static final int LARGE
+```
+
+
+Grande.
+
+### MEDIUM {#MEDIUM}
+```
+public static final int MEDIUM
+```
+
+
+Medio.
+
+### SMALL {#SMALL}
+```
+public static final int SMALL
+```
+
+
+Piccolo.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### VERY_SMALL {#VERY-SMALL}
+```
+public static final int VERY_SMALL
+```
+
+
+MoltoPiccolo.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/asposediagramprintdocument/_index.md
+++ b/italian/java/com.aspose.diagram/asposediagramprintdocument/_index.md
@@ -1,0 +1,143 @@
+---
+title: AsposeDiagramPrintDocument
+second_title: Riferimento API di Aspose.Diagram per Java
+description: La sua versione della classe .NET PrintDocument che può essere passata a un modulo PrintPreviewDialog per stampare e visualizzare in anteprima un diagramma.
+type: docs
+weight: 26
+url: /it/java/com.aspose.diagram/asposediagramprintdocument/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class AsposeDiagramPrintDocument
+```
+
+È la propria versione della classe .NET PrintDocument che può essere passata a un modulo PrintPreviewDialog per stampare e visualizzare in anteprima un diagramma.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [AsposeDiagramPrintDocument(Diagram diagram)](#AsposeDiagramPrintDocument-com.aspose.diagram.Diagram-) | Inizializza una nuova istanza di questa classe che può essere passata a un modulo PrintPreviewDialog per stampare e visualizzare in anteprima un diagramma. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AsposeDiagramPrintDocument(Diagram diagram) {#AsposeDiagramPrintDocument-com.aspose.diagram.Diagram-}
+```
+public AsposeDiagramPrintDocument(Diagram diagram)
+```
+
+
+Inizializza una nuova istanza di questa classe che può essere passata a un modulo PrintPreviewDialog per stampare e visualizzare in anteprima un diagramma.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| diagram | [Diagram](../../com.aspose.diagram/diagram) |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/autolinkcomparison/_index.md
+++ b/italian/java/com.aspose.diagram/autolinkcomparison/_index.md
@@ -1,0 +1,200 @@
+---
+title: AutoLinkComparison
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Definisce una regola che confronta una colonna nell'elemento DataRecordset padre con un elemento dati di forma dell'ultima azione di collegamento automatico riuscita eseguita nell'interfaccia utente.
+type: docs
+weight: 27
+url: /it/java/com.aspose.diagram/autolinkcomparison/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class AutoLinkComparison
+```
+
+Definisce una regola che confronta una colonna nell'elemento DataRecordset padre con un elemento dati di forma dell'ultima azione di collegamento automatico riuscita eseguita nell'interfaccia utente.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getColumnName()](#getColumnName--) | Corrisponde a un nome di colonna nel recordset ADO. |
+| [getContextType()](#getContextType--) | Specifica le proprietà del gruppo o della forma da utilizzare per il confronto. |
+| [getContextTypeLabel()](#getContextTypeLabel--) | Se il valore ContextType è 2 o 3, questo attributo è obbligatorio per definire un confronto. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setColumnName(String value)](#setColumnName-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getColumnName()](../../com.aspose.diagram/autolinkcomparison\#getColumnName--) |
+| [setContextType(int value)](#setContextType-int-) | Per la descrizione di questa proprietà, vedere [getContextType()](../../com.aspose.diagram/autolinkcomparison\#getContextType--) |
+| [setContextTypeLabel(String value)](#setContextTypeLabel-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getContextTypeLabel()](../../com.aspose.diagram/autolinkcomparison\#getContextTypeLabel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColumnName() {#getColumnName--}
+```
+public String getColumnName()
+```
+
+
+Corrisponde a un nome di colonna nel recordset ADO.
+
+**Returns:**
+java.lang.String
+### getContextType() {#getContextType--}
+```
+public int getContextType()
+```
+
+
+Specifica le proprietà del gruppo o della forma da utilizzare per il confronto. I valori possibili sono mostrati nella tabella seguente.
+
+**Returns:**
+int
+### getContextTypeLabel() {#getContextTypeLabel--}
+```
+public String getContextTypeLabel()
+```
+
+
+Se il valore ContextType è 2 o 3, questo attributo è obbligatorio per definire un confronto. Per ContextType = 2, ContextTypeLabel deve essere l'etichetta dell'elemento dati della forma, e se ContextType = 3, ContextTypeLabel deve essere il nome della riga locale.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setColumnName(String value) {#setColumnName-java.lang.String-}
+```
+public void setColumnName(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getColumnName()](../../com.aspose.diagram/autolinkcomparison\#getColumnName--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setContextType(int value) {#setContextType-int-}
+```
+public void setContextType(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getContextType()](../../com.aspose.diagram/autolinkcomparison\#getContextType--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setContextTypeLabel(String value) {#setContextTypeLabel-java.lang.String-}
+```
+public void setContextTypeLabel(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getContextTypeLabel()](../../com.aspose.diagram/autolinkcomparison\#getContextTypeLabel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/autospaceoptions/_index.md
+++ b/italian/java/com.aspose.diagram/autospaceoptions/_index.md
@@ -1,0 +1,186 @@
+---
+title: AutoSpaceOptions
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta le opzioni di spaziatura automatica.
+type: docs
+weight: 28
+url: /it/java/com.aspose.diagram/autospaceoptions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class AutoSpaceOptions
+```
+
+Rappresenta le opzioni di spaziatura automatica.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [AutoSpaceOptions()](#AutoSpaceOptions--) |  |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDistanceInHorizontal()](#getDistanceInHorizontal--) | Definisce la distanza tra le forme nella direzione orizzontale in pollici. |
+| [getDistanceInVertical()](#getDistanceInVertical--) | Definisce la distanza tra le forme nella direzione verticale in pollici. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDistanceInHorizontal(double value)](#setDistanceInHorizontal-double-) | Per la descrizione di questa proprietà, consultare [getDistanceInHorizontal()](../../com.aspose.diagram/autospaceoptions\#getDistanceInHorizontal--) |
+| [setDistanceInVertical(double value)](#setDistanceInVertical-double-) | Per la descrizione di questa proprietà, consultare [getDistanceInVertical()](../../com.aspose.diagram/autospaceoptions\#getDistanceInVertical--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AutoSpaceOptions() {#AutoSpaceOptions--}
+```
+public AutoSpaceOptions()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDistanceInHorizontal() {#getDistanceInHorizontal--}
+```
+public double getDistanceInHorizontal()
+```
+
+
+Definisce la distanza tra le forme nella direzione orizzontale in pollici. Valore predefinito 0,375 pollice.
+
+**Returns:**
+double
+### getDistanceInVertical() {#getDistanceInVertical--}
+```
+public double getDistanceInVertical()
+```
+
+
+Definisce la distanza tra le forme nella direzione verticale in pollici. Valore predefinito 0,375 pollice.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDistanceInHorizontal(double value) {#setDistanceInHorizontal-double-}
+```
+public void setDistanceInHorizontal(double value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getDistanceInHorizontal()](../../com.aspose.diagram/autospaceoptions\#getDistanceInHorizontal--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double |  |
+
+### setDistanceInVertical(double value) {#setDistanceInVertical-double-}
+```
+public void setDistanceInVertical(double value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getDistanceInVertical()](../../com.aspose.diagram/autospaceoptions\#getDistanceInVertical--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/bevel/_index.md
+++ b/italian/java/com.aspose.diagram/bevel/_index.md
@@ -1,0 +1,175 @@
+---
+title: Bevel
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta una smussatura di una forma
+type: docs
+weight: 30
+url: /it/java/com.aspose.diagram/bevel/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Bevel
+```
+
+Rappresenta una smussatura di una forma
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getHeight()](#getHeight--) | l'altezza del bevel, o quanto è sopra la forma a cui è applicato. |
+| [getWidth()](#getWidth--) | la larghezza del bevel, o quanto è dentro la forma a cui è applicato. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setHeight(DoubleValue value)](#setHeight-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getHeight()](../../com.aspose.diagram/bevel\#getHeight--) |
+| [setWidth(DoubleValue value)](#setWidth-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getWidth()](../../com.aspose.diagram/bevel\#getWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getHeight() {#getHeight--}
+```
+public DoubleValue getHeight()
+```
+
+
+l'altezza del bevel, o quanto è sopra la forma a cui è applicato. In unità di punti.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getWidth() {#getWidth--}
+```
+public DoubleValue getWidth()
+```
+
+
+la larghezza del bevel, o quanto è dentro la forma a cui è applicato.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setHeight(DoubleValue value) {#setHeight-com.aspose.diagram.DoubleValue-}
+```
+public void setHeight(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getHeight()](../../com.aspose.diagram/bevel\#getHeight--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setWidth(DoubleValue value) {#setWidth-com.aspose.diagram.DoubleValue-}
+```
+public void setWidth(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getWidth()](../../com.aspose.diagram/bevel\#getWidth--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/bevellightingtype/_index.md
+++ b/italian/java/com.aspose.diagram/bevellightingtype/_index.md
@@ -1,0 +1,179 @@
+---
+title: BevelLightingType
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica il tipo di ombra per una forma.
+type: docs
+weight: 31
+url: /it/java/com.aspose.diagram/bevellightingtype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class BevelLightingType
+```
+
+Specifica il tipo di ombra per una forma.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [BevelLightingType(int value)](#BevelLightingType-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Specifica il tipo di smussatura. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, consultare [getValue()](../../com.aspose.diagram/bevellightingtype\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BevelLightingType(int value) {#BevelLightingType-int-}
+```
+public BevelLightingType(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specifica il tipo di smussatura.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getValue()](../../com.aspose.diagram/bevellightingtype\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/bevellightingtypevalue/_index.md
+++ b/italian/java/com.aspose.diagram/bevellightingtypevalue/_index.md
@@ -1,0 +1,381 @@
+---
+title: BevelLightingTypeValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta una luce predefinita a destra che può essere applicata a una forma
+type: docs
+weight: 32
+url: /it/java/com.aspose.diagram/bevellightingtypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class BevelLightingTypeValue
+```
+
+Rappresenta una luce predefinita a destra che può essere applicata a una forma
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [BALANCED](#BALANCED) | Balanced |
+| [BRIGHT_ROOM](#BRIGHT-ROOM) | Bright room |
+| [CHILLY](#CHILLY) | Chilly |
+| [CONTRASTING](#CONTRASTING) | Contrasting |
+| [FLAT](#FLAT) | Flat |
+| [FLOOD](#FLOOD) | Flood |
+| [FREEZING](#FREEZING) | Freezing |
+| [GLOW](#GLOW) | Glow |
+| [HARSH](#HARSH) | Harsh |
+| [LEGACY_FLAT_1](#LEGACY-FLAT-1) | LegacyFlat1 |
+| [LEGACY_FLAT_2](#LEGACY-FLAT-2) | LegacyFlat2 |
+| [LEGACY_FLAT_3](#LEGACY-FLAT-3) | LegacyFlat3 |
+| [LEGACY_FLAT_4](#LEGACY-FLAT-4) | LegacyFlat4 |
+| [LEGACY_HARSH_1](#LEGACY-HARSH-1) | LegacyHarsh1 |
+| [LEGACY_HARSH_2](#LEGACY-HARSH-2) | LegacyHarsh2 |
+| [LEGACY_HARSH_3](#LEGACY-HARSH-3) | LegacyHarsh3 |
+| [LEGACY_HARSH_4](#LEGACY-HARSH-4) | LegacyHarsh4 |
+| [LEGACY_NORMAL_1](#LEGACY-NORMAL-1) | LegacyNormal1 |
+| [LEGACY_NORMAL_2](#LEGACY-NORMAL-2) | LegacyNormal2 |
+| [LEGACY_NORMAL_3](#LEGACY-NORMAL-3) | LegacyNormal3 |
+| [LEGACY_NORMAL_4](#LEGACY-NORMAL-4) | LegacyNormal4 |
+| [MORNING](#MORNING) | Morning |
+| [SOFT](#SOFT) | Morbido |
+| [SUNRISE](#SUNRISE) | Alba |
+| [SUNSET](#SUNSET) | Tramonto |
+| [THREE_POINT](#THREE-POINT) | Tre punti |
+| [TWO_POINT](#TWO-POINT) | Due punti |
+| [UNDEFINED](#UNDEFINED) | Nessun impianto di luce. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BALANCED {#BALANCED}
+```
+public static final int BALANCED
+```
+
+
+Balanced
+
+### BRIGHT_ROOM {#BRIGHT-ROOM}
+```
+public static final int BRIGHT_ROOM
+```
+
+
+Bright room
+
+### CHILLY {#CHILLY}
+```
+public static final int CHILLY
+```
+
+
+Chilly
+
+### CONTRASTING {#CONTRASTING}
+```
+public static final int CONTRASTING
+```
+
+
+Contrasting
+
+### FLAT {#FLAT}
+```
+public static final int FLAT
+```
+
+
+Flat
+
+### FLOOD {#FLOOD}
+```
+public static final int FLOOD
+```
+
+
+Flood
+
+### FREEZING {#FREEZING}
+```
+public static final int FREEZING
+```
+
+
+Freezing
+
+### GLOW {#GLOW}
+```
+public static final int GLOW
+```
+
+
+Glow
+
+### HARSH {#HARSH}
+```
+public static final int HARSH
+```
+
+
+Harsh
+
+### LEGACY_FLAT_1 {#LEGACY-FLAT-1}
+```
+public static final int LEGACY_FLAT_1
+```
+
+
+LegacyFlat1
+
+### LEGACY_FLAT_2 {#LEGACY-FLAT-2}
+```
+public static final int LEGACY_FLAT_2
+```
+
+
+LegacyFlat2
+
+### LEGACY_FLAT_3 {#LEGACY-FLAT-3}
+```
+public static final int LEGACY_FLAT_3
+```
+
+
+LegacyFlat3
+
+### LEGACY_FLAT_4 {#LEGACY-FLAT-4}
+```
+public static final int LEGACY_FLAT_4
+```
+
+
+LegacyFlat4
+
+### LEGACY_HARSH_1 {#LEGACY-HARSH-1}
+```
+public static final int LEGACY_HARSH_1
+```
+
+
+LegacyHarsh1
+
+### LEGACY_HARSH_2 {#LEGACY-HARSH-2}
+```
+public static final int LEGACY_HARSH_2
+```
+
+
+LegacyHarsh2
+
+### LEGACY_HARSH_3 {#LEGACY-HARSH-3}
+```
+public static final int LEGACY_HARSH_3
+```
+
+
+LegacyHarsh3
+
+### LEGACY_HARSH_4 {#LEGACY-HARSH-4}
+```
+public static final int LEGACY_HARSH_4
+```
+
+
+LegacyHarsh4
+
+### LEGACY_NORMAL_1 {#LEGACY-NORMAL-1}
+```
+public static final int LEGACY_NORMAL_1
+```
+
+
+LegacyNormal1
+
+### LEGACY_NORMAL_2 {#LEGACY-NORMAL-2}
+```
+public static final int LEGACY_NORMAL_2
+```
+
+
+LegacyNormal2
+
+### LEGACY_NORMAL_3 {#LEGACY-NORMAL-3}
+```
+public static final int LEGACY_NORMAL_3
+```
+
+
+LegacyNormal3
+
+### LEGACY_NORMAL_4 {#LEGACY-NORMAL-4}
+```
+public static final int LEGACY_NORMAL_4
+```
+
+
+LegacyNormal4
+
+### MORNING {#MORNING}
+```
+public static final int MORNING
+```
+
+
+Morning
+
+### SOFT {#SOFT}
+```
+public static final int SOFT
+```
+
+
+Morbido
+
+### SUNRISE {#SUNRISE}
+```
+public static final int SUNRISE
+```
+
+
+Alba
+
+### SUNSET {#SUNSET}
+```
+public static final int SUNSET
+```
+
+
+Tramonto
+
+### THREE_POINT {#THREE-POINT}
+```
+public static final int THREE_POINT
+```
+
+
+Tre punti
+
+### TWO_POINT {#TWO-POINT}
+```
+public static final int TWO_POINT
+```
+
+
+Due punti
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Nessun impianto di luce.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/bevelmaterialtype/_index.md
+++ b/italian/java/com.aspose.diagram/bevelmaterialtype/_index.md
@@ -1,0 +1,179 @@
+---
+title: BevelMaterialType
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica il tipo di ombra per una forma.
+type: docs
+weight: 33
+url: /it/java/com.aspose.diagram/bevelmaterialtype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class BevelMaterialType
+```
+
+Specifica il tipo di ombra per una forma.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [BevelMaterialType(int value)](#BevelMaterialType-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Specifica il tipo di smussatura. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/bevelmaterialtype\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BevelMaterialType(int value) {#BevelMaterialType-int-}
+```
+public BevelMaterialType(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specifica il tipo di smussatura.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/bevelmaterialtype\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/bevelmaterialtypevalue/_index.md
+++ b/italian/java/com.aspose.diagram/bevelmaterialtypevalue/_index.md
@@ -1,0 +1,271 @@
+---
+title: BevelMaterialTypeValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Descrive l'aspetto della superficie di una forma.
+type: docs
+weight: 34
+url: /it/java/com.aspose.diagram/bevelmaterialtypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class BevelMaterialTypeValue
+```
+
+Descrive l'aspetto della superficie di una forma.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [CLEAR](#CLEAR) | Cancella |
+| [DARK_EDGE](#DARK-EDGE) | Bordo scuro |
+| [FLAT](#FLAT) | Flat |
+| [LEGACY_MATTE](#LEGACY-MATTE) | Matte legacy |
+| [LEGACY_METAL](#LEGACY-METAL) | Metal legacy |
+| [LEGACY_PLASTIC](#LEGACY-PLASTIC) | Plastic legacy |
+| [LEGACY_WIREFRAME](#LEGACY-WIREFRAME) | Wireframe legacy |
+| [MATTE](#MATTE) | Matte |
+| [METAL](#METAL) | Metallo |
+| [PLASTIC](#PLASTIC) | Plastica |
+| [POWDER](#POWDER) | Powder |
+| [SOFT_EDGE](#SOFT-EDGE) | Soft edge |
+| [SOFT_METAL](#SOFT-METAL) | Soft metal |
+| [TRANSLUCENT_POWDER](#TRANSLUCENT-POWDER) | Translucent powder |
+| [UNDEFINED](#UNDEFINED) |  |
+| [WARM_MATTE](#WARM-MATTE) | Warm matte |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CLEAR {#CLEAR}
+```
+public static final int CLEAR
+```
+
+
+Cancella
+
+### DARK_EDGE {#DARK-EDGE}
+```
+public static final int DARK_EDGE
+```
+
+
+Bordo scuro
+
+### FLAT {#FLAT}
+```
+public static final int FLAT
+```
+
+
+Flat
+
+### LEGACY_MATTE {#LEGACY-MATTE}
+```
+public static final int LEGACY_MATTE
+```
+
+
+Matte legacy
+
+### LEGACY_METAL {#LEGACY-METAL}
+```
+public static final int LEGACY_METAL
+```
+
+
+Metal legacy
+
+### LEGACY_PLASTIC {#LEGACY-PLASTIC}
+```
+public static final int LEGACY_PLASTIC
+```
+
+
+Plastic legacy
+
+### LEGACY_WIREFRAME {#LEGACY-WIREFRAME}
+```
+public static final int LEGACY_WIREFRAME
+```
+
+
+Wireframe legacy
+
+### MATTE {#MATTE}
+```
+public static final int MATTE
+```
+
+
+Matte
+
+### METAL {#METAL}
+```
+public static final int METAL
+```
+
+
+Metallo
+
+### PLASTIC {#PLASTIC}
+```
+public static final int PLASTIC
+```
+
+
+Plastica
+
+### POWDER {#POWDER}
+```
+public static final int POWDER
+```
+
+
+Powder
+
+### SOFT_EDGE {#SOFT-EDGE}
+```
+public static final int SOFT_EDGE
+```
+
+
+Soft edge
+
+### SOFT_METAL {#SOFT-METAL}
+```
+public static final int SOFT_METAL
+```
+
+
+Soft metal
+
+### TRANSLUCENT_POWDER {#TRANSLUCENT-POWDER}
+```
+public static final int TRANSLUCENT_POWDER
+```
+
+
+Translucent powder
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+### WARM_MATTE {#WARM-MATTE}
+```
+public static final int WARM_MATTE
+```
+
+
+Warm matte
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/bevelpresettype/_index.md
+++ b/italian/java/com.aspose.diagram/bevelpresettype/_index.md
@@ -1,0 +1,246 @@
+---
+title: BevelPresetType
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta un preset per un tipo di smussatura che può essere applicato a una forma in 3D.
+type: docs
+weight: 35
+url: /it/java/com.aspose.diagram/bevelpresettype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class BevelPresetType
+```
+
+Rappresenta un preset per un tipo di smussatura che può essere applicato a una forma in 3D.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [ANGLE](#ANGLE) | Angolo |
+| [ART_DECO](#ART-DECO) | Art déco |
+| [CIRCLE](#CIRCLE) | Cerchio |
+| [CONVEX](#CONVEX) | Convesso |
+| [COOL_SLANT](#COOL-SLANT) | Inclinazione fresca |
+| [CROSS](#CROSS) | Croce |
+| [DIVOT](#DIVOT) | Fossa |
+| [HARD_EDGE](#HARD-EDGE) | Bordo rigido |
+| [NONE](#NONE) | Nessuna smussatura |
+| [RELAXED_INSET](#RELAXED-INSET) | Rientro rilassato |
+| [RIBLET](#RIBLET) | Ribetto |
+| [SLOPE](#SLOPE) | Pendenza |
+| [SOFT_ROUND](#SOFT-ROUND) | Arrotondamento morbido |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ANGLE {#ANGLE}
+```
+public static final int ANGLE
+```
+
+
+Angolo
+
+### ART_DECO {#ART-DECO}
+```
+public static final int ART_DECO
+```
+
+
+Art déco
+
+### CIRCLE {#CIRCLE}
+```
+public static final int CIRCLE
+```
+
+
+Cerchio
+
+### CONVEX {#CONVEX}
+```
+public static final int CONVEX
+```
+
+
+Convesso
+
+### COOL_SLANT {#COOL-SLANT}
+```
+public static final int COOL_SLANT
+```
+
+
+Inclinazione fresca
+
+### CROSS {#CROSS}
+```
+public static final int CROSS
+```
+
+
+Croce
+
+### DIVOT {#DIVOT}
+```
+public static final int DIVOT
+```
+
+
+Fossa
+
+### HARD_EDGE {#HARD-EDGE}
+```
+public static final int HARD_EDGE
+```
+
+
+Bordo rigido
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Nessuna smussatura
+
+### RELAXED_INSET {#RELAXED-INSET}
+```
+public static final int RELAXED_INSET
+```
+
+
+Rientro rilassato
+
+### RIBLET {#RIBLET}
+```
+public static final int RIBLET
+```
+
+
+Ribetto
+
+### SLOPE {#SLOPE}
+```
+public static final int SLOPE
+```
+
+
+Pendenza
+
+### SOFT_ROUND {#SOFT-ROUND}
+```
+public static final int SOFT_ROUND
+```
+
+
+Arrotondamento morbido
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/beveltype/_index.md
+++ b/italian/java/com.aspose.diagram/beveltype/_index.md
@@ -1,0 +1,179 @@
+---
+title: BevelType
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica il tipo di ombra per una forma.
+type: docs
+weight: 36
+url: /it/java/com.aspose.diagram/beveltype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class BevelType
+```
+
+Specifica il tipo di ombra per una forma.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [BevelType(int value)](#BevelType-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Specifica il tipo di smussatura. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/beveltype\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BevelType(int value) {#BevelType-int-}
+```
+public BevelType(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specifica il tipo di smussatura.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/beveltype\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/beveltypevalue/_index.md
+++ b/italian/java/com.aspose.diagram/beveltypevalue/_index.md
@@ -1,0 +1,255 @@
+---
+title: BevelTypeValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta un preset per un tipo di smussatura che può essere applicato a una forma in 3D.
+type: docs
+weight: 37
+url: /it/java/com.aspose.diagram/beveltypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class BevelTypeValue
+```
+
+Rappresenta un preset per un tipo di smussatura che può essere applicato a una forma in 3D.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [ANGLE](#ANGLE) | Angolo |
+| [ART_DECO](#ART-DECO) | Art déco |
+| [CIRCLE](#CIRCLE) | Cerchio |
+| [CONVEX](#CONVEX) | Convesso |
+| [COOL_SLANT](#COOL-SLANT) | Inclinazione fresca |
+| [CROSS](#CROSS) | Croce |
+| [DIVOT](#DIVOT) | Fossa |
+| [HARD_EDGE](#HARD-EDGE) | Bordo rigido |
+| [NONE](#NONE) | Nessuna smussatura |
+| [RELAXED_INSET](#RELAXED-INSET) | Rientro rilassato |
+| [RIBLET](#RIBLET) | Ribetto |
+| [SLOPE](#SLOPE) | Pendenza |
+| [SOFT_ROUND](#SOFT-ROUND) | Arrotondamento morbido |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ANGLE {#ANGLE}
+```
+public static final int ANGLE
+```
+
+
+Angolo
+
+### ART_DECO {#ART-DECO}
+```
+public static final int ART_DECO
+```
+
+
+Art déco
+
+### CIRCLE {#CIRCLE}
+```
+public static final int CIRCLE
+```
+
+
+Cerchio
+
+### CONVEX {#CONVEX}
+```
+public static final int CONVEX
+```
+
+
+Convesso
+
+### COOL_SLANT {#COOL-SLANT}
+```
+public static final int COOL_SLANT
+```
+
+
+Inclinazione fresca
+
+### CROSS {#CROSS}
+```
+public static final int CROSS
+```
+
+
+Croce
+
+### DIVOT {#DIVOT}
+```
+public static final int DIVOT
+```
+
+
+Fossa
+
+### HARD_EDGE {#HARD-EDGE}
+```
+public static final int HARD_EDGE
+```
+
+
+Bordo rigido
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Nessuna smussatura
+
+### RELAXED_INSET {#RELAXED-INSET}
+```
+public static final int RELAXED_INSET
+```
+
+
+Rientro rilassato
+
+### RIBLET {#RIBLET}
+```
+public static final int RIBLET
+```
+
+
+Ribetto
+
+### SLOPE {#SLOPE}
+```
+public static final int SLOPE
+```
+
+
+Pendenza
+
+### SOFT_ROUND {#SOFT-ROUND}
+```
+public static final int SOFT_ROUND
+```
+
+
+Arrotondamento morbido
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/bool/_index.md
+++ b/italian/java/com.aspose.diagram/bool/_index.md
@@ -1,0 +1,156 @@
+---
+title: BOOL
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Booleano.
+type: docs
+weight: 29
+url: /it/java/com.aspose.diagram/bool/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class BOOL
+```
+
+Booleano.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [FALSE](#FALSE) | Falso. |
+| [TRUE](#TRUE) | Vero. |
+| [UNDEFINED](#UNDEFINED) | Stato non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FALSE {#FALSE}
+```
+public static final int FALSE
+```
+
+
+Falso.
+
+### TRUE {#TRUE}
+```
+public static final int TRUE
+```
+
+
+Vero.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Stato non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/boolvalue/_index.md
+++ b/italian/java/com.aspose.diagram/boolvalue/_index.md
@@ -1,0 +1,230 @@
+---
+title: BoolValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Valore booleano.
+type: docs
+weight: 38
+url: /it/java/com.aspose.diagram/boolvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class BoolValue
+```
+
+Valore booleano.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [BoolValue(int value, int unit)](#BoolValue-int-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Attributi di un elemento. |
+| [getValue()](#getValue--) | Valore booleano |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [isThemed()](#isThemed--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setThemed(boolean value)](#setThemed-boolean-) | Per la descrizione di questa proprietà, consultare [isThemed()](../../com.aspose.diagram/boolvalue\#isThemed--) |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | Per la descrizione di questa proprietà, vedere [getUfe()](../../com.aspose.diagram/boolvalue\#getUfe--) |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/boolvalue\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BoolValue(int value, int unit) {#BoolValue-int-int-}
+```
+public BoolValue(int value, int unit)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+| unità | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Valore booleano
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### isThemed() {#isThemed--}
+```
+public boolean isThemed()
+```
+
+
+
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setThemed(boolean value) {#setThemed-boolean-}
+```
+public void setThemed(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [isThemed()](../../com.aspose.diagram/boolvalue\#isThemed--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getUfe()](../../com.aspose.diagram/boolvalue\#getUfe--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/boolvalue\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/bullet/_index.md
+++ b/italian/java/com.aspose.diagram/bullet/_index.md
@@ -1,0 +1,179 @@
+---
+title: Bullet
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Determina lo stile del punto elenco.
+type: docs
+weight: 39
+url: /it/java/com.aspose.diagram/bullet/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Bullet
+```
+
+Determina lo stile del punto elenco.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [Bullet(int value)](#Bullet-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Determina lo stile del punto elenco. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, consultare [getValue()](../../com.aspose.diagram/bullet\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Bullet(int value) {#Bullet-int-}
+```
+public Bullet(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Determina lo stile del punto elenco.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getValue()](../../com.aspose.diagram/bullet\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/bulletvalue/_index.md
+++ b/italian/java/com.aspose.diagram/bulletvalue/_index.md
@@ -1,0 +1,210 @@
+---
+title: BulletValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Determina lo stile del punto elenco.
+type: docs
+weight: 40
+url: /it/java/com.aspose.diagram/bulletvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class BulletValue
+```
+
+Determina lo stile del punto elenco.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [NONE](#NONE) | None. |
+| [STYLE_1](#STYLE-1) | Punto. |
+| [STYLE_2](#STYLE-2) | Rombo. |
+| [STYLE_3](#STYLE-3) | Quadrato. |
+| [STYLE_4](#STYLE-4) | Grande quadrato. |
+| [STYLE_5](#STYLE-5) | Rombi. |
+| [STYLE_6](#STYLE-6) | Arrow. |
+| [STYLE_7](#STYLE-7) | Spunta. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+None.
+
+### STYLE_1 {#STYLE-1}
+```
+public static final int STYLE_1
+```
+
+
+Punto.
+
+### STYLE_2 {#STYLE-2}
+```
+public static final int STYLE_2
+```
+
+
+Rombo.
+
+### STYLE_3 {#STYLE-3}
+```
+public static final int STYLE_3
+```
+
+
+Quadrato.
+
+### STYLE_4 {#STYLE-4}
+```
+public static final int STYLE_4
+```
+
+
+Grande quadrato.
+
+### STYLE_5 {#STYLE-5}
+```
+public static final int STYLE_5
+```
+
+
+Rombi.
+
+### STYLE_6 {#STYLE-6}
+```
+public static final int STYLE_6
+```
+
+
+Arrow.
+
+### STYLE_7 {#STYLE-7}
+```
+public static final int STYLE_7
+```
+
+
+Spunta.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/calendar/_index.md
+++ b/italian/java/com.aspose.diagram/calendar/_index.md
@@ -1,0 +1,204 @@
+---
+title: Calendar
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Determina il calendario utilizzato per i campi di testo delle proprietà personalizzate e le formule degli elementi.
+type: docs
+weight: 41
+url: /it/java/com.aspose.diagram/calendar/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Calendar
+```
+
+Determina il calendario utilizzato per le proprietà personalizzate, i campi di testo e le formule degli elementi.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [Calendar(int value)](#Calendar-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Determina il calendario utilizzato per le proprietà personalizzate, i campi di testo e le formule degli elementi. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | Per la descrizione di questa proprietà, vedere [getUfe()](../../com.aspose.diagram/calendar\#getUfe--) |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/calendar\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Calendar(int value) {#Calendar-int-}
+```
+public Calendar(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Determina il calendario utilizzato per le proprietà personalizzate, i campi di testo e le formule degli elementi.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getUfe()](../../com.aspose.diagram/calendar\#getUfe--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/calendar\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/calendarvalue/_index.md
+++ b/italian/java/com.aspose.diagram/calendarvalue/_index.md
@@ -1,0 +1,228 @@
+---
+title: CalendarValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Determina il calendario utilizzato per i campi di testo delle proprietà personalizzate e le formule degli elementi.
+type: docs
+weight: 42
+url: /it/java/com.aspose.diagram/calendarvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class CalendarValue
+```
+
+Determina il calendario utilizzato per le proprietà personalizzate, i campi di testo e le formule degli elementi.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [ARABIC_HIJIRI](#ARABIC-HIJIRI) | Arabic hijiri. |
+| [ENGLISH_TRANSLITERATED](#ENGLISH-TRANSLITERATED) | English Transliterated. |
+| [FRENCH_TRANSLITERATED](#FRENCH-TRANSLITERATED) | French Transliterated. |
+| [HEBREW_LUNAR](#HEBREW-LUNAR) | Hebrew lunar. |
+| [JAPANESE_EMPEROR_REIGN](#JAPANESE-EMPEROR-REIGN) | Japanese Emperor Reign. |
+| [KOREAN_DANKI](#KOREAN-DANKI) | Korean Danki. |
+| [SAKA_ERA](#SAKA-ERA) | Saka Era. |
+| [TAIWAN_CALENDAR](#TAIWAN-CALENDAR) | Taiwan calendar. |
+| [THAI_BUDDHIST](#THAI-BUDDHIST) | Thai Buddhist. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+| [WESTERN](#WESTERN) | Western. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ARABIC_HIJIRI {#ARABIC-HIJIRI}
+```
+public static final int ARABIC_HIJIRI
+```
+
+
+Arabic hijiri.
+
+### ENGLISH_TRANSLITERATED {#ENGLISH-TRANSLITERATED}
+```
+public static final int ENGLISH_TRANSLITERATED
+```
+
+
+English Transliterated.
+
+### FRENCH_TRANSLITERATED {#FRENCH-TRANSLITERATED}
+```
+public static final int FRENCH_TRANSLITERATED
+```
+
+
+French Transliterated.
+
+### HEBREW_LUNAR {#HEBREW-LUNAR}
+```
+public static final int HEBREW_LUNAR
+```
+
+
+Hebrew lunar.
+
+### JAPANESE_EMPEROR_REIGN {#JAPANESE-EMPEROR-REIGN}
+```
+public static final int JAPANESE_EMPEROR_REIGN
+```
+
+
+Japanese Emperor Reign.
+
+### KOREAN_DANKI {#KOREAN-DANKI}
+```
+public static final int KOREAN_DANKI
+```
+
+
+Korean Danki.
+
+### SAKA_ERA {#SAKA-ERA}
+```
+public static final int SAKA_ERA
+```
+
+
+Saka Era.
+
+### TAIWAN_CALENDAR {#TAIWAN-CALENDAR}
+```
+public static final int TAIWAN_CALENDAR
+```
+
+
+Taiwan calendar.
+
+### THAI_BUDDHIST {#THAI-BUDDHIST}
+```
+public static final int THAI_BUDDHIST
+```
+
+
+Thai Buddhist.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### WESTERN {#WESTERN}
+```
+public static final int WESTERN
+```
+
+
+Western.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/case/_index.md
+++ b/italian/java/com.aspose.diagram/case/_index.md
@@ -1,0 +1,204 @@
+---
+title: Case
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Determina il caso del testo di una forma.
+type: docs
+weight: 43
+url: /it/java/com.aspose.diagram/case/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Case
+```
+
+Determina il maiuscolo/minuscolo del testo di una forma.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [Case(int value)](#Case-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Determina il maiuscolo/minuscolo del testo di una forma. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | Per la descrizione di questa proprietà, vedere [getUfe()](../../com.aspose.diagram/case\#getUfe--) |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/case\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Case(int value) {#Case-int-}
+```
+public Case(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Determina il maiuscolo/minuscolo del testo di una forma.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getUfe()](../../com.aspose.diagram/case\#getUfe--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/case\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/casevalue/_index.md
+++ b/italian/java/com.aspose.diagram/casevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: CaseValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Determina il caso del testo di una forma.
+type: docs
+weight: 44
+url: /it/java/com.aspose.diagram/casevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class CaseValue
+```
+
+Determina il caso del testo di una forma. Tutte le lettere maiuscole (uppercase) (1) e le lettere iniziali maiuscole (2) non modificano l'aspetto del testo inserito interamente in maiuscolo. Il testo deve essere inserito in lettere minuscole affinché queste opzioni abbiano effetto.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [ALL_CAPITAL_LETTERS](#ALL-CAPITAL-LETTERS) | Tutte le lettere maiuscole (uppercase). |
+| [INITIAL_CAPITAL_LETTERS_ONLY](#INITIAL-CAPITAL-LETTERS-ONLY) | Solo lettere iniziali maiuscole. |
+| [NORMAL_CASE](#NORMAL-CASE) | Caso normale. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALL_CAPITAL_LETTERS {#ALL-CAPITAL-LETTERS}
+```
+public static final int ALL_CAPITAL_LETTERS
+```
+
+
+Tutte le lettere maiuscole (uppercase).
+
+### INITIAL_CAPITAL_LETTERS_ONLY {#INITIAL-CAPITAL-LETTERS-ONLY}
+```
+public static final int INITIAL_CAPITAL_LETTERS_ONLY
+```
+
+
+Solo lettere iniziali maiuscole.
+
+### NORMAL_CASE {#NORMAL-CASE}
+```
+public static final int NORMAL_CASE
+```
+
+
+Caso normale.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/char/_index.md
+++ b/italian/java/com.aspose.diagram/char/_index.md
@@ -1,0 +1,937 @@
+---
+title: Char
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene gli attributi di formattazione per il testo delle forme, come colore del carattere, stile del testo, maiuscole/minuscole, posizione relativa alla linea di base e dimensione in punti.
+type: docs
+weight: 45
+url: /it/java/com.aspose.diagram/char/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Char
+```
+
+Contiene gli attributi di formattazione per il testo della forma, come carattere, colore, stile del testo, maiuscolo/minuscolo, posizione relativa alla linea di base e dimensione in punti.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [Char()](#Char--) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAsianFont()](#getAsianFont--) | Specifica il numero ID del carattere utilizzato per formattare il testo contenente caratteri asiatici. |
+| [getAsianFontName()](#getAsianFontName--) | Specifica il nome del carattere asiatico del carattere usato per formattare il testo. È utilizzato per Visio 2013. |
+| [getCase()](#getCase--) | Determina il maiuscolo/minuscolo del testo di una forma. |
+| [getClass()](#getClass--) |  |
+| [getColor()](#getColor--) | Quando è contenuto in un elemento Char, l'elemento Color. |
+| [getColorTrans()](#getColorTrans--) | Determina il grado di trasparenza del colore del testo di un livello o di una forma, da 0 (completamente opaco) a 1 (completamente trasparente). |
+| [getComplexScriptFont()](#getComplexScriptFont--) | Contiene il numero del carattere utilizzato per formattare il testo composto da caratteri di script complessi. |
+| [getComplexScriptFontName()](#getComplexScriptFontName--) | Specifica il nome del carattere ComplexScript del carattere usato per formattare il testo. È utilizzato per Visio 2013. |
+| [getComplexScriptSize()](#getComplexScriptSize--) | La dimensione del carattere utilizzato per formattare il testo composto da caratteri di script complessi. |
+| [getDblUnderline()](#getDblUnderline--) | Specifica se l'intervallo di testo ha una doppia sottolineatura sotto di esso. |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getDoubleStrikethrough()](#getDoubleStrikethrough--) | Determina se il testo è formattato con doppia barratura. |
+| [getFont()](#getFont--) | Specifica il numero ID del carattere usato per formattare il testo. |
+| [getFontName()](#getFontName--) | Specifica il nome del carattere usato per formattare il testo. È utilizzato per Visio 2013 |
+| [getFontScale()](#getFontScale--) | Specifica la larghezza del carattere. |
+| [getHighlight()](#getHighlight--) | Specifica l'evidenziazione. |
+| [getIX()](#getIX--) | L'indice basato su zero dell'elemento all'interno del suo elemento genitore. |
+| [getLangID()](#getLangID--) | Indica l'ID locale (LCID) della lingua in cui è stata inserita la formula della cella, il testo, la proprietà personalizzata o il commento. |
+| [getLetterspace()](#getLetterspace--) | Specifica la quantità di spazio tra due o più caratteri. |
+| [getLocale()](#getLocale--) | Specifica la localizzazione dell'intervallo di testo per scopi di correzione ortografica. |
+| [getLocalizeFont()](#getLocalizeFont--) | Specifica se il testo della forma deve essere localizzato (tradotto in un'altra lingua). |
+| [getOverline()](#getOverline--) | Specifica se il testo ha una linea sopra di esso. |
+| [getPerpendicular()](#getPerpendicular--) | Specifica se un campo di testo appare perpendicolare al resto del testo in un blocco di testo. |
+| [getPos()](#getPos--) | Specifica la posizione del testo della forma rispetto alla linea di base. |
+| [getRTLText()](#getRTLText--) | Determina se la direzione del testo dell'intervallo di caratteri corrente è da sinistra a destra o da destra a sinistra. |
+| [getSize()](#getSize--) | Specifica la dimensione del testo nel blocco di testo della forma. |
+| [getStrikethru()](#getStrikethru--) | Specifica se il testo è formattato con barratura. |
+| [getStyle()](#getStyle--) | Specifica la formattazione dei caratteri applicata a un intervallo di testo nel blocco di testo della forma. |
+| [getUseVertical()](#getUseVertical--) | Determina se l'intervallo di caratteri è verticale o orizzontale. |
+| [hashCode()](#hashCode--) |  |
+| [isBold()](#isBold--) | Indica se il carattere è in grassetto. |
+| [isDoubleStrikethrough()](#isDoubleStrikethrough--) | Indica se il carattere ha doppia barratura. |
+| [isDoubleUnderline()](#isDoubleUnderline--) | Indica se il carattere ha doppia sottolineatura. |
+| [isItalic()](#isItalic--) | Indica se il carattere è in corsivo. |
+| [isStrikethrough()](#isStrikethrough--) | Indica se il carattere è barrato. |
+| [isSubscript()](#isSubscript--) | Indica se il carattere è pedice. |
+| [isSuperscript()](#isSuperscript--) | Indica se il carattere è apice. |
+| [isUnderline()](#isUnderline--) | Indica se il carattere è sottolineato. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAsianFont(IntValue value)](#setAsianFont-com.aspose.diagram.IntValue-) | Per la descrizione di questa proprietà, vedere [getAsianFont()](../../com.aspose.diagram/char\#getAsianFont--) |
+| [setAsianFontName(StrValue value)](#setAsianFontName-com.aspose.diagram.StrValue-) | Per la descrizione di questa proprietà, vedere [getAsianFontName()](../../com.aspose.diagram/char\#getAsianFontName--) |
+| [setCase(Case value)](#setCase-com.aspose.diagram.Case-) | Per la descrizione di questa proprietà, vedere [getCase()](../../com.aspose.diagram/char\#getCase--) |
+| [setColor(ColorValue value)](#setColor-com.aspose.diagram.ColorValue-) | Per la descrizione di questa proprietà, vedere [getColor()](../../com.aspose.diagram/char\#getColor--) |
+| [setColorTrans(DoubleValue value)](#setColorTrans-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getColorTrans()](../../com.aspose.diagram/char\#getColorTrans--) |
+| [setComplexScriptFont(IntValue value)](#setComplexScriptFont-com.aspose.diagram.IntValue-) | Per la descrizione di questa proprietà, vedere [getComplexScriptFont()](../../com.aspose.diagram/char\#getComplexScriptFont--) |
+| [setComplexScriptFontName(StrValue value)](#setComplexScriptFontName-com.aspose.diagram.StrValue-) | Per la descrizione di questa proprietà, vedere [getComplexScriptFontName()](../../com.aspose.diagram/char\#getComplexScriptFontName--) |
+| [setComplexScriptSize(DoubleValue value)](#setComplexScriptSize-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getComplexScriptSize()](../../com.aspose.diagram/char\#getComplexScriptSize--) |
+| [setDblUnderline(BoolValue value)](#setDblUnderline-com.aspose.diagram.BoolValue-) | Per la descrizione di questa proprietà, vedere [getDblUnderline()](../../com.aspose.diagram/char\#getDblUnderline--) |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/char\#getDel--) |
+| [setDoubleStrikethrough(BoolValue value)](#setDoubleStrikethrough-com.aspose.diagram.BoolValue-) | Per la descrizione di questa proprietà, vedere [getDoubleStrikethrough()](../../com.aspose.diagram/char\#getDoubleStrikethrough--) |
+| [setFont(IntValue value)](#setFont-com.aspose.diagram.IntValue-) | Per la descrizione di questa proprietà, vedere [getFont()](../../com.aspose.diagram/char\#getFont--) |
+| [setFontName(StrValue value)](#setFontName-com.aspose.diagram.StrValue-) | Per la descrizione di questa proprietà, vedere [getFontName()](../../com.aspose.diagram/char\#getFontName--) |
+| [setFontScale(DoubleValue value)](#setFontScale-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getFontScale()](../../com.aspose.diagram/char\#getFontScale--) |
+| [setHighlight(BoolValue value)](#setHighlight-com.aspose.diagram.BoolValue-) | Per la descrizione di questa proprietà, vedere [getHighlight()](../../com.aspose.diagram/char\#getHighlight--) |
+| [setIX(int value)](#setIX-int-) | Per la descrizione di questa proprietà, vedere [getIX()](../../com.aspose.diagram/char\#getIX--) |
+| [setLangID(IntValue value)](#setLangID-com.aspose.diagram.IntValue-) | Per la descrizione di questa proprietà, vedere [getLangID()](../../com.aspose.diagram/char\#getLangID--) |
+| [setLetterspace(DoubleValue value)](#setLetterspace-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getLetterspace()](../../com.aspose.diagram/char\#getLetterspace--) |
+| [setLocale(StrValue value)](#setLocale-com.aspose.diagram.StrValue-) | Per la descrizione di questa proprietà, vedere [getLocale()](../../com.aspose.diagram/char\#getLocale--) |
+| [setLocalizeFont(LocalizeFont value)](#setLocalizeFont-com.aspose.diagram.LocalizeFont-) | Per la descrizione di questa proprietà, vedere [getLocalizeFont()](../../com.aspose.diagram/char\#getLocalizeFont--) |
+| [setOverline(BoolValue value)](#setOverline-com.aspose.diagram.BoolValue-) | Per la descrizione di questa proprietà, vedere [getOverline()](../../com.aspose.diagram/char\#getOverline--) |
+| [setPerpendicular(StrValue value)](#setPerpendicular-com.aspose.diagram.StrValue-) | Per la descrizione di questa proprietà, vedere [getPerpendicular()](../../com.aspose.diagram/char\#getPerpendicular--) |
+| [setPos(Pos value)](#setPos-com.aspose.diagram.Pos-) | Per la descrizione di questa proprietà, vedere [getPos()](../../com.aspose.diagram/char\#getPos--) |
+| [setRTLText(BoolValue value)](#setRTLText-com.aspose.diagram.BoolValue-) | Per la descrizione di questa proprietà, vedere [getRTLText()](../../com.aspose.diagram/char\#getRTLText--) |
+| [setSize(DoubleValue value)](#setSize-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getSize()](../../com.aspose.diagram/char\#getSize--) |
+| [setStrikethru(BoolValue value)](#setStrikethru-com.aspose.diagram.BoolValue-) | Per la descrizione di questa proprietà, vedere [getStrikethru()](../../com.aspose.diagram/char\#getStrikethru--) |
+| [setStyle(Style value)](#setStyle-com.aspose.diagram.Style-) | Per la descrizione di questa proprietà, vedere [getStyle()](../../com.aspose.diagram/char\#getStyle--) |
+| [setUseVertical(BoolValue value)](#setUseVertical-com.aspose.diagram.BoolValue-) | Per la descrizione di questa proprietà, vedere [getUseVertical()](../../com.aspose.diagram/char\#getUseVertical--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Char() {#Char--}
+```
+public Char()
+```
+
+
+Costruttore.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAsianFont() {#getAsianFont--}
+```
+public IntValue getAsianFont()
+```
+
+
+Specifica il numero ID del carattere utilizzato per formattare il testo contenente caratteri asiatici.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getAsianFontName() {#getAsianFontName--}
+```
+public StrValue getAsianFontName()
+```
+
+
+Specifica il nome del carattere asiatico del carattere usato per formattare il testo. È utilizzato per Visio 2013.
+
+**Returns:**
+[StrValue](../../com.aspose.diagram/strvalue)
+### getCase() {#getCase--}
+```
+public Case getCase()
+```
+
+
+Determina il maiuscolo/minuscolo del testo di una forma.
+
+**Returns:**
+[Case](../../com.aspose.diagram/case)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColor() {#getColor--}
+```
+public ColorValue getColor()
+```
+
+
+Quando è contenuto in un elemento Char, l'elemento Color.
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getColorTrans() {#getColorTrans--}
+```
+public DoubleValue getColorTrans()
+```
+
+
+Determina il grado di trasparenza del colore del testo di un livello o di una forma, da 0 (completamente opaco) a 1 (completamente trasparente).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getComplexScriptFont() {#getComplexScriptFont--}
+```
+public IntValue getComplexScriptFont()
+```
+
+
+Contiene il numero del font utilizzato per formattare il testo composto da caratteri di script complessi. Gli script complessi sono lingue i cui caratteri richiedono legature o modellazione, come le lingue da destra a sinistra (arabo, farsi, ebraico e urdu) e diverse lingue dell'Asia meridionale.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getComplexScriptFontName() {#getComplexScriptFontName--}
+```
+public StrValue getComplexScriptFontName()
+```
+
+
+Specifica il nome del carattere ComplexScript del carattere usato per formattare il testo. È utilizzato per Visio 2013.
+
+**Returns:**
+[StrValue](../../com.aspose.diagram/strvalue)
+### getComplexScriptSize() {#getComplexScriptSize--}
+```
+public DoubleValue getComplexScriptSize()
+```
+
+
+La dimensione del carattere usata per formattare il testo composto da caratteri di script complessi. Gli script complessi sono lingue i cui caratteri richiedono legature o modellazione, come le lingue da destra a sinistra (arabo, farsi, ebraico e urdu) e diverse lingue dell'Asia meridionale.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDblUnderline() {#getDblUnderline--}
+```
+public BoolValue getDblUnderline()
+```
+
+
+Specifica se l'intervallo di testo ha una doppia sottolineatura sotto di esso.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getDoubleStrikethrough() {#getDoubleStrikethrough--}
+```
+public BoolValue getDoubleStrikethrough()
+```
+
+
+Determina se il testo è formattato con doppia barratura.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getFont() {#getFont--}
+```
+public IntValue getFont()
+```
+
+
+Specifica il numero ID del carattere usato per formattare il testo.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getFontName() {#getFontName--}
+```
+public StrValue getFontName()
+```
+
+
+Specifica il nome del carattere usato per formattare il testo. È utilizzato per Visio 2013
+
+**Returns:**
+[StrValue](../../com.aspose.diagram/strvalue)
+### getFontScale() {#getFontScale--}
+```
+public DoubleValue getFontScale()
+```
+
+
+Specifica la larghezza del carattere.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getHighlight() {#getHighlight--}
+```
+public BoolValue getHighlight()
+```
+
+
+Specifica l'evidenziazione.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+L'indice basato su zero dell'elemento all'interno del suo elemento genitore.
+
+**Returns:**
+int
+### getLangID() {#getLangID--}
+```
+public IntValue getLangID()
+```
+
+
+Indica l'ID locale (LCID) della lingua in cui è stata inserita la formula della cella, il testo, la proprietà personalizzata o il commento. Per un elenco delle lingue supportate dalle applicazioni Microsoft Office e i relativi ID lingua, vedere l'elemento DocLangID.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getLetterspace() {#getLetterspace--}
+```
+public DoubleValue getLetterspace()
+```
+
+
+Specifica la quantità di spazio tra due o più caratteri. Lo spazio può essere aggiunto o sottratto in incrementi di 1/20 di punto.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLocale() {#getLocale--}
+```
+public StrValue getLocale()
+```
+
+
+Specifica la localizzazione dell'intervallo di testo per scopi di correzione ortografica.
+
+**Returns:**
+[StrValue](../../com.aspose.diagram/strvalue)
+### getLocalizeFont() {#getLocalizeFont--}
+```
+public LocalizeFont getLocalizeFont()
+```
+
+
+Specifica se il testo della forma deve essere localizzato (tradotto in un'altra lingua).
+
+**Returns:**
+[LocalizeFont](../../com.aspose.diagram/localizefont)
+### getOverline() {#getOverline--}
+```
+public BoolValue getOverline()
+```
+
+
+Specifica se il testo ha una linea sopra di esso.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getPerpendicular() {#getPerpendicular--}
+```
+public StrValue getPerpendicular()
+```
+
+
+Specifica se un campo di testo appare perpendicolare al resto del testo in un blocco di testo.
+
+**Returns:**
+[StrValue](../../com.aspose.diagram/strvalue)
+### getPos() {#getPos--}
+```
+public Pos getPos()
+```
+
+
+Specifica la posizione del testo della forma rispetto alla linea di base.
+
+**Returns:**
+[Pos](../../com.aspose.diagram/pos)
+### getRTLText() {#getRTLText--}
+```
+public BoolValue getRTLText()
+```
+
+
+Determina se la direzione del testo dell'intervallo di caratteri corrente è da sinistra a destra o da destra a sinistra.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getSize() {#getSize--}
+```
+public DoubleValue getSize()
+```
+
+
+Specifica la dimensione del testo nel blocco di testo della forma.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getStrikethru() {#getStrikethru--}
+```
+public BoolValue getStrikethru()
+```
+
+
+Specifica se il testo è formattato con barratura.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getStyle() {#getStyle--}
+```
+public Style getStyle()
+```
+
+
+Specifica la formattazione dei caratteri applicata a un intervallo di testo nel blocco di testo della forma.
+
+**Returns:**
+[Style](../../com.aspose.diagram/style)
+### getUseVertical() {#getUseVertical--}
+```
+public BoolValue getUseVertical()
+```
+
+
+Determina se l'intervallo di caratteri è verticale o orizzontale.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isBold() {#isBold--}
+```
+public boolean isBold()
+```
+
+
+Indica se il carattere è in grassetto.
+
+**Returns:**
+boolean
+### isDoubleStrikethrough() {#isDoubleStrikethrough--}
+```
+public boolean isDoubleStrikethrough()
+```
+
+
+Indica se il carattere ha doppia barratura.
+
+**Returns:**
+boolean
+### isDoubleUnderline() {#isDoubleUnderline--}
+```
+public boolean isDoubleUnderline()
+```
+
+
+Indica se il carattere ha doppia sottolineatura.
+
+**Returns:**
+boolean
+### isItalic() {#isItalic--}
+```
+public boolean isItalic()
+```
+
+
+Indica se il carattere è in corsivo.
+
+**Returns:**
+boolean
+### isStrikethrough() {#isStrikethrough--}
+```
+public boolean isStrikethrough()
+```
+
+
+Indica se il carattere è barrato.
+
+**Returns:**
+boolean
+### isSubscript() {#isSubscript--}
+```
+public boolean isSubscript()
+```
+
+
+Indica se il carattere è pedice.
+
+**Returns:**
+boolean
+### isSuperscript() {#isSuperscript--}
+```
+public boolean isSuperscript()
+```
+
+
+Indica se il carattere è apice.
+
+**Returns:**
+boolean
+### isUnderline() {#isUnderline--}
+```
+public boolean isUnderline()
+```
+
+
+Indica se il carattere è sottolineato.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAsianFont(IntValue value) {#setAsianFont-com.aspose.diagram.IntValue-}
+```
+public void setAsianFont(IntValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getAsianFont()](../../com.aspose.diagram/char\#getAsianFont--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setAsianFontName(StrValue value) {#setAsianFontName-com.aspose.diagram.StrValue-}
+```
+public void setAsianFontName(StrValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getAsianFontName()](../../com.aspose.diagram/char\#getAsianFontName--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [StrValue](../../com.aspose.diagram/strvalue) |  |
+
+### setCase(Case value) {#setCase-com.aspose.diagram.Case-}
+```
+public void setCase(Case value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getCase()](../../com.aspose.diagram/char\#getCase--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [Case](../../com.aspose.diagram/case) |  |
+
+### setColor(ColorValue value) {#setColor-com.aspose.diagram.ColorValue-}
+```
+public void setColor(ColorValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getColor()](../../com.aspose.diagram/char\#getColor--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setColorTrans(DoubleValue value) {#setColorTrans-com.aspose.diagram.DoubleValue-}
+```
+public void setColorTrans(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getColorTrans()](../../com.aspose.diagram/char\#getColorTrans--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setComplexScriptFont(IntValue value) {#setComplexScriptFont-com.aspose.diagram.IntValue-}
+```
+public void setComplexScriptFont(IntValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getComplexScriptFont()](../../com.aspose.diagram/char\#getComplexScriptFont--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setComplexScriptFontName(StrValue value) {#setComplexScriptFontName-com.aspose.diagram.StrValue-}
+```
+public void setComplexScriptFontName(StrValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getComplexScriptFontName()](../../com.aspose.diagram/char\#getComplexScriptFontName--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [StrValue](../../com.aspose.diagram/strvalue) |  |
+
+### setComplexScriptSize(DoubleValue value) {#setComplexScriptSize-com.aspose.diagram.DoubleValue-}
+```
+public void setComplexScriptSize(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getComplexScriptSize()](../../com.aspose.diagram/char\#getComplexScriptSize--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDblUnderline(BoolValue value) {#setDblUnderline-com.aspose.diagram.BoolValue-}
+```
+public void setDblUnderline(BoolValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDblUnderline()](../../com.aspose.diagram/char\#getDblUnderline--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/char\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setDoubleStrikethrough(BoolValue value) {#setDoubleStrikethrough-com.aspose.diagram.BoolValue-}
+```
+public void setDoubleStrikethrough(BoolValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDoubleStrikethrough()](../../com.aspose.diagram/char\#getDoubleStrikethrough--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setFont(IntValue value) {#setFont-com.aspose.diagram.IntValue-}
+```
+public void setFont(IntValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getFont()](../../com.aspose.diagram/char\#getFont--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setFontName(StrValue value) {#setFontName-com.aspose.diagram.StrValue-}
+```
+public void setFontName(StrValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getFontName()](../../com.aspose.diagram/char\#getFontName--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [StrValue](../../com.aspose.diagram/strvalue) |  |
+
+### setFontScale(DoubleValue value) {#setFontScale-com.aspose.diagram.DoubleValue-}
+```
+public void setFontScale(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getFontScale()](../../com.aspose.diagram/char\#getFontScale--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setHighlight(BoolValue value) {#setHighlight-com.aspose.diagram.BoolValue-}
+```
+public void setHighlight(BoolValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getHighlight()](../../com.aspose.diagram/char\#getHighlight--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getIX()](../../com.aspose.diagram/char\#getIX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setLangID(IntValue value) {#setLangID-com.aspose.diagram.IntValue-}
+```
+public void setLangID(IntValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getLangID()](../../com.aspose.diagram/char\#getLangID--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setLetterspace(DoubleValue value) {#setLetterspace-com.aspose.diagram.DoubleValue-}
+```
+public void setLetterspace(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getLetterspace()](../../com.aspose.diagram/char\#getLetterspace--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setLocale(StrValue value) {#setLocale-com.aspose.diagram.StrValue-}
+```
+public void setLocale(StrValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getLocale()](../../com.aspose.diagram/char\#getLocale--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [StrValue](../../com.aspose.diagram/strvalue) |  |
+
+### setLocalizeFont(LocalizeFont value) {#setLocalizeFont-com.aspose.diagram.LocalizeFont-}
+```
+public void setLocalizeFont(LocalizeFont value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getLocalizeFont()](../../com.aspose.diagram/char\#getLocalizeFont--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [LocalizeFont](../../com.aspose.diagram/localizefont) |  |
+
+### setOverline(BoolValue value) {#setOverline-com.aspose.diagram.BoolValue-}
+```
+public void setOverline(BoolValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getOverline()](../../com.aspose.diagram/char\#getOverline--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setPerpendicular(StrValue value) {#setPerpendicular-com.aspose.diagram.StrValue-}
+```
+public void setPerpendicular(StrValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getPerpendicular()](../../com.aspose.diagram/char\#getPerpendicular--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [StrValue](../../com.aspose.diagram/strvalue) |  |
+
+### setPos(Pos value) {#setPos-com.aspose.diagram.Pos-}
+```
+public void setPos(Pos value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getPos()](../../com.aspose.diagram/char\#getPos--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [Pos](../../com.aspose.diagram/pos) |  |
+
+### setRTLText(BoolValue value) {#setRTLText-com.aspose.diagram.BoolValue-}
+```
+public void setRTLText(BoolValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getRTLText()](../../com.aspose.diagram/char\#getRTLText--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setSize(DoubleValue value) {#setSize-com.aspose.diagram.DoubleValue-}
+```
+public void setSize(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getSize()](../../com.aspose.diagram/char\#getSize--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setStrikethru(BoolValue value) {#setStrikethru-com.aspose.diagram.BoolValue-}
+```
+public void setStrikethru(BoolValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getStrikethru()](../../com.aspose.diagram/char\#getStrikethru--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setStyle(Style value) {#setStyle-com.aspose.diagram.Style-}
+```
+public void setStyle(Style value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getStyle()](../../com.aspose.diagram/char\#getStyle--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [Style](../../com.aspose.diagram/style) |  |
+
+### setUseVertical(BoolValue value) {#setUseVertical-com.aspose.diagram.BoolValue-}
+```
+public void setUseVertical(BoolValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getUseVertical()](../../com.aspose.diagram/char\#getUseVertical--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/charcollection/_index.md
+++ b/italian/java/com.aspose.diagram/charcollection/_index.md
@@ -1,0 +1,234 @@
+---
+title: CharCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Raccolta di caratteri.
+type: docs
+weight: 46
+url: /it/java/com.aspose.diagram/charcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class CharCollection extends Collection
+```
+
+Raccolta di caratteri.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [add(Char item)](#add-com.aspose.diagram.Char-) | Aggiungi l'oggetto Char nella collezione. |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getChar(int IX)](#getChar-int-) | Ottiene l'elemento all'IX specificato. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Char item)](#remove-com.aspose.diagram.Char-) | Rimuovi l'oggetto Char dalla collezione. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Char item) {#add-com.aspose.diagram.Char-}
+```
+public int add(Char item)
+```
+
+
+Aggiungi l'oggetto Char nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [Char](../../com.aspose.diagram/char) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Char get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[Char](../../com.aspose.diagram/char) - 
+### getChar(int IX) {#getChar-int-}
+```
+public Char getChar(int IX)
+```
+
+
+Ottiene l'elemento all'IX specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| IX | int | intL'indice basato su zero dell'elemento all'interno del suo elemento genitore. |
+
+**Returns:**
+[Char](../../com.aspose.diagram/char) - [Char](../../com.aspose.diagram/char)Char.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Char item) {#remove-com.aspose.diagram.Char-}
+```
+public void remove(Char item)
+```
+
+
+Rimuovi l'oggetto Char dalla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [Char](../../com.aspose.diagram/char) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/checkboxactivexcontrol/_index.md
+++ b/italian/java/com.aspose.diagram/checkboxactivexcontrol/_index.md
@@ -1,0 +1,704 @@
+---
+title: CheckBoxActiveXControl
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta un controllo ActiveX CheckBox.
+type: docs
+weight: 47
+url: /it/java/com.aspose.diagram/checkboxactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class CheckBoxActiveXControl extends ActiveXControl
+```
+
+Rappresenta un controllo ActiveX CheckBox.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAccelerator()](#getAccelerator--) | il tasto di accelerazione per il controllo. |
+| [getAlignment()](#getAlignment--) | la posizione della Caption relativa al controllo. |
+| [getBackOleColor()](#getBackOleColor--) | il colore OLE dello sfondo. |
+| [getCaption()](#getCaption--) | il testo descrittivo che appare su un controllo. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | i dati binari del controllo. |
+| [getForeOleColor()](#getForeOleColor--) | il colore OLE del primo piano. |
+| [getGroupName()](#getGroupName--) | il nome del gruppo. |
+| [getHeight()](#getHeight--) | l'altezza del controllo in unità di punti. |
+| [getIMEMode()](#getIMEMode--) | la modalità di esecuzione predefinita dell'Input Method Editor per il controllo quando riceve il fuoco. |
+| [getMouseIcon()](#getMouseIcon--) | un'icona personalizzata da visualizzare come puntatore del mouse per il controllo. |
+| [getMousePointer()](#getMousePointer--) | il tipo di icona visualizzata come puntatore del mouse per il controllo. |
+| [getPicture()](#getPicture--) | i dati dell'immagine. |
+| [getPicturePosition()](#getPicturePosition--) | la posizione dell'immagine del controllo rispetto alla sua didascalia. |
+| [getSpecialEffect()](#getSpecialEffect--) | l'effetto speciale del controllo. |
+| [getType()](#getType--) | Ottiene il tipo del controllo ActiveX. |
+| [getValue()](#getValue--) | Indica se il controllo è selezionato o meno. |
+| [getWidth()](#getWidth--) | la larghezza del controllo in unità di punti. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | Indica se il controllo ridimensionerà automaticamente per visualizzare tutto il contenuto. |
+| [isChecked()](#isChecked--) | Indica se la casella è selezionata. |
+| [isEnabled()](#isEnabled--) | Indica se il controllo può ricevere il focus e rispondere agli eventi generati dall'utente. |
+| [isLocked()](#isLocked--) | Indica se i dati nel controllo sono bloccati per la modifica. |
+| [isTransparent()](#isTransparent--) | Indica se il controllo è trasparente. |
+| [isTripleState()](#isTripleState--) | Indica come il controllo specificato visualizzerà i valori Null. |
+| [isWordWrapped()](#isWordWrapped--) | Indica se il contenuto del controllo avvolge automaticamente alla fine di una riga. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAccelerator(char value)](#setAccelerator-char-) | Per la descrizione di questa proprietà, vedere [getAccelerator()](../../com.aspose.diagram/checkboxactivexcontrol\#getAccelerator--) |
+| [setAlignment(int value)](#setAlignment-int-) | Per la descrizione di questa proprietà, vedere [getAlignment()](../../com.aspose.diagram/checkboxactivexcontrol\#getAlignment--) |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | Per la descrizione di questa proprietà, vedere [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | Per la descrizione di questa proprietà, vedere [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setCaption(String value)](#setCaption-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getCaption()](../../com.aspose.diagram/checkboxactivexcontrol\#getCaption--) |
+| [setChecked(boolean value)](#setChecked-boolean-) | Per la descrizione di questa proprietà, vedere [isChecked()](../../com.aspose.diagram/checkboxactivexcontrol\#isChecked--) |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | Per la descrizione di questa proprietà, vedere [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | Per la descrizione di questa proprietà, vedere [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setGroupName(String value)](#setGroupName-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getGroupName()](../../com.aspose.diagram/checkboxactivexcontrol\#getGroupName--) |
+| [setHeight(double value)](#setHeight-double-) | Per la descrizione di questa proprietà, vedere [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setIMEMode(int value)](#setIMEMode-int-) | Per la descrizione di questa proprietà, vedere [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) |
+| [setLocked(boolean value)](#setLocked-boolean-) | Per la descrizione di questa proprietà, vedere [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | Per la descrizione di questa proprietà, vedere [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | Per la descrizione di questa proprietà, vedere [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setPicture(byte[] value)](#setPicture-byte---) | Per la descrizione di questa proprietà, vedere [getPicture()](../../com.aspose.diagram/checkboxactivexcontrol\#getPicture--) |
+| [setPicturePosition(int value)](#setPicturePosition-int-) | Per la descrizione di questa proprietà, vedere [getPicturePosition()](../../com.aspose.diagram/checkboxactivexcontrol\#getPicturePosition--) |
+| [setSpecialEffect(int value)](#setSpecialEffect-int-) | Per la descrizione di questa proprietà, vedere [getSpecialEffect()](../../com.aspose.diagram/checkboxactivexcontrol\#getSpecialEffect--) |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | Per la descrizione di questa proprietà, vedere [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) |
+| [setTripleState(boolean value)](#setTripleState-boolean-) | Per la descrizione di questa proprietà, vedere [isTripleState()](../../com.aspose.diagram/checkboxactivexcontrol\#isTripleState--) |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/checkboxactivexcontrol\#getValue--) |
+| [setWidth(double value)](#setWidth-double-) | Per la descrizione di questa proprietà, vedere [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [setWordWrapped(boolean value)](#setWordWrapped-boolean-) | Per la descrizione di questa proprietà, vedere [isWordWrapped()](../../com.aspose.diagram/checkboxactivexcontrol\#isWordWrapped--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAccelerator() {#getAccelerator--}
+```
+public char getAccelerator()
+```
+
+
+il tasto di accelerazione per il controllo.
+
+**Returns:**
+char
+### getAlignment() {#getAlignment--}
+```
+public int getAlignment()
+```
+
+
+la posizione della Caption relativa al controllo.
+
+**Returns:**
+int
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+il colore OLE dello sfondo.
+
+**Returns:**
+int
+### getCaption() {#getCaption--}
+```
+public String getCaption()
+```
+
+
+il testo descrittivo che appare su un controllo.
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+i dati binari del controllo.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+Il colore OLE del primo piano. Non si applica al controllo Image.
+
+**Returns:**
+int
+### getGroupName() {#getGroupName--}
+```
+public String getGroupName()
+```
+
+
+il nome del gruppo.
+
+**Returns:**
+java.lang.String
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+l'altezza del controllo in unità di punti.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+la modalità di esecuzione predefinita dell'Input Method Editor per il controllo quando riceve il fuoco.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+un'icona personalizzata da visualizzare come puntatore del mouse per il controllo.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+il tipo di icona visualizzata come puntatore del mouse per il controllo.
+
+**Returns:**
+int
+### getPicture() {#getPicture--}
+```
+public byte[] getPicture()
+```
+
+
+i dati dell'immagine.
+
+**Returns:**
+byte[]
+### getPicturePosition() {#getPicturePosition--}
+```
+public int getPicturePosition()
+```
+
+
+la posizione dell'immagine del controllo rispetto alla sua didascalia.
+
+**Returns:**
+int
+### getSpecialEffect() {#getSpecialEffect--}
+```
+public int getSpecialEffect()
+```
+
+
+l'effetto speciale del controllo.
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Ottiene il tipo del controllo ActiveX.
+
+**Returns:**
+int
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Indica se il controllo è selezionato o meno.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+la larghezza del controllo in unità di punti.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+Indica se il controllo ridimensionerà automaticamente per visualizzare tutto il contenuto.
+
+**Returns:**
+boolean
+### isChecked() {#isChecked--}
+```
+public boolean isChecked()
+```
+
+
+Indica se la casella è selezionata.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+Indica se il controllo può ricevere il focus e rispondere agli eventi generati dall'utente.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+Indica se i dati nel controllo sono bloccati per la modifica.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+Indica se il controllo è trasparente.
+
+**Returns:**
+boolean
+### isTripleState() {#isTripleState--}
+```
+public boolean isTripleState()
+```
+
+
+Indica come il controllo specificato visualizzerà i valori Null.
+
+| ------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| Impostazione | Descrizione |
+| True    | Il controllo ciclerà attraverso gli stati per i valori Sì, No e Null. Il controllo appare attenuato (grigio) quando la sua proprietà Value è impostata su Null. |
+| False   | (Predefinito) Il controllo ciclerà attraverso gli stati per i valori Sì e No. I valori Null vengono visualizzati come se fossero valori No. |
+
+|
+
+**Returns:**
+boolean
+### isWordWrapped() {#isWordWrapped--}
+```
+public boolean isWordWrapped()
+```
+
+
+Indica se il contenuto del controllo avvolge automaticamente alla fine di una riga.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAccelerator(char value) {#setAccelerator-char-}
+```
+public void setAccelerator(char value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getAccelerator()](../../com.aspose.diagram/checkboxactivexcontrol\#getAccelerator--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | char |  |
+
+### setAlignment(int value) {#setAlignment-int-}
+```
+public void setAlignment(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getAlignment()](../../com.aspose.diagram/checkboxactivexcontrol\#getAlignment--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setCaption(String value) {#setCaption-java.lang.String-}
+```
+public void setCaption(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getCaption()](../../com.aspose.diagram/checkboxactivexcontrol\#getCaption--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setChecked(boolean value) {#setChecked-boolean-}
+```
+public void setChecked(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isChecked()](../../com.aspose.diagram/checkboxactivexcontrol\#isChecked--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setGroupName(String value) {#setGroupName-java.lang.String-}
+```
+public void setGroupName(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getGroupName()](../../com.aspose.diagram/checkboxactivexcontrol\#getGroupName--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setPicture(byte[] value) {#setPicture-byte---}
+```
+public void setPicture(byte[] value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getPicture()](../../com.aspose.diagram/checkboxactivexcontrol\#getPicture--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | byte[] |  |
+
+### setPicturePosition(int value) {#setPicturePosition-int-}
+```
+public void setPicturePosition(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getPicturePosition()](../../com.aspose.diagram/checkboxactivexcontrol\#getPicturePosition--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setSpecialEffect(int value) {#setSpecialEffect-int-}
+```
+public void setSpecialEffect(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getSpecialEffect()](../../com.aspose.diagram/checkboxactivexcontrol\#getSpecialEffect--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setTripleState(boolean value) {#setTripleState-boolean-}
+```
+public void setTripleState(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isTripleState()](../../com.aspose.diagram/checkboxactivexcontrol\#isTripleState--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/checkboxactivexcontrol\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double |  |
+
+### setWordWrapped(boolean value) {#setWordWrapped-boolean-}
+```
+public void setWordWrapped(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isWordWrapped()](../../com.aspose.diagram/checkboxactivexcontrol\#isWordWrapped--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/checkvaluetype/_index.md
+++ b/italian/java/com.aspose.diagram/checkvaluetype/_index.md
@@ -1,0 +1,156 @@
+---
+title: CheckValueType
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta il tipo di valore di spunta della casella di controllo.
+type: docs
+weight: 48
+url: /it/java/com.aspose.diagram/checkvaluetype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class CheckValueType
+```
+
+Rappresenta il tipo di valore di spunta della casella di controllo.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [CHECKED](#CHECKED) | Selezionato |
+| [MIXED](#MIXED) | Misto |
+| [UN_CHECKED](#UN-CHECKED) | Deselezionato |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CHECKED {#CHECKED}
+```
+public static final int CHECKED
+```
+
+
+Selezionato
+
+### MIXED {#MIXED}
+```
+public static final int MIXED
+```
+
+
+Misto
+
+### UN_CHECKED {#UN-CHECKED}
+```
+public static final int UN_CHECKED
+```
+
+
+Deselezionato
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/collection/_index.md
+++ b/italian/java/com.aspose.diagram/collection/_index.md
@@ -1,0 +1,188 @@
+---
+title: Collezione
+second_title: Riferimento API di Aspose.Diagram per Java
+description: È la classe base per le raccolte.
+type: docs
+weight: 49
+url: /it/java/com.aspose.diagram/collection/
+---
+
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+java.lang.Iterable
+```
+public abstract class Collection implements Iterable
+```
+
+È la classe base per le raccolte.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [Collection()](#Collection--) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Collection() {#Collection--}
+```
+public Collection()
+```
+
+
+Costruttore.
+
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/collectionbase/_index.md
+++ b/italian/java/com.aspose.diagram/collectionbase/_index.md
@@ -1,0 +1,264 @@
+---
+title: CollectionBase
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Fornisce la classe base astratta per una raccolta tipizzata fortemente.
+type: docs
+weight: 50
+url: /it/java/com.aspose.diagram/collectionbase/
+---
+
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+java.lang.Iterable
+```
+public abstract class CollectionBase implements Iterable
+```
+
+Fornisce la classe base astratta per una raccolta tipizzata fortemente.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [CollectionBase()](#CollectionBase--) | Inizializza una nuova istanza della classe CollectionBase con la capacità iniziale predefinita. |
+| [CollectionBase(int capacity)](#CollectionBase-int-) | Inizializza una nuova istanza della classe CollectionBase con la capacità specificata. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [add(Object o)](#add-java.lang.Object-) | Aggiunge un elemento all'istanza di CollectionBase. |
+| [clear()](#clear--) | Rimuove tutti gli oggetti dall'istanza di CollectionBase. |
+| [contains(Object o)](#contains-java.lang.Object-) | Restituisce se l'istanza contiene questo oggetto |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottieni un elemento nella posizione specificata. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi contenuti nell'istanza di CollectionBase. |
+| [hashCode()](#hashCode--) |  |
+| [indexOf(Object o)](#indexOf-java.lang.Object-) | Determina l'indice di un elemento specifico nell'istanza di CollectionBase. |
+| [iterator()](#iterator--) | Restituisce un enumeratore che itera attraverso l'istanza di CollectionBase. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [removeAt(int index)](#removeAt-int-) | Rimuove l'elemento all'indice specificato. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CollectionBase() {#CollectionBase--}
+```
+public CollectionBase()
+```
+
+
+Inizializza una nuova istanza della classe CollectionBase con la capacità iniziale predefinita.
+
+### CollectionBase(int capacity) {#CollectionBase-int-}
+```
+public CollectionBase(int capacity)
+```
+
+
+Inizializza una nuova istanza della classe CollectionBase con la capacità specificata.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| capacità | int | Il numero di elementi che la nuova lista può memorizzare inizialmente. |
+
+### add(Object o) {#add-java.lang.Object-}
+```
+public int add(Object o)
+```
+
+
+Aggiunge un elemento all'istanza di CollectionBase.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| o | java.lang.Object | L'oggetto da aggiungere all'istanza di CollectionBase. |
+
+**Returns:**
+int - La posizione in cui è stato inserito il nuovo elemento.
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli oggetti dall'istanza di CollectionBase.
+
+### contains(Object o) {#contains-java.lang.Object-}
+```
+public boolean contains(Object o)
+```
+
+
+Restituisce se l'istanza contiene questo oggetto
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| o | java.lang.Object | oggetto di test |
+
+**Returns:**
+boolean - Indica se l'istanza contiene questo oggetto
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Object get(int index)
+```
+
+
+Ottieni un elemento nella posizione specificata.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | Indice di posizione specificato. |
+
+**Returns:**
+java.lang.Object - L'elemento nella posizione specificata.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi contenuti nell'istanza di CollectionBase.
+
+**Returns:**
+int - Il numero di elementi contenuti nell'istanza di CollectionBase.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### indexOf(Object o) {#indexOf-java.lang.Object-}
+```
+public int indexOf(Object o)
+```
+
+
+Determina l'indice di un elemento specifico nell'istanza di CollectionBase.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| o | java.lang.Object | Determina l'indice di un elemento specifico nell'istanza di CollectionBase. |
+
+**Returns:**
+int - L'indice del valore se trovato nella lista; altrimenti, -1.
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Restituisce un enumeratore che itera attraverso l'istanza di CollectionBase.
+
+**Returns:**
+java.util.Iterator - Un iteratore per l'istanza di CollectionBase.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### removeAt(int index) {#removeAt-int-}
+```
+public void removeAt(int index)
+```
+
+
+Rimuove l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | L'indice basato su zero dell'elemento da rimuovere. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/color/_index.md
+++ b/italian/java/com.aspose.diagram/color/_index.md
@@ -1,0 +1,1819 @@
+---
+title: Color
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta un colore ARGB alfa rosso verde blu.
+type: docs
+weight: 51
+url: /it/java/com.aspose.diagram/color/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Color
+```
+
+Rappresenta un colore ARGB (alpha, rosso, verde, blu).
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [Color()](#Color--) | funzione costruttore |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object obj)](#equals-java.lang.Object-) | Verifica se l'oggetto specificato è un oggetto Color e se è equivalente a questo oggetto. |
+| [fromArgb(int argb)](#fromArgb-int-) | Crea un oggetto Color da un valore ARGB a 32 bit. |
+| [fromArgb(int red, int green, int blue)](#fromArgb-int-int-int-) | Crea un oggetto Color dai valori di colore a 8 bit specificati (rosso, verde e blu). |
+| [fromArgb(int alpha, int red, int green, int blue)](#fromArgb-int-int-int-int-) | Crea un oggetto Color dai quattro valori dei componenti ARGB (alfa, rosso, verde e blu). |
+| [getA()](#getA--) | Ottiene il valore del componente alfa di questo oggetto Color. |
+| [getAliceBlue()](#getAliceBlue--) | Ottieni un colore definito dal sistema. |
+| [getAntiqueWhite()](#getAntiqueWhite--) | Ottieni un colore definito dal sistema. |
+| [getAqua()](#getAqua--) | Ottieni un colore definito dal sistema. |
+| [getAquamarine()](#getAquamarine--) | Ottieni un colore definito dal sistema. |
+| [getAzure()](#getAzure--) | Ottieni un colore definito dal sistema. |
+| [getB()](#getB--) | Ottiene il valore del componente blu di questo oggetto Color. |
+| [getBeige()](#getBeige--) | Ottieni un colore definito dal sistema. |
+| [getBisque()](#getBisque--) | Ottieni un colore definito dal sistema. |
+| [getBlack()](#getBlack--) | Ottieni un colore definito dal sistema. |
+| [getBlanchedAlmond()](#getBlanchedAlmond--) | Ottieni un colore definito dal sistema. |
+| [getBlue()](#getBlue--) | Ottieni un colore definito dal sistema. |
+| [getBlueViolet()](#getBlueViolet--) | Ottieni un colore definito dal sistema. |
+| [getBrown()](#getBrown--) | Ottieni un colore definito dal sistema. |
+| [getBurlyWood()](#getBurlyWood--) | Ottieni un colore definito dal sistema. |
+| [getCadetBlue()](#getCadetBlue--) | Ottieni un colore definito dal sistema. |
+| [getChartreuse()](#getChartreuse--) | Ottieni un colore definito dal sistema. |
+| [getChocolate()](#getChocolate--) | Ottieni un colore definito dal sistema. |
+| [getClass()](#getClass--) |  |
+| [getCoral()](#getCoral--) | Ottieni un colore definito dal sistema. |
+| [getCornflowerBlue()](#getCornflowerBlue--) | Ottieni un colore definito dal sistema. |
+| [getCornsilk()](#getCornsilk--) | Ottieni un colore definito dal sistema. |
+| [getCrimson()](#getCrimson--) | Ottieni un colore definito dal sistema. |
+| [getCyan()](#getCyan--) | Ottieni un colore definito dal sistema. |
+| [getDarkBlue()](#getDarkBlue--) | Ottieni un colore definito dal sistema. |
+| [getDarkCyan()](#getDarkCyan--) | Ottieni un colore definito dal sistema. |
+| [getDarkGoldenrod()](#getDarkGoldenrod--) | Ottieni un colore definito dal sistema. |
+| [getDarkGray()](#getDarkGray--) | Ottieni un colore definito dal sistema. |
+| [getDarkGreen()](#getDarkGreen--) | Ottieni un colore definito dal sistema. |
+| [getDarkKhaki()](#getDarkKhaki--) | Ottieni un colore definito dal sistema. |
+| [getDarkMagenta()](#getDarkMagenta--) | Ottieni un colore definito dal sistema. |
+| [getDarkOliveGreen()](#getDarkOliveGreen--) | Ottieni un colore definito dal sistema. |
+| [getDarkOrange()](#getDarkOrange--) | Ottieni un colore definito dal sistema. |
+| [getDarkOrchid()](#getDarkOrchid--) | Ottieni un colore definito dal sistema. |
+| [getDarkRed()](#getDarkRed--) | Ottieni un colore definito dal sistema. |
+| [getDarkSalmon()](#getDarkSalmon--) | Ottieni un colore definito dal sistema. |
+| [getDarkSeaGreen()](#getDarkSeaGreen--) | Ottieni un colore definito dal sistema. |
+| [getDarkSlateBlue()](#getDarkSlateBlue--) | Ottieni un colore definito dal sistema. |
+| [getDarkSlateGray()](#getDarkSlateGray--) | Ottieni un colore definito dal sistema. |
+| [getDarkTurquoise()](#getDarkTurquoise--) | Ottieni un colore definito dal sistema. |
+| [getDarkViolet()](#getDarkViolet--) | Ottieni un colore definito dal sistema. |
+| [getDeepPink()](#getDeepPink--) | Ottieni un colore definito dal sistema. |
+| [getDeepSkyBlue()](#getDeepSkyBlue--) | Ottieni un colore definito dal sistema. |
+| [getDimGray()](#getDimGray--) | Ottieni un colore definito dal sistema. |
+| [getDodgerBlue()](#getDodgerBlue--) | Ottieni un colore definito dal sistema. |
+| [getEmpty()](#getEmpty--) | Ottieni un colore vuoto definito dal sistema. |
+| [getFirebrick()](#getFirebrick--) | Ottieni un colore definito dal sistema. |
+| [getFloralWhite()](#getFloralWhite--) | Ottieni un colore definito dal sistema. |
+| [getForestGreen()](#getForestGreen--) | Ottieni un colore definito dal sistema. |
+| [getFuchsia()](#getFuchsia--) | Ottieni un colore definito dal sistema. |
+| [getG()](#getG--) | Ottiene il valore del componente verde di questo oggetto Color. |
+| [getGainsboro()](#getGainsboro--) | Ottieni un colore definito dal sistema. |
+| [getGhostWhite()](#getGhostWhite--) | Ottieni un colore definito dal sistema. |
+| [getGold()](#getGold--) | Ottieni un colore definito dal sistema. |
+| [getGoldenrod()](#getGoldenrod--) | Ottieni un colore definito dal sistema. |
+| [getGray()](#getGray--) | Ottieni un colore definito dal sistema. |
+| [getGreen()](#getGreen--) | Ottieni un colore definito dal sistema. |
+| [getGreenYellow()](#getGreenYellow--) | Ottieni un colore definito dal sistema. |
+| [getHoneydew()](#getHoneydew--) | Ottieni un colore definito dal sistema. |
+| [getHotPink()](#getHotPink--) | Ottieni un colore definito dal sistema. |
+| [getIndianRed()](#getIndianRed--) | Ottieni un colore definito dal sistema. |
+| [getIndigo()](#getIndigo--) | Ottieni un colore definito dal sistema. |
+| [getIvory()](#getIvory--) | Ottieni un colore definito dal sistema. |
+| [getKhaki()](#getKhaki--) | Ottieni un colore definito dal sistema. |
+| [getLavender()](#getLavender--) | Ottieni un colore definito dal sistema. |
+| [getLavenderBlush()](#getLavenderBlush--) | Ottieni un colore definito dal sistema. |
+| [getLawnGreen()](#getLawnGreen--) | Ottieni un colore definito dal sistema. |
+| [getLemonChiffon()](#getLemonChiffon--) | Ottieni un colore definito dal sistema. |
+| [getLightBlue()](#getLightBlue--) | Ottieni un colore definito dal sistema. |
+| [getLightCoral()](#getLightCoral--) | Ottieni un colore definito dal sistema. |
+| [getLightCyan()](#getLightCyan--) | Ottieni un colore definito dal sistema. |
+| [getLightGoldenrodYellow()](#getLightGoldenrodYellow--) | Ottieni un colore definito dal sistema. |
+| [getLightGray()](#getLightGray--) | Ottieni un colore definito dal sistema. |
+| [getLightGreen()](#getLightGreen--) | Ottieni un colore definito dal sistema. |
+| [getLightPink()](#getLightPink--) | Ottieni un colore definito dal sistema. |
+| [getLightSalmon()](#getLightSalmon--) | Ottieni un colore definito dal sistema. |
+| [getLightSeaGreen()](#getLightSeaGreen--) | Ottieni un colore definito dal sistema. |
+| [getLightSkyBlue()](#getLightSkyBlue--) | Ottieni un colore definito dal sistema. |
+| [getLightSlateGray()](#getLightSlateGray--) | Ottieni un colore definito dal sistema. |
+| [getLightSteelBlue()](#getLightSteelBlue--) | Ottieni un colore definito dal sistema. |
+| [getLightYellow()](#getLightYellow--) | Ottieni un colore definito dal sistema. |
+| [getLime()](#getLime--) | Ottieni un colore definito dal sistema. |
+| [getLimeGreen()](#getLimeGreen--) | Ottieni un colore definito dal sistema. |
+| [getLinen()](#getLinen--) | Ottieni un colore definito dal sistema. |
+| [getMagenta()](#getMagenta--) | Ottieni un colore definito dal sistema. |
+| [getMaroon()](#getMaroon--) | Ottieni un colore definito dal sistema. |
+| [getMediumAquamarine()](#getMediumAquamarine--) | Ottieni un colore definito dal sistema. |
+| [getMediumBlue()](#getMediumBlue--) | Ottieni un colore definito dal sistema. |
+| [getMediumOrchid()](#getMediumOrchid--) | Ottieni un colore definito dal sistema. |
+| [getMediumPurple()](#getMediumPurple--) | Ottieni un colore definito dal sistema. |
+| [getMediumSeaGreen()](#getMediumSeaGreen--) | Ottieni un colore definito dal sistema. |
+| [getMediumSlateBlue()](#getMediumSlateBlue--) | Ottieni un colore definito dal sistema. |
+| [getMediumSpringGreen()](#getMediumSpringGreen--) | Ottieni un colore definito dal sistema. |
+| [getMediumTurquoise()](#getMediumTurquoise--) | Ottieni un colore definito dal sistema. |
+| [getMediumVioletRed()](#getMediumVioletRed--) | Ottieni un colore definito dal sistema. |
+| [getMidnightBlue()](#getMidnightBlue--) | Ottieni un colore definito dal sistema. |
+| [getMintCream()](#getMintCream--) | Ottieni un colore definito dal sistema. |
+| [getMistyRose()](#getMistyRose--) | Ottieni un colore definito dal sistema. |
+| [getMoccasin()](#getMoccasin--) | Ottieni un colore definito dal sistema. |
+| [getNavajoWhite()](#getNavajoWhite--) | Ottieni un colore definito dal sistema. |
+| [getNavy()](#getNavy--) | Ottieni un colore definito dal sistema. |
+| [getOldLace()](#getOldLace--) | Ottieni un colore definito dal sistema. |
+| [getOlive()](#getOlive--) | Ottieni un colore definito dal sistema. |
+| [getOliveDrab()](#getOliveDrab--) | Ottieni un colore definito dal sistema. |
+| [getOrange()](#getOrange--) | Ottieni un colore definito dal sistema. |
+| [getOrangeRed()](#getOrangeRed--) | Ottieni un colore definito dal sistema. |
+| [getOrchid()](#getOrchid--) | Ottieni un colore definito dal sistema. |
+| [getPaleGoldenrod()](#getPaleGoldenrod--) | Ottieni un colore definito dal sistema. |
+| [getPaleGreen()](#getPaleGreen--) | Ottieni un colore definito dal sistema. |
+| [getPaleTurquoise()](#getPaleTurquoise--) | Ottieni un colore definito dal sistema. |
+| [getPaleVioletRed()](#getPaleVioletRed--) | Ottieni un colore definito dal sistema. |
+| [getPapayaWhip()](#getPapayaWhip--) | Ottieni un colore definito dal sistema. |
+| [getPeachPuff()](#getPeachPuff--) | Ottieni un colore definito dal sistema. |
+| [getPeru()](#getPeru--) | Ottieni un colore definito dal sistema. |
+| [getPink()](#getPink--) | Ottieni un colore definito dal sistema. |
+| [getPlum()](#getPlum--) | Ottieni un colore definito dal sistema. |
+| [getPowderBlue()](#getPowderBlue--) | Ottieni un colore definito dal sistema. |
+| [getPurple()](#getPurple--) | Ottieni un colore definito dal sistema. |
+| [getR()](#getR--) | Ottiene il valore del componente rosso di questo oggetto Color. |
+| [getRed()](#getRed--) | Ottieni un colore definito dal sistema. |
+| [getRosyBrown()](#getRosyBrown--) | Ottieni un colore definito dal sistema. |
+| [getRoyalBlue()](#getRoyalBlue--) | Ottieni un colore definito dal sistema. |
+| [getSaddleBrown()](#getSaddleBrown--) | Ottieni un colore definito dal sistema. |
+| [getSalmon()](#getSalmon--) | Ottieni un colore definito dal sistema. |
+| [getSandyBrown()](#getSandyBrown--) | Ottieni un colore definito dal sistema. |
+| [getSeaGreen()](#getSeaGreen--) | Ottieni un colore definito dal sistema. |
+| [getSeaShell()](#getSeaShell--) | Ottieni un colore definito dal sistema. |
+| [getSienna()](#getSienna--) | Ottieni un colore definito dal sistema. |
+| [getSilver()](#getSilver--) | Ottieni un colore definito dal sistema. |
+| [getSkyBlue()](#getSkyBlue--) | Ottieni un colore definito dal sistema. |
+| [getSlateBlue()](#getSlateBlue--) | Ottieni un colore definito dal sistema. |
+| [getSlateGray()](#getSlateGray--) | Ottieni un colore definito dal sistema. |
+| [getSnow()](#getSnow--) | Ottieni un colore definito dal sistema. |
+| [getSpringGreen()](#getSpringGreen--) | Ottieni un colore definito dal sistema. |
+| [getSteelBlue()](#getSteelBlue--) | Ottieni un colore definito dal sistema. |
+| [getTan()](#getTan--) | Ottieni un colore definito dal sistema. |
+| [getTeal()](#getTeal--) | Ottieni un colore definito dal sistema. |
+| [getThistle()](#getThistle--) | Ottieni un colore definito dal sistema. |
+| [getTomato()](#getTomato--) | Ottieni un colore definito dal sistema. |
+| [getTransparent()](#getTransparent--) | Ottieni un colore definito dal sistema. |
+| [getTurquoise()](#getTurquoise--) | Ottieni un colore definito dal sistema. |
+| [getViolet()](#getViolet--) | Ottieni un colore definito dal sistema. |
+| [getWheat()](#getWheat--) | Ottieni un colore definito dal sistema. |
+| [getWhite()](#getWhite--) | Ottieni un colore definito dal sistema. |
+| [getWhiteSmoke()](#getWhiteSmoke--) | Ottieni un colore definito dal sistema. |
+| [getYellow()](#getYellow--) | Ottieni un colore definito dal sistema. |
+| [getYellowGreen()](#getYellowGreen--) | Ottieni un colore definito dal sistema. |
+| [hashCode()](#hashCode--) | Restituisce un codice hash per questo oggetto Color. |
+| [isEmpty()](#isEmpty--) | Specifica se questo oggetto Color non è inizializzato. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toArgb()](#toArgb--) | Ottiene il valore ARGB a 32 bit di questo oggetto Color. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Color() {#Color--}
+```
+public Color()
+```
+
+
+funzione costruttore
+
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+Verifica se l'oggetto specificato è un oggetto Color e se è equivalente a questo oggetto.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| obj | java.lang.Object | L'oggetto da testare. |
+
+**Returns:**
+boolean - true se obj è un oggetto Color e equivalente a questo oggetto Color; altrimenti, false.
+### fromArgb(int argb) {#fromArgb-int-}
+```
+public static Color fromArgb(int argb)
+```
+
+
+Crea un oggetto Color da un valore ARGB a 32 bit.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| argb | int | Un valore che specifica il valore ARGB a 32 bit. |
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - The Color object that this method creates.
+### fromArgb(int red, int green, int blue) {#fromArgb-int-int-int-}
+```
+public static Color fromArgb(int red, int green, int blue)
+```
+
+
+Crea un oggetto Color dai valori di colore a 8 bit specificati (rosso, verde e blu). Il valore alfa è implicitamente 255 (completamente opaco). Sebbene questo metodo consenta di passare un valore a 32 bit per ogni componente colore, il valore di ciascun componente è limitato a 8 bit.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| rosso | int | Il valore del componente rosso per il nuovo oggetto Color. I valori validi sono da 0 a 255. |
+| verde | int | Il valore del componente verde per il nuovo oggetto Color. I valori validi sono da 0 a 255. |
+| blu | int | Il valore del componente blu per il nuovo oggetto Color. I valori validi sono da 0 a 255. |
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - The Color object that this method creates.
+### fromArgb(int alpha, int red, int green, int blue) {#fromArgb-int-int-int-int-}
+```
+public static Color fromArgb(int alpha, int red, int green, int blue)
+```
+
+
+Crea un oggetto Color dai quattro valori dei componenti ARGB (alpha,red, green, and blue). Sebbene questo metodo consenta di passare un valore a 32 bit per ciascun componente, il valore di ogni componente è limitato a 8 bit.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| alpha | int | Il componente alpha. I valori validi sono da 0 a 255. |
+| rosso | int | Il componente rosso. I valori validi sono da 0 a 255. |
+| verde | int | Il componente verde. I valori validi sono da 0 a 255. |
+| blu | int | Il componente blu. I valori validi sono da 0 a 255. |
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - The Color object that this method creates.
+### getA() {#getA--}
+```
+public byte getA()
+```
+
+
+Ottiene il valore del componente alfa di questo oggetto Color.
+
+**Returns:**
+byte - Il valore del componente alpha di questo oggetto Color.
+### getAliceBlue() {#getAliceBlue--}
+```
+public static Color getAliceBlue()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getAntiqueWhite() {#getAntiqueWhite--}
+```
+public static Color getAntiqueWhite()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getAqua() {#getAqua--}
+```
+public static Color getAqua()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getAquamarine() {#getAquamarine--}
+```
+public static Color getAquamarine()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getAzure() {#getAzure--}
+```
+public static Color getAzure()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getB() {#getB--}
+```
+public byte getB()
+```
+
+
+Ottiene il valore del componente blu di questo oggetto Color.
+
+**Returns:**
+byte - Il valore del componente blu di questo oggetto Color.
+### getBeige() {#getBeige--}
+```
+public static Color getBeige()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getBisque() {#getBisque--}
+```
+public static Color getBisque()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getBlack() {#getBlack--}
+```
+public static Color getBlack()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getBlanchedAlmond() {#getBlanchedAlmond--}
+```
+public static Color getBlanchedAlmond()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getBlue() {#getBlue--}
+```
+public static Color getBlue()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getBlueViolet() {#getBlueViolet--}
+```
+public static Color getBlueViolet()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getBrown() {#getBrown--}
+```
+public static Color getBrown()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getBurlyWood() {#getBurlyWood--}
+```
+public static Color getBurlyWood()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getCadetBlue() {#getCadetBlue--}
+```
+public static Color getCadetBlue()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getChartreuse() {#getChartreuse--}
+```
+public static Color getChartreuse()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getChocolate() {#getChocolate--}
+```
+public static Color getChocolate()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCoral() {#getCoral--}
+```
+public static Color getCoral()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getCornflowerBlue() {#getCornflowerBlue--}
+```
+public static Color getCornflowerBlue()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getCornsilk() {#getCornsilk--}
+```
+public static Color getCornsilk()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getCrimson() {#getCrimson--}
+```
+public static Color getCrimson()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getCyan() {#getCyan--}
+```
+public static Color getCyan()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkBlue() {#getDarkBlue--}
+```
+public static Color getDarkBlue()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkCyan() {#getDarkCyan--}
+```
+public static Color getDarkCyan()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkGoldenrod() {#getDarkGoldenrod--}
+```
+public static Color getDarkGoldenrod()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkGray() {#getDarkGray--}
+```
+public static Color getDarkGray()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkGreen() {#getDarkGreen--}
+```
+public static Color getDarkGreen()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkKhaki() {#getDarkKhaki--}
+```
+public static Color getDarkKhaki()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkMagenta() {#getDarkMagenta--}
+```
+public static Color getDarkMagenta()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkOliveGreen() {#getDarkOliveGreen--}
+```
+public static Color getDarkOliveGreen()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkOrange() {#getDarkOrange--}
+```
+public static Color getDarkOrange()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkOrchid() {#getDarkOrchid--}
+```
+public static Color getDarkOrchid()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkRed() {#getDarkRed--}
+```
+public static Color getDarkRed()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkSalmon() {#getDarkSalmon--}
+```
+public static Color getDarkSalmon()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkSeaGreen() {#getDarkSeaGreen--}
+```
+public static Color getDarkSeaGreen()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkSlateBlue() {#getDarkSlateBlue--}
+```
+public static Color getDarkSlateBlue()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkSlateGray() {#getDarkSlateGray--}
+```
+public static Color getDarkSlateGray()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkTurquoise() {#getDarkTurquoise--}
+```
+public static Color getDarkTurquoise()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkViolet() {#getDarkViolet--}
+```
+public static Color getDarkViolet()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDeepPink() {#getDeepPink--}
+```
+public static Color getDeepPink()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDeepSkyBlue() {#getDeepSkyBlue--}
+```
+public static Color getDeepSkyBlue()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDimGray() {#getDimGray--}
+```
+public static Color getDimGray()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDodgerBlue() {#getDodgerBlue--}
+```
+public static Color getDodgerBlue()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getEmpty() {#getEmpty--}
+```
+public static Color getEmpty()
+```
+
+
+Ottieni un colore vuoto definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getFirebrick() {#getFirebrick--}
+```
+public static Color getFirebrick()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getFloralWhite() {#getFloralWhite--}
+```
+public static Color getFloralWhite()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getForestGreen() {#getForestGreen--}
+```
+public static Color getForestGreen()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getFuchsia() {#getFuchsia--}
+```
+public static Color getFuchsia()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getG() {#getG--}
+```
+public byte getG()
+```
+
+
+Ottiene il valore del componente verde di questo oggetto Color.
+
+**Returns:**
+byte - Il valore del componente verde di questo oggetto Color.
+### getGainsboro() {#getGainsboro--}
+```
+public static Color getGainsboro()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getGhostWhite() {#getGhostWhite--}
+```
+public static Color getGhostWhite()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getGold() {#getGold--}
+```
+public static Color getGold()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getGoldenrod() {#getGoldenrod--}
+```
+public static Color getGoldenrod()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getGray() {#getGray--}
+```
+public static Color getGray()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getGreen() {#getGreen--}
+```
+public static Color getGreen()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getGreenYellow() {#getGreenYellow--}
+```
+public static Color getGreenYellow()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getHoneydew() {#getHoneydew--}
+```
+public static Color getHoneydew()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getHotPink() {#getHotPink--}
+```
+public static Color getHotPink()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getIndianRed() {#getIndianRed--}
+```
+public static Color getIndianRed()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getIndigo() {#getIndigo--}
+```
+public static Color getIndigo()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getIvory() {#getIvory--}
+```
+public static Color getIvory()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getKhaki() {#getKhaki--}
+```
+public static Color getKhaki()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLavender() {#getLavender--}
+```
+public static Color getLavender()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLavenderBlush() {#getLavenderBlush--}
+```
+public static Color getLavenderBlush()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLawnGreen() {#getLawnGreen--}
+```
+public static Color getLawnGreen()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLemonChiffon() {#getLemonChiffon--}
+```
+public static Color getLemonChiffon()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightBlue() {#getLightBlue--}
+```
+public static Color getLightBlue()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightCoral() {#getLightCoral--}
+```
+public static Color getLightCoral()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightCyan() {#getLightCyan--}
+```
+public static Color getLightCyan()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightGoldenrodYellow() {#getLightGoldenrodYellow--}
+```
+public static Color getLightGoldenrodYellow()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightGray() {#getLightGray--}
+```
+public static Color getLightGray()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightGreen() {#getLightGreen--}
+```
+public static Color getLightGreen()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightPink() {#getLightPink--}
+```
+public static Color getLightPink()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightSalmon() {#getLightSalmon--}
+```
+public static Color getLightSalmon()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightSeaGreen() {#getLightSeaGreen--}
+```
+public static Color getLightSeaGreen()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightSkyBlue() {#getLightSkyBlue--}
+```
+public static Color getLightSkyBlue()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightSlateGray() {#getLightSlateGray--}
+```
+public static Color getLightSlateGray()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightSteelBlue() {#getLightSteelBlue--}
+```
+public static Color getLightSteelBlue()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightYellow() {#getLightYellow--}
+```
+public static Color getLightYellow()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLime() {#getLime--}
+```
+public static Color getLime()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLimeGreen() {#getLimeGreen--}
+```
+public static Color getLimeGreen()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLinen() {#getLinen--}
+```
+public static Color getLinen()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMagenta() {#getMagenta--}
+```
+public static Color getMagenta()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMaroon() {#getMaroon--}
+```
+public static Color getMaroon()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMediumAquamarine() {#getMediumAquamarine--}
+```
+public static Color getMediumAquamarine()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMediumBlue() {#getMediumBlue--}
+```
+public static Color getMediumBlue()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMediumOrchid() {#getMediumOrchid--}
+```
+public static Color getMediumOrchid()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMediumPurple() {#getMediumPurple--}
+```
+public static Color getMediumPurple()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMediumSeaGreen() {#getMediumSeaGreen--}
+```
+public static Color getMediumSeaGreen()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMediumSlateBlue() {#getMediumSlateBlue--}
+```
+public static Color getMediumSlateBlue()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMediumSpringGreen() {#getMediumSpringGreen--}
+```
+public static Color getMediumSpringGreen()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMediumTurquoise() {#getMediumTurquoise--}
+```
+public static Color getMediumTurquoise()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMediumVioletRed() {#getMediumVioletRed--}
+```
+public static Color getMediumVioletRed()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMidnightBlue() {#getMidnightBlue--}
+```
+public static Color getMidnightBlue()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMintCream() {#getMintCream--}
+```
+public static Color getMintCream()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMistyRose() {#getMistyRose--}
+```
+public static Color getMistyRose()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMoccasin() {#getMoccasin--}
+```
+public static Color getMoccasin()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getNavajoWhite() {#getNavajoWhite--}
+```
+public static Color getNavajoWhite()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getNavy() {#getNavy--}
+```
+public static Color getNavy()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getOldLace() {#getOldLace--}
+```
+public static Color getOldLace()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getOlive() {#getOlive--}
+```
+public static Color getOlive()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getOliveDrab() {#getOliveDrab--}
+```
+public static Color getOliveDrab()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getOrange() {#getOrange--}
+```
+public static Color getOrange()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getOrangeRed() {#getOrangeRed--}
+```
+public static Color getOrangeRed()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getOrchid() {#getOrchid--}
+```
+public static Color getOrchid()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPaleGoldenrod() {#getPaleGoldenrod--}
+```
+public static Color getPaleGoldenrod()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPaleGreen() {#getPaleGreen--}
+```
+public static Color getPaleGreen()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPaleTurquoise() {#getPaleTurquoise--}
+```
+public static Color getPaleTurquoise()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPaleVioletRed() {#getPaleVioletRed--}
+```
+public static Color getPaleVioletRed()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPapayaWhip() {#getPapayaWhip--}
+```
+public static Color getPapayaWhip()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPeachPuff() {#getPeachPuff--}
+```
+public static Color getPeachPuff()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPeru() {#getPeru--}
+```
+public static Color getPeru()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPink() {#getPink--}
+```
+public static Color getPink()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPlum() {#getPlum--}
+```
+public static Color getPlum()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPowderBlue() {#getPowderBlue--}
+```
+public static Color getPowderBlue()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPurple() {#getPurple--}
+```
+public static Color getPurple()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getR() {#getR--}
+```
+public byte getR()
+```
+
+
+Ottiene il valore del componente rosso di questo oggetto Color.
+
+**Returns:**
+byte - Il valore del componente rosso di questo oggetto Color.
+### getRed() {#getRed--}
+```
+public static Color getRed()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getRosyBrown() {#getRosyBrown--}
+```
+public static Color getRosyBrown()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getRoyalBlue() {#getRoyalBlue--}
+```
+public static Color getRoyalBlue()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSaddleBrown() {#getSaddleBrown--}
+```
+public static Color getSaddleBrown()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSalmon() {#getSalmon--}
+```
+public static Color getSalmon()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSandyBrown() {#getSandyBrown--}
+```
+public static Color getSandyBrown()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSeaGreen() {#getSeaGreen--}
+```
+public static Color getSeaGreen()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSeaShell() {#getSeaShell--}
+```
+public static Color getSeaShell()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSienna() {#getSienna--}
+```
+public static Color getSienna()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSilver() {#getSilver--}
+```
+public static Color getSilver()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSkyBlue() {#getSkyBlue--}
+```
+public static Color getSkyBlue()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSlateBlue() {#getSlateBlue--}
+```
+public static Color getSlateBlue()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSlateGray() {#getSlateGray--}
+```
+public static Color getSlateGray()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSnow() {#getSnow--}
+```
+public static Color getSnow()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSpringGreen() {#getSpringGreen--}
+```
+public static Color getSpringGreen()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSteelBlue() {#getSteelBlue--}
+```
+public static Color getSteelBlue()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getTan() {#getTan--}
+```
+public static Color getTan()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getTeal() {#getTeal--}
+```
+public static Color getTeal()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getThistle() {#getThistle--}
+```
+public static Color getThistle()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getTomato() {#getTomato--}
+```
+public static Color getTomato()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getTransparent() {#getTransparent--}
+```
+public static Color getTransparent()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getTurquoise() {#getTurquoise--}
+```
+public static Color getTurquoise()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getViolet() {#getViolet--}
+```
+public static Color getViolet()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getWheat() {#getWheat--}
+```
+public static Color getWheat()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getWhite() {#getWhite--}
+```
+public static Color getWhite()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getWhiteSmoke() {#getWhiteSmoke--}
+```
+public static Color getWhiteSmoke()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getYellow() {#getYellow--}
+```
+public static Color getYellow()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getYellowGreen() {#getYellowGreen--}
+```
+public static Color getYellowGreen()
+```
+
+
+Ottieni un colore definito dal sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Restituisce un codice hash per questo oggetto Color.
+
+**Returns:**
+int - Un valore intero che specifica il codice hash per questo oggetto Color.
+### isEmpty() {#isEmpty--}
+```
+public boolean isEmpty()
+```
+
+
+Specifica se questo oggetto Color non è inizializzato.
+
+**Returns:**
+boolean - Questa proprietà restituisce true se questo colore non è inizializzato; altrimenti, false.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toArgb() {#toArgb--}
+```
+public int toArgb()
+```
+
+
+Ottiene il valore ARGB a 32 bit di questo oggetto Color.
+
+**Returns:**
+int - Il valore ARGB a 32 bit di questo oggetto Color.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/colorentry/_index.md
+++ b/italian/java/com.aspose.diagram/colorentry/_index.md
@@ -1,0 +1,188 @@
+---
+title: ColorEntry
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene una voce della tabella dei colori.
+type: docs
+weight: 52
+url: /it/java/com.aspose.diagram/colorentry/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ColorEntry
+```
+
+Contiene una voce della tavola dei colori. Ogni voce della tavola dei colori specifica un colore standard disponibile per l'applicazione a oggetti come forme, testo e livelli nel documento.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [ColorEntry()](#ColorEntry--) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getColor()](#getColor--) | Rappresenta un colore ARGB. |
+| [getIX()](#getIX--) | int richiesto. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setColor(Color value)](#setColor-com.aspose.diagram.Color-) | Per la descrizione di questa proprietà, vedere [getColor()](../../com.aspose.diagram/colorentry\#getColor--) |
+| [setIX(int value)](#setIX-int-) | Per la descrizione di questa proprietà, vedere [getIX()](../../com.aspose.diagram/colorentry\#getIX--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ColorEntry() {#ColorEntry--}
+```
+public ColorEntry()
+```
+
+
+Costruttore.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColor() {#getColor--}
+```
+public Color getColor()
+```
+
+
+Rappresenta un colore ARGB.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color)
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+int richiesto. L'indice basato su zero dell'elemento all'interno del suo elemento padre.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setColor(Color value) {#setColor-com.aspose.diagram.Color-}
+```
+public void setColor(Color value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getColor()](../../com.aspose.diagram/colorentry\#getColor--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [Color](../../com.aspose.diagram/color) |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getIX()](../../com.aspose.diagram/colorentry\#getIX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/colorentrycollection/_index.md
+++ b/italian/java/com.aspose.diagram/colorentrycollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: ColorEntryCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene la tavola dei colori del documento.
+type: docs
+weight: 53
+url: /it/java/com.aspose.diagram/colorentrycollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ColorEntryCollection extends Collection
+```
+
+Contiene la tavola dei colori del documento. Ogni documento contiene una singola tavola dei colori, che elenca i 24 colori standard disponibili per l'applicazione a oggetti come forme, testo e livelli nel documento.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [add(ColorEntry color)](#add-com.aspose.diagram.ColorEntry-) | Aggiungi l'oggetto Color nella collezione. |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(ColorEntry color)](#remove-com.aspose.diagram.ColorEntry-) | Rimuovi l'oggetto Color dalla collezione. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(ColorEntry color) {#add-com.aspose.diagram.ColorEntry-}
+```
+public int add(ColorEntry color)
+```
+
+
+Aggiungi l'oggetto Color nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| color | [ColorEntry](../../com.aspose.diagram/colorentry) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public ColorEntry get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[ColorEntry](../../com.aspose.diagram/colorentry) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(ColorEntry color) {#remove-com.aspose.diagram.ColorEntry-}
+```
+public void remove(ColorEntry color)
+```
+
+
+Rimuovi l'oggetto Color dalla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| color | [ColorEntry](../../com.aspose.diagram/colorentry) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/colorvalue/_index.md
+++ b/italian/java/com.aspose.diagram/colorvalue/_index.md
@@ -1,0 +1,205 @@
+---
+title: ColorValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta il valore del colore
+type: docs
+weight: 54
+url: /it/java/com.aspose.diagram/colorvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ColorValue
+```
+
+Rappresenta il valore del colore
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [ColorValue(String value, int unit)](#ColorValue-java.lang.String-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Attributi di un elemento. |
+| [getValue()](#getValue--) | Valore colore. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | Per la descrizione di questa proprietà, vedere [getUfe()](../../com.aspose.diagram/colorvalue\#getUfe--) |
+| [setValue(String value)](#setValue-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/colorvalue\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ColorValue(String value, int unit) {#ColorValue-java.lang.String-int-}
+```
+public ColorValue(String value, int unit)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+| unità | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+Valore colore. Per impostare il colore, inserire un numero da 0 a 23 o il valore RGB in notazione esadecimale.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getUfe()](../../com.aspose.diagram/colorvalue\#getUfe--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(String value) {#setValue-java.lang.String-}
+```
+public void setValue(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/colorvalue\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/comboboxactivexcontrol/_index.md
+++ b/italian/java/com.aspose.diagram/comboboxactivexcontrol/_index.md
@@ -1,0 +1,972 @@
+---
+title: ComboBoxActiveXControl
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta un controllo ActiveX ComboBox.
+type: docs
+weight: 55
+url: /it/java/com.aspose.diagram/comboboxactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class ComboBoxActiveXControl extends ActiveXControl
+```
+
+Rappresenta un controllo ActiveX ComboBox.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBackOleColor()](#getBackOleColor--) | il colore OLE dello sfondo. |
+| [getBorderOleColor()](#getBorderOleColor--) | il colore OLE dello sfondo. |
+| [getBorderStyle()](#getBorderStyle--) | il tipo di bordo usato dal controllo. |
+| [getBoundColumn()](#getBoundColumn--) | Rappresenta come la proprietà Value viene determinata per una ComboBox o ListBox quando il valore della proprietà MultiSelect (fmMultiSelectSingle). |
+| [getClass()](#getClass--) |  |
+| [getColumnCount()](#getColumnCount--) | Rappresenta il numero di colonne da visualizzare in una ComboBox o ListBox. |
+| [getColumnWidths()](#getColumnWidths--) | la larghezza della colonna. |
+| [getData()](#getData--) | i dati binari del controllo. |
+| [getDropButtonStyle()](#getDropButtonStyle--) | Specifica il simbolo visualizzato sul pulsante a discesa |
+| [getEnterFieldBehavior()](#getEnterFieldBehavior--) | Specifica il comportamento di selezione quando si entra nel controllo. |
+| [getForeOleColor()](#getForeOleColor--) | il colore OLE del primo piano. |
+| [getHeight()](#getHeight--) | l'altezza del controllo in unità di punti. |
+| [getHideSelection()](#getHideSelection--) | Indica se il testo selezionato nel controllo appare evidenziato quando il controllo non ha il fuoco. |
+| [getIMEMode()](#getIMEMode--) | la modalità di esecuzione predefinita dell'Input Method Editor per il controllo quando riceve il fuoco. |
+| [getListRows()](#getListRows--) | Rappresenta il numero massimo di righe da visualizzare nell'elenco. |
+| [getListStyle()](#getListStyle--) | l'aspetto visivo. |
+| [getListWidth()](#getListWidth--) | la larghezza in unità di punti. |
+| [getMatchEntry()](#getMatchEntry--) | Indica come un ListBox o ComboBox ricerca la sua lista mentre l'utente digita. |
+| [getMaxLength()](#getMaxLength--) | il numero massimo di caratteri |
+| [getMouseIcon()](#getMouseIcon--) | un'icona personalizzata da visualizzare come puntatore del mouse per il controllo. |
+| [getMousePointer()](#getMousePointer--) | il tipo di icona visualizzata come puntatore del mouse per il controllo. |
+| [getSelectionMargin()](#getSelectionMargin--) | Indica se l'utente può selezionare una riga di testo facendo clic nella zona a sinistra del testo. |
+| [getShowColumnHeads()](#getShowColumnHeads--) | Indica se le intestazioni di colonna sono visualizzate. |
+| [getShowDropButtonTypeWhen()](#getShowDropButtonTypeWhen--) | Specifica il simbolo visualizzato sul pulsante a discesa |
+| [getSpecialEffect()](#getSpecialEffect--) | l'effetto speciale del controllo. |
+| [getTextColumn()](#getTextColumn--) | Rappresenta la colonna in un ComboBox o ListBox da visualizzare all'utente. |
+| [getType()](#getType--) | Ottiene il tipo del controllo ActiveX. |
+| [getValue()](#getValue--) | il valore del controllo. |
+| [getWidth()](#getWidth--) | la larghezza del controllo in unità di punti. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | Indica se il controllo ridimensionerà automaticamente per visualizzare tutto il contenuto. |
+| [isAutoWordSelected()](#isAutoWordSelected--) | Specifica l'unità di base utilizzata per estendere una selezione. |
+| [isDragBehaviorEnabled()](#isDragBehaviorEnabled--) | Indica se il trascinamento e il rilascio sono abilitati per il controllo. |
+| [isEditable()](#isEditable--) | Indica se l'utente può digitare nel controllo. |
+| [isEnabled()](#isEnabled--) | Indica se il controllo può ricevere il focus e rispondere agli eventi generati dall'utente. |
+| [isLocked()](#isLocked--) | Indica se i dati nel controllo sono bloccati per la modifica. |
+| [isTransparent()](#isTransparent--) | Indica se il controllo è trasparente. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | Per la descrizione di questa proprietà, vedere [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) |
+| [setAutoWordSelected(boolean value)](#setAutoWordSelected-boolean-) | Per la descrizione di questa proprietà, vedere [isAutoWordSelected()](../../com.aspose.diagram/comboboxactivexcontrol\#isAutoWordSelected--) |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | Per la descrizione di questa proprietà, vedere [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setBorderOleColor(int value)](#setBorderOleColor-int-) | Per la descrizione di questa proprietà, vedere [getBorderOleColor()](../../com.aspose.diagram/comboboxactivexcontrol\#getBorderOleColor--) |
+| [setBorderStyle(int value)](#setBorderStyle-int-) | Per la descrizione di questa proprietà, vedere [getBorderStyle()](../../com.aspose.diagram/comboboxactivexcontrol\#getBorderStyle--) |
+| [setBoundColumn(int value)](#setBoundColumn-int-) | Per la descrizione di questa proprietà, vedere [getBoundColumn()](../../com.aspose.diagram/comboboxactivexcontrol\#getBoundColumn--) |
+| [setColumnCount(int value)](#setColumnCount-int-) | Per la descrizione di questa proprietà, vedere [getColumnCount()](../../com.aspose.diagram/comboboxactivexcontrol\#getColumnCount--) |
+| [setColumnWidths(double value)](#setColumnWidths-double-) | Per la descrizione di questa proprietà, vedere [getColumnWidths()](../../com.aspose.diagram/comboboxactivexcontrol\#getColumnWidths--) |
+| [setDragBehaviorEnabled(boolean value)](#setDragBehaviorEnabled-boolean-) | Per la descrizione di questa proprietà, vedere [isDragBehaviorEnabled()](../../com.aspose.diagram/comboboxactivexcontrol\#isDragBehaviorEnabled--) |
+| [setDropButtonStyle(int value)](#setDropButtonStyle-int-) | Per la descrizione di questa proprietà, vedere [getDropButtonStyle()](../../com.aspose.diagram/comboboxactivexcontrol\#getDropButtonStyle--) |
+| [setEditable(boolean value)](#setEditable-boolean-) | Per la descrizione di questa proprietà, vedere [isEditable()](../../com.aspose.diagram/comboboxactivexcontrol\#isEditable--) |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | Per la descrizione di questa proprietà, vedere [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) |
+| [setEnterFieldBehavior(boolean value)](#setEnterFieldBehavior-boolean-) | Per la descrizione di questa proprietà, vedere [getEnterFieldBehavior()](../../com.aspose.diagram/comboboxactivexcontrol\#getEnterFieldBehavior--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | Per la descrizione di questa proprietà, vedere [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setHeight(double value)](#setHeight-double-) | Per la descrizione di questa proprietà, vedere [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setHideSelection(boolean value)](#setHideSelection-boolean-) | Per la descrizione di questa proprietà, vedere [getHideSelection()](../../com.aspose.diagram/comboboxactivexcontrol\#getHideSelection--) |
+| [setIMEMode(int value)](#setIMEMode-int-) | Per la descrizione di questa proprietà, vedere [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) |
+| [setListRows(int value)](#setListRows-int-) | Per la descrizione di questa proprietà, vedere [getListRows()](../../com.aspose.diagram/comboboxactivexcontrol\#getListRows--) |
+| [setListStyle(int value)](#setListStyle-int-) | Per la descrizione di questa proprietà, vedere [getListStyle()](../../com.aspose.diagram/comboboxactivexcontrol\#getListStyle--) |
+| [setListWidth(double value)](#setListWidth-double-) | Per la descrizione di questa proprietà, vedere [getListWidth()](../../com.aspose.diagram/comboboxactivexcontrol\#getListWidth--) |
+| [setLocked(boolean value)](#setLocked-boolean-) | Per la descrizione di questa proprietà, vedere [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) |
+| [setMatchEntry(int value)](#setMatchEntry-int-) | Per la descrizione di questa proprietà, vedere [getMatchEntry()](../../com.aspose.diagram/comboboxactivexcontrol\#getMatchEntry--) |
+| [setMaxLength(int value)](#setMaxLength-int-) | Per la descrizione di questa proprietà, vedere [getMaxLength()](../../com.aspose.diagram/comboboxactivexcontrol\#getMaxLength--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | Per la descrizione di questa proprietà, vedere [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | Per la descrizione di questa proprietà, vedere [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setSelectionMargin(boolean value)](#setSelectionMargin-boolean-) | Per la descrizione di questa proprietà, vedere [getSelectionMargin()](../../com.aspose.diagram/comboboxactivexcontrol\#getSelectionMargin--) |
+| [setShowColumnHeads(boolean value)](#setShowColumnHeads-boolean-) | Per la descrizione di questa proprietà, vedere [getShowColumnHeads()](../../com.aspose.diagram/comboboxactivexcontrol\#getShowColumnHeads--) |
+| [setShowDropButtonTypeWhen(int value)](#setShowDropButtonTypeWhen-int-) | Per la descrizione di questa proprietà, vedere [getShowDropButtonTypeWhen()](../../com.aspose.diagram/comboboxactivexcontrol\#getShowDropButtonTypeWhen--) |
+| [setSpecialEffect(int value)](#setSpecialEffect-int-) | Per la descrizione di questa proprietà, vedere [getSpecialEffect()](../../com.aspose.diagram/comboboxactivexcontrol\#getSpecialEffect--) |
+| [setTextColumn(int value)](#setTextColumn-int-) | Per la descrizione di questa proprietà, vedere [getTextColumn()](../../com.aspose.diagram/comboboxactivexcontrol\#getTextColumn--) |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | Per la descrizione di questa proprietà, vedere [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) |
+| [setValue(String value)](#setValue-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/comboboxactivexcontrol\#getValue--) |
+| [setWidth(double value)](#setWidth-double-) | Per la descrizione di questa proprietà, vedere [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+il colore OLE dello sfondo.
+
+**Returns:**
+int
+### getBorderOleColor() {#getBorderOleColor--}
+```
+public int getBorderOleColor()
+```
+
+
+il colore OLE dello sfondo.
+
+**Returns:**
+int
+### getBorderStyle() {#getBorderStyle--}
+```
+public int getBorderStyle()
+```
+
+
+il tipo di bordo usato dal controllo.
+
+**Returns:**
+int
+### getBoundColumn() {#getBoundColumn--}
+```
+public int getBoundColumn()
+```
+
+
+Rappresenta come la proprietà Value viene determinata per una ComboBox o ListBox quando il valore della proprietà MultiSelect (fmMultiSelectSingle).
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColumnCount() {#getColumnCount--}
+```
+public int getColumnCount()
+```
+
+
+Rappresenta il numero di colonne da visualizzare in una ComboBox o ListBox.
+
+**Returns:**
+int
+### getColumnWidths() {#getColumnWidths--}
+```
+public double getColumnWidths()
+```
+
+
+la larghezza della colonna.
+
+**Returns:**
+double
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+i dati binari del controllo.
+
+**Returns:**
+byte[]
+### getDropButtonStyle() {#getDropButtonStyle--}
+```
+public int getDropButtonStyle()
+```
+
+
+Specifica il simbolo visualizzato sul pulsante a discesa
+
+**Returns:**
+int
+### getEnterFieldBehavior() {#getEnterFieldBehavior--}
+```
+public boolean getEnterFieldBehavior()
+```
+
+
+Specifica il comportamento di selezione all'ingresso del controllo. True specifica che la selezione rimane invariata rispetto all'ultima volta che il controllo era attivo. False specifica che tutto il testo nel controllo sarà selezionato all'ingresso del controllo.
+
+**Returns:**
+boolean
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+Il colore OLE del primo piano. Non si applica al controllo Image.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+l'altezza del controllo in unità di punti.
+
+**Returns:**
+double
+### getHideSelection() {#getHideSelection--}
+```
+public boolean getHideSelection()
+```
+
+
+Indica se il testo selezionato nel controllo appare evidenziato quando il controllo non ha il fuoco.
+
+**Returns:**
+boolean
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+la modalità di esecuzione predefinita dell'Input Method Editor per il controllo quando riceve il fuoco.
+
+**Returns:**
+int
+### getListRows() {#getListRows--}
+```
+public int getListRows()
+```
+
+
+Rappresenta il numero massimo di righe da visualizzare nell'elenco.
+
+**Returns:**
+int
+### getListStyle() {#getListStyle--}
+```
+public int getListStyle()
+```
+
+
+l'aspetto visivo.
+
+**Returns:**
+int
+### getListWidth() {#getListWidth--}
+```
+public double getListWidth()
+```
+
+
+la larghezza in unità di punti.
+
+**Returns:**
+double
+### getMatchEntry() {#getMatchEntry--}
+```
+public int getMatchEntry()
+```
+
+
+Indica come un ListBox o ComboBox ricerca la sua lista mentre l'utente digita.
+
+**Returns:**
+int
+### getMaxLength() {#getMaxLength--}
+```
+public int getMaxLength()
+```
+
+
+il numero massimo di caratteri
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+un'icona personalizzata da visualizzare come puntatore del mouse per il controllo.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+il tipo di icona visualizzata come puntatore del mouse per il controllo.
+
+**Returns:**
+int
+### getSelectionMargin() {#getSelectionMargin--}
+```
+public boolean getSelectionMargin()
+```
+
+
+Indica se l'utente può selezionare una riga di testo facendo clic nella zona a sinistra del testo.
+
+**Returns:**
+boolean
+### getShowColumnHeads() {#getShowColumnHeads--}
+```
+public boolean getShowColumnHeads()
+```
+
+
+Indica se le intestazioni di colonna sono visualizzate.
+
+**Returns:**
+boolean
+### getShowDropButtonTypeWhen() {#getShowDropButtonTypeWhen--}
+```
+public int getShowDropButtonTypeWhen()
+```
+
+
+Specifica il simbolo visualizzato sul pulsante a discesa
+
+**Returns:**
+int
+### getSpecialEffect() {#getSpecialEffect--}
+```
+public int getSpecialEffect()
+```
+
+
+l'effetto speciale del controllo.
+
+**Returns:**
+int
+### getTextColumn() {#getTextColumn--}
+```
+public int getTextColumn()
+```
+
+
+Rappresenta la colonna in un ComboBox o ListBox da visualizzare all'utente.
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Ottiene il tipo del controllo ActiveX.
+
+**Returns:**
+int
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+il valore del controllo.
+
+**Returns:**
+java.lang.String
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+la larghezza del controllo in unità di punti.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+Indica se il controllo ridimensionerà automaticamente per visualizzare tutto il contenuto.
+
+**Returns:**
+boolean
+### isAutoWordSelected() {#isAutoWordSelected--}
+```
+public boolean isAutoWordSelected()
+```
+
+
+Specifica l'unità di base utilizzata per estendere una selezione. True specifica che l'unità di base è un singolo carattere. false specifica che l'unità di base è una parola intera.
+
+**Returns:**
+boolean
+### isDragBehaviorEnabled() {#isDragBehaviorEnabled--}
+```
+public boolean isDragBehaviorEnabled()
+```
+
+
+Indica se il trascinamento e il rilascio sono abilitati per il controllo.
+
+**Returns:**
+boolean
+### isEditable() {#isEditable--}
+```
+public boolean isEditable()
+```
+
+
+Indica se l'utente può digitare nel controllo.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+Indica se il controllo può ricevere il focus e rispondere agli eventi generati dall'utente.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+Indica se i dati nel controllo sono bloccati per la modifica.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+Indica se il controllo è trasparente.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setAutoWordSelected(boolean value) {#setAutoWordSelected-boolean-}
+```
+public void setAutoWordSelected(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isAutoWordSelected()](../../com.aspose.diagram/comboboxactivexcontrol\#isAutoWordSelected--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setBorderOleColor(int value) {#setBorderOleColor-int-}
+```
+public void setBorderOleColor(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getBorderOleColor()](../../com.aspose.diagram/comboboxactivexcontrol\#getBorderOleColor--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setBorderStyle(int value) {#setBorderStyle-int-}
+```
+public void setBorderStyle(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getBorderStyle()](../../com.aspose.diagram/comboboxactivexcontrol\#getBorderStyle--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setBoundColumn(int value) {#setBoundColumn-int-}
+```
+public void setBoundColumn(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getBoundColumn()](../../com.aspose.diagram/comboboxactivexcontrol\#getBoundColumn--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setColumnCount(int value) {#setColumnCount-int-}
+```
+public void setColumnCount(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getColumnCount()](../../com.aspose.diagram/comboboxactivexcontrol\#getColumnCount--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setColumnWidths(double value) {#setColumnWidths-double-}
+```
+public void setColumnWidths(double value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getColumnWidths()](../../com.aspose.diagram/comboboxactivexcontrol\#getColumnWidths--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double |  |
+
+### setDragBehaviorEnabled(boolean value) {#setDragBehaviorEnabled-boolean-}
+```
+public void setDragBehaviorEnabled(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isDragBehaviorEnabled()](../../com.aspose.diagram/comboboxactivexcontrol\#isDragBehaviorEnabled--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setDropButtonStyle(int value) {#setDropButtonStyle-int-}
+```
+public void setDropButtonStyle(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDropButtonStyle()](../../com.aspose.diagram/comboboxactivexcontrol\#getDropButtonStyle--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setEditable(boolean value) {#setEditable-boolean-}
+```
+public void setEditable(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isEditable()](../../com.aspose.diagram/comboboxactivexcontrol\#isEditable--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setEnterFieldBehavior(boolean value) {#setEnterFieldBehavior-boolean-}
+```
+public void setEnterFieldBehavior(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getEnterFieldBehavior()](../../com.aspose.diagram/comboboxactivexcontrol\#getEnterFieldBehavior--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double |  |
+
+### setHideSelection(boolean value) {#setHideSelection-boolean-}
+```
+public void setHideSelection(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getHideSelection()](../../com.aspose.diagram/comboboxactivexcontrol\#getHideSelection--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setListRows(int value) {#setListRows-int-}
+```
+public void setListRows(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getListRows()](../../com.aspose.diagram/comboboxactivexcontrol\#getListRows--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setListStyle(int value) {#setListStyle-int-}
+```
+public void setListStyle(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getListStyle()](../../com.aspose.diagram/comboboxactivexcontrol\#getListStyle--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setListWidth(double value) {#setListWidth-double-}
+```
+public void setListWidth(double value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getListWidth()](../../com.aspose.diagram/comboboxactivexcontrol\#getListWidth--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setMatchEntry(int value) {#setMatchEntry-int-}
+```
+public void setMatchEntry(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getMatchEntry()](../../com.aspose.diagram/comboboxactivexcontrol\#getMatchEntry--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setMaxLength(int value) {#setMaxLength-int-}
+```
+public void setMaxLength(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getMaxLength()](../../com.aspose.diagram/comboboxactivexcontrol\#getMaxLength--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setSelectionMargin(boolean value) {#setSelectionMargin-boolean-}
+```
+public void setSelectionMargin(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getSelectionMargin()](../../com.aspose.diagram/comboboxactivexcontrol\#getSelectionMargin--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setShowColumnHeads(boolean value) {#setShowColumnHeads-boolean-}
+```
+public void setShowColumnHeads(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getShowColumnHeads()](../../com.aspose.diagram/comboboxactivexcontrol\#getShowColumnHeads--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setShowDropButtonTypeWhen(int value) {#setShowDropButtonTypeWhen-int-}
+```
+public void setShowDropButtonTypeWhen(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getShowDropButtonTypeWhen()](../../com.aspose.diagram/comboboxactivexcontrol\#getShowDropButtonTypeWhen--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setSpecialEffect(int value) {#setSpecialEffect-int-}
+```
+public void setSpecialEffect(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getSpecialEffect()](../../com.aspose.diagram/comboboxactivexcontrol\#getSpecialEffect--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setTextColumn(int value) {#setTextColumn-int-}
+```
+public void setTextColumn(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getTextColumn()](../../com.aspose.diagram/comboboxactivexcontrol\#getTextColumn--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setValue(String value) {#setValue-java.lang.String-}
+```
+public void setValue(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/comboboxactivexcontrol\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/commandbuttonactivexcontrol/_index.md
+++ b/italian/java/com.aspose.diagram/commandbuttonactivexcontrol/_index.md
@@ -1,0 +1,572 @@
+---
+title: CommandButtonActiveXControl
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta un pulsante di comando.
+type: docs
+weight: 56
+url: /it/java/com.aspose.diagram/commandbuttonactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class CommandButtonActiveXControl extends ActiveXControl
+```
+
+Rappresenta un pulsante di comando.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAccelerator()](#getAccelerator--) | il tasto di accelerazione per il controllo. |
+| [getBackOleColor()](#getBackOleColor--) | il colore OLE dello sfondo. |
+| [getCaption()](#getCaption--) | il testo descrittivo che appare su un controllo. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | i dati binari del controllo. |
+| [getForeOleColor()](#getForeOleColor--) | il colore OLE del primo piano. |
+| [getHeight()](#getHeight--) | l'altezza del controllo in unità di punti. |
+| [getIMEMode()](#getIMEMode--) | la modalità di esecuzione predefinita dell'Input Method Editor per il controllo quando riceve il fuoco. |
+| [getMouseIcon()](#getMouseIcon--) | un'icona personalizzata da visualizzare come puntatore del mouse per il controllo. |
+| [getMousePointer()](#getMousePointer--) | il tipo di icona visualizzata come puntatore del mouse per il controllo. |
+| [getPicture()](#getPicture--) | i dati dell'immagine. |
+| [getPicturePosition()](#getPicturePosition--) | la posizione dell'immagine del controllo rispetto alla sua didascalia. |
+| [getTakeFocusOnClick()](#getTakeFocusOnClick--) | Indica se il controllo prende il focus quando viene cliccato. |
+| [getType()](#getType--) | Ottiene il tipo del controllo ActiveX. |
+| [getWidth()](#getWidth--) | la larghezza del controllo in unità di punti. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | Indica se il controllo ridimensionerà automaticamente per visualizzare tutto il contenuto. |
+| [isEnabled()](#isEnabled--) | Indica se il controllo può ricevere il focus e rispondere agli eventi generati dall'utente. |
+| [isLocked()](#isLocked--) | Indica se i dati nel controllo sono bloccati per la modifica. |
+| [isTransparent()](#isTransparent--) | Indica se il controllo è trasparente. |
+| [isWordWrapped()](#isWordWrapped--) | Indica se il contenuto del controllo avvolge automaticamente alla fine di una riga. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAccelerator(char value)](#setAccelerator-char-) | Per la descrizione di questa proprietà, consultare [getAccelerator()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getAccelerator--) |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | Per la descrizione di questa proprietà, vedere [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | Per la descrizione di questa proprietà, vedere [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setCaption(String value)](#setCaption-java.lang.String-) | Per la descrizione di questa proprietà, consultare [getCaption()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getCaption--) |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | Per la descrizione di questa proprietà, vedere [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | Per la descrizione di questa proprietà, vedere [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setHeight(double value)](#setHeight-double-) | Per la descrizione di questa proprietà, vedere [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setIMEMode(int value)](#setIMEMode-int-) | Per la descrizione di questa proprietà, vedere [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) |
+| [setLocked(boolean value)](#setLocked-boolean-) | Per la descrizione di questa proprietà, vedere [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | Per la descrizione di questa proprietà, vedere [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | Per la descrizione di questa proprietà, vedere [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setPicture(byte[] value)](#setPicture-byte---) | Per la descrizione di questa proprietà, consultare [getPicture()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getPicture--) |
+| [setPicturePosition(int value)](#setPicturePosition-int-) | Per la descrizione di questa proprietà, consultare [getPicturePosition()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getPicturePosition--) |
+| [setTakeFocusOnClick(boolean value)](#setTakeFocusOnClick-boolean-) | Per la descrizione di questa proprietà, consultare [getTakeFocusOnClick()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getTakeFocusOnClick--) |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | Per la descrizione di questa proprietà, vedere [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) |
+| [setWidth(double value)](#setWidth-double-) | Per la descrizione di questa proprietà, vedere [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [setWordWrapped(boolean value)](#setWordWrapped-boolean-) | Per la descrizione di questa proprietà, consultare [isWordWrapped()](../../com.aspose.diagram/commandbuttonactivexcontrol\#isWordWrapped--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAccelerator() {#getAccelerator--}
+```
+public char getAccelerator()
+```
+
+
+il tasto di accelerazione per il controllo.
+
+**Returns:**
+char
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+il colore OLE dello sfondo.
+
+**Returns:**
+int
+### getCaption() {#getCaption--}
+```
+public String getCaption()
+```
+
+
+il testo descrittivo che appare su un controllo.
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+i dati binari del controllo.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+Il colore OLE del primo piano. Non si applica al controllo Image.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+l'altezza del controllo in unità di punti.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+la modalità di esecuzione predefinita dell'Input Method Editor per il controllo quando riceve il fuoco.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+un'icona personalizzata da visualizzare come puntatore del mouse per il controllo.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+il tipo di icona visualizzata come puntatore del mouse per il controllo.
+
+**Returns:**
+int
+### getPicture() {#getPicture--}
+```
+public byte[] getPicture()
+```
+
+
+i dati dell'immagine.
+
+**Returns:**
+byte[]
+### getPicturePosition() {#getPicturePosition--}
+```
+public int getPicturePosition()
+```
+
+
+la posizione dell'immagine del controllo rispetto alla sua didascalia.
+
+**Returns:**
+int
+### getTakeFocusOnClick() {#getTakeFocusOnClick--}
+```
+public boolean getTakeFocusOnClick()
+```
+
+
+Indica se il controllo prende il focus quando viene cliccato.
+
+**Returns:**
+boolean
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Ottiene il tipo del controllo ActiveX.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+la larghezza del controllo in unità di punti.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+Indica se il controllo ridimensionerà automaticamente per visualizzare tutto il contenuto.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+Indica se il controllo può ricevere il focus e rispondere agli eventi generati dall'utente.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+Indica se i dati nel controllo sono bloccati per la modifica.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+Indica se il controllo è trasparente.
+
+**Returns:**
+boolean
+### isWordWrapped() {#isWordWrapped--}
+```
+public boolean isWordWrapped()
+```
+
+
+Indica se il contenuto del controllo avvolge automaticamente alla fine di una riga.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAccelerator(char value) {#setAccelerator-char-}
+```
+public void setAccelerator(char value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getAccelerator()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getAccelerator--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | char |  |
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setCaption(String value) {#setCaption-java.lang.String-}
+```
+public void setCaption(String value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getCaption()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getCaption--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setPicture(byte[] value) {#setPicture-byte---}
+```
+public void setPicture(byte[] value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getPicture()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getPicture--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | byte[] |  |
+
+### setPicturePosition(int value) {#setPicturePosition-int-}
+```
+public void setPicturePosition(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getPicturePosition()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getPicturePosition--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setTakeFocusOnClick(boolean value) {#setTakeFocusOnClick-boolean-}
+```
+public void setTakeFocusOnClick(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getTakeFocusOnClick()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getTakeFocusOnClick--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double |  |
+
+### setWordWrapped(boolean value) {#setWordWrapped-boolean-}
+```
+public void setWordWrapped(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [isWordWrapped()](../../com.aspose.diagram/commandbuttonactivexcontrol\#isWordWrapped--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/compositingquality/_index.md
+++ b/italian/java/com.aspose.diagram/compositingquality/_index.md
@@ -1,0 +1,183 @@
+---
+title: CompositingQuality
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica il livello di qualità da utilizzare durante il compositing.
+type: docs
+weight: 57
+url: /it/java/com.aspose.diagram/compositingquality/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class CompositingQuality
+```
+
+Specifica il livello di qualità da utilizzare durante il compositing.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [ASSUME_LINEAR](#ASSUME-LINEAR) | Assumi valori lineari. |
+| [DEFAULT](#DEFAULT) | Qualità predefinita. |
+| [GAMMA_CORRECTED](#GAMMA-CORRECTED) | Viene utilizzata la correzione gamma. |
+| [HIGH_QUALITY](#HIGH-QUALITY) | Composizione ad alta qualità e bassa velocità. |
+| [HIGH_SPEED](#HIGH-SPEED) | Alta velocità, bassa qualità. |
+| [INVALID](#INVALID) | Qualità non valida. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ASSUME_LINEAR {#ASSUME-LINEAR}
+```
+public static final int ASSUME_LINEAR
+```
+
+
+Assumi valori lineari.
+
+### DEFAULT {#DEFAULT}
+```
+public static final int DEFAULT
+```
+
+
+Qualità predefinita.
+
+### GAMMA_CORRECTED {#GAMMA-CORRECTED}
+```
+public static final int GAMMA_CORRECTED
+```
+
+
+Viene utilizzata la correzione gamma.
+
+### HIGH_QUALITY {#HIGH-QUALITY}
+```
+public static final int HIGH_QUALITY
+```
+
+
+Composizione ad alta qualità e bassa velocità.
+
+### HIGH_SPEED {#HIGH-SPEED}
+```
+public static final int HIGH_SPEED
+```
+
+
+Alta velocità, bassa qualità.
+
+### INVALID {#INVALID}
+```
+public static final int INVALID
+```
+
+
+Qualità non valida.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/compoundtype/_index.md
+++ b/italian/java/com.aspose.diagram/compoundtype/_index.md
@@ -1,0 +1,179 @@
+---
+title: CompoundType
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica la dimensione della punta della freccia della linea.
+type: docs
+weight: 58
+url: /it/java/com.aspose.diagram/compoundtype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class CompoundType
+```
+
+Specifica la dimensione della punta della freccia della linea.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [CompoundType(int value)](#CompoundType-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Specifica la dimensione della punta della freccia della linea. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, consultare [getValue()](../../com.aspose.diagram/compoundtype\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CompoundType(int value) {#CompoundType-int-}
+```
+public CompoundType(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specifica la dimensione della punta della freccia della linea.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getValue()](../../com.aspose.diagram/compoundtype\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/compoundtypevalue/_index.md
+++ b/italian/java/com.aspose.diagram/compoundtypevalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: CompoundTypeValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta lo stile di disegno delle linee.
+type: docs
+weight: 59
+url: /it/java/com.aspose.diagram/compoundtypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class CompoundTypeValue
+```
+
+Rappresenta lo stile di disegno delle linee.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [SINGLE](#SINGLE) | Linea singola (di larghezza lineWidth) |
+| [THICK_BETWEEN_THIN](#THICK-BETWEEN-THIN) | Tre linee, sottile, spessa, sottile |
+| [THICK_THIN](#THICK-THIN) | Doppie linee, una spessa, una sottile |
+| [THIN_THICK](#THIN-THICK) | Doppie linee, una sottile, una spessa |
+| [THIN_THIN](#THIN-THIN) | Doppie linee di larghezza uguale |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SINGLE {#SINGLE}
+```
+public static final int SINGLE
+```
+
+
+Linea singola (di larghezza lineWidth)
+
+### THICK_BETWEEN_THIN {#THICK-BETWEEN-THIN}
+```
+public static final int THICK_BETWEEN_THIN
+```
+
+
+Tre linee, sottile, spessa, sottile
+
+### THICK_THIN {#THICK-THIN}
+```
+public static final int THICK_THIN
+```
+
+
+Doppie linee, una spessa, una sottile
+
+### THIN_THICK {#THIN-THICK}
+```
+public static final int THIN_THICK
+```
+
+
+Doppie linee, una sottile, una spessa
+
+### THIN_THIN {#THIN-THIN}
+```
+public static final int THIN_THIN
+```
+
+
+Doppie linee di larghezza uguale
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/compressiontype/_index.md
+++ b/italian/java/com.aspose.diagram/compressiontype/_index.md
@@ -1,0 +1,183 @@
+---
+title: CompressionType
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Questo attributo ha senso solo se i dati esterni sono un oggetto esterno basato su raster, come un file DIB, JPG, PNG, TIFF o GIF.
+type: docs
+weight: 60
+url: /it/java/com.aspose.diagram/compressiontype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class CompressionType
+```
+
+Questo attributo ha senso solo se i dati esterni sono un oggetto esterno basato su raster, come un file DIB, JPG, PNG, TIFF o GIF. Il valore indica il tipo di compressione applicato al file.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [GIF](#GIF) | Compressione GIF. |
+| [JPEG](#JPEG) | Compressione JPEG. |
+| [NO](#NO) | Nessuna compressione (predefinita). |
+| [PNG](#PNG) | Compressione PNG. |
+| [TIFF](#TIFF) | Compressione TIFF. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GIF {#GIF}
+```
+public static final int GIF
+```
+
+
+Compressione GIF.
+
+### JPEG {#JPEG}
+```
+public static final int JPEG
+```
+
+
+Compressione JPEG.
+
+### NO {#NO}
+```
+public static final int NO
+```
+
+
+Nessuna compressione (predefinita).
+
+### PNG {#PNG}
+```
+public static final int PNG
+```
+
+
+Compressione PNG.
+
+### TIFF {#TIFF}
+```
+public static final int TIFF
+```
+
+
+Compressione TIFF.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/confixedcode/_index.md
+++ b/italian/java/com.aspose.diagram/confixedcode/_index.md
@@ -1,0 +1,179 @@
+---
+title: ConFixedCode
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Determina quando un connettore viene ricalcolato.
+type: docs
+weight: 61
+url: /it/java/com.aspose.diagram/confixedcode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ConFixedCode
+```
+
+Determina quando un connettore viene ricalcolato.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [ConFixedCode(int value)](#ConFixedCode-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Determina quando un connettore viene ricalcolato. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/confixedcode\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ConFixedCode(int value) {#ConFixedCode-int-}
+```
+public ConFixedCode(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Determina quando un connettore viene ricalcolato.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/confixedcode\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/confixedcodevalue/_index.md
+++ b/italian/java/com.aspose.diagram/confixedcodevalue/_index.md
@@ -1,0 +1,201 @@
+---
+title: ConFixedCodeValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Determina quando un connettore viene ricalcolato.
+type: docs
+weight: 62
+url: /it/java/com.aspose.diagram/confixedcodevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConFixedCodeValue
+```
+
+Determina quando un connettore viene ricalcolato.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [NEVER_REROUTE](#NEVER-REROUTE) | Mai riorientare. |
+| [REROUTE_FREELY](#REROUTE-FREELY) | Riorienta liberamente. |
+| [REROUTE_NEEDED](#REROUTE-NEEDED) | Riorienta secondo necessità. |
+| [REROUTE_ON_CROSSOVER](#REROUTE-ON-CROSSOVER) | Riorienta al crossover. |
+| [RESERVED_1](#RESERVED-1) | Riservato solo per uso interno. |
+| [RESERVED_2](#RESERVED-2) | Riservato solo per uso interno. |
+| [RESERVED_3](#RESERVED-3) | Riservato solo per uso interno. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### NEVER_REROUTE {#NEVER-REROUTE}
+```
+public static final int NEVER_REROUTE
+```
+
+
+Mai riorientare.
+
+### REROUTE_FREELY {#REROUTE-FREELY}
+```
+public static final int REROUTE_FREELY
+```
+
+
+Riorienta liberamente.
+
+### REROUTE_NEEDED {#REROUTE-NEEDED}
+```
+public static final int REROUTE_NEEDED
+```
+
+
+Riorienta secondo necessità.
+
+### REROUTE_ON_CROSSOVER {#REROUTE-ON-CROSSOVER}
+```
+public static final int REROUTE_ON_CROSSOVER
+```
+
+
+Riorienta al crossover.
+
+### RESERVED_1 {#RESERVED-1}
+```
+public static final int RESERVED_1
+```
+
+
+Riservato solo per uso interno.
+
+### RESERVED_2 {#RESERVED-2}
+```
+public static final int RESERVED_2
+```
+
+
+Riservato solo per uso interno.
+
+### RESERVED_3 {#RESERVED-3}
+```
+public static final int RESERVED_3
+```
+
+
+Riservato solo per uso interno.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/conlinejumpcode/_index.md
+++ b/italian/java/com.aspose.diagram/conlinejumpcode/_index.md
@@ -1,0 +1,179 @@
+---
+title: ConLineJumpCode
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Determina se un connettore salta quando due connettori si incrociano.
+type: docs
+weight: 63
+url: /it/java/com.aspose.diagram/conlinejumpcode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ConLineJumpCode
+```
+
+Determina se un connettore salta quando due connettori si incrociano.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [ConLineJumpCode(int value)](#ConLineJumpCode-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Determina se un connettore salta quando due connettori si incrociano. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/conlinejumpcode\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ConLineJumpCode(int value) {#ConLineJumpCode-int-}
+```
+public ConLineJumpCode(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Determina se un connettore salta quando due connettori si incrociano.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/conlinejumpcode\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/conlinejumpcodevalue/_index.md
+++ b/italian/java/com.aspose.diagram/conlinejumpcodevalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: ConLineJumpCodeValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Determina se un connettore salta quando due connettori si incrociano.
+type: docs
+weight: 64
+url: /it/java/com.aspose.diagram/conlinejumpcodevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConLineJumpCodeValue
+```
+
+Determina se un connettore salta quando due connettori si incrociano.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [ALWAYS](#ALWAYS) | Sempre |
+| [NEITHER_CONNECTOR_JUMPS](#NEITHER-CONNECTOR-JUMPS) | Nessun salto di connettore. |
+| [NEVER](#NEVER) | Mai. |
+| [OTHER_CONNECTOR_JUMPS](#OTHER-CONNECTOR-JUMPS) | Altri salti di connettore. |
+| [PAGE_DEFAULT](#PAGE-DEFAULT) | Pagina predefinita. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALWAYS {#ALWAYS}
+```
+public static final int ALWAYS
+```
+
+
+Sempre
+
+### NEITHER_CONNECTOR_JUMPS {#NEITHER-CONNECTOR-JUMPS}
+```
+public static final int NEITHER_CONNECTOR_JUMPS
+```
+
+
+Nessun salto di connettore.
+
+### NEVER {#NEVER}
+```
+public static final int NEVER
+```
+
+
+Mai.
+
+### OTHER_CONNECTOR_JUMPS {#OTHER-CONNECTOR-JUMPS}
+```
+public static final int OTHER_CONNECTOR_JUMPS
+```
+
+
+Altri salti di connettore.
+
+### PAGE_DEFAULT {#PAGE-DEFAULT}
+```
+public static final int PAGE_DEFAULT
+```
+
+
+Pagina predefinita.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/conlinejumpdirx/_index.md
+++ b/italian/java/com.aspose.diagram/conlinejumpdirx/_index.md
@@ -1,0 +1,179 @@
+---
+title: ConLineJumpDirX
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Determina la direzione del salto di linea per i salti di linea che si verificano su un segmento orizzontale di un connettore dinamico.
+type: docs
+weight: 65
+url: /it/java/com.aspose.diagram/conlinejumpdirx/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ConLineJumpDirX
+```
+
+Determina la direzione del salto di linea per i salti di linea che si verificano su un segmento orizzontale di un connettore dinamico.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [ConLineJumpDirX(int value)](#ConLineJumpDirX-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Determina la direzione del salto di linea per i salti di linea che si verificano su un segmento orizzontale di un connettore dinamico. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/conlinejumpdirx\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ConLineJumpDirX(int value) {#ConLineJumpDirX-int-}
+```
+public ConLineJumpDirX(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Determina la direzione del salto di linea per i salti di linea che si verificano su un segmento orizzontale di un connettore dinamico.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/conlinejumpdirx\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/conlinejumpdirxvalue/_index.md
+++ b/italian/java/com.aspose.diagram/conlinejumpdirxvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: ConLineJumpDirXValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Determina la direzione del salto di linea per i salti di linea che si verificano su un segmento orizzontale di un connettore dinamico.
+type: docs
+weight: 66
+url: /it/java/com.aspose.diagram/conlinejumpdirxvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConLineJumpDirXValue
+```
+
+Determina la direzione del salto di linea per i salti di linea che si verificano su un segmento orizzontale di un connettore dinamico.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [DOWN](#DOWN) | Giù. |
+| [PAGE_DEFAULT](#PAGE-DEFAULT) | Pagina predefinita. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+| [UP](#UP) | Su. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DOWN {#DOWN}
+```
+public static final int DOWN
+```
+
+
+Giù.
+
+### PAGE_DEFAULT {#PAGE-DEFAULT}
+```
+public static final int PAGE_DEFAULT
+```
+
+
+Pagina predefinita.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### UP {#UP}
+```
+public static final int UP
+```
+
+
+Su.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/conlinejumpdiry/_index.md
+++ b/italian/java/com.aspose.diagram/conlinejumpdiry/_index.md
@@ -1,0 +1,179 @@
+---
+title: ConLineJumpDirY
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Determina la direzione del salto di linea per i salti di linea che si verificano su un segmento verticale di un connettore dinamico.
+type: docs
+weight: 67
+url: /it/java/com.aspose.diagram/conlinejumpdiry/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ConLineJumpDirY
+```
+
+Determina la direzione del salto di linea per i salti di linea che si verificano su un segmento verticale di un connettore dinamico.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [ConLineJumpDirY(int value)](#ConLineJumpDirY-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Determina la direzione del salto di linea per i salti di linea che si verificano su un segmento verticale di un connettore dinamico. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, consultare [getValue()](../../com.aspose.diagram/conlinejumpdiry\\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ConLineJumpDirY(int value) {#ConLineJumpDirY-int-}
+```
+public ConLineJumpDirY(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Determina la direzione del salto di linea per i salti di linea che si verificano su un segmento verticale di un connettore dinamico.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getValue()](../../com.aspose.diagram/conlinejumpdiry\\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/conlinejumpdiryvalue/_index.md
+++ b/italian/java/com.aspose.diagram/conlinejumpdiryvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: ConLineJumpDirYValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Determina la direzione del salto di linea per i salti di linea che si verificano su un segmento verticale di un connettore dinamico.
+type: docs
+weight: 68
+url: /it/java/com.aspose.diagram/conlinejumpdiryvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConLineJumpDirYValue
+```
+
+Determina la direzione del salto di linea per i salti di linea che si verificano su un segmento verticale di un connettore dinamico.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [LEFT](#LEFT) | Sinistra. |
+| [PAGE_DEFAULT](#PAGE-DEFAULT) | Pagina predefinita. |
+| [RIGHT](#RIGHT) | Destra. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LEFT {#LEFT}
+```
+public static final int LEFT
+```
+
+
+Sinistra.
+
+### PAGE_DEFAULT {#PAGE-DEFAULT}
+```
+public static final int PAGE_DEFAULT
+```
+
+
+Pagina predefinita.
+
+### RIGHT {#RIGHT}
+```
+public static final int RIGHT
+```
+
+
+Destra.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/conlinejumpstyle/_index.md
+++ b/italian/java/com.aspose.diagram/conlinejumpstyle/_index.md
@@ -1,0 +1,179 @@
+---
+title: ConLineJumpStyle
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Determina lo stile del salto di linea per i salti di linea su un connettore dinamico.
+type: docs
+weight: 69
+url: /it/java/com.aspose.diagram/conlinejumpstyle/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ConLineJumpStyle
+```
+
+Determina lo stile del salto di linea per i salti di linea su un connettore dinamico.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [ConLineJumpStyle(int value)](#ConLineJumpStyle-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Determina lo stile del salto di linea per i salti di linea su un connettore dinamico. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, consultare [getValue()](../../com.aspose.diagram/conlinejumpstyle\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ConLineJumpStyle(int value) {#ConLineJumpStyle-int-}
+```
+public ConLineJumpStyle(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Determina lo stile del salto di linea per i salti di linea su un connettore dinamico.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getValue()](../../com.aspose.diagram/conlinejumpstyle\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/conlinejumpstylevalue/_index.md
+++ b/italian/java/com.aspose.diagram/conlinejumpstylevalue/_index.md
@@ -1,0 +1,228 @@
+---
+title: ConLineJumpStyleValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Determina lo stile del salto di linea per i salti di linea su un connettore dinamico.
+type: docs
+weight: 70
+url: /it/java/com.aspose.diagram/conlinejumpstylevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConLineJumpStyleValue
+```
+
+Determina lo stile del salto di linea per i salti di linea su un connettore dinamico.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [ARC](#ARC) | Arco. |
+| [GAP](#GAP) | Spazio. |
+| [PAGE_DEFAULT](#PAGE-DEFAULT) | Pagina predefinita. |
+| [SIDES_2](#SIDES-2) | Sides2. |
+| [SIDES_3](#SIDES-3) | Sides3. |
+| [SIDES_4](#SIDES-4) | Sides4. |
+| [SIDES_5](#SIDES-5) | Sides5. |
+| [SIDES_6](#SIDES-6) | Sides6. |
+| [SIDES_7](#SIDES-7) | Sides7 |
+| [SQUARE](#SQUARE) | Quadrato. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ARC {#ARC}
+```
+public static final int ARC
+```
+
+
+Arco.
+
+### GAP {#GAP}
+```
+public static final int GAP
+```
+
+
+Spazio.
+
+### PAGE_DEFAULT {#PAGE-DEFAULT}
+```
+public static final int PAGE_DEFAULT
+```
+
+
+Pagina predefinita.
+
+### SIDES_2 {#SIDES-2}
+```
+public static final int SIDES_2
+```
+
+
+Sides2.
+
+### SIDES_3 {#SIDES-3}
+```
+public static final int SIDES_3
+```
+
+
+Sides3.
+
+### SIDES_4 {#SIDES-4}
+```
+public static final int SIDES_4
+```
+
+
+Sides4.
+
+### SIDES_5 {#SIDES-5}
+```
+public static final int SIDES_5
+```
+
+
+Sides5.
+
+### SIDES_6 {#SIDES-6}
+```
+public static final int SIDES_6
+```
+
+
+Sides6.
+
+### SIDES_7 {#SIDES-7}
+```
+public static final int SIDES_7
+```
+
+
+Sides7
+
+### SQUARE {#SQUARE}
+```
+public static final int SQUARE
+```
+
+
+Quadrato.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/conlinerouteext/_index.md
+++ b/italian/java/com.aspose.diagram/conlinerouteext/_index.md
@@ -1,0 +1,179 @@
+---
+title: ConLineRouteExt
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Determina l'aspetto di un connettore.
+type: docs
+weight: 71
+url: /it/java/com.aspose.diagram/conlinerouteext/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ConLineRouteExt
+```
+
+Determina l'aspetto di un connettore.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [ConLineRouteExt(int value)](#ConLineRouteExt-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Determina l'aspetto di un connettore. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, consultare [getValue()](../../com.aspose.diagram/conlinerouteext\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ConLineRouteExt(int value) {#ConLineRouteExt-int-}
+```
+public ConLineRouteExt(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Determina l'aspetto di un connettore.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getValue()](../../com.aspose.diagram/conlinerouteext\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/conlinerouteextvalue/_index.md
+++ b/italian/java/com.aspose.diagram/conlinerouteextvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: ConLineRouteExtValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Determina l'aspetto di un connettore.
+type: docs
+weight: 72
+url: /it/java/com.aspose.diagram/conlinerouteextvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConLineRouteExtValue
+```
+
+Determina l'aspetto di un connettore.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [CURVED](#CURVED) | Curvo. |
+| [PAGE_DEFAULT](#PAGE-DEFAULT) | Pagina predefinita. |
+| [STRAIGHT](#STRAIGHT) | Retto. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CURVED {#CURVED}
+```
+public static final int CURVED
+```
+
+
+Curvo.
+
+### PAGE_DEFAULT {#PAGE-DEFAULT}
+```
+public static final int PAGE_DEFAULT
+```
+
+
+Pagina predefinita.
+
+### STRAIGHT {#STRAIGHT}
+```
+public static final int STRAIGHT
+```
+
+
+Retto.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/connect/_index.md
+++ b/italian/java/com.aspose.diagram/connect/_index.md
@@ -1,0 +1,299 @@
+---
+title: Connect
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta una connessione tra due forme in un disegno, come una linea e una casella in un organigramma.
+type: docs
+weight: 75
+url: /it/java/com.aspose.diagram/connect/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Connect
+```
+
+Rappresenta una connessione tra due forme in un disegno, come una linea e una casella in un organigramma.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [Connect()](#Connect--) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFromCell()](#getFromCell--) | La cella da cui viene effettuata una connessione. |
+| [getFromPart()](#getFromPart--) | La cella da cui ha origine una connessione. |
+| [getFromSheet()](#getFromSheet--) | L'ID della forma da cui ha origine una o più connessioni. |
+| [getToCell()](#getToCell--) | La cella a cui viene effettuata una connessione. |
+| [getToPart()](#getToPart--) | La parte di una forma a cui viene effettuata una connessione. |
+| [getToSheet()](#getToSheet--) | L'ID della forma a cui viene effettuata una o più connessioni |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setFromCell(String value)](#setFromCell-java.lang.String-) | Per la descrizione di questa proprietà, consultare [getFromCell()](../../com.aspose.diagram/connect\#getFromCell--) |
+| [setFromPart(int value)](#setFromPart-int-) | Per la descrizione di questa proprietà, consultare [getFromPart()](../../com.aspose.diagram/connect\#getFromPart--) |
+| [setFromSheet(long value)](#setFromSheet-long-) | Per la descrizione di questa proprietà, consultare [getFromSheet()](../../com.aspose.diagram/connect\#getFromSheet--) |
+| [setToCell(String value)](#setToCell-java.lang.String-) | Per la descrizione di questa proprietà, consultare [getToCell()](../../com.aspose.diagram/connect\#getToCell--) |
+| [setToPart(int value)](#setToPart-int-) | Per la descrizione di questa proprietà, consultare [getToPart()](../../com.aspose.diagram/connect\#getToPart--) |
+| [setToSheet(long value)](#setToSheet-long-) | Per la descrizione di questa proprietà, consultare [getToSheet()](../../com.aspose.diagram/connect\#getToSheet--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Connect() {#Connect--}
+```
+public Connect()
+```
+
+
+Costruttore.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFromCell() {#getFromCell--}
+```
+public String getFromCell()
+```
+
+
+La cella da cui viene effettuata una connessione.
+
+**Returns:**
+java.lang.String
+### getFromPart() {#getFromPart--}
+```
+public int getFromPart()
+```
+
+
+La cella da cui ha origine una connessione.
+
+**Returns:**
+int
+### getFromSheet() {#getFromSheet--}
+```
+public long getFromSheet()
+```
+
+
+L'ID della forma da cui ha origine una o più connessioni.
+
+**Returns:**
+long
+### getToCell() {#getToCell--}
+```
+public String getToCell()
+```
+
+
+La cella a cui viene effettuata una connessione.
+
+**Returns:**
+java.lang.String
+### getToPart() {#getToPart--}
+```
+public int getToPart()
+```
+
+
+La parte di una forma a cui viene effettuata una connessione.
+
+**Returns:**
+int
+### getToSheet() {#getToSheet--}
+```
+public long getToSheet()
+```
+
+
+L'ID della forma a cui viene effettuata una o più connessioni
+
+**Returns:**
+long
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setFromCell(String value) {#setFromCell-java.lang.String-}
+```
+public void setFromCell(String value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getFromCell()](../../com.aspose.diagram/connect\#getFromCell--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setFromPart(int value) {#setFromPart-int-}
+```
+public void setFromPart(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getFromPart()](../../com.aspose.diagram/connect\#getFromPart--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setFromSheet(long value) {#setFromSheet-long-}
+```
+public void setFromSheet(long value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getFromSheet()](../../com.aspose.diagram/connect\#getFromSheet--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | long |  |
+
+### setToCell(String value) {#setToCell-java.lang.String-}
+```
+public void setToCell(String value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getToCell()](../../com.aspose.diagram/connect\#getToCell--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setToPart(int value) {#setToPart-int-}
+```
+public void setToPart(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getToPart()](../../com.aspose.diagram/connect\#getToPart--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setToSheet(long value) {#setToSheet-long-}
+```
+public void setToSheet(long value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getToSheet()](../../com.aspose.diagram/connect\#getToSheet--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | long |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/connectcollection/_index.md
+++ b/italian/java/com.aspose.diagram/connectcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: ConnectCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Raccolta Connect.
+type: docs
+weight: 76
+url: /it/java/com.aspose.diagram/connectcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ConnectCollection extends Collection
+```
+
+Raccolta Connect.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [add(Connect connect)](#add-com.aspose.diagram.Connect-) | Add the connect in the collection. |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Connect connect)](#remove-com.aspose.diagram.Connect-) | Remove the connect from the collection. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Connect connect) {#add-com.aspose.diagram.Connect-}
+```
+public int add(Connect connect)
+```
+
+
+Add the connect in the collection.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| connect | [Connect](../../com.aspose.diagram/connect) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Connect get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[Connect](../../com.aspose.diagram/connect) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Connect connect) {#remove-com.aspose.diagram.Connect-}
+```
+public void remove(Connect connect)
+```
+
+
+Remove the connect from the collection.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| connect | [Connect](../../com.aspose.diagram/connect) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/connectedshapesflags/_index.md
+++ b/italian/java/com.aspose.diagram/connectedshapesflags/_index.md
@@ -1,0 +1,156 @@
+---
+title: ConnectedShapesFlags
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Filtra l'array di ID forma restituiti in base alla direzionalità dei connettori.
+type: docs
+weight: 77
+url: /it/java/com.aspose.diagram/connectedshapesflags/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConnectedShapesFlags
+```
+
+Filtra l'array di ID forma restituiti in base alla direzionalità dei connettori.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [CONNECTED_SHAPES_ALL_NODES](#CONNECTED-SHAPES-ALL-NODES) | Restituisce gli ID delle forme associate sia a connessioni in ingresso che in uscita. |
+| [CONNECTED_SHAPES_INCOMING_NODES](#CONNECTED-SHAPES-INCOMING-NODES) | Restituisce gli ID delle forme associate a connessioni in ingresso. |
+| [CONNECTED_SHAPES_OUTGOING_NODES](#CONNECTED-SHAPES-OUTGOING-NODES) | Restituisce gli ID delle forme associate a connessioni in uscita. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CONNECTED_SHAPES_ALL_NODES {#CONNECTED-SHAPES-ALL-NODES}
+```
+public static final int CONNECTED_SHAPES_ALL_NODES
+```
+
+
+Restituisce gli ID delle forme associate sia a connessioni in ingresso che in uscita.
+
+### CONNECTED_SHAPES_INCOMING_NODES {#CONNECTED-SHAPES-INCOMING-NODES}
+```
+public static final int CONNECTED_SHAPES_INCOMING_NODES
+```
+
+
+Restituisce gli ID delle forme associate a connessioni in ingresso.
+
+### CONNECTED_SHAPES_OUTGOING_NODES {#CONNECTED-SHAPES-OUTGOING-NODES}
+```
+public static final int CONNECTED_SHAPES_OUTGOING_NODES
+```
+
+
+Restituisce gli ID delle forme associate a connessioni in uscita.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/connection/_index.md
+++ b/italian/java/com.aspose.diagram/connection/_index.md
@@ -1,0 +1,351 @@
+---
+title: Connection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene elementi per un punto di connessione definito per la forma.
+type: docs
+weight: 78
+url: /it/java/com.aspose.diagram/connection/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Connection
+```
+
+Contiene elementi per un punto di connessione definito per la forma.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [Connection()](#Connection--) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAutoGen()](#getAutoGen--) | Specifica se il punto di connessione è generato automaticamente. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getDirX()](#getDirX--) | Specifica la componente x del vettore di allineamento richiesto per un punto di connessione corrispondente. |
+| [getDirY()](#getDirY--) | Specifica la componente y del vettore di allineamento richiesto per un punto di connessione corrispondente. |
+| [getID()](#getID--) | L'ID univoco dell'elemento all'interno del suo elemento genitore. |
+| [getIX()](#getIX--) | L'indice basato su zero dell'elemento all'interno del suo elemento genitore. |
+| [getName()](#getName--) | Il nome dell'elemento. |
+| [getNameU()](#getNameU--) | Il nome universale dell'elemento. |
+| [getPrompt()](#getPrompt--) | Contiene informazioni di prompt variabili, in base all'elemento in cui è contenuto. |
+| [getType()](#getType--) | Specifica vari tipi, in base all'elemento in cui è contenuto. |
+| [getX()](#getX--) | Specifica una coordinata x su una forma in coordinate locali. |
+| [getY()](#getY--) | Specifica una coordinata y su una forma in coordinate locali. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, consultare [getDel()](../../com.aspose.diagram/connection\#getDel--) |
+| [setID(int value)](#setID-int-) | Per la descrizione di questa proprietà, consultare [getID()](../../com.aspose.diagram/connection\#getID--) |
+| [setIX(int value)](#setIX-int-) | Per la descrizione di questa proprietà, consultare [getIX()](../../com.aspose.diagram/connection\#getIX--) |
+| [setName(String value)](#setName-java.lang.String-) | Per la descrizione di questa proprietà, consultare [getName()](../../com.aspose.diagram/connection\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | Per la descrizione di questa proprietà, consultare [getNameU()](../../com.aspose.diagram/connection\#getNameU--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Connection() {#Connection--}
+```
+public Connection()
+```
+
+
+Costruttore.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAutoGen() {#getAutoGen--}
+```
+public BoolValue getAutoGen()
+```
+
+
+Specifica se il punto di connessione è generato automaticamente. Un valore di 1 indica che il punto di connessione è generato automaticamente.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getDirX() {#getDirX--}
+```
+public DoubleValue getDirX()
+```
+
+
+Specifica la componente x del vettore di allineamento richiesto per un punto di connessione corrispondente. L'elemento DirX è inoltre utilizzato per orientare la gamba collegata di un connettore dinamico.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDirY() {#getDirY--}
+```
+public DoubleValue getDirY()
+```
+
+
+Specifica la componente y del vettore di allineamento richiesto per un punto di connessione corrispondente. L'elemento DirY è inoltre utilizzato per orientare la gamba collegata di un connettore dinamico.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+L'ID univoco dell'elemento all'interno del suo elemento genitore.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+L'indice basato su zero dell'elemento all'interno del suo elemento genitore.
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Il nome dell'elemento.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+Il nome universale dell'elemento.
+
+**Returns:**
+java.lang.String
+### getPrompt() {#getPrompt--}
+```
+public Str2Value getPrompt()
+```
+
+
+Contiene informazioni di prompt variabili, in base all'elemento in cui è contenuto.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getType() {#getType--}
+```
+public TypeConnection getType()
+```
+
+
+Specifica vari tipi, in base all'elemento in cui è contenuto.
+
+**Returns:**
+[TypeConnection](../../com.aspose.diagram/typeconnection)
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+Specifica una coordinata x su una forma in coordinate locali.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+Specifica una coordinata y su una forma in coordinate locali. Le coordinate locali sono quelle il cui riferimento è la forma, anziché la pagina.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getDel()](../../com.aspose.diagram/connection\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getID()](../../com.aspose.diagram/connection\#getID--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getIX()](../../com.aspose.diagram/connection\#getIX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getName()](../../com.aspose.diagram/connection\#getName--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getNameU()](../../com.aspose.diagram/connection\#getNameU--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/connectionabcd/_index.md
+++ b/italian/java/com.aspose.diagram/connectionabcd/_index.md
@@ -1,0 +1,340 @@
+---
+title: ConnectionABCD
+second_title: Riferimento API di Aspose.Diagram per Java
+description: L'elemento ConnectionABCD è una versione obsoleta dell'elemento Connection e esiste solo per compatibilità retroattiva.
+type: docs
+weight: 79
+url: /it/java/com.aspose.diagram/connectionabcd/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ConnectionABCD
+```
+
+L'elemento ConnectionABCD è una versione obsoleta dell'elemento Connection e esiste solo per compatibilità retroattiva.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [ConnectionABCD()](#ConnectionABCD--) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | Rappresenta informazioni diverse a seconda del suo elemento genitore. |
+| [getB()](#getB--) | Rappresenta informazioni diverse a seconda del suo elemento genitore. |
+| [getC()](#getC--) | Rappresenta informazioni diverse in base al suo elemento genitore. |
+| [getClass()](#getClass--) |  |
+| [getD()](#getD--) | Rappresenta informazioni diverse in base al suo elemento genitore. |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getID()](#getID--) | L'ID univoco dell'elemento all'interno del suo elemento genitore. |
+| [getIX()](#getIX--) | L'indice basato su zero dell'elemento all'interno del suo elemento genitore. |
+| [getName()](#getName--) | Il nome dell'elemento. |
+| [getNameU()](#getNameU--) | Il nome universale dell'elemento. |
+| [getX()](#getX--) | Specifica una coordinata x su una forma in coordinate locali. |
+| [getY()](#getY--) | Specifica una coordinata y su una forma in coordinate locali. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/connectionabcd\#getDel--) |
+| [setID(int value)](#setID-int-) | Per la descrizione di questa proprietà, vedere [getID()](../../com.aspose.diagram/connectionabcd\#getID--) |
+| [setIX(int value)](#setIX-int-) | Per la descrizione di questa proprietà, vedere [getIX()](../../com.aspose.diagram/connectionabcd\#getIX--) |
+| [setName(String value)](#setName-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getName()](../../com.aspose.diagram/connectionabcd\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getNameU()](../../com.aspose.diagram/connectionabcd\#getNameU--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ConnectionABCD() {#ConnectionABCD--}
+```
+public ConnectionABCD()
+```
+
+
+Costruttore.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+Rappresenta informazioni diverse a seconda del suo elemento genitore.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getB() {#getB--}
+```
+public DoubleValue getB()
+```
+
+
+Rappresenta informazioni diverse a seconda del suo elemento genitore.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getC() {#getC--}
+```
+public DoubleValue getC()
+```
+
+
+Rappresenta informazioni diverse in base al suo elemento genitore.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getD() {#getD--}
+```
+public DoubleValue getD()
+```
+
+
+Rappresenta informazioni diverse in base al suo elemento genitore.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+L'ID univoco dell'elemento all'interno del suo elemento genitore.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+L'indice basato su zero dell'elemento all'interno del suo elemento genitore.
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Il nome dell'elemento.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+Il nome universale dell'elemento.
+
+**Returns:**
+java.lang.String
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+Specifica una coordinata x su una forma in coordinate locali. La tabella seguente descrive l'elemento X in base all'elemento che lo contiene.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+Specifica una coordinata y su una forma in coordinate locali. Le coordinate locali sono quelle il cui riferimento è la forma, anziché la pagina.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/connectionabcd\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getID()](../../com.aspose.diagram/connectionabcd\#getID--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getIX()](../../com.aspose.diagram/connectionabcd\#getIX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getName()](../../com.aspose.diagram/connectionabcd\#getName--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getNameU()](../../com.aspose.diagram/connectionabcd\#getNameU--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/connectionabcdcollection/_index.md
+++ b/italian/java/com.aspose.diagram/connectionabcdcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: ConnectionABCDCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Raccolta ConnectionABCD.
+type: docs
+weight: 80
+url: /it/java/com.aspose.diagram/connectionabcdcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ConnectionABCDCollection extends Collection
+```
+
+Raccolta ConnectionABCD.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [add(ConnectionABCD item)](#add-com.aspose.diagram.ConnectionABCD-) | Aggiungi l'oggetto ConnectionABCD nella collezione. |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(ConnectionABCD item)](#remove-com.aspose.diagram.ConnectionABCD-) | Rimuovi l'oggetto ConnectionABCD dalla collezione. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(ConnectionABCD item) {#add-com.aspose.diagram.ConnectionABCD-}
+```
+public int add(ConnectionABCD item)
+```
+
+
+Aggiungi l'oggetto ConnectionABCD nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [ConnectionABCD](../../com.aspose.diagram/connectionabcd) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public ConnectionABCD get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[ConnectionABCD](../../com.aspose.diagram/connectionabcd) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(ConnectionABCD item) {#remove-com.aspose.diagram.ConnectionABCD-}
+```
+public void remove(ConnectionABCD item)
+```
+
+
+Rimuovi l'oggetto ConnectionABCD dalla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [ConnectionABCD](../../com.aspose.diagram/connectionabcd) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/connectioncollection/_index.md
+++ b/italian/java/com.aspose.diagram/connectioncollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: ConnectionCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Raccolta Connection.
+type: docs
+weight: 81
+url: /it/java/com.aspose.diagram/connectioncollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ConnectionCollection extends Collection
+```
+
+Raccolta Connection.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [add(Connection item)](#add-com.aspose.diagram.Connection-) | Aggiungi l'oggetto Connection nella collezione. |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Connection item)](#remove-com.aspose.diagram.Connection-) | Rimuovi l'oggetto Connection dalla collezione. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Connection item) {#add-com.aspose.diagram.Connection-}
+```
+public int add(Connection item)
+```
+
+
+Aggiungi l'oggetto Connection nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [Connection](../../com.aspose.diagram/connection) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Connection get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[Connection](../../com.aspose.diagram/connection) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Connection item) {#remove-com.aspose.diagram.Connection-}
+```
+public void remove(Connection item)
+```
+
+
+Rimuovi l'oggetto Connection dalla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [Connection](../../com.aspose.diagram/connection) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/connectionpointplace/_index.md
+++ b/italian/java/com.aspose.diagram/connectionpointplace/_index.md
@@ -1,0 +1,174 @@
+---
+title: ConnectionPointPlace
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica la posizione sulla forma dove il connettore sarà collegato.
+type: docs
+weight: 82
+url: /it/java/com.aspose.diagram/connectionpointplace/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConnectionPointPlace
+```
+
+Specifica la posizione sulla forma dove il connettore sarà collegato.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [BOTTOM](#BOTTOM) | Parte inferiore della forma. |
+| [CENTER](#CENTER) | Centro della forma. |
+| [LEFT](#LEFT) | Lato sinistro della forma. |
+| [RIGHT](#RIGHT) | Lato destro della forma. |
+| [TOP](#TOP) | Parte superiore della forma. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOTTOM {#BOTTOM}
+```
+public static final int BOTTOM
+```
+
+
+Parte inferiore della forma.
+
+### CENTER {#CENTER}
+```
+public static final int CENTER
+```
+
+
+Centro della forma.
+
+### LEFT {#LEFT}
+```
+public static final int LEFT
+```
+
+
+Lato sinistro della forma.
+
+### RIGHT {#RIGHT}
+```
+public static final int RIGHT
+```
+
+
+Lato destro della forma.
+
+### TOP {#TOP}
+```
+public static final int TOP
+```
+
+
+Parte superiore della forma.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/connectorrule/_index.md
+++ b/italian/java/com.aspose.diagram/connectorrule/_index.md
@@ -1,0 +1,169 @@
+---
+title: ConnectorRule
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta la regola del connettore tra due forme con un connectorIncluding che indica il punto di connessione di quale forma inizia dalla forma finale e il suo punto di connessione.
+type: docs
+weight: 83
+url: /it/java/com.aspose.diagram/connectorrule/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ConnectorRule
+```
+
+Rappresenta la regola del connettore tra due forme con un connettore, includendo quale punto di connessione di quale forma parte, la forma finale e il suo punto di connessione.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getEndShapeConnection()](#getEndShapeConnection--) | La connessione della forma a cui viene effettuata una connessione. |
+| [getEndShapeId()](#getEndShapeId--) | La forma a cui viene effettuata una connessione. |
+| [getStartShapeConnection()](#getStartShapeConnection--) | La connessione della forma da cui viene effettuata una connessione. |
+| [getStartShapeId()](#getStartShapeId--) | La forma da cui viene effettuata una connessione. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getEndShapeConnection() {#getEndShapeConnection--}
+```
+public Connection getEndShapeConnection()
+```
+
+
+La connessione della forma a cui viene effettuata una connessione.
+
+**Returns:**
+[Connection](../../com.aspose.diagram/connection)
+### getEndShapeId() {#getEndShapeId--}
+```
+public long getEndShapeId()
+```
+
+
+La forma a cui viene effettuata una connessione.
+
+**Returns:**
+long
+### getStartShapeConnection() {#getStartShapeConnection--}
+```
+public Connection getStartShapeConnection()
+```
+
+
+La connessione della forma da cui viene effettuata una connessione.
+
+**Returns:**
+[Connection](../../com.aspose.diagram/connection)
+### getStartShapeId() {#getStartShapeId--}
+```
+public long getStartShapeId()
+```
+
+
+La forma da cui viene effettuata una connessione.
+
+**Returns:**
+long
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/connectorstypevalue/_index.md
+++ b/italian/java/com.aspose.diagram/connectorstypevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: ConnectorsTypeValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Può essere uno dei seguenti valori RightAngle StraightLines o CurvedLines.
+type: docs
+weight: 84
+url: /it/java/com.aspose.diagram/connectorstypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConnectorsTypeValue
+```
+
+Può essere uno dei seguenti valori: RightAngle, StraightLines o CurvedLines. Rilevante solo quando WindowType è specificato come Drawing o Sheet.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [CURVED_LINES](#CURVED-LINES) | CurvedLines. |
+| [RIGHT_ANGLE](#RIGHT-ANGLE) | RightAngle. |
+| [STRAIGHT_LINES](#STRAIGHT-LINES) | StraightLines. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CURVED_LINES {#CURVED-LINES}
+```
+public static final int CURVED_LINES
+```
+
+
+CurvedLines.
+
+### RIGHT_ANGLE {#RIGHT-ANGLE}
+```
+public static final int RIGHT_ANGLE
+```
+
+
+RightAngle.
+
+### STRAIGHT_LINES {#STRAIGHT-LINES}
+```
+public static final int STRAIGHT_LINES
+```
+
+
+StraightLines.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/containertypevalue/_index.md
+++ b/italian/java/com.aspose.diagram/containertypevalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: ContainerTypeValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: May be one of the following values Document Page or Master.
+type: docs
+weight: 85
+url: /it/java/com.aspose.diagram/containertypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ContainerTypeValue
+```
+
+May be one of the following values: Document, Page, or Master. Only relevant when WindowType is specified as Drawing or Sheet.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [DOCUMENT](#DOCUMENT) | Document. |
+| [MASTER](#MASTER) | Master. |
+| [PAGE](#PAGE) | Page. |
+| [STYLE](#STYLE) | Master. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DOCUMENT {#DOCUMENT}
+```
+public static final int DOCUMENT
+```
+
+
+Document.
+
+### MASTER {#MASTER}
+```
+public static final int MASTER
+```
+
+
+Master.
+
+### PAGE {#PAGE}
+```
+public static final int PAGE
+```
+
+
+Page.
+
+### STYLE {#STYLE}
+```
+public static final int STYLE
+```
+
+
+Master.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/contexttypevalue/_index.md
+++ b/italian/java/com.aspose.diagram/contexttypevalue/_index.md
@@ -1,0 +1,255 @@
+---
+title: ContextTypeValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica le proprietà del gruppo o della forma da utilizzare per il confronto.
+type: docs
+weight: 86
+url: /it/java/com.aspose.diagram/contexttypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ContextTypeValue
+```
+
+Specifica le proprietà del gruppo o della forma da utilizzare per il confronto. I valori possibili sono mostrati nella tabella seguente.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [DATA_1](#DATA-1) | Data1. |
+| [DATA_2](#DATA-2) | Data2. |
+| [DATA_3](#DATA-3) | Data3. |
+| [GEOMETRY_ANGLE](#GEOMETRY-ANGLE) | Angolo della geometria. |
+| [GEOMETRY_HEIGHT](#GEOMETRY-HEIGHT) | Altezza della geometria. |
+| [GEOMETRY_WIDTH](#GEOMETRY-WIDTH) | Geometry width. |
+| [MASTER_NAME](#MASTER-NAME) | Master name. |
+| [SHAPE_DATA_ITEM_CUSTOM_PROPERTY_LABEL](#SHAPE-DATA-ITEM-CUSTOM-PROPERTY-LABEL) | Shape-data-item (custom property) label. |
+| [SHAPE_ID](#SHAPE-ID) | Shape ID. |
+| [SHAPE_LOCAL_NAME](#SHAPE-LOCAL-NAME) | Shape local name. |
+| [SHAPE_TEXT](#SHAPE-TEXT) | Shape text. |
+| [SHAPE_TYPE](#SHAPE-TYPE) | Shape type. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+| [USER_CELL_LOCAL_ROW_NAME](#USER-CELL-LOCAL-ROW-NAME) | User cell local row name. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DATA_1 {#DATA-1}
+```
+public static final int DATA_1
+```
+
+
+Data1.
+
+### DATA_2 {#DATA-2}
+```
+public static final int DATA_2
+```
+
+
+Data2.
+
+### DATA_3 {#DATA-3}
+```
+public static final int DATA_3
+```
+
+
+Data3.
+
+### GEOMETRY_ANGLE {#GEOMETRY-ANGLE}
+```
+public static final int GEOMETRY_ANGLE
+```
+
+
+Angolo della geometria.
+
+### GEOMETRY_HEIGHT {#GEOMETRY-HEIGHT}
+```
+public static final int GEOMETRY_HEIGHT
+```
+
+
+Altezza della geometria.
+
+### GEOMETRY_WIDTH {#GEOMETRY-WIDTH}
+```
+public static final int GEOMETRY_WIDTH
+```
+
+
+Geometry width.
+
+### MASTER_NAME {#MASTER-NAME}
+```
+public static final int MASTER_NAME
+```
+
+
+Master name.
+
+### SHAPE_DATA_ITEM_CUSTOM_PROPERTY_LABEL {#SHAPE-DATA-ITEM-CUSTOM-PROPERTY-LABEL}
+```
+public static final int SHAPE_DATA_ITEM_CUSTOM_PROPERTY_LABEL
+```
+
+
+Shape-data-item (custom property) label.
+
+### SHAPE_ID {#SHAPE-ID}
+```
+public static final int SHAPE_ID
+```
+
+
+Shape ID.
+
+### SHAPE_LOCAL_NAME {#SHAPE-LOCAL-NAME}
+```
+public static final int SHAPE_LOCAL_NAME
+```
+
+
+Shape local name.
+
+### SHAPE_TEXT {#SHAPE-TEXT}
+```
+public static final int SHAPE_TEXT
+```
+
+
+Shape text.
+
+### SHAPE_TYPE {#SHAPE-TYPE}
+```
+public static final int SHAPE_TYPE
+```
+
+
+Shape type.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### USER_CELL_LOCAL_ROW_NAME {#USER-CELL-LOCAL-ROW-NAME}
+```
+public static final int USER_CELL_LOCAL_ROW_NAME
+```
+
+
+User cell local row name.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/control/_index.md
+++ b/italian/java/com.aspose.diagram/control/_index.md
@@ -1,0 +1,474 @@
+---
+title: Controllo
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene elementi per le coordinate x e y di ciascuna maniglia di controllo definita per una forma e elementi che specificano il modo in cui la maniglia di controllo deve comportarsi.
+type: docs
+weight: 87
+url: /it/java/com.aspose.diagram/control/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Control
+```
+
+Contiene elementi per le coordinate x e y di ogni maniglia di controllo definita per una forma, e elementi che specificano il modo in cui la maniglia di controllo dovrebbe comportarsi.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [Control()](#Control--) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [canGlue()](#canGlue--) | Determina se una maniglia di controllo può essere incollata ad altre forme. |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getID()](#getID--) | L'ID univoco dell'elemento all'interno del suo elemento genitore. |
+| [getIX()](#getIX--) | L'indice basato su zero dell'elemento all'interno del suo elemento genitore. |
+| [getName()](#getName--) | Il nome dell'elemento. |
+| [getNameU()](#getNameU--) | Il nome universale dell'elemento. |
+| [getPrompt()](#getPrompt--) | L'elemento Prompt specifica il testo descrittivo che appare come suggerimento quando il puntatore del mouse è fermo sopra la maniglia di controllo di una forma. |
+| [getX()](#getX--) | La coordinata x che indica la posizione della maniglia di controllo di una forma. |
+| [getXCon()](#getXCon--) | Specifica il tipo di comportamento che la coordinata x della maniglia di controllo presenta dopo che la maniglia è stata spostata. |
+| [getXDyn()](#getXDyn--) | Specifica la coordinata x per il punto di ancoraggio di una maniglia di controllo in coordinate locali. |
+| [getY()](#getY--) | La coordinata y che indica la posizione della maniglia di controllo di una forma. |
+| [getYCon()](#getYCon--) | Specifica il tipo di comportamento che la coordinata x della maniglia di controllo presenta dopo che la maniglia è stata spostata. |
+| [getYDyn()](#getYDyn--) | Specifica la coordinata y per il punto di ancoraggio di una maniglia di controllo in coordinate locali. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCanGlue(BoolValue value)](#setCanGlue-com.aspose.diagram.BoolValue-) | Per la descrizione di questa proprietà, consultare [canGlue()](../../com.aspose.diagram/control\#canGlue--) |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, consultare [getDel()](../../com.aspose.diagram/control\#getDel--) |
+| [setID(int value)](#setID-int-) | Per la descrizione di questa proprietà, consultare [getID()](../../com.aspose.diagram/control\#getID--) |
+| [setIX(int value)](#setIX-int-) | Per la descrizione di questa proprietà, consultare [getIX()](../../com.aspose.diagram/control\#getIX--) |
+| [setName(String value)](#setName-java.lang.String-) | Per la descrizione di questa proprietà, consultare [getName()](../../com.aspose.diagram/control\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | Per la descrizione di questa proprietà, consultare [getNameU()](../../com.aspose.diagram/control\#getNameU--) |
+| [setPrompt(Str2Value value)](#setPrompt-com.aspose.diagram.Str2Value-) | Per la descrizione di questa proprietà, consultare [getPrompt()](../../com.aspose.diagram/control\#getPrompt--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, consultare [getX()](../../com.aspose.diagram/control\#getX--) |
+| [setXCon(ConType value)](#setXCon-com.aspose.diagram.ConType-) | Per la descrizione di questa proprietà, consultare [getXCon()](../../com.aspose.diagram/control\#getXCon--) |
+| [setXDyn(DoubleValue value)](#setXDyn-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, consultare [getXDyn()](../../com.aspose.diagram/control\#getXDyn--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, consultare [getY()](../../com.aspose.diagram/control\#getY--) |
+| [setYCon(ConType value)](#setYCon-com.aspose.diagram.ConType-) | Per la descrizione di questa proprietà, consultare [getYCon()](../../com.aspose.diagram/control\#getYCon--) |
+| [setYDyn(DoubleValue value)](#setYDyn-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getYDyn()](../../com.aspose.diagram/control\#getYDyn--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Control() {#Control--}
+```
+public Control()
+```
+
+
+Costruttore.
+
+### canGlue() {#canGlue--}
+```
+public BoolValue canGlue()
+```
+
+
+Determina se una maniglia di controllo può essere incollata ad altre forme.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+L'ID univoco dell'elemento all'interno del suo elemento genitore.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+L'indice basato su zero dell'elemento all'interno del suo elemento genitore.
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Il nome dell'elemento.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+Il nome universale dell'elemento.
+
+**Returns:**
+java.lang.String
+### getPrompt() {#getPrompt--}
+```
+public Str2Value getPrompt()
+```
+
+
+L'elemento Prompt specifica il testo descrittivo che appare come suggerimento quando il puntatore del mouse è fermo sopra la maniglia di controllo di una forma.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+La coordinata x che indica la posizione della maniglia di controllo di una forma.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getXCon() {#getXCon--}
+```
+public ConType getXCon()
+```
+
+
+Specifica il tipo di comportamento che la coordinata x della maniglia di controllo presenta dopo che la maniglia è stata spostata.
+
+**Returns:**
+[ConType](../../com.aspose.diagram/contype)
+### getXDyn() {#getXDyn--}
+```
+public DoubleValue getXDyn()
+```
+
+
+Specifica la coordinata x del punto di ancoraggio di una maniglia di controllo in coordinate locali. Il punto di ancoraggio è usato per il rubber-banding durante le dinamiche.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+La coordinata y che indica la posizione della maniglia di controllo di una forma.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getYCon() {#getYCon--}
+```
+public ConType getYCon()
+```
+
+
+Specifica il tipo di comportamento che la coordinata x della maniglia di controllo presenta dopo che la maniglia è stata spostata.
+
+**Returns:**
+[ConType](../../com.aspose.diagram/contype)
+### getYDyn() {#getYDyn--}
+```
+public DoubleValue getYDyn()
+```
+
+
+Specifica la coordinata y del punto di ancoraggio di una maniglia di controllo in coordinate locali. Il punto di ancoraggio è usato per il rubber-banding durante le dinamiche.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCanGlue(BoolValue value) {#setCanGlue-com.aspose.diagram.BoolValue-}
+```
+public void setCanGlue(BoolValue value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [canGlue()](../../com.aspose.diagram/control\#canGlue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getDel()](../../com.aspose.diagram/control\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getID()](../../com.aspose.diagram/control\#getID--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getIX()](../../com.aspose.diagram/control\#getIX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getName()](../../com.aspose.diagram/control\#getName--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getNameU()](../../com.aspose.diagram/control\#getNameU--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setPrompt(Str2Value value) {#setPrompt-com.aspose.diagram.Str2Value-}
+```
+public void setPrompt(Str2Value value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getPrompt()](../../com.aspose.diagram/control\#getPrompt--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [Str2Value](../../com.aspose.diagram/str2value) |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getX()](../../com.aspose.diagram/control\#getX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setXCon(ConType value) {#setXCon-com.aspose.diagram.ConType-}
+```
+public void setXCon(ConType value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getXCon()](../../com.aspose.diagram/control\#getXCon--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [ConType](../../com.aspose.diagram/contype) |  |
+
+### setXDyn(DoubleValue value) {#setXDyn-com.aspose.diagram.DoubleValue-}
+```
+public void setXDyn(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getXDyn()](../../com.aspose.diagram/control\#getXDyn--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getY()](../../com.aspose.diagram/control\#getY--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setYCon(ConType value) {#setYCon-com.aspose.diagram.ConType-}
+```
+public void setYCon(ConType value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getYCon()](../../com.aspose.diagram/control\#getYCon--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [ConType](../../com.aspose.diagram/contype) |  |
+
+### setYDyn(DoubleValue value) {#setYDyn-com.aspose.diagram.DoubleValue-}
+```
+public void setYDyn(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getYDyn()](../../com.aspose.diagram/control\#getYDyn--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/controlbordertype/_index.md
+++ b/italian/java/com.aspose.diagram/controlbordertype/_index.md
@@ -1,0 +1,147 @@
+---
+title: ControlBorderType
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta il tipo di bordo del controllo ActiveX.
+type: docs
+weight: 88
+url: /it/java/com.aspose.diagram/controlbordertype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlBorderType
+```
+
+Rappresenta il tipo di bordo del controllo ActiveX.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [NONE](#NONE) | Nessun bordo. |
+| [SINGLE](#SINGLE) | La linea singola. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Nessun bordo.
+
+### SINGLE {#SINGLE}
+```
+public static final int SINGLE
+```
+
+
+La linea singola.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/controlcaptionalignmenttype/_index.md
+++ b/italian/java/com.aspose.diagram/controlcaptionalignmenttype/_index.md
@@ -1,0 +1,147 @@
+---
+title: ControlCaptionAlignmentType
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta la posizione della didascalia rispetto al controllo.
+type: docs
+weight: 89
+url: /it/java/com.aspose.diagram/controlcaptionalignmenttype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlCaptionAlignmentType
+```
+
+Rappresenta la posizione della didascalia rispetto al controllo.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [LEFT](#LEFT) | Il lato sinistro del controllo. |
+| [RIGHT](#RIGHT) | Il lato destro del controllo. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LEFT {#LEFT}
+```
+public static final int LEFT
+```
+
+
+Il lato sinistro del controllo.
+
+### RIGHT {#RIGHT}
+```
+public static final int RIGHT
+```
+
+
+Il lato destro del controllo.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/controlcollection/_index.md
+++ b/italian/java/com.aspose.diagram/controlcollection/_index.md
@@ -1,0 +1,266 @@
+---
+title: ControlCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Raccolta Control.
+type: docs
+weight: 90
+url: /it/java/com.aspose.diagram/controlcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ControlCollection extends Collection
+```
+
+Raccolta Control.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [add(Control item)](#add-com.aspose.diagram.Control-) | Aggiungi l'oggetto Control nella collezione. |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getClass()](#getClass--) |  |
+| [getControl(int IX)](#getControl-int-) | Ottiene l'elemento all'indice specificato IX. |
+| [getControlFromId(int ID)](#getControlFromId-int-) | Restituisce l'elemento con l'ID specificato. |
+| [getControlFromName(String name)](#getControlFromName-java.lang.String-) | Restituisce l'elemento con il nome specificato. |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Control item)](#remove-com.aspose.diagram.Control-) | Rimuovi l'oggetto Control dalla collezione. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Control item) {#add-com.aspose.diagram.Control-}
+```
+public int add(Control item)
+```
+
+
+Aggiungi l'oggetto Control nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [Control](../../com.aspose.diagram/control) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Control get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[Control](../../com.aspose.diagram/control) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getControl(int IX) {#getControl-int-}
+```
+public Control getControl(int IX)
+```
+
+
+Ottiene l'elemento all'indice specificato IX.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| IX | int |  |
+
+**Returns:**
+[Control](../../com.aspose.diagram/control) - 
+### getControlFromId(int ID) {#getControlFromId-int-}
+```
+public Control getControlFromId(int ID)
+```
+
+
+Restituisce l'elemento con l'ID specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| ID | int |  |
+
+**Returns:**
+[Control](../../com.aspose.diagram/control) - 
+### getControlFromName(String name) {#getControlFromName-java.lang.String-}
+```
+public Control getControlFromName(String name)
+```
+
+
+Restituisce l'elemento con il nome specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| nome | java.lang.String |  |
+
+**Returns:**
+[Control](../../com.aspose.diagram/control) - 
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Control item) {#remove-com.aspose.diagram.Control-}
+```
+public void remove(Control item)
+```
+
+
+Rimuovi l'oggetto Control dalla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [Control](../../com.aspose.diagram/control) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/controlliststyle/_index.md
+++ b/italian/java/com.aspose.diagram/controlliststyle/_index.md
@@ -1,0 +1,147 @@
+---
+title: ControlListStyle
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta l'aspetto visivo dell'elenco in un ListBox o ComboBox.
+type: docs
+weight: 91
+url: /it/java/com.aspose.diagram/controlliststyle/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlListStyle
+```
+
+Rappresenta l'aspetto visivo dell'elenco in un ListBox o ComboBox.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [OPTION](#OPTION) | Visualizza un elenco in cui un pulsante di opzione o una casella di controllo accanto a ciascuna voce mostra lo stato di selezione di quell'elemento. |
+| [PLAIN](#PLAIN) | Visualizza un elenco in cui lo sfondo di un elemento è evidenziato quando è selezionato. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### OPTION {#OPTION}
+```
+public static final int OPTION
+```
+
+
+Visualizza un elenco in cui un pulsante di opzione o una casella di controllo accanto a ciascuna voce mostra lo stato di selezione di quell'elemento.
+
+### PLAIN {#PLAIN}
+```
+public static final int PLAIN
+```
+
+
+Visualizza un elenco in cui lo sfondo di un elemento è evidenziato quando è selezionato.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/controlmatchentrytype/_index.md
+++ b/italian/java/com.aspose.diagram/controlmatchentrytype/_index.md
@@ -1,0 +1,156 @@
+---
+title: ControlMatchEntryType
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta come un ListBox o ComboBox ricerca la sua lista mentre l'utente digita.
+type: docs
+weight: 92
+url: /it/java/com.aspose.diagram/controlmatchentrytype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlMatchEntryType
+```
+
+Rappresenta come un ListBox o ComboBox ricerca la sua lista mentre l'utente digita.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [COMPLETE](#COMPLETE) | Man mano che viene digitato ogni carattere, il controllo cerca una voce che corrisponda a tutti i caratteri inseriti. |
+| [FIRST_LETTER](#FIRST-LETTER) | Il controllo cerca la voce successiva che inizia con il carattere inserito. |
+| [NONE](#NONE) | L'elenco non verrà cercato quando vengono digitati i caratteri. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### COMPLETE {#COMPLETE}
+```
+public static final int COMPLETE
+```
+
+
+Man mano che viene digitato ogni carattere, il controllo cerca una voce che corrisponda a tutti i caratteri inseriti.
+
+### FIRST_LETTER {#FIRST-LETTER}
+```
+public static final int FIRST_LETTER
+```
+
+
+Il controllo cerca la voce successiva che inizia con il carattere inserito. Digitare ripetutamente la stessa lettera scorre tutte le voci che iniziano con quella lettera.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+L'elenco non verrà cercato quando vengono digitati i caratteri.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/controlmousepointertype/_index.md
+++ b/italian/java/com.aspose.diagram/controlmousepointertype/_index.md
@@ -1,0 +1,264 @@
+---
+title: ControlMousePointerType
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta il tipo di icona visualizzata come puntatore del mouse per il controllo.
+type: docs
+weight: 93
+url: /it/java/com.aspose.diagram/controlmousepointertype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlMousePointerType
+```
+
+Rappresenta il tipo di icona visualizzata come puntatore del mouse per il controllo.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [APP_STARTING](#APP-STARTING) | Arrow with an hourglass. |
+| [ARROW](#ARROW) | Arrow. |
+| [CROSS](#CROSS) | Cross-hair pointer. |
+| [CUSTOM](#CUSTOM) | Uses the icon specified by the MouseIcon property. |
+| [DEFAULT](#DEFAULT) | Standard pointer. |
+| [HELP](#HELP) | Arrow with a question mark. |
+| [HOUR_GLASS](#HOUR-GLASS) | Clessidra. |
+| [I_BEAM](#I-BEAM) | Trave a I. |
+| [NO_DROP](#NO-DROP) | \\u9225\\u6de3ot\\u9225? |
+| [SIZE_ALL](#SIZE-ALL) | \\u9225\\u6deaize-all\\u9225? |
+| [SIZE_NESW](#SIZE-NESW) | Doppia freccia che punta a nord-est e sud-ovest. |
+| [SIZE_NS](#SIZE-NS) | Doppia freccia che punta a nord e sud. |
+| [SIZE_NWSE](#SIZE-NWSE) | Doppia freccia che punta a nord-ovest e sud-est. |
+| [SIZE_WE](#SIZE-WE) | Doppia freccia che punta a ovest e est. |
+| [UP_ARROW](#UP-ARROW) | Freccia verso l'alto. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### APP_STARTING {#APP-STARTING}
+```
+public static final int APP_STARTING
+```
+
+
+Arrow with an hourglass.
+
+### ARROW {#ARROW}
+```
+public static final int ARROW
+```
+
+
+Arrow.
+
+### CROSS {#CROSS}
+```
+public static final int CROSS
+```
+
+
+Cross-hair pointer.
+
+### CUSTOM {#CUSTOM}
+```
+public static final int CUSTOM
+```
+
+
+Uses the icon specified by the MouseIcon property.
+
+### DEFAULT {#DEFAULT}
+```
+public static final int DEFAULT
+```
+
+
+Standard pointer.
+
+### HELP {#HELP}
+```
+public static final int HELP
+```
+
+
+Arrow with a question mark.
+
+### HOUR_GLASS {#HOUR-GLASS}
+```
+public static final int HOUR_GLASS
+```
+
+
+Clessidra.
+
+### I_BEAM {#I-BEAM}
+```
+public static final int I_BEAM
+```
+
+
+Trave a I.
+
+### NO_DROP {#NO-DROP}
+```
+public static final int NO_DROP
+```
+
+
+\\u9225\\u6de3ot\\u9225?simbolo (cerchio con una linea diagonale) sopra l'oggetto trascinato.
+
+### SIZE_ALL {#SIZE-ALL}
+```
+public static final int SIZE_ALL
+```
+
+
+\\u9225\\u6deaize-all\\u9225?cursore (frecce che puntano a nord, sud, est e ovest).
+
+### SIZE_NESW {#SIZE-NESW}
+```
+public static final int SIZE_NESW
+```
+
+
+Doppia freccia che punta a nord-est e sud-ovest.
+
+### SIZE_NS {#SIZE-NS}
+```
+public static final int SIZE_NS
+```
+
+
+Doppia freccia che punta a nord e sud.
+
+### SIZE_NWSE {#SIZE-NWSE}
+```
+public static final int SIZE_NWSE
+```
+
+
+Doppia freccia che punta a nord-ovest e sud-est.
+
+### SIZE_WE {#SIZE-WE}
+```
+public static final int SIZE_WE
+```
+
+
+Doppia freccia che punta a ovest e est.
+
+### UP_ARROW {#UP-ARROW}
+```
+public static final int UP_ARROW
+```
+
+
+Freccia verso l'alto.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/controlpicturealignmenttype/_index.md
+++ b/italian/java/com.aspose.diagram/controlpicturealignmenttype/_index.md
@@ -1,0 +1,174 @@
+---
+title: ControlPictureAlignmentType
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta l'allineamento dell'immagine all'interno del Form o dell'Image.
+type: docs
+weight: 94
+url: /it/java/com.aspose.diagram/controlpicturealignmenttype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlPictureAlignmentType
+```
+
+Rappresenta l'allineamento dell'immagine all'interno del Form o dell'Image.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [BOTTOM_LEFT](#BOTTOM-LEFT) | L'angolo in basso a sinistra. |
+| [BOTTOM_RIGHT](#BOTTOM-RIGHT) | L'angolo in basso a destra. |
+| [CENTER](#CENTER) | Il centro. |
+| [TOP_LEFT](#TOP-LEFT) | L'angolo in alto a sinistra. |
+| [TOP_RIGHT](#TOP-RIGHT) | L'angolo in alto a destra. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOTTOM_LEFT {#BOTTOM-LEFT}
+```
+public static final int BOTTOM_LEFT
+```
+
+
+L'angolo in basso a sinistra.
+
+### BOTTOM_RIGHT {#BOTTOM-RIGHT}
+```
+public static final int BOTTOM_RIGHT
+```
+
+
+L'angolo in basso a destra.
+
+### CENTER {#CENTER}
+```
+public static final int CENTER
+```
+
+
+Il centro.
+
+### TOP_LEFT {#TOP-LEFT}
+```
+public static final int TOP_LEFT
+```
+
+
+L'angolo in alto a sinistra.
+
+### TOP_RIGHT {#TOP-RIGHT}
+```
+public static final int TOP_RIGHT
+```
+
+
+L'angolo in alto a destra.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/controlpicturepositiontype/_index.md
+++ b/italian/java/com.aspose.diagram/controlpicturepositiontype/_index.md
@@ -1,0 +1,246 @@
+---
+title: ControlPicturePositionType
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta la posizione dell'immagine del controllo rispetto alla sua didascalia.
+type: docs
+weight: 95
+url: /it/java/com.aspose.diagram/controlpicturepositiontype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlPicturePositionType
+```
+
+Rappresenta la posizione dell'immagine del controllo rispetto alla sua didascalia.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [ABOVE_CENTER](#ABOVE-CENTER) | L'immagine appare sopra la didascalia. |
+| [ABOVE_LEFT](#ABOVE-LEFT) | L'immagine appare sopra la didascalia. |
+| [ABOVE_RIGHT](#ABOVE-RIGHT) | L'immagine appare sopra la didascalia. |
+| [BELOW_CENTER](#BELOW-CENTER) | L'immagine appare sotto la didascalia. |
+| [BELOW_LEFT](#BELOW-LEFT) | L'immagine appare sotto la didascalia. |
+| [BELOW_RIGHT](#BELOW-RIGHT) | L'immagine appare sotto la didascalia. |
+| [CENTER](#CENTER) | L'immagine appare al centro del controllo. |
+| [LEFT_BOTTOM](#LEFT-BOTTOM) | L'immagine appare a sinistra della didascalia. |
+| [LEFT_CENTER](#LEFT-CENTER) | L'immagine appare a sinistra della didascalia. |
+| [LEFT_TOP](#LEFT-TOP) | L'immagine appare a sinistra della didascalia. |
+| [RIGHT_BOTTOM](#RIGHT-BOTTOM) | L'immagine appare a destra della didascalia. |
+| [RIGHT_CENTER](#RIGHT-CENTER) | L'immagine appare a destra della didascalia. |
+| [RIGHT_TOP](#RIGHT-TOP) | L'immagine appare a destra della didascalia. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ABOVE_CENTER {#ABOVE-CENTER}
+```
+public static final int ABOVE_CENTER
+```
+
+
+L'immagine appare sopra la didascalia. La didascalia è centrata sotto l'immagine.
+
+### ABOVE_LEFT {#ABOVE-LEFT}
+```
+public static final int ABOVE_LEFT
+```
+
+
+L'immagine appare sopra la didascalia. La didascalia è allineata al bordo sinistro dell'immagine.
+
+### ABOVE_RIGHT {#ABOVE-RIGHT}
+```
+public static final int ABOVE_RIGHT
+```
+
+
+L'immagine appare sopra la didascalia. La didascalia è allineata al bordo destro dell'immagine.
+
+### BELOW_CENTER {#BELOW-CENTER}
+```
+public static final int BELOW_CENTER
+```
+
+
+L'immagine appare sotto la didascalia. La didascalia è centrata sopra l'immagine.
+
+### BELOW_LEFT {#BELOW-LEFT}
+```
+public static final int BELOW_LEFT
+```
+
+
+L'immagine appare sotto la didascalia. La didascalia è allineata al bordo sinistro dell'immagine.
+
+### BELOW_RIGHT {#BELOW-RIGHT}
+```
+public static final int BELOW_RIGHT
+```
+
+
+L'immagine appare sotto la didascalia. La didascalia è allineata al bordo destro dell'immagine.
+
+### CENTER {#CENTER}
+```
+public static final int CENTER
+```
+
+
+L'immagine appare al centro del controllo. La didascalia è centrata orizzontalmente e verticalmente sopra l'immagine.
+
+### LEFT_BOTTOM {#LEFT-BOTTOM}
+```
+public static final int LEFT_BOTTOM
+```
+
+
+L'immagine appare a sinistra della didascalia. La didascalia è allineata al bordo inferiore dell'immagine.
+
+### LEFT_CENTER {#LEFT-CENTER}
+```
+public static final int LEFT_CENTER
+```
+
+
+L'immagine appare a sinistra della didascalia. La didascalia è centrata rispetto all'immagine.
+
+### LEFT_TOP {#LEFT-TOP}
+```
+public static final int LEFT_TOP
+```
+
+
+L'immagine appare a sinistra della didascalia. La didascalia è allineata al bordo superiore dell'immagine.
+
+### RIGHT_BOTTOM {#RIGHT-BOTTOM}
+```
+public static final int RIGHT_BOTTOM
+```
+
+
+L'immagine appare a destra della didascalia. La didascalia è allineata al bordo inferiore dell'immagine.
+
+### RIGHT_CENTER {#RIGHT-CENTER}
+```
+public static final int RIGHT_CENTER
+```
+
+
+L'immagine appare a destra della didascalia. La didascalia è centrata rispetto all'immagine.
+
+### RIGHT_TOP {#RIGHT-TOP}
+```
+public static final int RIGHT_TOP
+```
+
+
+L'immagine appare a destra della didascalia. La didascalia è allineata al bordo superiore dell'immagine.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/controlpicturesizemode/_index.md
+++ b/italian/java/com.aspose.diagram/controlpicturesizemode/_index.md
@@ -1,0 +1,156 @@
+---
+title: ControlPictureSizeMode
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta come visualizzare l'immagine.
+type: docs
+weight: 96
+url: /it/java/com.aspose.diagram/controlpicturesizemode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlPictureSizeMode
+```
+
+Rappresenta come visualizzare l'immagine.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [CLIP](#CLIP) | Ritaglia qualsiasi parte dell'immagine che sia più grande dei confini del controllo. |
+| [STRETCH](#STRETCH) | Allunga l'immagine per riempire l'area del controllo. |
+| [ZOOM](#ZOOM) | Ingrandisce l'immagine, ma non la distorce né in orizzontale né in verticale. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CLIP {#CLIP}
+```
+public static final int CLIP
+```
+
+
+Ritaglia qualsiasi parte dell'immagine che sia più grande dei confini del controllo.
+
+### STRETCH {#STRETCH}
+```
+public static final int STRETCH
+```
+
+
+Allunga l'immagine per riempire l'area del controllo. Questa impostazione distorce l'immagine sia in orizzontale sia in verticale.
+
+### ZOOM {#ZOOM}
+```
+public static final int ZOOM
+```
+
+
+Ingrandisce l'immagine, ma non la distorce né in orizzontale né in verticale.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/controlscrollbartype/_index.md
+++ b/italian/java/com.aspose.diagram/controlscrollbartype/_index.md
@@ -1,0 +1,165 @@
+---
+title: ControlScrollBarType
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta il tipo di barra di scorrimento.
+type: docs
+weight: 97
+url: /it/java/com.aspose.diagram/controlscrollbartype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlScrollBarType
+```
+
+Rappresenta il tipo di barra di scorrimento.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [BARS_BOTH](#BARS-BOTH) | Visualizza sia una barra di scorrimento orizzontale che una verticale. |
+| [BARS_VERTICAL](#BARS-VERTICAL) | Visualizza una barra di scorrimento verticale. |
+| [HORIZONTAL](#HORIZONTAL) | Visualizza una barra di scorrimento orizzontale. |
+| [NONE](#NONE) | Non visualizza barre di scorrimento. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BARS_BOTH {#BARS-BOTH}
+```
+public static final int BARS_BOTH
+```
+
+
+Visualizza sia una barra di scorrimento orizzontale che una verticale.
+
+### BARS_VERTICAL {#BARS-VERTICAL}
+```
+public static final int BARS_VERTICAL
+```
+
+
+Visualizza una barra di scorrimento verticale.
+
+### HORIZONTAL {#HORIZONTAL}
+```
+public static final int HORIZONTAL
+```
+
+
+Visualizza una barra di scorrimento orizzontale.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Non visualizza barre di scorrimento.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/controlscrollorientation/_index.md
+++ b/italian/java/com.aspose.diagram/controlscrollorientation/_index.md
@@ -1,0 +1,156 @@
+---
+title: ControlScrollOrientation
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta il tipo di orientamento dello scorrimento.
+type: docs
+weight: 98
+url: /it/java/com.aspose.diagram/controlscrollorientation/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlScrollOrientation
+```
+
+Rappresenta il tipo di orientamento dello scorrimento.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [AUTO](#AUTO) | Control is rendered horizontally when the control's width is greater than its height. |
+| [HORIZONTAL](#HORIZONTAL) | Control is rendered horizontally. |
+| [VERTICAL](#VERTICAL) | Control is rendered vertically. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AUTO {#AUTO}
+```
+public static final int AUTO
+```
+
+
+Il controllo viene visualizzato orizzontalmente quando la larghezza del controllo è maggiore della sua altezza. Il controllo viene visualizzato verticalmente altrimenti.
+
+### HORIZONTAL {#HORIZONTAL}
+```
+public static final int HORIZONTAL
+```
+
+
+Control is rendered horizontally.
+
+### VERTICAL {#VERTICAL}
+```
+public static final int VERTICAL
+```
+
+
+Control is rendered vertically.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/controlspecialeffecttype/_index.md
+++ b/italian/java/com.aspose.diagram/controlspecialeffecttype/_index.md
@@ -1,0 +1,174 @@
+---
+title: ControlSpecialEffectType
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta il tipo di effetto speciale.
+type: docs
+weight: 99
+url: /it/java/com.aspose.diagram/controlspecialeffecttype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlSpecialEffectType
+```
+
+Rappresenta il tipo di effetto speciale.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [BUMP](#BUMP) | Bump |
+| [ETCHED](#ETCHED) | Etched |
+| [FLAT](#FLAT) | Flat |
+| [RAISED](#RAISED) | Raised |
+| [SUNKEN](#SUNKEN) | Sunken |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BUMP {#BUMP}
+```
+public static final int BUMP
+```
+
+
+Bump
+
+### ETCHED {#ETCHED}
+```
+public static final int ETCHED
+```
+
+
+Etched
+
+### FLAT {#FLAT}
+```
+public static final int FLAT
+```
+
+
+Flat
+
+### RAISED {#RAISED}
+```
+public static final int RAISED
+```
+
+
+Raised
+
+### SUNKEN {#SUNKEN}
+```
+public static final int SUNKEN
+```
+
+
+Sunken
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/controltype/_index.md
+++ b/italian/java/com.aspose.diagram/controltype/_index.md
@@ -1,0 +1,237 @@
+---
+title: ControlType
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta tutti i tipi di controllo ActiveX.
+type: docs
+weight: 100
+url: /it/java/com.aspose.diagram/controltype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlType
+```
+
+Rappresenta tutti i tipi di controllo ActiveX.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [CHECK_BOX](#CHECK-BOX) | CheckBox |
+| [COMBO_BOX](#COMBO-BOX) | ComboBox |
+| [COMMAND_BUTTON](#COMMAND-BUTTON) | Button |
+| [IMAGE](#IMAGE) | Immagine |
+| [LABEL](#LABEL) | Label |
+| [LIST_BOX](#LIST-BOX) | ListBox |
+| [RADIO_BUTTON](#RADIO-BUTTON) | RadioButton |
+| [SCROLL_BAR](#SCROLL-BAR) | ScrollBar |
+| [SPIN_BUTTON](#SPIN-BUTTON) | Spinner |
+| [TEXT_BOX](#TEXT-BOX) | TextBox |
+| [TOGGLE_BUTTON](#TOGGLE-BUTTON) | ToggleButton |
+| [UNKNOWN](#UNKNOWN) | Unknown |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CHECK_BOX {#CHECK-BOX}
+```
+public static final int CHECK_BOX
+```
+
+
+CheckBox
+
+### COMBO_BOX {#COMBO-BOX}
+```
+public static final int COMBO_BOX
+```
+
+
+ComboBox
+
+### COMMAND_BUTTON {#COMMAND-BUTTON}
+```
+public static final int COMMAND_BUTTON
+```
+
+
+Button
+
+### IMAGE {#IMAGE}
+```
+public static final int IMAGE
+```
+
+
+Immagine
+
+### LABEL {#LABEL}
+```
+public static final int LABEL
+```
+
+
+Label
+
+### LIST_BOX {#LIST-BOX}
+```
+public static final int LIST_BOX
+```
+
+
+ListBox
+
+### RADIO_BUTTON {#RADIO-BUTTON}
+```
+public static final int RADIO_BUTTON
+```
+
+
+RadioButton
+
+### SCROLL_BAR {#SCROLL-BAR}
+```
+public static final int SCROLL_BAR
+```
+
+
+ScrollBar
+
+### SPIN_BUTTON {#SPIN-BUTTON}
+```
+public static final int SPIN_BUTTON
+```
+
+
+Spinner
+
+### TEXT_BOX {#TEXT-BOX}
+```
+public static final int TEXT_BOX
+```
+
+
+TextBox
+
+### TOGGLE_BUTTON {#TOGGLE-BUTTON}
+```
+public static final int TOGGLE_BUTTON
+```
+
+
+ToggleButton
+
+### UNKNOWN {#UNKNOWN}
+```
+public static final int UNKNOWN
+```
+
+
+Unknown
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/contype/_index.md
+++ b/italian/java/com.aspose.diagram/contype/_index.md
@@ -1,0 +1,204 @@
+---
+title: ConType
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica il tipo di comportamento che la coordinata x o y della maniglia di controllo mostra dopo che la maniglia è stata spostata.
+type: docs
+weight: 73
+url: /it/java/com.aspose.diagram/contype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ConType
+```
+
+Specifica il tipo di comportamento che la coordinata x o y della maniglia di controllo mostra dopo che la maniglia è stata spostata.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [ConType(int value)](#ConType-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Specifica il tipo di comportamento che la coordinata x o y della maniglia di controllo mostra dopo che la maniglia è stata spostata. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | Per la descrizione di questa proprietà, consultare [getUfe()](../../com.aspose.diagram/contype\#getUfe--) |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, consultare [getValue()](../../com.aspose.diagram/contype\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ConType(int value) {#ConType-int-}
+```
+public ConType(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specifica il tipo di comportamento che la coordinata x o y della maniglia di controllo mostra dopo che la maniglia è stata spostata.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getUfe()](../../com.aspose.diagram/contype\#getUfe--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getValue()](../../com.aspose.diagram/contype\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/convalue/_index.md
+++ b/italian/java/com.aspose.diagram/convalue/_index.md
@@ -1,0 +1,228 @@
+---
+title: ConValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica il tipo di comportamento che la coordinata x o y della maniglia di controllo mostra dopo che la maniglia è stata spostata.
+type: docs
+weight: 74
+url: /it/java/com.aspose.diagram/convalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConValue
+```
+
+Specifica il tipo di comportamento che la coordinata x o y della maniglia di controllo mostra dopo che la maniglia è stata spostata.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [OFFSET_FROM_CENTER](#OFFSET-FROM-CENTER) | Offset dal centro. |
+| [OFFSET_FROM_CENTER_HIDDEN](#OFFSET-FROM-CENTER-HIDDEN) | Offset dal centro, nascosto. |
+| [OFFSET_FROM_LEFT_EDGE](#OFFSET-FROM-LEFT-EDGE) | Offset dal bordo sinistro. |
+| [OFFSET_FROM_LEFT_EDGE_HIDDEN](#OFFSET-FROM-LEFT-EDGE-HIDDEN) | Offset dal bordo sinistro, nascosto. |
+| [OFFSET_FROM_RIGHT_EDGE](#OFFSET-FROM-RIGHT-EDGE) | Offset dal bordo destro. |
+| [OFFSET_FROM_RIGHT_EDGE_HIDDEN](#OFFSET-FROM-RIGHT-EDGE-HIDDEN) | Scostamento dal bordo destro, nascosto. |
+| [PROPORTIONAL](#PROPORTIONAL) | Proporzionale. |
+| [PROPORTIONAL_HIDDEN](#PROPORTIONAL-HIDDEN) | Proporzionale, nascosto.Stesso di 0, ma la maniglia di controllo non è visibile. |
+| [PROPORTIONAL_LOCKED](#PROPORTIONAL-LOCKED) | Proporzionale bloccato. |
+| [PROPORTIONAL_LOCKED_HIDDEN](#PROPORTIONAL-LOCKED-HIDDEN) | Proporzionale bloccato, nascosto. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### OFFSET_FROM_CENTER {#OFFSET-FROM-CENTER}
+```
+public static final int OFFSET_FROM_CENTER
+```
+
+
+Scostamento dal centro. La maniglia di controllo è spostata di una distanza costante dal centro della forma.
+
+### OFFSET_FROM_CENTER_HIDDEN {#OFFSET-FROM-CENTER-HIDDEN}
+```
+public static final int OFFSET_FROM_CENTER_HIDDEN
+```
+
+
+Scostamento dal centro, nascosto. Stesso di 3, ma la maniglia di controllo non è visibile.
+
+### OFFSET_FROM_LEFT_EDGE {#OFFSET-FROM-LEFT-EDGE}
+```
+public static final int OFFSET_FROM_LEFT_EDGE
+```
+
+
+Scostamento dal bordo sinistro. La maniglia di controllo è spostata di una distanza costante dal lato sinistro della forma.
+
+### OFFSET_FROM_LEFT_EDGE_HIDDEN {#OFFSET-FROM-LEFT-EDGE-HIDDEN}
+```
+public static final int OFFSET_FROM_LEFT_EDGE_HIDDEN
+```
+
+
+Scostamento dal bordo sinistro, nascosto. Stesso di 2, ma la maniglia di controllo non è visibile.
+
+### OFFSET_FROM_RIGHT_EDGE {#OFFSET-FROM-RIGHT-EDGE}
+```
+public static final int OFFSET_FROM_RIGHT_EDGE
+```
+
+
+Scostamento dal bordo destro. La maniglia di controllo è spostata di una distanza costante dal lato destro della forma.
+
+### OFFSET_FROM_RIGHT_EDGE_HIDDEN {#OFFSET-FROM-RIGHT-EDGE-HIDDEN}
+```
+public static final int OFFSET_FROM_RIGHT_EDGE_HIDDEN
+```
+
+
+Scostamento dal bordo destro, nascosto. Stesso di 4, ma la maniglia di controllo non è visibile.
+
+### PROPORTIONAL {#PROPORTIONAL}
+```
+public static final int PROPORTIONAL
+```
+
+
+Proporzionale. La maniglia di controllo può essere spostata e si muove anche in proporzione alla forma quando questa viene allungata.
+
+### PROPORTIONAL_HIDDEN {#PROPORTIONAL-HIDDEN}
+```
+public static final int PROPORTIONAL_HIDDEN
+```
+
+
+Proporzionale, nascosto.Stesso di 0, ma la maniglia di controllo non è visibile.
+
+### PROPORTIONAL_LOCKED {#PROPORTIONAL-LOCKED}
+```
+public static final int PROPORTIONAL_LOCKED
+```
+
+
+Proporzionale bloccato. La maniglia di controllo si muove in proporzione alla forma, ma la stessa maniglia non può essere spostata.
+
+### PROPORTIONAL_LOCKED_HIDDEN {#PROPORTIONAL-LOCKED-HIDDEN}
+```
+public static final int PROPORTIONAL_LOCKED_HIDDEN
+```
+
+
+Proporzionale bloccato, nascosto. Stesso di 1, ma la maniglia di controllo non è visibile.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/coordinate/_index.md
+++ b/italian/java/com.aspose.diagram/coordinate/_index.md
@@ -1,0 +1,197 @@
+---
+title: Coordinate
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Classe astratta per le coordinate x e y.
+type: docs
+weight: 101
+url: /it/java/com.aspose.diagram/coordinate/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public abstract class Coordinate
+```
+
+Classe astratta per le coordinate x e y.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [Coordinate()](#Coordinate--) |  |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getIX()](#getIX--) | L'indice basato su zero dell'elemento all'interno del suo elemento genitore. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, vedere @PREF1\_ |
+| [setIX(int value)](#setIX-int-) | Per la descrizione di questa proprietà, vedere @PREF0\_ |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Coordinate() {#Coordinate--}
+```
+public Coordinate()
+```
+
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public abstract int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public abstract int getIX()
+```
+
+
+L'indice basato su zero dell'elemento all'interno del suo elemento genitore.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public abstract void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere @PREF1\_
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public abstract void setIX(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere @PREF0\_
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/coordinatecollection/_index.md
+++ b/italian/java/com.aspose.diagram/coordinatecollection/_index.md
@@ -1,0 +1,833 @@
+---
+title: CoordinateCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Raccolta di coordinate.
+type: docs
+weight: 102
+url: /it/java/com.aspose.diagram/coordinatecollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class CoordinateCollection extends Collection
+```
+
+Raccolta di coordinate.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [add(ArcTo item)](#add-com.aspose.diagram.ArcTo-) | Aggiunge l'oggetto ArcTo alla collezione. |
+| [add(Coordinate item)](#add-com.aspose.diagram.Coordinate-) | Aggiunge l'oggetto Coordinate alla collezione. |
+| [add(Ellipse item)](#add-com.aspose.diagram.Ellipse-) | Aggiunge l'oggetto Ellipse alla collezione. |
+| [add(EllipticalArcTo item)](#add-com.aspose.diagram.EllipticalArcTo-) | Aggiunge l'oggetto EllipticalArcTo alla collezione. |
+| [add(InfiniteLine item)](#add-com.aspose.diagram.InfiniteLine-) | Aggiunge l'oggetto InfiniteLine alla collezione. |
+| [add(LineTo item)](#add-com.aspose.diagram.LineTo-) | Aggiunge l'oggetto LineTo alla collezione. |
+| [add(MoveTo item)](#add-com.aspose.diagram.MoveTo-) | Aggiunge l'oggetto MoveTo alla collezione. |
+| [add(NURBSTo item)](#add-com.aspose.diagram.NURBSTo-) | Aggiunge l'oggetto NURBSTo alla collezione. |
+| [add(PolylineTo item)](#add-com.aspose.diagram.PolylineTo-) | Aggiunge l'oggetto PolylineTo alla collezione. |
+| [add(RelCubBezTo item)](#add-com.aspose.diagram.RelCubBezTo-) | Aggiunge l'oggetto RelCubBezTo alla collezione. |
+| [add(RelEllipticalArcTo item)](#add-com.aspose.diagram.RelEllipticalArcTo-) | Aggiungi l'oggetto RelEllipticalArcTo nella collezione. |
+| [add(RelLineTo item)](#add-com.aspose.diagram.RelLineTo-) | Aggiungi l'oggetto RelLineTo nella collezione. |
+| [add(RelMoveTo item)](#add-com.aspose.diagram.RelMoveTo-) | Aggiungi l'oggetto RelMoveTo nella collezione. |
+| [add(RelQuadBezTo item)](#add-com.aspose.diagram.RelQuadBezTo-) | Aggiungi l'oggetto RelQuadBezTo nella collezione. |
+| [add(SplineKnot item)](#add-com.aspose.diagram.SplineKnot-) | Aggiungi l'oggetto SplineKnot nella collezione. |
+| [add(SplineStart item)](#add-com.aspose.diagram.SplineStart-) | Aggiungi l'oggetto SplineStart nella collezione. |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getArcToCol()](#getArcToCol--) | Contiene le coordinate x e y e l'arco di un arco circolare rappresentati rispettivamente dagli elementi X, Y e A. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [getEllipseCol()](#getEllipseCol--) | Contiene elementi che specificano le coordinate x e y del punto centrale dell'ellisse e due punti sull'ellisse. |
+| [getEllipticalArcToCol()](#getEllipticalArcToCol--) | Contiene elementi che specificano informazioni su un arco ellittico. |
+| [getInfiniteLineCol()](#getInfiniteLineCol--) | Contiene elementi che specificano le coordinate x e y di due punti su una linea infinita. |
+| [getLineToCol()](#getLineToCol--) | Contiene le coordinate x e y del vertice finale di un segmento di linea retta. |
+| [getMoveToCol()](#getMoveToCol--) | Contiene le coordinate x e y del primo vertice di una forma, oppure le coordinate x e y del primo vertice dopo un'interruzione in un percorso. |
+| [getNURBSToCol()](#getNURBSToCol--) | Contiene le coordinate x e y, la posizione del penultimo nodo, la posizione dell'ultimo peso, la posizione del primo nodo, la posizione del primo peso e la formula per una B-spline razionale non uniforme (NURBS). |
+| [getPolylineToCol()](#getPolylineToCol--) | Contiene le coordinate x e y dell'ultimo punto di una polilinea e la formula della polilinea. |
+| [getRelCubBezToCol()](#getRelCubBezToCol--) | Contiene le coordinate x e y per i punti di un RelCubBezTo. Le coordinate sono specificate come coordinate relative. |
+| [getRelEllipticalArcToCol()](#getRelEllipticalArcToCol--) | Contiene elementi che specificano informazioni su un arco ellittico. Le coordinate sono specificate come coordinate relative. |
+| [getRelLineToCol()](#getRelLineToCol--) | Contiene le coordinate x e y del vertice finale di un segmento di linea retta. |
+| [getRelMoveToCol()](#getRelMoveToCol--) | Contiene le coordinate x e y del primo vertice di una forma, o contiene le coordinate x e y del primo vertice dopo un'interruzione in un percorso. Le coordinate sono specificate come coordinate relative. |
+| [getRelQuadBezToCol()](#getRelQuadBezToCol--) | Contiene le coordinate x e y per i punti di un RelQuadBezTo. Le coordinate sono specificate come coordinate relative. |
+| [getSplineKnotCol()](#getSplineKnotCol--) | Contiene le coordinate x e y per il punto di controllo di una spline e per un nodo della spline, rappresentati rispettivamente dagli elementi X, Y e A. |
+| [getSplineStartCol()](#getSplineStartCol--) | Contiene le coordinate x e y per il secondo punto di controllo di una spline, il suo secondo nodo, il suo primo nodo, l'ultimo nodo e il grado della spline. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(ArcTo item)](#remove-com.aspose.diagram.ArcTo-) | Rimuovi l'oggetto ArcTo dalla collezione. |
+| [remove(Coordinate item)](#remove-com.aspose.diagram.Coordinate-) | Rimuovi l'oggetto Coordinate dalla collezione. |
+| [remove(Ellipse item)](#remove-com.aspose.diagram.Ellipse-) | Rimuovi l'oggetto Ellipse dalla collezione. |
+| [remove(EllipticalArcTo item)](#remove-com.aspose.diagram.EllipticalArcTo-) | Rimuovi l'oggetto EllipticalArcTo dalla collezione. |
+| [remove(InfiniteLine item)](#remove-com.aspose.diagram.InfiniteLine-) | Rimuovi l'oggetto InfiniteLine dalla collezione. |
+| [remove(LineTo item)](#remove-com.aspose.diagram.LineTo-) | Rimuovi l'oggetto LineTo dalla collezione. |
+| [remove(MoveTo item)](#remove-com.aspose.diagram.MoveTo-) | Rimuovi l'oggetto MoveTo dalla collezione. |
+| [remove(NURBSTo item)](#remove-com.aspose.diagram.NURBSTo-) | Rimuovi l'oggetto NURBSTo dalla collezione. |
+| [remove(PolylineTo item)](#remove-com.aspose.diagram.PolylineTo-) | Rimuovi l'oggetto PolylineTo dalla collezione. |
+| [remove(RelCubBezTo item)](#remove-com.aspose.diagram.RelCubBezTo-) | Rimuovi l'oggetto RelCubBezTo dalla collezione. |
+| [remove(RelEllipticalArcTo item)](#remove-com.aspose.diagram.RelEllipticalArcTo-) | Rimuovi l'oggetto RelEllipticalArcTo dalla collezione. |
+| [remove(RelLineTo item)](#remove-com.aspose.diagram.RelLineTo-) | Rimuovi l'oggetto RelLineTo dalla collezione. |
+| [remove(RelMoveTo item)](#remove-com.aspose.diagram.RelMoveTo-) | Rimuovi l'oggetto RelMoveTo dalla collezione. |
+| [remove(RelQuadBezTo item)](#remove-com.aspose.diagram.RelQuadBezTo-) | Rimuovi l'oggetto RelQuadBezTo dalla collezione. |
+| [remove(SplineKnot item)](#remove-com.aspose.diagram.SplineKnot-) | Rimuovi l'oggetto SplineKnot dalla collezione. |
+| [remove(SplineStart item)](#remove-com.aspose.diagram.SplineStart-) | Rimuovi l'oggetto SplineStart dalla collezione. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(ArcTo item) {#add-com.aspose.diagram.ArcTo-}
+```
+public int add(ArcTo item)
+```
+
+
+Aggiunge l'oggetto ArcTo alla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [ArcTo](../../com.aspose.diagram/arcto) |  |
+
+**Returns:**
+int -
+### add(Coordinate item) {#add-com.aspose.diagram.Coordinate-}
+```
+public int add(Coordinate item)
+```
+
+
+Aggiunge l'oggetto Coordinate alla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [Coordinate](../../com.aspose.diagram/coordinate) |  |
+
+**Returns:**
+int
+### add(Ellipse item) {#add-com.aspose.diagram.Ellipse-}
+```
+public int add(Ellipse item)
+```
+
+
+Aggiunge l'oggetto Ellipse alla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [Ellipse](../../com.aspose.diagram/ellipse) |  |
+
+**Returns:**
+int -
+### add(EllipticalArcTo item) {#add-com.aspose.diagram.EllipticalArcTo-}
+```
+public int add(EllipticalArcTo item)
+```
+
+
+Aggiunge l'oggetto EllipticalArcTo alla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [EllipticalArcTo](../../com.aspose.diagram/ellipticalarcto) |  |
+
+**Returns:**
+int -
+### add(InfiniteLine item) {#add-com.aspose.diagram.InfiniteLine-}
+```
+public int add(InfiniteLine item)
+```
+
+
+Aggiunge l'oggetto InfiniteLine alla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [InfiniteLine](../../com.aspose.diagram/infiniteline) |  |
+
+**Returns:**
+int -
+### add(LineTo item) {#add-com.aspose.diagram.LineTo-}
+```
+public int add(LineTo item)
+```
+
+
+Aggiunge l'oggetto LineTo alla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [LineTo](../../com.aspose.diagram/lineto) |  |
+
+**Returns:**
+int -
+### add(MoveTo item) {#add-com.aspose.diagram.MoveTo-}
+```
+public int add(MoveTo item)
+```
+
+
+Aggiunge l'oggetto MoveTo alla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [MoveTo](../../com.aspose.diagram/moveto) |  |
+
+**Returns:**
+int -
+### add(NURBSTo item) {#add-com.aspose.diagram.NURBSTo-}
+```
+public int add(NURBSTo item)
+```
+
+
+Aggiunge l'oggetto NURBSTo alla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [NURBSTo](../../com.aspose.diagram/nurbsto) |  |
+
+**Returns:**
+int -
+### add(PolylineTo item) {#add-com.aspose.diagram.PolylineTo-}
+```
+public int add(PolylineTo item)
+```
+
+
+Aggiunge l'oggetto PolylineTo alla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [PolylineTo](../../com.aspose.diagram/polylineto) |  |
+
+**Returns:**
+int -
+### add(RelCubBezTo item) {#add-com.aspose.diagram.RelCubBezTo-}
+```
+public int add(RelCubBezTo item)
+```
+
+
+Aggiunge l'oggetto RelCubBezTo alla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [RelCubBezTo](../../com.aspose.diagram/relcubbezto) |  |
+
+**Returns:**
+int -
+### add(RelEllipticalArcTo item) {#add-com.aspose.diagram.RelEllipticalArcTo-}
+```
+public int add(RelEllipticalArcTo item)
+```
+
+
+Aggiungi l'oggetto RelEllipticalArcTo nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [RelEllipticalArcTo](../../com.aspose.diagram/relellipticalarcto) |  |
+
+**Returns:**
+int -
+### add(RelLineTo item) {#add-com.aspose.diagram.RelLineTo-}
+```
+public int add(RelLineTo item)
+```
+
+
+Aggiungi l'oggetto RelLineTo nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [RelLineTo](../../com.aspose.diagram/rellineto) |  |
+
+**Returns:**
+int -
+### add(RelMoveTo item) {#add-com.aspose.diagram.RelMoveTo-}
+```
+public int add(RelMoveTo item)
+```
+
+
+Aggiungi l'oggetto RelMoveTo nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [RelMoveTo](../../com.aspose.diagram/relmoveto) |  |
+
+**Returns:**
+int -
+### add(RelQuadBezTo item) {#add-com.aspose.diagram.RelQuadBezTo-}
+```
+public int add(RelQuadBezTo item)
+```
+
+
+Aggiungi l'oggetto RelQuadBezTo nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [RelQuadBezTo](../../com.aspose.diagram/relquadbezto) |  |
+
+**Returns:**
+int -
+### add(SplineKnot item) {#add-com.aspose.diagram.SplineKnot-}
+```
+public int add(SplineKnot item)
+```
+
+
+Aggiungi l'oggetto SplineKnot nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [SplineKnot](../../com.aspose.diagram/splineknot) |  |
+
+**Returns:**
+int -
+### add(SplineStart item) {#add-com.aspose.diagram.SplineStart-}
+```
+public int add(SplineStart item)
+```
+
+
+Aggiungi l'oggetto SplineStart nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [SplineStart](../../com.aspose.diagram/splinestart) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Coordinate get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[Coordinate](../../com.aspose.diagram/coordinate) - 
+### getArcToCol() {#getArcToCol--}
+```
+public ArcToCollection getArcToCol()
+```
+
+
+Contiene le coordinate x e y e l'arco di un arco circolare rappresentati rispettivamente dagli elementi X, Y e A.
+
+**Returns:**
+[ArcToCollection](../../com.aspose.diagram/arctocollection)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### getEllipseCol() {#getEllipseCol--}
+```
+public EllipseCollection getEllipseCol()
+```
+
+
+Contiene elementi che specificano le coordinate x e y del punto centrale dell'ellisse e due punti sull'ellisse.
+
+**Returns:**
+[EllipseCollection](../../com.aspose.diagram/ellipsecollection)
+### getEllipticalArcToCol() {#getEllipticalArcToCol--}
+```
+public EllipticalArcToCollection getEllipticalArcToCol()
+```
+
+
+Contiene elementi che specificano informazioni su un arco ellittico.
+
+**Returns:**
+[EllipticalArcToCollection](../../com.aspose.diagram/ellipticalarctocollection)
+### getInfiniteLineCol() {#getInfiniteLineCol--}
+```
+public InfiniteLineCollection getInfiniteLineCol()
+```
+
+
+Contiene gli elementi che specificano le coordinate x e y di due punti su una linea infinita. Gli elementi X e Y specificano le coordinate x e y del primo punto, e gli elementi A e B specificano le coordinate x e y del secondo punto.
+
+**Returns:**
+[InfiniteLineCollection](../../com.aspose.diagram/infinitelinecollection)
+### getLineToCol() {#getLineToCol--}
+```
+public LineToCollection getLineToCol()
+```
+
+
+Contiene le coordinate x e y del vertice finale di un segmento di linea retta. Queste coordinate sono contenute rispettivamente negli elementi X e Y.
+
+**Returns:**
+[LineToCollection](../../com.aspose.diagram/linetocollection)
+### getMoveToCol() {#getMoveToCol--}
+```
+public MoveToCollection getMoveToCol()
+```
+
+
+Contiene le coordinate x e y del primo vertice di una forma, oppure le coordinate x e y del primo vertice dopo un'interruzione in un percorso.
+
+**Returns:**
+[MoveToCollection](../../com.aspose.diagram/movetocollection)
+### getNURBSToCol() {#getNURBSToCol--}
+```
+public NURBSToCollection getNURBSToCol()
+```
+
+
+Contiene le coordinate x e y, la posizione del penultimo nodo, la posizione dell'ultimo peso, la posizione del primo nodo, la posizione del primo peso e la formula per una B-spline razionale non uniforme (NURBS). Queste informazioni sono specificate rispettivamente negli elementi X, Y, A, B, C, D ed E.
+
+**Returns:**
+[NURBSToCollection](../../com.aspose.diagram/nurbstocollection)
+### getPolylineToCol() {#getPolylineToCol--}
+```
+public PolylineToCollection getPolylineToCol()
+```
+
+
+Contiene le coordinate x e y dell'ultimo punto di una polilinea e una formula di polilinea. Le coordinate sono specificate negli elementi X e Y, e la formula è specificata nell'elemento A.
+
+**Returns:**
+[PolylineToCollection](../../com.aspose.diagram/polylinetocollection)
+### getRelCubBezToCol() {#getRelCubBezToCol--}
+```
+public RelCubBezToCollection getRelCubBezToCol()
+```
+
+
+Contiene le coordinate x e y per i punti di un RelCubBezTo. Le coordinate sono specificate come coordinate relative.
+
+**Returns:**
+[RelCubBezToCollection](../../com.aspose.diagram/relcubbeztocollection)
+### getRelEllipticalArcToCol() {#getRelEllipticalArcToCol--}
+```
+public RelEllipticalArcToCollection getRelEllipticalArcToCol()
+```
+
+
+Contiene elementi che specificano informazioni su un arco ellittico. Le coordinate sono specificate come coordinate relative.
+
+**Returns:**
+[RelEllipticalArcToCollection](../../com.aspose.diagram/relellipticalarctocollection)
+### getRelLineToCol() {#getRelLineToCol--}
+```
+public RelLineToCollection getRelLineToCol()
+```
+
+
+Contiene le coordinate x e y del vertice finale di un segmento di linea retta. Queste coordinate sono contenute rispettivamente negli elementi X e Y.Coordinate specificate come coordinate relative.
+
+**Returns:**
+[RelLineToCollection](../../com.aspose.diagram/rellinetocollection)
+### getRelMoveToCol() {#getRelMoveToCol--}
+```
+public RelMoveToCollection getRelMoveToCol()
+```
+
+
+Contiene le coordinate x e y del primo vertice di una forma, o contiene le coordinate x e y del primo vertice dopo un'interruzione in un percorso. Le coordinate sono specificate come coordinate relative.
+
+**Returns:**
+[RelMoveToCollection](../../com.aspose.diagram/relmovetocollection)
+### getRelQuadBezToCol() {#getRelQuadBezToCol--}
+```
+public RelQuadBezToCollection getRelQuadBezToCol()
+```
+
+
+Contiene le coordinate x e y per i punti di un RelQuadBezTo. Le coordinate sono specificate come coordinate relative.
+
+**Returns:**
+[RelQuadBezToCollection](../../com.aspose.diagram/relquadbeztocollection)
+### getSplineKnotCol() {#getSplineKnotCol--}
+```
+public SplineKnotCollection getSplineKnotCol()
+```
+
+
+Contiene le coordinate x e y per il punto di controllo di una spline e per un nodo della spline, rappresentati rispettivamente dagli elementi X, Y e A.
+
+**Returns:**
+[SplineKnotCollection](../../com.aspose.diagram/splineknotcollection)
+### getSplineStartCol() {#getSplineStartCol--}
+```
+public SplineStartCollection getSplineStartCol()
+```
+
+
+Contiene le coordinate x e y per il secondo punto di controllo di una spline, il suo secondo nodo, il suo primo nodo, l'ultimo nodo e il grado della spline. Queste informazioni sono contenute rispettivamente negli elementi X, Y, A, B, C e D.
+
+**Returns:**
+[SplineStartCollection](../../com.aspose.diagram/splinestartcollection)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(ArcTo item) {#remove-com.aspose.diagram.ArcTo-}
+```
+public void remove(ArcTo item)
+```
+
+
+Rimuovi l'oggetto ArcTo dalla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [ArcTo](../../com.aspose.diagram/arcto) |  |
+
+### remove(Coordinate item) {#remove-com.aspose.diagram.Coordinate-}
+```
+public void remove(Coordinate item)
+```
+
+
+Rimuovi l'oggetto Coordinate dalla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [Coordinate](../../com.aspose.diagram/coordinate) |  |
+
+### remove(Ellipse item) {#remove-com.aspose.diagram.Ellipse-}
+```
+public void remove(Ellipse item)
+```
+
+
+Rimuovi l'oggetto Ellipse dalla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [Ellipse](../../com.aspose.diagram/ellipse) |  |
+
+### remove(EllipticalArcTo item) {#remove-com.aspose.diagram.EllipticalArcTo-}
+```
+public void remove(EllipticalArcTo item)
+```
+
+
+Rimuovi l'oggetto EllipticalArcTo dalla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [EllipticalArcTo](../../com.aspose.diagram/ellipticalarcto) |  |
+
+### remove(InfiniteLine item) {#remove-com.aspose.diagram.InfiniteLine-}
+```
+public void remove(InfiniteLine item)
+```
+
+
+Rimuovi l'oggetto InfiniteLine dalla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [InfiniteLine](../../com.aspose.diagram/infiniteline) |  |
+
+### remove(LineTo item) {#remove-com.aspose.diagram.LineTo-}
+```
+public void remove(LineTo item)
+```
+
+
+Rimuovi l'oggetto LineTo dalla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [LineTo](../../com.aspose.diagram/lineto) |  |
+
+### remove(MoveTo item) {#remove-com.aspose.diagram.MoveTo-}
+```
+public void remove(MoveTo item)
+```
+
+
+Rimuovi l'oggetto MoveTo dalla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [MoveTo](../../com.aspose.diagram/moveto) |  |
+
+### remove(NURBSTo item) {#remove-com.aspose.diagram.NURBSTo-}
+```
+public void remove(NURBSTo item)
+```
+
+
+Rimuovi l'oggetto NURBSTo dalla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [NURBSTo](../../com.aspose.diagram/nurbsto) |  |
+
+### remove(PolylineTo item) {#remove-com.aspose.diagram.PolylineTo-}
+```
+public void remove(PolylineTo item)
+```
+
+
+Rimuovi l'oggetto PolylineTo dalla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [PolylineTo](../../com.aspose.diagram/polylineto) |  |
+
+### remove(RelCubBezTo item) {#remove-com.aspose.diagram.RelCubBezTo-}
+```
+public void remove(RelCubBezTo item)
+```
+
+
+Rimuovi l'oggetto RelCubBezTo dalla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [RelCubBezTo](../../com.aspose.diagram/relcubbezto) |  |
+
+### remove(RelEllipticalArcTo item) {#remove-com.aspose.diagram.RelEllipticalArcTo-}
+```
+public void remove(RelEllipticalArcTo item)
+```
+
+
+Rimuovi l'oggetto RelEllipticalArcTo dalla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [RelEllipticalArcTo](../../com.aspose.diagram/relellipticalarcto) |  |
+
+### remove(RelLineTo item) {#remove-com.aspose.diagram.RelLineTo-}
+```
+public void remove(RelLineTo item)
+```
+
+
+Rimuovi l'oggetto RelLineTo dalla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [RelLineTo](../../com.aspose.diagram/rellineto) |  |
+
+### remove(RelMoveTo item) {#remove-com.aspose.diagram.RelMoveTo-}
+```
+public void remove(RelMoveTo item)
+```
+
+
+Rimuovi l'oggetto RelMoveTo dalla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [RelMoveTo](../../com.aspose.diagram/relmoveto) |  |
+
+### remove(RelQuadBezTo item) {#remove-com.aspose.diagram.RelQuadBezTo-}
+```
+public void remove(RelQuadBezTo item)
+```
+
+
+Rimuovi l'oggetto RelQuadBezTo dalla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [RelQuadBezTo](../../com.aspose.diagram/relquadbezto) |  |
+
+### remove(SplineKnot item) {#remove-com.aspose.diagram.SplineKnot-}
+```
+public void remove(SplineKnot item)
+```
+
+
+Rimuovi l'oggetto SplineKnot dalla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [SplineKnot](../../com.aspose.diagram/splineknot) |  |
+
+### remove(SplineStart item) {#remove-com.aspose.diagram.SplineStart-}
+```
+public void remove(SplineStart item)
+```
+
+
+Rimuovi l'oggetto SplineStart dalla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [SplineStart](../../com.aspose.diagram/splinestart) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/countrycode/_index.md
+++ b/italian/java/com.aspose.diagram/countrycode/_index.md
@@ -1,0 +1,579 @@
+---
+title: CodicePaese
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta gli identificatori dei paesi del diagramma.
+type: docs
+weight: 103
+url: /it/java/com.aspose.diagram/countrycode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class CountryCode
+```
+
+Rappresenta gli identificatori dei paesi del diagramma.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [ALGERIA](#ALGERIA) | Algeria |
+| [AUSTRALIA](#AUSTRALIA) | Australia |
+| [AUSTRIA](#AUSTRIA) | Austria |
+| [BELGIUM](#BELGIUM) | Belgio |
+| [BRAZIL](#BRAZIL) | Brasile |
+| [CANADA](#CANADA) | Canada |
+| [CHINA](#CHINA) | Repubblica Popolare Cinese |
+| [CZECH](#CZECH) | Repubblica Ceca |
+| [DEFAULT](#DEFAULT) |  |
+| [DENMARK](#DENMARK) | Danimarca |
+| [EGYPT](#EGYPT) | Egitto |
+| [FINLAND](#FINLAND) | Finlandia |
+| [FRANCE](#FRANCE) | Francia |
+| [GERMANY](#GERMANY) | Germania |
+| [GREECE](#GREECE) | Grecia |
+| [HUNGARY](#HUNGARY) | Ungheria |
+| [ICELAND](#ICELAND) | Islanda |
+| [INDIA](#INDIA) | India |
+| [IRAN](#IRAN) | Iran |
+| [IRAQ](#IRAQ) | Iraq |
+| [ISRAEL](#ISRAEL) | Israele |
+| [ITALY](#ITALY) | Italia |
+| [JAPAN](#JAPAN) | Giappone |
+| [JORDAN](#JORDAN) | Giordania |
+| [KUWAIT](#KUWAIT) | Kuwait |
+| [LATIN_AMERIC](#LATIN-AMERIC) | America Latina, eccetto il Brasile |
+| [LEBANON](#LEBANON) | Libano |
+| [LIBYA](#LIBYA) | Libia |
+| [MEXICO](#MEXICO) | Messico |
+| [MOROCCO](#MOROCCO) | Morocco |
+| [NETHERLANDS](#NETHERLANDS) | Netherlands |
+| [NEW_ZEALAND](#NEW-ZEALAND) | New Zealand |
+| [NORWAY](#NORWAY) | Norway |
+| [POLAND](#POLAND) | Poland |
+| [PORTUGAL](#PORTUGAL) | Portugal |
+| [QATAR](#QATAR) | Qatar |
+| [RUSSIA](#RUSSIA) | Russia |
+| [SAUDI](#SAUDI) | Saudi Arabia |
+| [SOUTH_KOREA](#SOUTH-KOREA) | SouthKorea |
+| [SPAIN](#SPAIN) | Spain |
+| [SWEDEN](#SWEDEN) | Sweden |
+| [SWITZERLAND](#SWITZERLAND) | Switzerland |
+| [SYRIA](#SYRIA) | Syria |
+| [TAIWAN](#TAIWAN) | Taiwan |
+| [THAILAND](#THAILAND) | Thailand |
+| [TURKEY](#TURKEY) | Turkey |
+| [UNITED_ARAB_EMIRATES](#UNITED-ARAB-EMIRATES) | United Arab Emirates |
+| [UNITED_KINGDOM](#UNITED-KINGDOM) | United Kingdom |
+| [USA](#USA) | United States |
+| [VIET_NAM](#VIET-NAM) | Viet Nam |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALGERIA {#ALGERIA}
+```
+public static final int ALGERIA
+```
+
+
+Algeria
+
+### AUSTRALIA {#AUSTRALIA}
+```
+public static final int AUSTRALIA
+```
+
+
+Australia
+
+### AUSTRIA {#AUSTRIA}
+```
+public static final int AUSTRIA
+```
+
+
+Austria
+
+### BELGIUM {#BELGIUM}
+```
+public static final int BELGIUM
+```
+
+
+Belgio
+
+### BRAZIL {#BRAZIL}
+```
+public static final int BRAZIL
+```
+
+
+Brasile
+
+### CANADA {#CANADA}
+```
+public static final int CANADA
+```
+
+
+Canada
+
+### CHINA {#CHINA}
+```
+public static final int CHINA
+```
+
+
+Repubblica Popolare Cinese
+
+### CZECH {#CZECH}
+```
+public static final int CZECH
+```
+
+
+Repubblica Ceca
+
+### DEFAULT {#DEFAULT}
+```
+public static final int DEFAULT
+```
+
+
+
+
+### DENMARK {#DENMARK}
+```
+public static final int DENMARK
+```
+
+
+Danimarca
+
+### EGYPT {#EGYPT}
+```
+public static final int EGYPT
+```
+
+
+Egitto
+
+### FINLAND {#FINLAND}
+```
+public static final int FINLAND
+```
+
+
+Finlandia
+
+### FRANCE {#FRANCE}
+```
+public static final int FRANCE
+```
+
+
+Francia
+
+### GERMANY {#GERMANY}
+```
+public static final int GERMANY
+```
+
+
+Germania
+
+### GREECE {#GREECE}
+```
+public static final int GREECE
+```
+
+
+Grecia
+
+### HUNGARY {#HUNGARY}
+```
+public static final int HUNGARY
+```
+
+
+Ungheria
+
+### ICELAND {#ICELAND}
+```
+public static final int ICELAND
+```
+
+
+Islanda
+
+### INDIA {#INDIA}
+```
+public static final int INDIA
+```
+
+
+India
+
+### IRAN {#IRAN}
+```
+public static final int IRAN
+```
+
+
+Iran
+
+### IRAQ {#IRAQ}
+```
+public static final int IRAQ
+```
+
+
+Iraq
+
+### ISRAEL {#ISRAEL}
+```
+public static final int ISRAEL
+```
+
+
+Israele
+
+### ITALY {#ITALY}
+```
+public static final int ITALY
+```
+
+
+Italia
+
+### JAPAN {#JAPAN}
+```
+public static final int JAPAN
+```
+
+
+Giappone
+
+### JORDAN {#JORDAN}
+```
+public static final int JORDAN
+```
+
+
+Giordania
+
+### KUWAIT {#KUWAIT}
+```
+public static final int KUWAIT
+```
+
+
+Kuwait
+
+### LATIN_AMERIC {#LATIN-AMERIC}
+```
+public static final int LATIN_AMERIC
+```
+
+
+America Latina, eccetto il Brasile
+
+### LEBANON {#LEBANON}
+```
+public static final int LEBANON
+```
+
+
+Libano
+
+### LIBYA {#LIBYA}
+```
+public static final int LIBYA
+```
+
+
+Libia
+
+### MEXICO {#MEXICO}
+```
+public static final int MEXICO
+```
+
+
+Messico
+
+### MOROCCO {#MOROCCO}
+```
+public static final int MOROCCO
+```
+
+
+Morocco
+
+### NETHERLANDS {#NETHERLANDS}
+```
+public static final int NETHERLANDS
+```
+
+
+Netherlands
+
+### NEW_ZEALAND {#NEW-ZEALAND}
+```
+public static final int NEW_ZEALAND
+```
+
+
+New Zealand
+
+### NORWAY {#NORWAY}
+```
+public static final int NORWAY
+```
+
+
+Norway
+
+### POLAND {#POLAND}
+```
+public static final int POLAND
+```
+
+
+Poland
+
+### PORTUGAL {#PORTUGAL}
+```
+public static final int PORTUGAL
+```
+
+
+Portugal
+
+### QATAR {#QATAR}
+```
+public static final int QATAR
+```
+
+
+Qatar
+
+### RUSSIA {#RUSSIA}
+```
+public static final int RUSSIA
+```
+
+
+Russia
+
+### SAUDI {#SAUDI}
+```
+public static final int SAUDI
+```
+
+
+Saudi Arabia
+
+### SOUTH_KOREA {#SOUTH-KOREA}
+```
+public static final int SOUTH_KOREA
+```
+
+
+SouthKorea
+
+### SPAIN {#SPAIN}
+```
+public static final int SPAIN
+```
+
+
+Spain
+
+### SWEDEN {#SWEDEN}
+```
+public static final int SWEDEN
+```
+
+
+Sweden
+
+### SWITZERLAND {#SWITZERLAND}
+```
+public static final int SWITZERLAND
+```
+
+
+Switzerland
+
+### SYRIA {#SYRIA}
+```
+public static final int SYRIA
+```
+
+
+Syria
+
+### TAIWAN {#TAIWAN}
+```
+public static final int TAIWAN
+```
+
+
+Taiwan
+
+### THAILAND {#THAILAND}
+```
+public static final int THAILAND
+```
+
+
+Thailand
+
+### TURKEY {#TURKEY}
+```
+public static final int TURKEY
+```
+
+
+Turkey
+
+### UNITED_ARAB_EMIRATES {#UNITED-ARAB-EMIRATES}
+```
+public static final int UNITED_ARAB_EMIRATES
+```
+
+
+United Arab Emirates
+
+### UNITED_KINGDOM {#UNITED-KINGDOM}
+```
+public static final int UNITED_KINGDOM
+```
+
+
+United Kingdom
+
+### USA {#USA}
+```
+public static final int USA
+```
+
+
+United States
+
+### VIET_NAM {#VIET-NAM}
+```
+public static final int VIET_NAM
+```
+
+
+Viet Nam
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/cp/_index.md
+++ b/italian/java/com.aspose.diagram/cp/_index.md
@@ -1,0 +1,154 @@
+---
+title: Cp
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Segna l'inizio di una sequenza di proprietà del carattere formattata secondo l'elemento Char corrispondente.
+type: docs
+weight: 104
+url: /it/java/com.aspose.diagram/cp/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.FormatTxt](../../com.aspose.diagram/formattxt)
+```
+public class Cp extends FormatTxt
+```
+
+Segna l'inizio di una sequenza di proprietà del carattere formattata secondo l'elemento Char corrispondente. La sequenza è definita fino alla fine del testo o fino al successivo
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [Cp(int IX)](#Cp-int-) | Costruttore |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getValue()](#getValue--) | Valore |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Cp(int IX) {#Cp-int-}
+```
+public Cp(int IX)
+```
+
+
+Costruttore
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| IX | int | L'indice dell'elemento Char che questa sequenza di proprietà rappresenta. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+Valore
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/customprop/_index.md
+++ b/italian/java/com.aspose.diagram/customprop/_index.md
@@ -1,0 +1,211 @@
+---
+title: CustomProp
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Struttura CustomProp.
+type: docs
+weight: 105
+url: /it/java/com.aspose.diagram/customprop/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class CustomProp
+```
+
+Struttura CustomProp.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [CustomProp()](#CustomProp--) |  |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCustomValue()](#getCustomValue--) | Valore della proprietà. |
+| [getName()](#getName--) | Il nome della proprietà personalizzata. |
+| [getPropType()](#getPropType--) | Il tipo di dati della proprietà personalizzata. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCustomValue(CustomValue value)](#setCustomValue-com.aspose.diagram.CustomValue-) | Per la descrizione di questa proprietà, consultare [getCustomValue()](../../com.aspose.diagram/customprop\#getCustomValue--) |
+| [setName(String value)](#setName-java.lang.String-) | Per la descrizione di questa proprietà, consultare [getName()](../../com.aspose.diagram/customprop\#getName--) |
+| [setPropType(int value)](#setPropType-int-) | Per la descrizione di questa proprietà, consultare [getPropType()](../../com.aspose.diagram/customprop\#getPropType--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CustomProp() {#CustomProp--}
+```
+public CustomProp()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCustomValue() {#getCustomValue--}
+```
+public CustomValue getCustomValue()
+```
+
+
+Valore della proprietà.
+
+**Returns:**
+[CustomValue](../../com.aspose.diagram/customvalue)
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Il nome della proprietà personalizzata.
+
+**Returns:**
+java.lang.String
+### getPropType() {#getPropType--}
+```
+public int getPropType()
+```
+
+
+Il tipo di dati della proprietà personalizzata.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCustomValue(CustomValue value) {#setCustomValue-com.aspose.diagram.CustomValue-}
+```
+public void setCustomValue(CustomValue value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getCustomValue()](../../com.aspose.diagram/customprop\#getCustomValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [CustomValue](../../com.aspose.diagram/customvalue) |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getName()](../../com.aspose.diagram/customprop\#getName--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setPropType(int value) {#setPropType-int-}
+```
+public void setPropType(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getPropType()](../../com.aspose.diagram/customprop\#getPropType--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/custompropcollection/_index.md
+++ b/italian/java/com.aspose.diagram/custompropcollection/_index.md
@@ -1,0 +1,231 @@
+---
+title: CustomPropCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Raccolta CustomProps.
+type: docs
+weight: 106
+url: /it/java/com.aspose.diagram/custompropcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class CustomPropCollection extends Collection
+```
+
+Raccolta CustomProps.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [CustomPropCollection()](#CustomPropCollection--) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [add(CustomProp customProp)](#add-com.aspose.diagram.CustomProp-) | Aggiungi l'oggetto CustomProp nella collezione. |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(CustomProp customProp)](#remove-com.aspose.diagram.CustomProp-) | Rimuovi l'oggetto CustomProp dalla collezione. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CustomPropCollection() {#CustomPropCollection--}
+```
+public CustomPropCollection()
+```
+
+
+Costruttore.
+
+### add(CustomProp customProp) {#add-com.aspose.diagram.CustomProp-}
+```
+public int add(CustomProp customProp)
+```
+
+
+Aggiungi l'oggetto CustomProp nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| customProp | [CustomProp](../../com.aspose.diagram/customprop) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public CustomProp get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[CustomProp](../../com.aspose.diagram/customprop) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(CustomProp customProp) {#remove-com.aspose.diagram.CustomProp-}
+```
+public void remove(CustomProp customProp)
+```
+
+
+Rimuovi l'oggetto CustomProp dalla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| customProp | [CustomProp](../../com.aspose.diagram/customprop) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/customvalue/_index.md
+++ b/italian/java/com.aspose.diagram/customvalue/_index.md
@@ -1,0 +1,236 @@
+---
+title: CustomValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Valore della proprietà.
+type: docs
+weight: 107
+url: /it/java/com.aspose.diagram/customvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class CustomValue
+```
+
+Valore della proprietà.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [CustomValue()](#CustomValue--) |  |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getValueBool()](#getValueBool--) | Valore booleano. |
+| [getValueDate()](#getValueDate--) | Valore di data e ora. |
+| [getValueNumber()](#getValueNumber--) | Valore numerico. |
+| [getValueString()](#getValueString--) | Valore stringa. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValueBool(boolean value)](#setValueBool-boolean-) | Per la descrizione di questa proprietà, vedere [getValueBool()](../../com.aspose.diagram/customvalue\#getValueBool--) |
+| [setValueDate(DateTime value)](#setValueDate-com.aspose.diagram.DateTime-) | Per la descrizione di questa proprietà, vedere [getValueDate()](../../com.aspose.diagram/customvalue\#getValueDate--) |
+| [setValueNumber(double value)](#setValueNumber-double-) | Per la descrizione di questa proprietà, vedere [getValueNumber()](../../com.aspose.diagram/customvalue\#getValueNumber--) |
+| [setValueString(String value)](#setValueString-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getValueString()](../../com.aspose.diagram/customvalue\#getValueString--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CustomValue() {#CustomValue--}
+```
+public CustomValue()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getValueBool() {#getValueBool--}
+```
+public boolean getValueBool()
+```
+
+
+Valore booleano.
+
+**Returns:**
+boolean
+### getValueDate() {#getValueDate--}
+```
+public DateTime getValueDate()
+```
+
+
+Valore di data e ora.
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### getValueNumber() {#getValueNumber--}
+```
+public double getValueNumber()
+```
+
+
+Valore numerico.
+
+**Returns:**
+double
+### getValueString() {#getValueString--}
+```
+public String getValueString()
+```
+
+
+Valore stringa.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValueBool(boolean value) {#setValueBool-boolean-}
+```
+public void setValueBool(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValueBool()](../../com.aspose.diagram/customvalue\#getValueBool--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setValueDate(DateTime value) {#setValueDate-com.aspose.diagram.DateTime-}
+```
+public void setValueDate(DateTime value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValueDate()](../../com.aspose.diagram/customvalue\#getValueDate--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setValueNumber(double value) {#setValueNumber-double-}
+```
+public void setValueNumber(double value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValueNumber()](../../com.aspose.diagram/customvalue\#getValueNumber--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double |  |
+
+### setValueString(String value) {#setValueString-java.lang.String-}
+```
+public void setValueString(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValueString()](../../com.aspose.diagram/customvalue\#getValueString--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/datacolumn/_index.md
+++ b/italian/java/com.aspose.diagram/datacolumn/_index.md
@@ -1,0 +1,488 @@
+---
+title: DataColumn
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Definisce come una colonna dati appare nella finestra Dati esterni nell'interfaccia utente di Visio e qualifica i dati nella colonna definendo il suo tipo di dato e la formattazione.
+type: docs
+weight: 108
+url: /it/java/com.aspose.diagram/datacolumn/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DataColumn
+```
+
+Definisce come una colonna dati appare nella finestra Dati esterni nell'interfaccia utente di Visio e qualifica i dati nella colonna definendo il suo tipo di dato e la formattazione.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [DataColumn()](#DataColumn--) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCalendar()](#getCalendar--) | ID del calendario della colonna dati. |
+| [getClass()](#getClass--) |  |
+| [getColumnNameID()](#getColumnNameID--) | Nome esterno della colonna dati. |
+| [getCurrency()](#getCurrency--) | ID della valuta della colonna dati. |
+| [getDataType()](#getDataType--) | Tipo dei dati nella colonna dati. |
+| [getDegree()](#getDegree--) | Specifica il grado (potenza) delle unità, ad esempio quadrato o cubico. |
+| [getDisplayOrder()](#getDisplayOrder--) | Definisce la posizione di visualizzazione della colonna dati nella finestra Dati esterni, dalla colonna più a sinistra (0) alla colonna più a destra (valore più grande). |
+| [getDisplayWidth()](#getDisplayWidth--) | Larghezza della colonna dati nella finestra Dati esterni. |
+| [getHyperlink()](#getHyperlink--) | Indica se la colonna dati crea un collegamento ipertestuale in una forma quando la forma è collegata ai dati. |
+| [getLabel()](#getLabel--) | Etichetta della colonna dati. |
+| [getLangID()](#getLangID--) | L'ID della lingua della colonna dati |
+| [getMapped()](#getMapped--) | Specifica se la colonna è visibile nella finestra Dati esterni. |
+| [getName()](#getName--) | Nome interno della colonna dati. |
+| [getOrigLabel()](#getOrigLabel--) | Etichetta della colonna restituita a Visio dall'interfaccia ADO sottostante. |
+| [getUnitType()](#getUnitType--) | Tipo di unità dei dati nella colonna dati. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCalendar(int value)](#setCalendar-int-) | Per la descrizione di questa proprietà, vedere \{@link DataColumn\#(getCalendar() & 0xFFFF)\} |
+| [setColumnNameID(String value)](#setColumnNameID-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getColumnNameID()](../../com.aspose.diagram/datacolumn\#getColumnNameID--) |
+| [setCurrency(int value)](#setCurrency-int-) | Per la descrizione di questa proprietà, vedere \{@link DataColumn\#(getCurrency() & 0xFFFF)\} |
+| [setDataType(int value)](#setDataType-int-) | Per la descrizione di questa proprietà, vedere \{@link DataColumn\#(getDataType() & 0xFFFF)\} |
+| [setDegree(long value)](#setDegree-long-) | Per la descrizione di questa proprietà, vedere [getDegree()](../../com.aspose.diagram/datacolumn\#getDegree--) |
+| [setDisplayOrder(long value)](#setDisplayOrder-long-) | Per la descrizione di questa proprietà, vedere [getDisplayOrder()](../../com.aspose.diagram/datacolumn\#getDisplayOrder--) |
+| [setDisplayWidth(long value)](#setDisplayWidth-long-) | Per la descrizione di questa proprietà, vedere [getDisplayWidth()](../../com.aspose.diagram/datacolumn\#getDisplayWidth--) |
+| [setHyperlink(int value)](#setHyperlink-int-) | Per la descrizione di questa proprietà, vedere [getHyperlink()](../../com.aspose.diagram/datacolumn\#getHyperlink--) |
+| [setLabel(String value)](#setLabel-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getLabel()](../../com.aspose.diagram/datacolumn\#getLabel--) |
+| [setLangID(long value)](#setLangID-long-) | Per la descrizione di questa proprietà, vedere [getLangID()](../../com.aspose.diagram/datacolumn\#getLangID--) |
+| [setMapped(int value)](#setMapped-int-) | Per la descrizione di questa proprietà, vedere [getMapped()](../../com.aspose.diagram/datacolumn\#getMapped--) |
+| [setName(String value)](#setName-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getName()](../../com.aspose.diagram/datacolumn\#getName--) |
+| [setOrigLabel(String value)](#setOrigLabel-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getOrigLabel()](../../com.aspose.diagram/datacolumn\#getOrigLabel--) |
+| [setUnitType(String value)](#setUnitType-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getUnitType()](../../com.aspose.diagram/datacolumn\#getUnitType--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DataColumn() {#DataColumn--}
+```
+public DataColumn()
+```
+
+
+Costruttore.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCalendar() {#getCalendar--}
+```
+public int getCalendar()
+```
+
+
+ID del calendario della colonna dati.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColumnNameID() {#getColumnNameID--}
+```
+public String getColumnNameID()
+```
+
+
+Nome esterno della colonna dati. Compare nelle intestazioni nella finestra Dati esterni e nelle etichette nei grafici dati.
+
+**Returns:**
+java.lang.String
+### getCurrency() {#getCurrency--}
+```
+public int getCurrency()
+```
+
+
+ID della valuta della colonna dati.
+
+**Returns:**
+int
+### getDataType() {#getDataType--}
+```
+public int getDataType()
+```
+
+
+Tipo dei dati nella colonna dati.
+
+**Returns:**
+int
+### getDegree() {#getDegree--}
+```
+public long getDegree()
+```
+
+
+Specifica il grado (potenza) delle unità, ad esempio quadrato o cubico. Il valore predefinito (attributo assente) è 1.
+
+**Returns:**
+long
+### getDisplayOrder() {#getDisplayOrder--}
+```
+public long getDisplayOrder()
+```
+
+
+Definisce la posizione di visualizzazione della colonna dati nella finestra Dati esterni, dalla colonna più a sinistra (0) alla colonna più a destra (valore più grande).
+
+**Returns:**
+long
+### getDisplayWidth() {#getDisplayWidth--}
+```
+public long getDisplayWidth()
+```
+
+
+Larghezza della colonna dati nella finestra Dati esterni.
+
+**Returns:**
+long
+### getHyperlink() {#getHyperlink--}
+```
+public int getHyperlink()
+```
+
+
+Indica se la colonna dati crea un collegamento ipertestuale in una forma quando la forma è collegata ai dati.
+
+**Returns:**
+int
+### getLabel() {#getLabel--}
+```
+public String getLabel()
+```
+
+
+Etichetta della colonna dati.
+
+**Returns:**
+java.lang.String
+### getLangID() {#getLangID--}
+```
+public long getLangID()
+```
+
+
+L'ID della lingua della colonna dati
+
+**Returns:**
+long
+### getMapped() {#getMapped--}
+```
+public int getMapped()
+```
+
+
+Specifica se la colonna è visibile nella finestra Dati esterni. True (1) per rendere la colonna visibile; false (0) per renderla non visibile. Il valore predefinito (attributo assente) è che la colonna sia visibile.
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Nome interno della colonna dati. Utilizzato come nome della riga per l'elemento dati forma (proprietà personalizzata) aggiunto a una forma quando la forma è collegata a una riga dati.
+
+**Returns:**
+java.lang.String
+### getOrigLabel() {#getOrigLabel--}
+```
+public String getOrigLabel()
+```
+
+
+Etichetta della colonna restituita a Visio dall'interfaccia ADO sottostante.
+
+**Returns:**
+java.lang.String
+### getUnitType() {#getUnitType--}
+```
+public String getUnitType()
+```
+
+
+Tipo di unità dei dati nella colonna dati.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCalendar(int value) {#setCalendar-int-}
+```
+public void setCalendar(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere \{@link DataColumn\#(getCalendar() & 0xFFFF)\}
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setColumnNameID(String value) {#setColumnNameID-java.lang.String-}
+```
+public void setColumnNameID(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getColumnNameID()](../../com.aspose.diagram/datacolumn\#getColumnNameID--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setCurrency(int value) {#setCurrency-int-}
+```
+public void setCurrency(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere \{@link DataColumn\#(getCurrency() & 0xFFFF)\}
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setDataType(int value) {#setDataType-int-}
+```
+public void setDataType(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere \{@link DataColumn\#(getDataType() & 0xFFFF)\}
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setDegree(long value) {#setDegree-long-}
+```
+public void setDegree(long value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDegree()](../../com.aspose.diagram/datacolumn\#getDegree--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | long |  |
+
+### setDisplayOrder(long value) {#setDisplayOrder-long-}
+```
+public void setDisplayOrder(long value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDisplayOrder()](../../com.aspose.diagram/datacolumn\#getDisplayOrder--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | long |  |
+
+### setDisplayWidth(long value) {#setDisplayWidth-long-}
+```
+public void setDisplayWidth(long value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDisplayWidth()](../../com.aspose.diagram/datacolumn\#getDisplayWidth--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | long |  |
+
+### setHyperlink(int value) {#setHyperlink-int-}
+```
+public void setHyperlink(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getHyperlink()](../../com.aspose.diagram/datacolumn\#getHyperlink--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setLabel(String value) {#setLabel-java.lang.String-}
+```
+public void setLabel(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getLabel()](../../com.aspose.diagram/datacolumn\#getLabel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setLangID(long value) {#setLangID-long-}
+```
+public void setLangID(long value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getLangID()](../../com.aspose.diagram/datacolumn\#getLangID--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | long |  |
+
+### setMapped(int value) {#setMapped-int-}
+```
+public void setMapped(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getMapped()](../../com.aspose.diagram/datacolumn\#getMapped--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getName()](../../com.aspose.diagram/datacolumn\#getName--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setOrigLabel(String value) {#setOrigLabel-java.lang.String-}
+```
+public void setOrigLabel(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getOrigLabel()](../../com.aspose.diagram/datacolumn\#getOrigLabel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setUnitType(String value) {#setUnitType-java.lang.String-}
+```
+public void setUnitType(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getUnitType()](../../com.aspose.diagram/datacolumn\#getUnitType--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/datacolumncollection/_index.md
+++ b/italian/java/com.aspose.diagram/datacolumncollection/_index.md
@@ -1,0 +1,268 @@
+---
+title: DataColumnCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Raccolta DataColumn.
+type: docs
+weight: 109
+url: /it/java/com.aspose.diagram/datacolumncollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class DataColumnCollection extends Collection
+```
+
+Raccolta DataColumn.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [add(DataColumn dataColumn)](#add-com.aspose.diagram.DataColumn-) | Aggiungi la dataColumn alla collezione. |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [getSortAsc()](#getSortAsc--) | Indica se ordinare la colonna SortColumn in ordine ascendente (1) o discendente (0). |
+| [getSortColumn()](#getSortColumn--) | La colonna su cui ordinare i dati. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(DataColumn dataColumn)](#remove-com.aspose.diagram.DataColumn-) | Rimuovi la dataColumn dalla collezione. |
+| [setSortAsc(int value)](#setSortAsc-int-) | Per la descrizione di questa proprietà, consultare [getSortAsc()](../../com.aspose.diagram/datacolumncollection\#getSortAsc--) |
+| [setSortColumn(String value)](#setSortColumn-java.lang.String-) | Per la descrizione di questa proprietà, consultare [getSortColumn()](../../com.aspose.diagram/datacolumncollection\#getSortColumn--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(DataColumn dataColumn) {#add-com.aspose.diagram.DataColumn-}
+```
+public int add(DataColumn dataColumn)
+```
+
+
+Aggiungi la dataColumn alla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| dataColumn | [DataColumn](../../com.aspose.diagram/datacolumn) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public DataColumn get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[DataColumn](../../com.aspose.diagram/datacolumn) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### getSortAsc() {#getSortAsc--}
+```
+public int getSortAsc()
+```
+
+
+Indica se ordinare la colonna SortColumn in ordine ascendente (1) o discendente (0).
+
+**Returns:**
+int
+### getSortColumn() {#getSortColumn--}
+```
+public String getSortColumn()
+```
+
+
+La colonna su cui ordinare i dati.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(DataColumn dataColumn) {#remove-com.aspose.diagram.DataColumn-}
+```
+public void remove(DataColumn dataColumn)
+```
+
+
+Rimuovi la dataColumn dalla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| dataColumn | [DataColumn](../../com.aspose.diagram/datacolumn) |  |
+
+### setSortAsc(int value) {#setSortAsc-int-}
+```
+public void setSortAsc(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getSortAsc()](../../com.aspose.diagram/datacolumncollection\#getSortAsc--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setSortColumn(String value) {#setSortColumn-java.lang.String-}
+```
+public void setSortColumn(String value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getSortColumn()](../../com.aspose.diagram/datacolumncollection\#getSortColumn--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/dataconnection/_index.md
+++ b/italian/java/com.aspose.diagram/dataconnection/_index.md
@@ -1,0 +1,288 @@
+---
+title: DataConnection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Astrazione della comunicazione tra uno o più elementi DataRecordset e una fonte dati non XML.
+type: docs
+weight: 110
+url: /it/java/com.aspose.diagram/dataconnection/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DataConnection
+```
+
+Astrazione della comunicazione tra uno o più elementi DataRecordset e una fonte dati non XML.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [DataConnection()](#DataConnection--) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAlwaysUseConnectionFile()](#getAlwaysUseConnectionFile--) | Il valore predefinito è falso. |
+| [getClass()](#getClass--) |  |
+| [getCommand()](#getCommand--) | La stringa di comando utilizzata per interrogare la fonte dati. |
+| [getConnectionString()](#getConnectionString--) | La stringa di connessione che definisce i parametri necessari per connettersi a una fonte dati. |
+| [getFileName()](#getFileName--) | Il nome del file di connessione. |
+| [getID()](#getID--) | L'ID assegnato da Visio per una determinata connessione, unico all'interno del documento. |
+| [getTimeout()](#getTimeout--) | Tempo di attesa in minuti durante il tentativo di stabilire una connessione prima di terminare il tentativo. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAlwaysUseConnectionFile(int value)](#setAlwaysUseConnectionFile-int-) | Per la descrizione di questa proprietà, vedere [getAlwaysUseConnectionFile()](../../com.aspose.diagram/dataconnection\#getAlwaysUseConnectionFile--) |
+| [setCommand(String value)](#setCommand-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getCommand()](../../com.aspose.diagram/dataconnection\#getCommand--) |
+| [setConnectionString(String value)](#setConnectionString-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getConnectionString()](../../com.aspose.diagram/dataconnection\#getConnectionString--) |
+| [setFileName(String value)](#setFileName-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getFileName()](../../com.aspose.diagram/dataconnection\#getFileName--) |
+| [setID(long value)](#setID-long-) | Per la descrizione di questa proprietà, vedere \{@link DataConnection\#(getID() & 0xFFFFFFFFL)\} |
+| [setTimeout(long value)](#setTimeout-long-) | Per la descrizione di questa proprietà, vedere [getTimeout()](../../com.aspose.diagram/dataconnection\#getTimeout--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DataConnection() {#DataConnection--}
+```
+public DataConnection()
+```
+
+
+Costruttore.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAlwaysUseConnectionFile() {#getAlwaysUseConnectionFile--}
+```
+public int getAlwaysUseConnectionFile()
+```
+
+
+Il valore predefinito è false. Vedere Note per ulteriori informazioni.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCommand() {#getCommand--}
+```
+public String getCommand()
+```
+
+
+La stringa di comando utilizzata per interrogare la fonte dati.
+
+**Returns:**
+java.lang.String
+### getConnectionString() {#getConnectionString--}
+```
+public String getConnectionString()
+```
+
+
+La stringa di connessione che definisce i parametri necessari per connettersi a una fonte dati.
+
+**Returns:**
+java.lang.String
+### getFileName() {#getFileName--}
+```
+public String getFileName()
+```
+
+
+Il nome del file di connessione. Vedere Note per ulteriori informazioni.
+
+**Returns:**
+java.lang.String
+### getID() {#getID--}
+```
+public long getID()
+```
+
+
+L'ID assegnato da Visio per una determinata connessione, unico all'interno del documento.
+
+**Returns:**
+long
+### getTimeout() {#getTimeout--}
+```
+public long getTimeout()
+```
+
+
+Tempo di attesa in minuti durante il tentativo di stabilire una connessione prima di terminare il tentativo.
+
+**Returns:**
+long
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAlwaysUseConnectionFile(int value) {#setAlwaysUseConnectionFile-int-}
+```
+public void setAlwaysUseConnectionFile(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getAlwaysUseConnectionFile()](../../com.aspose.diagram/dataconnection\#getAlwaysUseConnectionFile--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setCommand(String value) {#setCommand-java.lang.String-}
+```
+public void setCommand(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getCommand()](../../com.aspose.diagram/dataconnection\#getCommand--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setConnectionString(String value) {#setConnectionString-java.lang.String-}
+```
+public void setConnectionString(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getConnectionString()](../../com.aspose.diagram/dataconnection\#getConnectionString--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setFileName(String value) {#setFileName-java.lang.String-}
+```
+public void setFileName(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getFileName()](../../com.aspose.diagram/dataconnection\#getFileName--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setID(long value) {#setID-long-}
+```
+public void setID(long value)
+```
+
+
+Per la descrizione di questa proprietà, vedere \{@link DataConnection\#(getID() & 0xFFFFFFFFL)\}
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | long |  |
+
+### setTimeout(long value) {#setTimeout-long-}
+```
+public void setTimeout(long value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getTimeout()](../../com.aspose.diagram/dataconnection\#getTimeout--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | long |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/dataconnectioncollection/_index.md
+++ b/italian/java/com.aspose.diagram/dataconnectioncollection/_index.md
@@ -1,0 +1,259 @@
+---
+title: DataConnectionCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Raccolta DataConnection.
+type: docs
+weight: 111
+url: /it/java/com.aspose.diagram/dataconnectioncollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class DataConnectionCollection extends Collection
+```
+
+Raccolta DataConnection.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [add(DataConnection dataConnection)](#add-com.aspose.diagram.DataConnection-) | Aggiungi la dataConnection nella collezione. |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [getDataConnection(long ID)](#getDataConnection-long-) | Restituisce l'elemento con l'ID specificato. |
+| [getNextID()](#getNextID--) | Il prossimo ID disponibile per nuove connessioni. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(DataConnection dataConnection)](#remove-com.aspose.diagram.DataConnection-) | Rimuovi la dataConnection dalla collezione. |
+| [setNextID(long value)](#setNextID-long-) | Per la descrizione di questa proprietà, vedere \{@link DataConnectionCollection\#(getNextID() & 0xFFFFFFFFL)\} |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(DataConnection dataConnection) {#add-com.aspose.diagram.DataConnection-}
+```
+public int add(DataConnection dataConnection)
+```
+
+
+Aggiungi la dataConnection nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| dataConnection | [DataConnection](../../com.aspose.diagram/dataconnection) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public DataConnection get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[DataConnection](../../com.aspose.diagram/dataconnection) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### getDataConnection(long ID) {#getDataConnection-long-}
+```
+public DataConnection getDataConnection(long ID)
+```
+
+
+Restituisce l'elemento con l'ID specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| ID | long | ID di DataConnectionUInt32. |
+
+**Returns:**
+[DataConnection](../../com.aspose.diagram/dataconnection) - DataConnection [DataConnection](../../com.aspose.diagram/dataconnection).
+### getNextID() {#getNextID--}
+```
+public long getNextID()
+```
+
+
+Il prossimo ID disponibile per nuove connessioni.
+
+**Returns:**
+long
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(DataConnection dataConnection) {#remove-com.aspose.diagram.DataConnection-}
+```
+public void remove(DataConnection dataConnection)
+```
+
+
+Rimuovi la dataConnection dalla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| dataConnection | [DataConnection](../../com.aspose.diagram/dataconnection) |  |
+
+### setNextID(long value) {#setNextID-long-}
+```
+public void setNextID(long value)
+```
+
+
+Per la descrizione di questa proprietà, vedere \{@link DataConnectionCollection\#(getNextID() & 0xFFFFFFFFL)\}
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | long |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/dataconnectiontype/_index.md
+++ b/italian/java/com.aspose.diagram/dataconnectiontype/_index.md
@@ -1,0 +1,165 @@
+---
+title: DataConnectionType
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Consente di configurare le opzioni per le connessioni al database.
+type: docs
+weight: 112
+url: /it/java/com.aspose.diagram/dataconnectiontype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class DataConnectionType
+```
+
+Consente di configurare le opzioni per le connessioni al database.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [ODBC](#ODBC) | Usage System.Data.Odbc.OdbcConnection. |
+| [QLEDB](#QLEDB) | Usage System.Data.OleDb.OleDbConnection. |
+| [SQL](#SQL) | Usage System.Data.SqlClient.SqlConnection. |
+| [UNKNOWN](#UNKNOWN) | Unknown type of connection. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ODBC {#ODBC}
+```
+public static final int ODBC
+```
+
+
+Usage System.Data.Odbc.OdbcConnection.
+
+### QLEDB {#QLEDB}
+```
+public static final int QLEDB
+```
+
+
+Usage System.Data.OleDb.OleDbConnection.
+
+### SQL {#SQL}
+```
+public static final int SQL
+```
+
+
+Usage System.Data.SqlClient.SqlConnection.
+
+### UNKNOWN {#UNKNOWN}
+```
+public static final int UNKNOWN
+```
+
+
+Unknown type of connection.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/datarecordset/_index.md
+++ b/italian/java/com.aspose.diagram/datarecordset/_index.md
@@ -1,0 +1,557 @@
+---
+title: DataRecordSet
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Memorizza formati, aggiornamenti e espone i dati interrogati da un database in Microsoft Visio.
+type: docs
+weight: 113
+url: /it/java/com.aspose.diagram/datarecordset/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DataRecordSet
+```
+
+Memorizza, formatta, aggiorna e espone i dati interrogati da un database in Microsoft Visio.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [DataRecordSet()](#DataRecordSet--) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getADOData()](#getADOData--) | Contiene XML che conforma allo schema XML classico ADO per un recordset ADO e che descrive i dati nel recordset di dati. |
+| [getAutoLinkComparison()](#getAutoLinkComparison--) | Definisce una regola che confronta una colonna nell'elemento DataRecordset padre con un elemento dati di forma dell'ultima azione di collegamento automatico riuscita eseguita nell'interfaccia utente. |
+| [getChecksum()](#getChecksum--) | Un valore di checksum, generato da Visio, basato sulle proprietà del recordset di dati. |
+| [getClass()](#getClass--) |  |
+| [getCommand()](#getCommand--) | La stringa di comando utilizzata per interrogare i dati dalla fonte dati. |
+| [getConnectionID()](#getConnectionID--) | L'ID di connessione per l'oggetto DataConnection associato. |
+| [getDataColumns()](#getDataColumns--) | Contiene tutti gli elementi DataColumn in un recordset di dati. |
+| [getID()](#getID--) | L'ID del recordset di dati, unico all'interno del documento. |
+| [getName()](#getName--) | Il nome visualizzato (o "amichevole") del recordset di dati. |
+| [getNextRowID()](#getNextRowID--) | Il prossimo ID di riga Visio disponibile. |
+| [getOptions()](#getOptions--) | Opzioni da applicare al recordset di dati. |
+| [getPrimaryKeys()](#getPrimaryKeys--) | Identifica una o più colonne chiave primaria nel recordset di dati. |
+| [getRefreshConflicts()](#getRefreshConflicts--) | Indica una riga nel recordset di dati collegata a una forma che è in conflitto dopo che il recordset di dati è stato aggiornato. |
+| [getRefreshInterval()](#getRefreshInterval--) | Quanto spesso (in minuti) Visio aggiorna automaticamente il recordset di dati. |
+| [getRefreshNoReconciliationUI()](#getRefreshNoReconciliationUI--) | Se l'interfaccia utente di riconciliazione dei dati dovrebbe essere disabilitata. |
+| [getRefreshOverwriteAll()](#getRefreshOverwriteAll--) | Se sovrascrivere le modifiche dell'utente agli elementi dati della forma nelle forme collegate ai dati quando il recordset di dati è aggiornato. |
+| [getReplaceLinks()](#getReplaceLinks--) | Definisce come i collegamenti forma-dati sono trattati quando le forme vengono copiate o tagliate. 1 per sostituire i collegamenti esistenti nella forma di destinazione. 0 per mantenere i collegamenti esistenti nella forma di destinazione. |
+| [getRowMaps()](#getRowMaps--) | Mappa una riga del recordset di dati a una forma. |
+| [getRowOrder()](#getRowOrder--) | Se utilizzare l'ordine delle righe nel recordset di dati come chiave primaria. |
+| [getTimeRefreshed()](#getTimeRefreshed--) | La data e l'ora in cui il recordset di dati è stato aggiornato l'ultima volta. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [refresh(int connectionType)](#refresh-int-) | Esegue la stringa di query associata al DataRecordset connesso (non basato su XML) e aggiorna le forme collegate con nuovi dati dalla fonte dati restituiti dalla query. |
+| [setADOData(String value)](#setADOData-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getADOData()](../../com.aspose.diagram/datarecordset\#getADOData--) |
+| [setChecksum(long value)](#setChecksum-long-) | Per la descrizione di questa proprietà, vedere \{@link DataRecordSet\#(getChecksum() & 0xFFFFFFFFL)\} |
+| [setCommand(String value)](#setCommand-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getCommand()](../../com.aspose.diagram/datarecordset\#getCommand--) |
+| [setConnectionID(long value)](#setConnectionID-long-) | Per la descrizione di questa proprietà, vedere \{@link DataRecordSet\#(getConnectionID() & 0xFFFFFFFFL)\} |
+| [setID(long value)](#setID-long-) | Per la descrizione di questa proprietà, vedere \{@link DataRecordSet\#(getID() & 0xFFFFFFFFL)\} |
+| [setName(String value)](#setName-java.lang.String-) | For the description of this property, please see [getName()](../../com.aspose.diagram/datarecordset\#getName--) |
+| [setNextRowID(long value)](#setNextRowID-long-) | For the description of this property, please see \{@link DataRecordSet\#(getNextRowID() & 0xFFFFFFFFL)\} |
+| [setOptions(int value)](#setOptions-int-) | For the description of this property, please see [getOptions()](../../com.aspose.diagram/datarecordset\#getOptions--) |
+| [setRefreshInterval(long value)](#setRefreshInterval-long-) | For the description of this property, please see \{@link DataRecordSet\#(getRefreshInterval() & 0xFFFFFFFFL)\} |
+| [setRefreshNoReconciliationUI(int value)](#setRefreshNoReconciliationUI-int-) | For the description of this property, please see [getRefreshNoReconciliationUI()](../../com.aspose.diagram/datarecordset\#getRefreshNoReconciliationUI--) |
+| [setRefreshOverwriteAll(int value)](#setRefreshOverwriteAll-int-) | For the description of this property, please see [getRefreshOverwriteAll()](../../com.aspose.diagram/datarecordset\#getRefreshOverwriteAll--) |
+| [setReplaceLinks(int value)](#setReplaceLinks-int-) | For the description of this property, please see [getReplaceLinks()](../../com.aspose.diagram/datarecordset\#getReplaceLinks--) |
+| [setRowOrder(int value)](#setRowOrder-int-) | For the description of this property, please see [getRowOrder()](../../com.aspose.diagram/datarecordset\#getRowOrder--) |
+| [setTimeRefreshed(DateTime value)](#setTimeRefreshed-com.aspose.diagram.DateTime-) | For the description of this property, please see [getTimeRefreshed()](../../com.aspose.diagram/datarecordset\#getTimeRefreshed--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DataRecordSet() {#DataRecordSet--}
+```
+public DataRecordSet()
+```
+
+
+Costruttore.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getADOData() {#getADOData--}
+```
+public String getADOData()
+```
+
+
+Contiene XML che conforma allo schema XML classico ADO per un recordset ADO e che descrive i dati nel recordset di dati.
+
+**Returns:**
+java.lang.String
+### getAutoLinkComparison() {#getAutoLinkComparison--}
+```
+public AutoLinkComparison getAutoLinkComparison()
+```
+
+
+Definisce una regola che confronta una colonna nell'elemento DataRecordset padre con un elemento dati di forma dell'ultima azione di collegamento automatico riuscita eseguita nell'interfaccia utente.
+
+**Returns:**
+[AutoLinkComparison](../../com.aspose.diagram/autolinkcomparison)
+### getChecksum() {#getChecksum--}
+```
+public long getChecksum()
+```
+
+
+A checksum value, generated by Visio, and based on data-recordset properties. Set this attribute to 0; Visio recalculates this value at runtime.
+
+**Returns:**
+long
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCommand() {#getCommand--}
+```
+public String getCommand()
+```
+
+
+La stringa di comando utilizzata per interrogare i dati dalla fonte dati.
+
+**Returns:**
+java.lang.String
+### getConnectionID() {#getConnectionID--}
+```
+public long getConnectionID()
+```
+
+
+The connection ID for the associated DataConnection object. Does not exist for XML data sources.
+
+**Returns:**
+long
+### getDataColumns() {#getDataColumns--}
+```
+public DataColumnCollection getDataColumns()
+```
+
+
+Contiene tutti gli elementi DataColumn in un recordset di dati.
+
+**Returns:**
+[DataColumnCollection](../../com.aspose.diagram/datacolumncollection)
+### getID() {#getID--}
+```
+public long getID()
+```
+
+
+L'ID del recordset di dati, unico all'interno del documento.
+
+**Returns:**
+long
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Il nome visualizzato (o "amichevole") del recordset di dati.
+
+**Returns:**
+java.lang.String
+### getNextRowID() {#getNextRowID--}
+```
+public long getNextRowID()
+```
+
+
+Il prossimo ID di riga Visio disponibile.
+
+**Returns:**
+long
+### getOptions() {#getOptions--}
+```
+public int getOptions()
+```
+
+
+Options to apply to the data recordset. Possible values can be any combination of one or more of those shown in the following table.
+
+**Returns:**
+int
+### getPrimaryKeys() {#getPrimaryKeys--}
+```
+public ArrayList<String> getPrimaryKeys()
+```
+
+
+Identifica una o più colonne chiave primaria nel recordset di dati.
+
+**Returns:**
+java.util.ArrayList<java.lang.String>
+### getRefreshConflicts() {#getRefreshConflicts--}
+```
+public RowCollection getRefreshConflicts()
+```
+
+
+Indicates a row in the data recordset linked to a shape that is in conflict after the data recordset is refreshed. RowID - Indicates a row in the data recordset linked to a shape that is in conflict after the data recordset is refreshed. ShapeID - Shape ID of the shape involved in the conflict. PageID - Page ID of the shape involved in the conflict.
+
+**Returns:**
+[RowCollection](../../com.aspose.diagram/rowcollection)
+### getRefreshInterval() {#getRefreshInterval--}
+```
+public long getRefreshInterval()
+```
+
+
+How often (in minutes) Visio refreshes the data recordset automatically. This value must be 1 or larger.
+
+**Returns:**
+long
+### getRefreshNoReconciliationUI() {#getRefreshNoReconciliationUI--}
+```
+public int getRefreshNoReconciliationUI()
+```
+
+
+Whether the data-reconciliation user interface should be disabled. True (1) to disable the user interface (UI). False (0) to enable the UI.
+
+**Returns:**
+int
+### getRefreshOverwriteAll() {#getRefreshOverwriteAll--}
+```
+public int getRefreshOverwriteAll()
+```
+
+
+Se sovrascrivere le modifiche dell'utente agli elementi dati della forma nelle forme collegate ai dati quando il recordset di dati è aggiornato.
+
+**Returns:**
+int
+### getReplaceLinks() {#getReplaceLinks--}
+```
+public int getReplaceLinks()
+```
+
+
+Defines how shape-data links are treated when shapes are copied or cut. 1 to replace existing links in the target shape. 0 to maintain existing links in the target shape. If this attribute is absent, Visio asks the user whether to replace links on copy or cut.
+
+**Returns:**
+int
+### getRowMaps() {#getRowMaps--}
+```
+public RowCollection getRowMaps()
+```
+
+
+Maps a data-recordset row to a shape. RowID - Row ID of the row, unique within the data recordset. ShapeID - Shape ID of the shape linked to data in the data-recordset row identified by RowID. PageID - Page ID of the shape linked to data in the data-recordset row identified by RowID.
+
+**Returns:**
+[RowCollection](../../com.aspose.diagram/rowcollection)
+### getRowOrder() {#getRowOrder--}
+```
+public int getRowOrder()
+```
+
+
+Whether to use the order of the rows in the data recordset as the primary key. True (1) if row IDs are determined by row order. False (0) if row IDs are determined by values in the primary key column(s) of the data recordset.
+
+**Returns:**
+int
+### getTimeRefreshed() {#getTimeRefreshed--}
+```
+public DateTime getTimeRefreshed()
+```
+
+
+La data e l'ora in cui il recordset di dati è stato aggiornato l'ultima volta.
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### refresh(int connectionType) {#refresh-int-}
+```
+public void refresh(int connectionType)
+```
+
+
+Esegue la stringa di query associata al DataRecordset connesso (non basato su XML) e aggiorna le forme collegate con nuovi dati dalla fonte dati restituiti dalla query.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| connectionType | int | The type of provider which will be used for connectionAspose.Diagram.Manipulation.DataConnectionType. |
+
+### setADOData(String value) {#setADOData-java.lang.String-}
+```
+public void setADOData(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getADOData()](../../com.aspose.diagram/datarecordset\#getADOData--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setChecksum(long value) {#setChecksum-long-}
+```
+public void setChecksum(long value)
+```
+
+
+Per la descrizione di questa proprietà, vedere \{@link DataRecordSet\#(getChecksum() & 0xFFFFFFFFL)\}
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | long |  |
+
+### setCommand(String value) {#setCommand-java.lang.String-}
+```
+public void setCommand(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getCommand()](../../com.aspose.diagram/datarecordset\#getCommand--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setConnectionID(long value) {#setConnectionID-long-}
+```
+public void setConnectionID(long value)
+```
+
+
+Per la descrizione di questa proprietà, vedere \{@link DataRecordSet\#(getConnectionID() & 0xFFFFFFFFL)\}
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | long |  |
+
+### setID(long value) {#setID-long-}
+```
+public void setID(long value)
+```
+
+
+Per la descrizione di questa proprietà, vedere \{@link DataRecordSet\#(getID() & 0xFFFFFFFFL)\}
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | long |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+For the description of this property, please see [getName()](../../com.aspose.diagram/datarecordset\#getName--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setNextRowID(long value) {#setNextRowID-long-}
+```
+public void setNextRowID(long value)
+```
+
+
+For the description of this property, please see \{@link DataRecordSet\#(getNextRowID() & 0xFFFFFFFFL)\}
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | long |  |
+
+### setOptions(int value) {#setOptions-int-}
+```
+public void setOptions(int value)
+```
+
+
+For the description of this property, please see [getOptions()](../../com.aspose.diagram/datarecordset\#getOptions--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setRefreshInterval(long value) {#setRefreshInterval-long-}
+```
+public void setRefreshInterval(long value)
+```
+
+
+For the description of this property, please see \{@link DataRecordSet\#(getRefreshInterval() & 0xFFFFFFFFL)\}
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | long |  |
+
+### setRefreshNoReconciliationUI(int value) {#setRefreshNoReconciliationUI-int-}
+```
+public void setRefreshNoReconciliationUI(int value)
+```
+
+
+For the description of this property, please see [getRefreshNoReconciliationUI()](../../com.aspose.diagram/datarecordset\#getRefreshNoReconciliationUI--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setRefreshOverwriteAll(int value) {#setRefreshOverwriteAll-int-}
+```
+public void setRefreshOverwriteAll(int value)
+```
+
+
+For the description of this property, please see [getRefreshOverwriteAll()](../../com.aspose.diagram/datarecordset\#getRefreshOverwriteAll--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setReplaceLinks(int value) {#setReplaceLinks-int-}
+```
+public void setReplaceLinks(int value)
+```
+
+
+For the description of this property, please see [getReplaceLinks()](../../com.aspose.diagram/datarecordset\#getReplaceLinks--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setRowOrder(int value) {#setRowOrder-int-}
+```
+public void setRowOrder(int value)
+```
+
+
+For the description of this property, please see [getRowOrder()](../../com.aspose.diagram/datarecordset\#getRowOrder--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setTimeRefreshed(DateTime value) {#setTimeRefreshed-com.aspose.diagram.DateTime-}
+```
+public void setTimeRefreshed(DateTime value)
+```
+
+
+For the description of this property, please see [getTimeRefreshed()](../../com.aspose.diagram/datarecordset\#getTimeRefreshed--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/datarecordsetcollection/_index.md
+++ b/italian/java/com.aspose.diagram/datarecordsetcollection/_index.md
@@ -1,0 +1,268 @@
+---
+title: DataRecordSetCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Raccolta DataRecordSet.
+type: docs
+weight: 114
+url: /it/java/com.aspose.diagram/datarecordsetcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class DataRecordSetCollection extends Collection
+```
+
+Raccolta DataRecordSet.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [add(DataRecordSet dataRecordSet)](#add-com.aspose.diagram.DataRecordSet-) | Aggiungi il dataRecordSet nella collezione. |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getActiveRecordsetId()](#getActiveRecordsetId--) | ActiveRecordsetID |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [getNextId()](#getNextId--) | NextID |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(DataRecordSet dataRecordSet)](#remove-com.aspose.diagram.DataRecordSet-) | Rimuovi il dataRecordSet dalla collezione. |
+| [setActiveRecordsetId(String value)](#setActiveRecordsetId-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getActiveRecordsetId()](../../com.aspose.diagram/datarecordsetcollection\#getActiveRecordsetId--) |
+| [setNextId(String value)](#setNextId-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getNextId()](../../com.aspose.diagram/datarecordsetcollection\#getNextId--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(DataRecordSet dataRecordSet) {#add-com.aspose.diagram.DataRecordSet-}
+```
+public int add(DataRecordSet dataRecordSet)
+```
+
+
+Aggiungi il dataRecordSet nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| dataRecordSet | [DataRecordSet](../../com.aspose.diagram/datarecordset) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public DataRecordSet get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[DataRecordSet](../../com.aspose.diagram/datarecordset) - 
+### getActiveRecordsetId() {#getActiveRecordsetId--}
+```
+public String getActiveRecordsetId()
+```
+
+
+ActiveRecordsetID
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### getNextId() {#getNextId--}
+```
+public String getNextId()
+```
+
+
+NextID
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(DataRecordSet dataRecordSet) {#remove-com.aspose.diagram.DataRecordSet-}
+```
+public void remove(DataRecordSet dataRecordSet)
+```
+
+
+Rimuovi il dataRecordSet dalla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| dataRecordSet | [DataRecordSet](../../com.aspose.diagram/datarecordset) |  |
+
+### setActiveRecordsetId(String value) {#setActiveRecordsetId-java.lang.String-}
+```
+public void setActiveRecordsetId(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getActiveRecordsetId()](../../com.aspose.diagram/datarecordsetcollection\#getActiveRecordsetId--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setNextId(String value) {#setNextId-java.lang.String-}
+```
+public void setNextId(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getNextId()](../../com.aspose.diagram/datarecordsetcollection\#getNextId--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/datetime/_index.md
+++ b/italian/java/com.aspose.diagram/datetime/_index.md
@@ -1,0 +1,510 @@
+---
+title: DateTime
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta un istante nel tempo tipicamente espresso come data e ora del giorno.
+type: docs
+weight: 115
+url: /it/java/com.aspose.diagram/datetime/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DateTime
+```
+
+Rappresenta un istante nel tempo, tipicamente espresso come data e ora del giorno.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [DateTime(int year, int month, int day)](#DateTime-int-int-int-) | Inizializza una nuova istanza dell'oggetto DateTime con l'anno, il mese e il giorno specificati. |
+| [DateTime(int year, int month, int day, int hour, int minute, int second)](#DateTime-int-int-int-int-int-int-) | Inizializza una nuova istanza dell'oggetto DateTime con l'anno, il mese, il giorno, l'ora, il minuto e il secondo specificati. |
+| [DateTime(int year, int month, int day, int hour, int minute, int second, int millisecond)](#DateTime-int-int-int-int-int-int-int-) | Inizializza una nuova istanza dell'oggetto DateTime con l'anno, il mese, il giorno, l'ora, il minuto, il secondo e il millisecondo specificati. |
+| [DateTime(Date date)](#DateTime-java.util.Date-) | Inizializza una nuova istanza dell'oggetto DateTime con l'oggetto Date specificato. |
+| [DateTime(Calendar cld)](#DateTime-java.util.Calendar-) | Inizializza una nuova istanza dell'oggetto DateTime con l'oggetto Calendar specificato. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [addDays(double value)](#addDays-double-) | Aggiunge il numero specificato di giorni al valore di questa istanza. |
+| [addHours(double value)](#addHours-double-) | Aggiunge il numero specificato di ore al valore di questa istanza. |
+| [addMilliseconds(double value)](#addMilliseconds-double-) | Aggiunge il numero specificato di millisecondi al valore di questa istanza. |
+| [addMinutes(double value)](#addMinutes-double-) | Aggiunge il numero specificato di minuti al valore di questa istanza. |
+| [addMonths(int months)](#addMonths-int-) | Aggiunge il numero specificato di mesi al valore di questa istanza. |
+| [addSeconds(double value)](#addSeconds-double-) | Aggiunge il numero specificato di secondi al valore di questa istanza. |
+| [addYears(int value)](#addYears-int-) | Aggiunge il numero specificato di anni al valore di questa istanza. |
+| [compareTo(DateTime value)](#compareTo-com.aspose.diagram.DateTime-) | Confronta il valore di questa istanza con un valore DateTime specificato e restituisce un intero che indica se questa istanza è precedente, uguale o successiva al valore DateTime specificato. |
+| [compareTo(Object value)](#compareTo-java.lang.Object-) | Confronta il valore di questa istanza con un oggetto specificato che contiene un valore DateTime specificato e restituisce un intero che indica se questa istanza è precedente, uguale o successiva al valore DateTime specificato. |
+| [equals(Object value)](#equals-java.lang.Object-) | Restituisce un valore che indica se questa istanza è uguale a un oggetto specificato. |
+| [getClass()](#getClass--) |  |
+| [getDay()](#getDay--) | Ottiene il giorno del mese rappresentato da questa istanza. |
+| [getDayOfWeek()](#getDayOfWeek--) | Ottiene il giorno della settimana rappresentato da questa istanza. |
+| [getDayOfYear()](#getDayOfYear--) | Restituisce il giorno dell'anno rappresentato da questa istanza. |
+| [getHour()](#getHour--) | Restituisce la componente ora della data rappresentata da questa istanza. |
+| [getMillisecond()](#getMillisecond--) | Restituisce la componente millisecondi della data rappresentata da questa istanza. |
+| [getMinute()](#getMinute--) | Restituisce la componente minuti della data rappresentata da questa istanza. |
+| [getMonth()](#getMonth--) | Restituisce la componente mese della data rappresentata da questa istanza. |
+| [getNow()](#getNow--) | Restituisce un oggetto DateTime impostato alla data e ora correnti su questo computer, espresso come ora locale. |
+| [getSecond()](#getSecond--) | Restituisce la componente secondi della data rappresentata da questa istanza. |
+| [getYear()](#getYear--) | Restituisce la componente anno della data rappresentata da questa istanza. |
+| [hashCode()](#hashCode--) | Restituisce il codice hash per questa istanza. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toCalendar()](#toCalendar--) | Converte il valore dell'oggetto DateTime corrente in un oggetto Calendar. |
+| [toDate()](#toDate--) | Converte il valore dell'oggetto DateTime corrente in un oggetto Date. |
+| [toLocalTime()](#toLocalTime--) | Converte il valore dell'oggetto DateTime corrente in ora locale. |
+| [toString()](#toString--) | Converte il valore dell'oggetto DateTime corrente nella sua rappresentazione stringa equivalente. |
+| [toUniversalTime()](#toUniversalTime--) | Converte il valore dell'oggetto DateTime corrente in Coordinated Universal Time (UTC). |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DateTime(int year, int month, int day) {#DateTime-int-int-int-}
+```
+public DateTime(int year, int month, int day)
+```
+
+
+Inizializza una nuova istanza dell'oggetto DateTime con l'anno, il mese e il giorno specificati.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| anno | int | L'anno (da 1 a 9999). |
+| mese | int | Il mese (da 1 a 12). |
+| giorno | int | Il giorno (da 1 al numero di giorni nel mese). |
+
+### DateTime(int year, int month, int day, int hour, int minute, int second) {#DateTime-int-int-int-int-int-int-}
+```
+public DateTime(int year, int month, int day, int hour, int minute, int second)
+```
+
+
+Inizializza una nuova istanza dell'oggetto DateTime con l'anno, il mese, il giorno, l'ora, il minuto e il secondo specificati.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| anno | int | L'anno (da 1 a 9999). |
+| mese | int | Il mese (da 1 a 12). |
+| giorno | int | Il giorno (da 1 al numero di giorni nel mese). |
+| ora | int | Le ore (da 0 a 23). |
+| minuto | int | I minuti (da 0 a 59). |
+| secondo | int | I secondi (da 0 a 59). |
+
+### DateTime(int year, int month, int day, int hour, int minute, int second, int millisecond) {#DateTime-int-int-int-int-int-int-int-}
+```
+public DateTime(int year, int month, int day, int hour, int minute, int second, int millisecond)
+```
+
+
+Inizializza una nuova istanza dell'oggetto DateTime con l'anno, il mese, il giorno, l'ora, il minuto, il secondo e il millisecondo specificati.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| anno | int | L'anno (da 1 a 9999). |
+| mese | int | Il mese (da 1 a 12). |
+| giorno | int | Il giorno (da 1 al numero di giorni nel mese). |
+| ora | int | Le ore (da 0 a 23). |
+| minuto | int | I minuti (da 0 a 59). |
+| secondo | int | I secondi (da 0 a 59). |
+| millisecondo | int | I millisecondi (da 0 a 999). |
+
+### DateTime(Date date) {#DateTime-java.util.Date-}
+```
+public DateTime(Date date)
+```
+
+
+Inizializza una nuova istanza dell'oggetto DateTime con l'oggetto Date specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| data | java.util.Date | L'oggetto Date |
+
+### DateTime(Calendar cld) {#DateTime-java.util.Calendar-}
+```
+public DateTime(Calendar cld)
+```
+
+
+Inizializza una nuova istanza dell'oggetto DateTime con l'oggetto Calendar specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| cld | java.util.Calendar | L'oggetto Calendar |
+
+### addDays(double value) {#addDays-double-}
+```
+public DateTime addDays(double value)
+```
+
+
+Aggiunge il numero specificato di giorni al valore di questa istanza.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double | Un numero di giorni interi e frazionari. Il parametro value può essere negativo o positivo. |
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object whose value is the sum of the date and time represented by this instance and the number of days represented by value.
+### addHours(double value) {#addHours-double-}
+```
+public DateTime addHours(double value)
+```
+
+
+Aggiunge il numero specificato di ore al valore di questa istanza.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double | Un numero di ore intere e frazionarie. Il parametro value può essere negativo o positivo. |
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object whose value is the sum of the date and time represented by this instance and the number of hours represented by value.
+### addMilliseconds(double value) {#addMilliseconds-double-}
+```
+public DateTime addMilliseconds(double value)
+```
+
+
+Aggiunge il numero specificato di millisecondi al valore di questa istanza.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double | Un numero di millisecondi interi e frazionari. Il parametro value può essere negativo o positivo. Nota che questo valore è arrotondato all'intero più vicino. |
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object whose value is the sum of the date and time represented by this instance and the number of milliseconds represented by value.
+### addMinutes(double value) {#addMinutes-double-}
+```
+public DateTime addMinutes(double value)
+```
+
+
+Aggiunge il numero specificato di minuti al valore di questa istanza.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double | Un numero di minuti interi e frazionari. Il parametro value può essere negativo o positivo. |
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object whose value is the sum of the date and time represented by this instance and the number of minutes represented by value.
+### addMonths(int months) {#addMonths-int-}
+```
+public DateTime addMonths(int months)
+```
+
+
+Aggiunge il numero specificato di mesi al valore di questa istanza.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| mesi | int | Un numero di mesi. Il parametro months può essere negativo o positivo. |
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object whose value is the sum of the date and time represented by this instance and months.
+### addSeconds(double value) {#addSeconds-double-}
+```
+public DateTime addSeconds(double value)
+```
+
+
+Aggiunge il numero specificato di secondi al valore di questa istanza.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double | Un numero di secondi interi e frazionari. Il parametro value può essere negativo o positivo. |
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object whose value is the sum of the date and time represented by this instance and the number of seconds represented by value.
+### addYears(int value) {#addYears-int-}
+```
+public DateTime addYears(int value)
+```
+
+
+Aggiunge il numero specificato di anni al valore di questa istanza.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int | Un numero di anni. Il parametro value può essere negativo o positivo. |
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object whose value is the sum of the date and time represented by this instance and the number of years represented by value.
+### compareTo(DateTime value) {#compareTo-com.aspose.diagram.DateTime-}
+```
+public int compareTo(DateTime value)
+```
+
+
+Confronta il valore di questa istanza con un valore DateTime specificato e restituisce un intero che indica se questa istanza è precedente, uguale o successiva al valore DateTime specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) | Un oggetto DateTime da confrontare. |
+
+**Returns:**
+int - Un numero con segno che indica i valori relativi di questa istanza e del parametro value. Descrizione del valore Meno di zero Questa istanza è precedente a value. Zero Questa istanza è uguale a value. Maggiore di zero Questa istanza è successiva a value.
+### compareTo(Object value) {#compareTo-java.lang.Object-}
+```
+public int compareTo(Object value)
+```
+
+
+Confronta il valore di questa istanza con un oggetto specificato che contiene un valore DateTime specificato e restituisce un intero che indica se questa istanza è precedente, uguale o successiva al valore DateTime specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object | Un oggetto DateTime incapsulato da confrontare, o null. |
+
+**Returns:**
+int - Un numero con segno che indica i valori relativi di questa istanza e value. Descrizione del valore Meno di zero Questa istanza è precedente a value. Zero Questa istanza è uguale a value. Maggiore di zero Questa istanza è successiva a value, o value è null.
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Restituisce un valore che indica se questa istanza è uguale a un oggetto specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object | Un oggetto da confrontare con questa istanza. |
+
+**Returns:**
+boolean - true se value è un'istanza di DateTime e uguale al valore di questa istanza; altrimenti, false.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDay() {#getDay--}
+```
+public int getDay()
+```
+
+
+Ottiene il giorno del mese rappresentato da questa istanza.
+
+**Returns:**
+int - Il componente giorno, espresso come valore compreso tra 1 e 31.
+### getDayOfWeek() {#getDayOfWeek--}
+```
+public int getDayOfWeek()
+```
+
+
+Ottiene il giorno della settimana rappresentato da questa istanza.
+
+**Returns:**
+int - il giorno della settimana di questo valore DateTime.
+### getDayOfYear() {#getDayOfYear--}
+```
+public int getDayOfYear()
+```
+
+
+Restituisce il giorno dell'anno rappresentato da questa istanza.
+
+**Returns:**
+int - Il giorno dell'anno, espresso come valore compreso tra 1 e 366.
+### getHour() {#getHour--}
+```
+public int getHour()
+```
+
+
+Restituisce la componente ora della data rappresentata da questa istanza.
+
+**Returns:**
+int - Il componente dell'ora, espresso come valore compreso tra 0 e 23.
+### getMillisecond() {#getMillisecond--}
+```
+public int getMillisecond()
+```
+
+
+Restituisce la componente millisecondi della data rappresentata da questa istanza.
+
+**Returns:**
+int - Il componente dei millisecondi, espresso come valore compreso tra 0 e 999.
+### getMinute() {#getMinute--}
+```
+public int getMinute()
+```
+
+
+Restituisce la componente minuti della data rappresentata da questa istanza.
+
+**Returns:**
+int - Il componente dei minuti, espresso come valore compreso tra 0 e 59.
+### getMonth() {#getMonth--}
+```
+public int getMonth()
+```
+
+
+Restituisce la componente mese della data rappresentata da questa istanza.
+
+**Returns:**
+int - Il componente del mese, espresso come valore compreso tra 1 e 12.
+### getNow() {#getNow--}
+```
+public static DateTime getNow()
+```
+
+
+Restituisce un oggetto DateTime impostato alla data e ora correnti su questo computer, espresso come ora locale.
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object whose value is the current local date and time.
+### getSecond() {#getSecond--}
+```
+public int getSecond()
+```
+
+
+Restituisce la componente secondi della data rappresentata da questa istanza.
+
+**Returns:**
+int - I secondi, compresi tra 0 e 59.
+### getYear() {#getYear--}
+```
+public int getYear()
+```
+
+
+Restituisce la componente anno della data rappresentata da questa istanza.
+
+**Returns:**
+int - L'anno, compreso tra 1 e 9999.
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Restituisce il codice hash per questa istanza.
+
+**Returns:**
+int - Un codice hash intero con segno a 32 bit.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toCalendar() {#toCalendar--}
+```
+public Calendar toCalendar()
+```
+
+
+Converte il valore dell'oggetto DateTime corrente in un oggetto Calendar.
+
+**Returns:**
+[Calendar](../../java.util/calendar) - Calendar object
+### toDate() {#toDate--}
+```
+public Date toDate()
+```
+
+
+Converte il valore dell'oggetto DateTime corrente in un oggetto Date.
+
+**Returns:**
+java.util.Date - oggetto Date
+### toLocalTime() {#toLocalTime--}
+```
+public DateTime toLocalTime()
+```
+
+
+Converte il valore dell'oggetto DateTime corrente in ora locale.
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object of local
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+Converte il valore dell'oggetto DateTime corrente nella sua rappresentazione stringa equivalente.
+
+**Returns:**
+java.lang.String - Una rappresentazione stringa del valore dell'oggetto DateTime corrente.
+### toUniversalTime() {#toUniversalTime--}
+```
+public DateTime toUniversalTime()
+```
+
+
+Converte il valore dell'oggetto DateTime corrente in Coordinated Universal Time (UTC).
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object of UTC
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/datevalue/_index.md
+++ b/italian/java/com.aspose.diagram/datevalue/_index.md
@@ -1,0 +1,180 @@
+---
+title: DateValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Valore di data e ora.
+type: docs
+weight: 116
+url: /it/java/com.aspose.diagram/datevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DateValue
+```
+
+Valore di data e ora.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [DateValue(DateTime value, int unit)](#DateValue-com.aspose.diagram.DateTime-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Attributi di un elemento. |
+| [getValue()](#getValue--) | Valore di data e ora. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(DateTime value)](#setValue-com.aspose.diagram.DateTime-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/datevalue\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DateValue(DateTime value, int unit) {#DateValue-com.aspose.diagram.DateTime-int-}
+```
+public DateValue(DateTime value, int unit)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+| unità | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public DateTime getValue()
+```
+
+
+Valore di data e ora.
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(DateTime value) {#setValue-com.aspose.diagram.DateTime-}
+```
+public void setValue(DateTime value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/datevalue\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/diagram/_index.md
+++ b/italian/java/com.aspose.diagram/diagram/_index.md
@@ -1,0 +1,1130 @@
+---
+title: Diagramma
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Elemento radice della gerarchia degli oggetti Visio.
+type: docs
+weight: 117
+url: /it/java/com.aspose.diagram/diagram/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Diagram
+```
+
+Elemento radice della gerarchia degli oggetti Visio.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [Diagram()](#Diagram--) |  |
+| [Diagram(String filename)](#Diagram-java.lang.String-) | Costruttore pubblico della classe, carica il diagramma dal file. |
+| [Diagram(InputStream stream)](#Diagram-java.io.InputStream-) | Costruttore pubblico della classe, carica il diagramma dallo stream. |
+| [Diagram(InputStream stream, int format)](#Diagram-java.io.InputStream-int-) | Costruttore pubblico della classe, carica il diagramma dallo stream usando il formato predefinito. |
+| [Diagram(InputStream stream, LoadOptions options)](#Diagram-java.io.InputStream-com.aspose.diagram.LoadOptions-) | Costruttore pubblico della classe, carica il diagramma dallo stream usando le opzioni di caricamento predefinite. |
+| [Diagram(String filename, int format)](#Diagram-java.lang.String-int-) | Costruttore pubblico della classe, carica il diagramma dal file usando il formato predefinito. |
+| [Diagram(String filename, LoadOptions options)](#Diagram-java.lang.String-com.aspose.diagram.LoadOptions-) | Costruttore pubblico della classe, carica il diagramma dal file usando le opzioni di caricamento predefinite. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [addMaster(Diagram srcDiagram, String masterName)](#addMaster-com.aspose.diagram.Diagram-java.lang.String-) | Aggiunge il master al diagramma dal diagramma sorgente per Name o NameU del master. |
+| [addMaster(InputStream templateStream, int masterID)](#addMaster-java.io.InputStream-int-) | Aggiunge il master al diagramma dallo stream del modello per ID del master. |
+| [addMaster(InputStream templateStream, String masterName)](#addMaster-java.io.InputStream-java.lang.String-) | Aggiunge il master al diagramma dallo stream del modello per Name o NameU del master. |
+| [addMaster(String templateFilePath, int masterID)](#addMaster-java.lang.String-int-) | Aggiunge il master al diagramma dal file del modello per ID del master. |
+| [addMaster(String templateFilePath, String masterName)](#addMaster-java.lang.String-java.lang.String-) | Aggiunge il master al diagramma dal file del modello per Name o NameU del master. |
+| [addShape(Shape newShape, String masterName, int pageNumber)](#addShape-com.aspose.diagram.Shape-java.lang.String-int-) | Aggiunge una forma creata dal master a una pagina specifica. |
+| [addShape(double pinX, double pinY, double width, double height, String masterName, int pageNumber)](#addShape-double-double-double-double-java.lang.String-int-) | Aggiunge una forma creata dal master sulla pagina con PinX, PinY, larghezza e altezza definiti. |
+| [addShape(double pinX, double pinY, String masterName, int pageNumber)](#addShape-double-double-java.lang.String-int-) | Aggiunge una forma creata dal master sulla pagina con PinX e PinY definiti. |
+| [combine(Diagram secondDiagram)](#combine-com.aspose.diagram.Diagram-) | Combina un altro oggetto Diagram. |
+| [copyTheme(Diagram source)](#copyTheme-com.aspose.diagram.Diagram-) | Copia il Tema da un Diagramma sorgente. |
+| [dispose()](#dispose--) | Esegue operazioni definite dall'applicazione associate al rilascio, alla liberazione o al reset delle risorse non gestite. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [export(InputStream inputVsd, InputStream outputVdw)](#export-java.io.InputStream-java.io.InputStream-) | Esporta il diagramma dallo stream vsd al formato stream vdw. |
+| [export(InputStream inputVsd, String outputVdw)](#export-java.io.InputStream-java.lang.String-) | Esporta il diagramma dallo stream vsd al formato file *.vdw. |
+| [export(String inputVsd, InputStream outputVdw)](#export-java.lang.String-java.io.InputStream-) | Esporta il diagramma dal file vsd al formato stream vdw. |
+| [export(String inputVsd, String outputVdw)](#export-java.lang.String-java.lang.String-) | Esporta il diagramma da vsd a formato vdw. |
+| [getActivePage()](#getActivePage--) | Specifica la pagina attiva |
+| [getBuildnum()](#getBuildnum--) | Il numero di build dell'istanza Visio usata per creare il documento. |
+| [getClass()](#getClass--) |  |
+| [getColors()](#getColors--) | Contiene la tabella dei colori del documento. |
+| [getDataConnections()](#getDataConnections--) | Contiene gli elementi DataConnection per il documento. |
+| [getDataRecordSets()](#getDataRecordSets--) | La collezione di oggetti DataRecordset associati a un oggetto Document. |
+| [getDefaultFontDir()](#getDefaultFontDir--) | Ottieni il percorso della cartella Font predefinita |
+| [getDocLangID()](#getDocLangID--) | L'ID univoco della lingua dell'interfaccia utente specificata dall'utente nelle Preferenze lingua di Microsoft Office 2010. |
+| [getDocumentProps()](#getDocumentProps--) | Contiene elementi di proprietà del documento come il titolo del documento, l'autore e così via. |
+| [getDocumentSettings()](#getDocumentSettings--) | Contiene elementi che specificano le impostazioni del documento. |
+| [getDocumentSheet()](#getDocumentSheet--) | Specifica la struttura ShapeSheet di un documento. |
+| [getEmailRoutingData()](#getEmailRoutingData--) | Contiene una busta di instradamento e-mail MAPI codificata in MIME (Multipurpose Internet Mail Extensions) per il documento. |
+| [getEventItems()](#getEventItems--) | Contiene un elemento EventItem per ogni evento a cui un oggetto dovrebbe rispondere. |
+| [getFonts()](#getFonts--) | Contiene una raccolta di elementi Font |
+| [getHeaderFooter()](#getHeaderFooter--) | Contiene gli elementi per l'intestazione e il piè di pagina di un documento. |
+| [getInterruptMonitor()](#getInterruptMonitor--) | il monitor di interruzione. |
+| [getKey()](#getKey--) | Indica se il documento è stato modificato al di fuori di Visio. |
+| [getMasters()](#getMasters--) | Raccolta di oggetti Master. |
+| [getMetric()](#getMetric--) | Indica se utilizzare unità metriche nel disegno. |
+| [getPages()](#getPages--) | Raccolta di oggetti Page. |
+| [getRibbonX()](#getRibbonX--) | La stringa Ribbon XML che viene passata al documento per personalizzare l'interfaccia utente del ribbon. |
+| [getSolutionXMLs()](#getSolutionXMLs--) | Valore XML. |
+| [getStart()](#getStart--) | Indica se il documento è stato modificato al di fuori di Visio. |
+| [getStyleSheets()](#getStyleSheets--) | Raccolta di oggetti StyleSheet. |
+| [getUnusedStyles()](#getUnusedStyles--) | Ottieni gli Stili non utilizzati |
+| [getUserCustomUI()](#getUserCustomUI--) | La stringa Ribbon XML che viene passata al documento per personalizzare la barra degli strumenti di accesso rapido o il ribbon. |
+| [getValidation()](#getValidation--) | Memorizza informazioni sulla convalida del diagramma per il documento. |
+| [getVbProjectData()](#getVbProjectData--) | Contiene i dati del progetto Microsoft Visual Basic for Applications in formato codificato MIME (Multipurpose Internet Mail Extensions). |
+| [getVbaProject()](#getVbaProject--) | Ottiene il VbaProject[getVbaProject()](../../com.aspose.diagram/diagram\\#getVbaProject--). |
+| [getVersion()](#getVersion--) | Il numero di versione dell'istanza di Visio. |
+| [getWindows()](#getWindows--) | Contiene gli elementi Window per un documento. |
+| [hasHiddenInfo()](#hasHiddenInfo--) | Indica se questo diagramma contiene informazioni nascoste. |
+| [hashCode()](#hashCode--) |  |
+| [layout(LayoutOptions options)](#layout-com.aspose.diagram.LayoutOptions-) | Dispone le forme e/o riorienta i connettori per tutte le pagine del diagramma. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [print(String printerName)](#print-java.lang.String-) | Stampa l'intero documento sulla stampante specificata,utilizzando il controller di stampa standard (senza interfaccia utente). |
+| [print(String printerName, PrintSaveOptions options)](#print-java.lang.String-com.aspose.diagram.PrintSaveOptions-) | Stampa l'intero documento sulla stampante specificata,utilizzando il controller di stampa standard (senza interfaccia utente). |
+| [print(String printerName, String documentName)](#print-java.lang.String-java.lang.String-) | Stampa il documento,utilizzando il controller di stampa standard (senza interfaccia utente) e un nome documento. |
+| [print(String printerName, String documentName, PrintSaveOptions options)](#print-java.lang.String-java.lang.String-com.aspose.diagram.PrintSaveOptions-) | Stampa il documento,utilizzando il controller di stampa standard (senza interfaccia utente) e un nome documento. |
+| [removeHiddenInformation(int item)](#removeHiddenInformation-int-) | Rimuovi le informazioni non utilizzate |
+| [removeMacro()](#removeMacro--) | Rimuove VBA/macro da questo diagramma. |
+| [save(OutputStream stream, SaveOptions saveOptions)](#save-java.io.OutputStream-com.aspose.diagram.SaveOptions-) | Salva il diagramma sullo stream. |
+| [save(OutputStream stream, int format)](#save-java.io.OutputStream-int-) | Salva il diagramma sullo stream. |
+| [save(String filename, SaveOptions options)](#save-java.lang.String-com.aspose.diagram.SaveOptions-) | Salva il documento su un file utilizzando le opzioni di salvataggio specificate. |
+| [save(String filename, int format)](#save-java.lang.String-int-) | Salva i dati del diagramma sul file. |
+| [setBuildnum(long value)](#setBuildnum-long-) | Per la descrizione di questa proprietà, vedere [getBuildnum()](../../com.aspose.diagram/diagram\#getBuildnum--) |
+| [setDocLangID(int value)](#setDocLangID-int-) | Per la descrizione di questa proprietà, vedere [getDocLangID()](../../com.aspose.diagram/diagram\#getDocLangID--) |
+| [setEmailRoutingData(byte[] value)](#setEmailRoutingData-byte---) | Per la descrizione di questa proprietà, vedere [getEmailRoutingData()](../../com.aspose.diagram/diagram\#getEmailRoutingData--) |
+| [setFontDirs(String[] value)](#setFontDirs-java.lang.String---) | Indica il percorso della cartella Fonts |
+| [setInterruptMonitor(AbstractInterruptMonitor value)](#setInterruptMonitor-com.aspose.diagram.AbstractInterruptMonitor-) | Per la descrizione di questa proprietà, vedere [getInterruptMonitor()](../../com.aspose.diagram/diagram\#getInterruptMonitor--) |
+| [setKey(String value)](#setKey-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getKey()](../../com.aspose.diagram/diagram\#getKey--) |
+| [setMetric(int value)](#setMetric-int-) | Per la descrizione di questa proprietà, vedere [getMetric()](../../com.aspose.diagram/diagram\#getMetric--) |
+| [setRibbonX(String value)](#setRibbonX-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getRibbonX()](../../com.aspose.diagram/diagram\#getRibbonX--) |
+| [setStart(long value)](#setStart-long-) | Per la descrizione di questa proprietà, vedere [getStart()](../../com.aspose.diagram/diagram\#getStart--) |
+| [setUserCustomUI(String value)](#setUserCustomUI-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getUserCustomUI()](../../com.aspose.diagram/diagram\#getUserCustomUI--) |
+| [setVbProjectData(byte[] value)](#setVbProjectData-byte---) | Per la descrizione di questa proprietà, vedere [getVbProjectData()](../../com.aspose.diagram/diagram\#getVbProjectData--) |
+| [setVersion(String value)](#setVersion-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getVersion()](../../com.aspose.diagram/diagram\#getVersion--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Diagram() {#Diagram--}
+```
+public Diagram()
+```
+
+
+### Diagram(String filename) {#Diagram-java.lang.String-}
+```
+public Diagram(String filename)
+```
+
+
+Costruttore pubblico della classe, carica il diagramma dal file.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| filename | java.lang.String | Il nome del file. |
+
+### Diagram(InputStream stream) {#Diagram-java.io.InputStream-}
+```
+public Diagram(InputStream stream)
+```
+
+
+Costruttore pubblico della classe, carica il diagramma dallo stream.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| flusso | java.io.InputStream | Il flusso di dati. |
+
+### Diagram(InputStream stream, int format) {#Diagram-java.io.InputStream-int-}
+```
+public Diagram(InputStream stream, int format)
+```
+
+
+Costruttore pubblico della classe, carica il diagramma dallo stream usando il formato predefinito.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| flusso | java.io.InputStream | Il flusso di dati. |
+| formato | int | I dati Aspose.Diagram.LoadFileFormat. |
+
+### Diagram(InputStream stream, LoadOptions options) {#Diagram-java.io.InputStream-com.aspose.diagram.LoadOptions-}
+```
+public Diagram(InputStream stream, LoadOptions options)
+```
+
+
+Costruttore pubblico della classe, carica il diagramma dallo stream usando le opzioni di caricamento predefinite.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| flusso | java.io.InputStream | Il flusso di dati. |
+| options | [LoadOptions](../../com.aspose.diagram/loadoptions) | I dati [LoadOptions](../../com.aspose.diagram/loadoptions). |
+
+### Diagram(String filename, int format) {#Diagram-java.lang.String-int-}
+```
+public Diagram(String filename, int format)
+```
+
+
+Costruttore pubblico della classe, carica il diagramma dal file usando il formato predefinito.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| filename | java.lang.String | Il nome del file. |
+| formato | int | Il formato del file. |
+
+### Diagram(String filename, LoadOptions options) {#Diagram-java.lang.String-com.aspose.diagram.LoadOptions-}
+```
+public Diagram(String filename, LoadOptions options)
+```
+
+
+Costruttore pubblico della classe, carica il diagramma dal file usando le opzioni di caricamento predefinite.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| filename | java.lang.String | Il nome del file. |
+| options | [LoadOptions](../../com.aspose.diagram/loadoptions) | I dati [LoadOptions](../../com.aspose.diagram/loadoptions). |
+
+### addMaster(Diagram srcDiagram, String masterName) {#addMaster-com.aspose.diagram.Diagram-java.lang.String-}
+```
+public int addMaster(Diagram srcDiagram, String masterName)
+```
+
+
+Aggiunge il master al diagramma dal diagramma sorgente per Name o NameU del master.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| srcDiagram | [Diagram](../../com.aspose.diagram/diagram) | diagramma di origine. |
+| masterName | java.lang.String | Nome del master o NameU. |
+
+**Returns:**
+int - L'ID univoco del master nella raccolta dei master in questo diagramma.
+### addMaster(InputStream templateStream, int masterID) {#addMaster-java.io.InputStream-int-}
+```
+public int addMaster(InputStream templateStream, int masterID)
+```
+
+
+Aggiunge il master al diagramma dallo stream del modello per ID del master.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| templateStream | java.io.InputStream | flusso del modello. |
+| masterID | int | L'ID univoco del master nella raccolta dei master nel modello. |
+
+**Returns:**
+int - L'ID univoco del master nella raccolta dei master in questo diagramma.
+### addMaster(InputStream templateStream, String masterName) {#addMaster-java.io.InputStream-java.lang.String-}
+```
+public int addMaster(InputStream templateStream, String masterName)
+```
+
+
+Aggiunge il master al diagramma dallo stream del modello per Name o NameU del master.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| templateStream | java.io.InputStream | flusso del modello. |
+| masterName | java.lang.String | Nome del master o NameU. |
+
+**Returns:**
+int - L'ID univoco del master nella raccolta dei master in questo diagramma.
+### addMaster(String templateFilePath, int masterID) {#addMaster-java.lang.String-int-}
+```
+public int addMaster(String templateFilePath, int masterID)
+```
+
+
+Aggiunge il master al diagramma dal file del modello per ID del master.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| templateFilePath | java.lang.String | Percorso del file modello (può essere in formato vdx, vst o vsd). |
+| masterID | int | L'ID univoco del master nella raccolta dei master nel modello. |
+
+**Returns:**
+int - L'ID univoco del master nella raccolta dei master in questo diagramma.
+### addMaster(String templateFilePath, String masterName) {#addMaster-java.lang.String-java.lang.String-}
+```
+public int addMaster(String templateFilePath, String masterName)
+```
+
+
+Aggiunge il master al diagramma dal file del modello per Name o NameU del master.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| templateFilePath | java.lang.String | Percorso del file modello (può essere in formato vdx, vst o vsd). |
+| masterName | java.lang.String | Nome del master o NameU. |
+
+**Returns:**
+int - L'ID univoco del master nella raccolta dei master in questo diagramma.
+### addShape(Shape newShape, String masterName, int pageNumber) {#addShape-com.aspose.diagram.Shape-java.lang.String-int-}
+```
+public long addShape(Shape newShape, String masterName, int pageNumber)
+```
+
+
+Aggiunge una forma creata dal master a una pagina specifica.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| newShape | [Shape](../../com.aspose.diagram/shape) | Nuovo oggetto shape[Shape](../../com.aspose.diagram/shape). |
+| masterName | java.lang.String | Nome del master. |
+| pageNumber | int | Indice della pagina. |
+
+**Returns:**
+long - L'ID univoco della forma all'interno della collezione di forme nella pagina specificata.
+### addShape(double pinX, double pinY, double width, double height, String masterName, int pageNumber) {#addShape-double-double-double-double-java.lang.String-int-}
+```
+public long addShape(double pinX, double pinY, double width, double height, String masterName, int pageNumber)
+```
+
+
+Aggiunge una forma creata dal master sulla pagina con PinX, PinY, larghezza e altezza definiti.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| pinX | double | Specifica la coordinata x del perno della forma (centro di rotazione) in relazione alla pagina. |
+| pinY | double | Specifica la coordinata y del perno della forma (centro di rotazione) in relazione alla pagina. |
+| width | double | Specifica la larghezza della forma in pollici. |
+| height | double | Specifica l'altezza della forma in pollici. |
+| masterName | java.lang.String | Nome del master. |
+| pageNumber | int | Indice della pagina. |
+
+**Returns:**
+long - L'ID univoco della forma all'interno della collezione di forme nella pagina specificata.
+### addShape(double pinX, double pinY, String masterName, int pageNumber) {#addShape-double-double-java.lang.String-int-}
+```
+public long addShape(double pinX, double pinY, String masterName, int pageNumber)
+```
+
+
+Aggiunge una forma creata dal master sulla pagina con PinX e PinY definiti.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| pinX | double | Specifica la coordinata x del perno della forma (centro di rotazione) in relazione alla pagina. |
+| pinY | double | Specifica la coordinata y del perno della forma (centro di rotazione) in relazione alla pagina. |
+| masterName | java.lang.String | Nome del master. |
+| pageNumber | int | Indice della pagina. |
+
+**Returns:**
+long - L'ID univoco della forma all'interno della collezione di forme nella pagina specificata.
+### combine(Diagram secondDiagram) {#combine-com.aspose.diagram.Diagram-}
+```
+public void combine(Diagram secondDiagram)
+```
+
+
+Combina un altro oggetto Diagram.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| secondDiagram | [Diagram](../../com.aspose.diagram/diagram) | Un altro oggetto Diagram. |
+
+### copyTheme(Diagram source) {#copyTheme-com.aspose.diagram.Diagram-}
+```
+public void copyTheme(Diagram source)
+```
+
+
+Copia il Tema da un Diagramma sorgente.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| source | [Diagram](../../com.aspose.diagram/diagram) | diagramma di origine. |
+
+### dispose() {#dispose--}
+```
+public void dispose()
+```
+
+
+Esegue operazioni definite dall'applicazione associate al rilascio, alla liberazione o al reset delle risorse non gestite.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### export(InputStream inputVsd, InputStream outputVdw) {#export-java.io.InputStream-java.io.InputStream-}
+```
+public static void export(InputStream inputVsd, InputStream outputVdw)
+```
+
+
+Esporta il diagramma dallo stream vsd al formato stream vdw. Non ancora implementato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| inputVsd | java.io.InputStream | stream vsd. |
+| outputVdw | java.io.InputStream | stream vdw. |
+
+### export(InputStream inputVsd, String outputVdw) {#export-java.io.InputStream-java.lang.String-}
+```
+public static void export(InputStream inputVsd, String outputVdw)
+```
+
+
+Esporta il diagramma dallo stream vsd al formato file \*.vdw. Non ancora implementato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| inputVsd | java.io.InputStream | Nome file \*.vsd. |
+| outputVdw | java.lang.String | stream vdw. |
+
+### export(String inputVsd, InputStream outputVdw) {#export-java.lang.String-java.io.InputStream-}
+```
+public static void export(String inputVsd, InputStream outputVdw)
+```
+
+
+Esporta il diagramma dal file vsd al formato stream vdw. Non ancora implementato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| inputVsd | java.lang.String | Nome file \*.vsd. |
+| outputVdw | java.io.InputStream | stream vdw. |
+
+### export(String inputVsd, String outputVdw) {#export-java.lang.String-java.lang.String-}
+```
+public static void export(String inputVsd, String outputVdw)
+```
+
+
+Esporta il diagramma da vsd a formato vdw. Non ancora implementato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| inputVsd | java.lang.String | Nome file \*.vsd. |
+| outputVdw | java.lang.String | Nome file \*.vdw. |
+
+### getActivePage() {#getActivePage--}
+```
+public Page getActivePage()
+```
+
+
+Specifica la pagina attiva
+
+**Returns:**
+[Page](../../com.aspose.diagram/page)
+### getBuildnum() {#getBuildnum--}
+```
+public long getBuildnum()
+```
+
+
+Il numero di build dell'istanza Visio usata per creare il documento.
+
+**Returns:**
+long
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColors() {#getColors--}
+```
+public ColorEntryCollection getColors()
+```
+
+
+Contiene la tavola dei colori del documento. Ogni documento contiene una singola tavola dei colori, che elenca i 24 colori standard disponibili per l'applicazione a oggetti come forme, testo e livelli nel documento.
+
+**Returns:**
+[ColorEntryCollection](../../com.aspose.diagram/colorentrycollection)
+### getDataConnections() {#getDataConnections--}
+```
+public DataConnectionCollection getDataConnections()
+```
+
+
+Contiene gli elementi DataConnection per il documento.
+
+**Returns:**
+[DataConnectionCollection](../../com.aspose.diagram/dataconnectioncollection)
+### getDataRecordSets() {#getDataRecordSets--}
+```
+public DataRecordSetCollection getDataRecordSets()
+```
+
+
+La collezione di oggetti DataRecordset associati a un oggetto Document.
+
+**Returns:**
+[DataRecordSetCollection](../../com.aspose.diagram/datarecordsetcollection)
+### getDefaultFontDir() {#getDefaultFontDir--}
+```
+public String getDefaultFontDir()
+```
+
+
+Ottieni il percorso della cartella Font predefinita
+
+**Returns:**
+java.lang.String
+### getDocLangID() {#getDocLangID--}
+```
+public int getDocLangID()
+```
+
+
+L'ID univoco della lingua dell'interfaccia utente specificata dall'utente nelle Preferenze lingua di Microsoft Office 2010.
+
+**Returns:**
+int
+### getDocumentProps() {#getDocumentProps--}
+```
+public DocumentProperties getDocumentProps()
+```
+
+
+Contiene elementi di proprietà del documento come il titolo del documento, l'autore e così via.
+
+**Returns:**
+[DocumentProperties](../../com.aspose.diagram/documentproperties)
+### getDocumentSettings() {#getDocumentSettings--}
+```
+public DocumentSettings getDocumentSettings()
+```
+
+
+Contiene elementi che specificano le impostazioni del documento.
+
+**Returns:**
+[DocumentSettings](../../com.aspose.diagram/documentsettings)
+### getDocumentSheet() {#getDocumentSheet--}
+```
+public DocumentSheet getDocumentSheet()
+```
+
+
+Specifica la struttura ShapeSheet di un documento.
+
+**Returns:**
+[DocumentSheet](../../com.aspose.diagram/documentsheet)
+### getEmailRoutingData() {#getEmailRoutingData--}
+```
+public byte[] getEmailRoutingData()
+```
+
+
+Contiene una busta di instradamento e-mail MAPI codificata in MIME (Multipurpose Internet Mail Extensions) per il documento.
+
+**Returns:**
+byte[]
+### getEventItems() {#getEventItems--}
+```
+public EventItemCollection getEventItems()
+```
+
+
+Contiene un elemento EventItem per ogni evento a cui un oggetto dovrebbe rispondere.
+
+**Returns:**
+[EventItemCollection](../../com.aspose.diagram/eventitemcollection)
+### getFonts() {#getFonts--}
+```
+public FontCollection getFonts()
+```
+
+
+Contiene una raccolta di elementi Font
+
+**Returns:**
+[FontCollection](../../com.aspose.diagram/fontcollection)
+### getHeaderFooter() {#getHeaderFooter--}
+```
+public HeaderFooter getHeaderFooter()
+```
+
+
+Contiene gli elementi per l'intestazione e il piè di pagina di un documento.
+
+**Returns:**
+[HeaderFooter](../../com.aspose.diagram/headerfooter)
+### getInterruptMonitor() {#getInterruptMonitor--}
+```
+public AbstractInterruptMonitor getInterruptMonitor()
+```
+
+
+il monitor di interruzione.
+
+**Returns:**
+[AbstractInterruptMonitor](../../com.aspose.diagram/abstractinterruptmonitor)
+### getKey() {#getKey--}
+```
+public String getKey()
+```
+
+
+Indica se il documento è stato modificato al di fuori di Visio. Se presente, Visio testerà completamente il contenuto del file. Omettere per i file creati al di fuori di Visio.
+
+**Returns:**
+java.lang.String
+### getMasters() {#getMasters--}
+```
+public MasterCollection getMasters()
+```
+
+
+Raccolta di oggetti Master.
+
+**Returns:**
+[MasterCollection](../../com.aspose.diagram/mastercollection)
+### getMetric() {#getMetric--}
+```
+public int getMetric()
+```
+
+
+Indica se utilizzare unità metriche nel disegno. Impostare questo attributo su True (1) per usare unità metriche; impostarlo su False (0) per usare unità inglesi.
+
+**Returns:**
+int
+### getPages() {#getPages--}
+```
+public PageCollection getPages()
+```
+
+
+Raccolta di oggetti Page.
+
+**Returns:**
+[PageCollection](../../com.aspose.diagram/pagecollection)
+### getRibbonX() {#getRibbonX--}
+```
+public String getRibbonX()
+```
+
+
+La stringa Ribbon XML che viene passata al documento per personalizzare l'interfaccia utente del ribbon.
+
+**Returns:**
+java.lang.String
+### getSolutionXMLs() {#getSolutionXMLs--}
+```
+public SolutionXMLCollection getSolutionXMLs()
+```
+
+
+Valore XML.
+
+**Returns:**
+[SolutionXMLCollection](../../com.aspose.diagram/solutionxmlcollection)
+### getStart() {#getStart--}
+```
+public long getStart()
+```
+
+
+Indica se il documento è stato modificato al di fuori di Visio. Se presente, Visio testerà completamente il contenuto del file. Omettere per i file creati al di fuori di Visio.
+
+**Returns:**
+long
+### getStyleSheets() {#getStyleSheets--}
+```
+public StyleSheetCollection getStyleSheets()
+```
+
+
+Raccolta di oggetti StyleSheet.
+
+**Returns:**
+[StyleSheetCollection](../../com.aspose.diagram/stylesheetcollection)
+### getUnusedStyles() {#getUnusedStyles--}
+```
+public StyleSheetCollection getUnusedStyles()
+```
+
+
+Ottieni gli Stili non utilizzati
+
+**Returns:**
+[StyleSheetCollection](../../com.aspose.diagram/stylesheetcollection)
+### getUserCustomUI() {#getUserCustomUI--}
+```
+public String getUserCustomUI()
+```
+
+
+La stringa Ribbon XML che viene passata al documento per personalizzare la barra degli strumenti di accesso rapido o il ribbon.
+
+**Returns:**
+java.lang.String
+### getValidation() {#getValidation--}
+```
+public Validation getValidation()
+```
+
+
+Memorizza informazioni sulla convalida del diagramma per il documento.
+
+**Returns:**
+[Validation](../../com.aspose.diagram/validation)
+### getVbProjectData() {#getVbProjectData--}
+```
+public byte[] getVbProjectData()
+```
+
+
+Contiene i dati del progetto Microsoft Visual Basic for Applications in formato codificato MIME (Multipurpose Internet Mail Extensions).
+
+**Returns:**
+byte[]
+### getVbaProject() {#getVbaProject--}
+```
+public VbaProject getVbaProject()
+```
+
+
+Ottiene il VbaProject[getVbaProject()](../../com.aspose.diagram/diagram\\#getVbaProject--).
+
+**Returns:**
+[VbaProject](../../com.aspose.diagram/vbaproject)
+### getVersion() {#getVersion--}
+```
+public String getVersion()
+```
+
+
+Il numero di versione dell'istanza di Visio. Microsoft Visio 2010 = 14.
+
+**Returns:**
+java.lang.String
+### getWindows() {#getWindows--}
+```
+public WindowCollection getWindows()
+```
+
+
+Contiene gli elementi Window per un documento.
+
+**Returns:**
+[WindowCollection](../../com.aspose.diagram/windowcollection)
+### hasHiddenInfo() {#hasHiddenInfo--}
+```
+public boolean hasHiddenInfo()
+```
+
+
+Indica se questo diagramma contiene informazioni nascoste.
+
+**Returns:**
+boolean
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### layout(LayoutOptions options) {#layout-com.aspose.diagram.LayoutOptions-}
+```
+public void layout(LayoutOptions options)
+```
+
+
+Dispone le forme e/o riorienta i connettori per tutte le pagine del diagramma.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| options | [LayoutOptions](../../com.aspose.diagram/layoutoptions) | Utilizzando [LayoutOptions](../../com.aspose.diagram/layoutoptions) per configurare le opzioni del layout. |
+
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### print(String printerName) {#print-java.lang.String-}
+```
+public void print(String printerName)
+```
+
+
+Stampa l'intero documento sulla stampante specificata, usando il controller di stampa standard (senza interfaccia utente). Se printerName è Null o vuoto verrà usata la stampante predefinita.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| printerName | java.lang.String | Il nome della stampante. Può essere Null. |
+
+### print(String printerName, PrintSaveOptions options) {#print-java.lang.String-com.aspose.diagram.PrintSaveOptions-}
+```
+public void print(String printerName, PrintSaveOptions options)
+```
+
+
+Stampa l'intero documento sulla stampante specificata, usando il controller di stampa standard (senza interfaccia utente). Se printerName è Null o vuoto verrà usata la stampante predefinita.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| printerName | java.lang.String | Il nome della stampante. Può essere Null. |
+| options | [PrintSaveOptions](../../com.aspose.diagram/printsaveoptions) | Le opzioni di stampa. |
+
+### print(String printerName, String documentName) {#print-java.lang.String-java.lang.String-}
+```
+public void print(String printerName, String documentName)
+```
+
+
+Stampa il documento,utilizzando il controller di stampa standard (senza interfaccia utente) e un nome documento.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| printerName | java.lang.String | Il nome della stampante. Può essere Null. |
+| documentName | java.lang.String | Il nome del documento da visualizzare (ad esempio, in una finestra di dialogo di stato di stampa o nella coda della stampante) durante la stampa del documento. |
+
+### print(String printerName, String documentName, PrintSaveOptions options) {#print-java.lang.String-java.lang.String-com.aspose.diagram.PrintSaveOptions-}
+```
+public void print(String printerName, String documentName, PrintSaveOptions options)
+```
+
+
+Stampa il documento,utilizzando il controller di stampa standard (senza interfaccia utente) e un nome documento.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| printerName | java.lang.String | Il nome della stampante. Può essere Null. |
+| documentName | java.lang.String | Il nome del documento da visualizzare (ad esempio, in una finestra di dialogo di stato di stampa o nella coda della stampante) durante la stampa del documento. |
+| options | [PrintSaveOptions](../../com.aspose.diagram/printsaveoptions) | Le opzioni di stampa. |
+
+### removeHiddenInformation(int item) {#removeHiddenInformation-int-}
+```
+public void removeHiddenInformation(int item)
+```
+
+
+Rimuovi le informazioni non utilizzate
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | int | RemoveHiddenInfoItem. |
+
+### removeMacro() {#removeMacro--}
+```
+public void removeMacro()
+```
+
+
+Rimuove VBA/macro da questo diagramma.
+
+### save(OutputStream stream, SaveOptions saveOptions) {#save-java.io.OutputStream-com.aspose.diagram.SaveOptions-}
+```
+public void save(OutputStream stream, SaveOptions saveOptions)
+```
+
+
+Salva il diagramma sullo stream.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| flusso | java.io.OutputStream | Il flusso di file. |
+| saveOptions | [SaveOptions](../../com.aspose.diagram/saveoptions) | Le opzioni di salvataggio. |
+
+### save(OutputStream stream, int format) {#save-java.io.OutputStream-int-}
+```
+public void save(OutputStream stream, int format)
+```
+
+
+Salva il diagramma sullo stream.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| flusso | java.io.OutputStream | Il flusso di file. |
+| formato | int |  |
+
+### save(String filename, SaveOptions options) {#save-java.lang.String-com.aspose.diagram.SaveOptions-}
+```
+public void save(String filename, SaveOptions options)
+```
+
+
+Salva il documento su un file utilizzando le opzioni di salvataggio specificate.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| filename | java.lang.String | Il nome del file. |
+| options | [SaveOptions](../../com.aspose.diagram/saveoptions) | [SaveOptions](../../com.aspose.diagram/saveoptions) salva le opzioni del diagramma. |
+
+### save(String filename, int format) {#save-java.lang.String-int-}
+```
+public void save(String filename, int format)
+```
+
+
+Salva i dati del diagramma sul file.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| filename | java.lang.String | Il nome del file. |
+| formato | int | Aspose.Diagram.SaveFileFormat salva il formato del file. |
+
+### setBuildnum(long value) {#setBuildnum-long-}
+```
+public void setBuildnum(long value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getBuildnum()](../../com.aspose.diagram/diagram\#getBuildnum--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | long |  |
+
+### setDocLangID(int value) {#setDocLangID-int-}
+```
+public void setDocLangID(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDocLangID()](../../com.aspose.diagram/diagram\#getDocLangID--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setEmailRoutingData(byte[] value) {#setEmailRoutingData-byte---}
+```
+public void setEmailRoutingData(byte[] value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getEmailRoutingData()](../../com.aspose.diagram/diagram\#getEmailRoutingData--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | byte[] |  |
+
+### setFontDirs(String[] value) {#setFontDirs-java.lang.String---}
+```
+public void setFontDirs(String[] value)
+```
+
+
+Indica il percorso della cartella Fonts
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String[] |  |
+
+### setInterruptMonitor(AbstractInterruptMonitor value) {#setInterruptMonitor-com.aspose.diagram.AbstractInterruptMonitor-}
+```
+public void setInterruptMonitor(AbstractInterruptMonitor value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getInterruptMonitor()](../../com.aspose.diagram/diagram\#getInterruptMonitor--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [AbstractInterruptMonitor](../../com.aspose.diagram/abstractinterruptmonitor) |  |
+
+### setKey(String value) {#setKey-java.lang.String-}
+```
+public void setKey(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getKey()](../../com.aspose.diagram/diagram\#getKey--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setMetric(int value) {#setMetric-int-}
+```
+public void setMetric(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getMetric()](../../com.aspose.diagram/diagram\#getMetric--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setRibbonX(String value) {#setRibbonX-java.lang.String-}
+```
+public void setRibbonX(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getRibbonX()](../../com.aspose.diagram/diagram\#getRibbonX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setStart(long value) {#setStart-long-}
+```
+public void setStart(long value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getStart()](../../com.aspose.diagram/diagram\#getStart--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | long |  |
+
+### setUserCustomUI(String value) {#setUserCustomUI-java.lang.String-}
+```
+public void setUserCustomUI(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getUserCustomUI()](../../com.aspose.diagram/diagram\#getUserCustomUI--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setVbProjectData(byte[] value) {#setVbProjectData-byte---}
+```
+public void setVbProjectData(byte[] value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getVbProjectData()](../../com.aspose.diagram/diagram\#getVbProjectData--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | byte[] |  |
+
+### setVersion(String value) {#setVersion-java.lang.String-}
+```
+public void setVersion(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getVersion()](../../com.aspose.diagram/diagram\#getVersion--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/diagramexception/_index.md
+++ b/italian/java/com.aspose.diagram/diagramexception/_index.md
@@ -1,0 +1,290 @@
+---
+title: DiagramException
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Classe base per tutte le eccezioni di Aspose.Diagram
+type: docs
+weight: 118
+url: /it/java/com.aspose.diagram/diagramexception/
+---
+
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception
+```
+public class DiagramException extends Exception
+```
+
+Classe base per tutte le eccezioni di Aspose.Diagram
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [DiagramException(String msg)](#DiagramException-java.lang.String-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DiagramException(String msg) {#DiagramException-java.lang.String-}
+```
+public DiagramException(String msg)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| msg | java.lang.String |  |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/diagramsaveoptions/_index.md
+++ b/italian/java/com.aspose.diagram/diagramsaveoptions/_index.md
@@ -1,0 +1,268 @@
+---
+title: DiagramSaveOptions
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Può essere usato per specificare opzioni aggiuntive durante il salvataggio di un diagramma nel formato Visio VDXVSX.
+type: docs
+weight: 119
+url: /it/java/com.aspose.diagram/diagramsaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.SaveOptions](../../com.aspose.diagram/saveoptions)
+```
+public class DiagramSaveOptions extends SaveOptions
+```
+
+Può essere usato per specificare opzioni aggiuntive durante il salvataggio di un diagramma nel formato Visio (VDX\\VSX). Al momento fornisce solo la proprietà SaveFormat, ma in futuro verranno aggiunte altre opzioni.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [DiagramSaveOptions()](#DiagramSaveOptions--) | Inizializza una nuova istanza di questa classe che può essere usata per salvare un diagramma nel formato VDX. |
+| [DiagramSaveOptions(int saveFormat)](#DiagramSaveOptions-int-) | Inizializza una nuova istanza di questa classe che può essere utilizzata per salvare un diagramma nel formato VDX o VSX. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | Crea un oggetto di opzioni di salvataggio di una classe adatta al formato di salvataggio specificato. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAutoFitPageToDrawingContent()](#getAutoFitPageToDrawingContent--) | Definisce se è necessario ingrandire la pagina per adattare il contenuto del disegno o meno. |
+| [getClass()](#getClass--) |  |
+| [getDefaultFont()](#getDefaultFont--) | Quando i caratteri nel diagramma sono Unicode e non vengono impostati con il valore di carattere corretto o il carattere non è installato localmente, possono apparire come blocchi in PDF, immagine o XPS. |
+| [getSaveFormat()](#getSaveFormat--) | Specifica il formato in cui il diagramma renderizzato verrà salvato se viene utilizzato questo oggetto di opzioni di salvataggio. |
+| [getWarningCallback()](#getWarningCallback--) | callback di avviso. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAutoFitPageToDrawingContent(boolean value)](#setAutoFitPageToDrawingContent-boolean-) | Per la descrizione di questa proprietà, consultare [getAutoFitPageToDrawingContent()](../../com.aspose.diagram/diagramsaveoptions\#getAutoFitPageToDrawingContent--) |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--) |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | Per la descrizione di questa proprietà, consultare [getSaveFormat()](../../com.aspose.diagram/diagramsaveoptions\#getSaveFormat--) |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DiagramSaveOptions() {#DiagramSaveOptions--}
+```
+public DiagramSaveOptions()
+```
+
+
+Inizializza una nuova istanza di questa classe che può essere usata per salvare un diagramma nel formato VDX.
+
+### DiagramSaveOptions(int saveFormat) {#DiagramSaveOptions-int-}
+```
+public DiagramSaveOptions(int saveFormat)
+```
+
+
+Inizializza una nuova istanza di questa classe che può essere utilizzata per salvare un diagramma nel formato VDX o VSX.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| saveFormat | int |  |
+
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+Crea un oggetto di opzioni di salvataggio di una classe adatta al formato di salvataggio specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| saveFormat | int | Il Aspose.Diagram.SaveFileFormat per il quale creare un oggetto di opzioni di salvataggio. |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAutoFitPageToDrawingContent() {#getAutoFitPageToDrawingContent--}
+```
+public boolean getAutoFitPageToDrawingContent()
+```
+
+
+Definisce se è necessario ingrandire la pagina per adattare il contenuto del disegno o meno. Il valore predefinito è false.
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+Quando i caratteri nel diagramma sono Unicode e non sono impostati con il valore di font corretto o il font non è installato localmente, possono apparire come blocchi in PDF, immagine o XPS. Impostare il DefaultFont, ad esempio MingLiu o MS Gothic, per visualizzare questi caratteri.
+
+**Returns:**
+java.lang.String
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+Specifica il formato in cui il diagramma renderizzato verrà salvato se viene utilizzato questo oggetto di opzioni di salvataggio. Può essere Aspose.Diagram.SaveFileFormat o Aspose.Diagram.SaveFileFormat.
+
+**Returns:**
+int
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+callback di avviso.
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAutoFitPageToDrawingContent(boolean value) {#setAutoFitPageToDrawingContent-boolean-}
+```
+public void setAutoFitPageToDrawingContent(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getAutoFitPageToDrawingContent()](../../com.aspose.diagram/diagramsaveoptions\#getAutoFitPageToDrawingContent--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getSaveFormat()](../../com.aspose.diagram/diagramsaveoptions\#getSaveFormat--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/displaymode/_index.md
+++ b/italian/java/com.aspose.diagram/displaymode/_index.md
@@ -1,0 +1,179 @@
+---
+title: DisplayMode
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Quando è contenuto in un elemento Group, l'elemento DisplayMode specifica come viene visualizzata una forma di gruppo e i suoi membri.
+type: docs
+weight: 120
+url: /it/java/com.aspose.diagram/displaymode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DisplayMode
+```
+
+Quando è contenuto in un elemento Group, l'elemento DisplayMode specifica come viene visualizzata una forma di gruppo e i suoi membri. Quando è contenuto in un elemento SmartTagDef, l'elemento DisplayMode determina se il tag intelligente appare quando l'utente ferma il mouse sul tag, quando la forma è selezionata, o in ogni momento.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [DisplayMode(int value)](#DisplayMode-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Quando è contenuto in un elemento Group, l'elemento DisplayMode specifica come viene visualizzata una forma di gruppo e i suoi membri. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/displaymode\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DisplayMode(int value) {#DisplayMode-int-}
+```
+public DisplayMode(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Quando è contenuto in un elemento Group, l'elemento DisplayMode specifica come viene visualizzata una forma di gruppo e i suoi membri. Quando è contenuto in un elemento SmartTagDef, l'elemento DisplayMode determina se il tag intelligente appare quando l'utente ferma il mouse sul tag, quando la forma è selezionata, o in ogni momento.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/displaymode\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/displaymodesmarttagdef/_index.md
+++ b/italian/java/com.aspose.diagram/displaymodesmarttagdef/_index.md
@@ -1,0 +1,179 @@
+---
+title: DisplayModeSmartTagDef
+second_title: Riferimento API di Aspose.Diagram per Java
+description: L'elemento DisplayMode determina se il tag intelligente appare quando l'utente ferma il mouse sul tag mentre la forma è selezionata o in ogni momento.
+type: docs
+weight: 121
+url: /it/java/com.aspose.diagram/displaymodesmarttagdef/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DisplayModeSmartTagDef
+```
+
+L'elemento DisplayMode determina se il tag intelligente appare quando l'utente ferma il mouse sul tag, quando la forma è selezionata, o in ogni momento.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [DisplayModeSmartTagDef(int value)](#DisplayModeSmartTagDef-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | L'elemento DisplayMode determina se il tag intelligente appare quando l'utente ferma il mouse sul tag, quando la forma è selezionata, o in ogni momento. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/displaymodesmarttagdef\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DisplayModeSmartTagDef(int value) {#DisplayModeSmartTagDef-int-}
+```
+public DisplayModeSmartTagDef(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+L'elemento DisplayMode determina se il tag intelligente appare quando l'utente ferma il mouse sul tag, quando la forma è selezionata, o in ogni momento.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/displaymodesmarttagdef\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/displaymodesmarttagdefvalue/_index.md
+++ b/italian/java/com.aspose.diagram/displaymodesmarttagdefvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: DisplayModeSmartTagDefValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: L'elemento DisplayMode determina se il tag intelligente appare quando l'utente ferma il mouse sul tag mentre la forma è selezionata o in ogni momento.
+type: docs
+weight: 122
+url: /it/java/com.aspose.diagram/displaymodesmarttagdefvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class DisplayModeSmartTagDefValue
+```
+
+L'elemento DisplayMode determina se il tag intelligente appare quando l'utente ferma il mouse sul tag, quando la forma è selezionata, o in ogni momento.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [ALL_TIME](#ALL-TIME) | Visualizza la forma di gruppo davanti alle forme dei membri. |
+| [MOUSE_IS_PAUSED](#MOUSE-IS-PAUSED) | Nasconde la forma di gruppo e il testo. |
+| [SHAPE_IS_SELECTED](#SHAPE-IS-SELECTED) | Visualizza la forma di gruppo dietro le forme dei membri. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALL_TIME {#ALL-TIME}
+```
+public static final int ALL_TIME
+```
+
+
+Visualizza la forma di gruppo davanti alle forme dei membri.
+
+### MOUSE_IS_PAUSED {#MOUSE-IS-PAUSED}
+```
+public static final int MOUSE_IS_PAUSED
+```
+
+
+Nasconde la forma di gruppo e il testo.
+
+### SHAPE_IS_SELECTED {#SHAPE-IS-SELECTED}
+```
+public static final int SHAPE_IS_SELECTED
+```
+
+
+Visualizza la forma di gruppo dietro le forme dei membri.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/displaymodevalue/_index.md
+++ b/italian/java/com.aspose.diagram/displaymodevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: DisplayModeValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Quando è contenuto in un elemento Group, l'elemento DisplayMode specifica come viene visualizzata una forma di gruppo e i suoi membri.
+type: docs
+weight: 123
+url: /it/java/com.aspose.diagram/displaymodevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class DisplayModeValue
+```
+
+Quando è contenuto in un elemento Group, l'elemento DisplayMode specifica come viene visualizzata una forma di gruppo e i suoi membri. Quando è contenuto in un elemento SmartTagDef, l'elemento DisplayMode determina se il tag intelligente appare quando l'utente ferma il mouse sul tag, quando la forma è selezionata, o in ogni momento.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [DISPLAYS_SHAPE_BEHIND_MEMBER_SHAPES](#DISPLAYS-SHAPE-BEHIND-MEMBER-SHAPES) | Visualizza la forma di gruppo dietro le forme dei membri. |
+| [DISPLAYS_SHAPE_FRONT_MEMBER_SHAPES](#DISPLAYS-SHAPE-FRONT-MEMBER-SHAPES) | Visualizza la forma di gruppo davanti alle forme dei membri. |
+| [HIDES_SHAPE_TEXT](#HIDES-SHAPE-TEXT) | Nasconde la forma di gruppo e il testo. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DISPLAYS_SHAPE_BEHIND_MEMBER_SHAPES {#DISPLAYS-SHAPE-BEHIND-MEMBER-SHAPES}
+```
+public static final int DISPLAYS_SHAPE_BEHIND_MEMBER_SHAPES
+```
+
+
+Visualizza la forma di gruppo dietro le forme dei membri.
+
+### DISPLAYS_SHAPE_FRONT_MEMBER_SHAPES {#DISPLAYS-SHAPE-FRONT-MEMBER-SHAPES}
+```
+public static final int DISPLAYS_SHAPE_FRONT_MEMBER_SHAPES
+```
+
+
+Visualizza la forma di gruppo davanti alle forme dei membri.
+
+### HIDES_SHAPE_TEXT {#HIDES-SHAPE-TEXT}
+```
+public static final int HIDES_SHAPE_TEXT
+```
+
+
+Nasconde la forma di gruppo e il testo.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/docprops/_index.md
+++ b/italian/java/com.aspose.diagram/docprops/_index.md
@@ -1,0 +1,227 @@
+---
+title: DocProps
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene elementi che controllano l'ambito della qualità dell'anteprima dei documenti e il formato di output.
+type: docs
+weight: 124
+url: /it/java/com.aspose.diagram/docprops/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DocProps
+```
+
+Contiene elementi che controllano la qualità dell'anteprima del documento, l'ambito e il formato di output.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAddMarkup()](#getAddMarkup--) | Indica se il documento è in revisione per markup. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getDocLangID()](#getDocLangID--) | Indica la lingua predefinita per il documento. |
+| [getLockPreview()](#getLockPreview--) | Specifica se un'anteprima viene salvata ogni volta che si salva un disegno. |
+| [getOutputFormat()](#getOutputFormat--) | Specifica il formato di output per un disegno. |
+| [getPreviewQuality()](#getPreviewQuality--) | Specifica se l'anteprima del disegno è di qualità bozza o dettagliata. |
+| [getPreviewScope()](#getPreviewScope--) | Specifica se il documento include un'anteprima e, in tal caso, se l'anteprima mostra solo la prima pagina o tutte le pagine del documento. |
+| [getViewMarkup()](#getViewMarkup--) | Determina se il markup appare nella finestra del disegno. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/docprops\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAddMarkup() {#getAddMarkup--}
+```
+public BoolValue getAddMarkup()
+```
+
+
+Indica se il documento è in revisione per markup.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getDocLangID() {#getDocLangID--}
+```
+public IntValue getDocLangID()
+```
+
+
+Indica la lingua predefinita per il documento.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getLockPreview() {#getLockPreview--}
+```
+public BoolValue getLockPreview()
+```
+
+
+Specifica se un'anteprima viene salvata ogni volta che si salva un disegno.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getOutputFormat() {#getOutputFormat--}
+```
+public OutputFormat getOutputFormat()
+```
+
+
+Specifica il formato di output per un disegno.
+
+**Returns:**
+[OutputFormat](../../com.aspose.diagram/outputformat)
+### getPreviewQuality() {#getPreviewQuality--}
+```
+public BoolValue getPreviewQuality()
+```
+
+
+Specifica se l'anteprima del disegno è di qualità bozza o dettagliata.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getPreviewScope() {#getPreviewScope--}
+```
+public PreviewScope getPreviewScope()
+```
+
+
+Specifica se il documento include un'anteprima e, in tal caso, se l'anteprima mostra solo la prima pagina o tutte le pagine del documento.
+
+**Returns:**
+[PreviewScope](../../com.aspose.diagram/previewscope)
+### getViewMarkup() {#getViewMarkup--}
+```
+public BoolValue getViewMarkup()
+```
+
+
+Determina se il markup appare nella finestra del disegno.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/docprops\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/documentproperties/_index.md
+++ b/italian/java/com.aspose.diagram/documentproperties/_index.md
@@ -1,0 +1,616 @@
+---
+title: DocumentProperties
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene elementi di proprietà del documento come il titolo del documento, l'autore e così via.
+type: docs
+weight: 125
+url: /it/java/com.aspose.diagram/documentproperties/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DocumentProperties
+```
+
+Contiene elementi di proprietà del documento come il titolo del documento, l'autore e così via.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAlternateNames()](#getAlternateNames--) | Specifica i nomi alternativi per un documento. |
+| [getBuildNumberCreated()](#getBuildNumberCreated--) | Contiene il numero di build completo dell'istanza usata per creare il documento. |
+| [getBuildNumberEdited()](#getBuildNumberEdited--) | Contiene il numero di build dell'istanza usata per l'ultima modifica del documento. |
+| [getCategory()](#getCategory--) | Specifica il testo descrittivo per il tipo di disegno, come diagramma di flusso o layout d'ufficio. |
+| [getClass()](#getClass--) |  |
+| [getCompany()](#getCompany--) | Contiene informazioni inserite dall'utente che identificano l'azienda che crea il disegno o l'azienda per cui il disegno è stato creato. |
+| [getCreator()](#getCreator--) | Identifica chi ha creato o aggiornato per ultimo il file. |
+| [getCustomProps()](#getCustomProps--) | Raccolta di CustomProp. |
+| [getDesc()](#getDesc--) | Contiene una stringa di testo descrittiva per un documento. |
+| [getHyperlinkBase()](#getHyperlinkBase--) | Contiene il percorso da utilizzare per collegamenti ipertestuali relativi (collegamenti ipertestuali per i quali la posizione del file collegato è descritta in relazione al diagramma Microsoft Visio). |
+| [getKeywords()](#getKeywords--) | Contiene una stringa di testo che identifica argomenti o altre informazioni importanti sul file, come il nome del progetto, il nome del cliente o il numero di versione. |
+| [getLanguage()](#getLanguage--) | Specifica la lingua |
+| [getManager()](#getManager--) | Contiene una stringa di testo inserita dall'utente che identifica la persona responsabile del progetto o del dipartimento. |
+| [getPreviewPicture()](#getPreviewPicture--) | Contiene un flusso metafile che funge da anteprima del documento. |
+| [getSubject()](#getSubject--) | Contiene una stringa di testo definita dall'utente che descrive il contenuto del documento. |
+| [getTemplate()](#getTemplate--) | Contiene un valore stringa che specifica il nome file del modello da cui è stato creato il documento. |
+| [getTimeCreated()](#getTimeCreated--) | Contiene il valore di data e ora che indica quando il documento è stato creato. |
+| [getTimeEdited()](#getTimeEdited--) | Contiene il valore di data e ora che indica quando il documento è stato modificato l'ultima volta. |
+| [getTimePrinted()](#getTimePrinted--) | Contiene il valore di data e ora che indica quando il documento è stato stampato l'ultima volta. |
+| [getTimeSaved()](#getTimeSaved--) | Contiene il valore di data e ora che indica quando il documento è stato salvato l'ultima volta. |
+| [getTitle()](#getTitle--) | Contiene una stringa di testo definita dall'utente che funge da titolo descrittivo per il documento. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAlternateNames(String value)](#setAlternateNames-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getAlternateNames()](../../com.aspose.diagram/documentproperties\#getAlternateNames--) |
+| [setBuildNumberCreated(String value)](#setBuildNumberCreated-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getBuildNumberCreated()](../../com.aspose.diagram/documentproperties\#getBuildNumberCreated--) |
+| [setBuildNumberEdited(String value)](#setBuildNumberEdited-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getBuildNumberEdited()](../../com.aspose.diagram/documentproperties\#getBuildNumberEdited--) |
+| [setCategory(String value)](#setCategory-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getCategory()](../../com.aspose.diagram/documentproperties\#getCategory--) |
+| [setCompany(String value)](#setCompany-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getCompany()](../../com.aspose.diagram/documentproperties\#getCompany--) |
+| [setCreator(String value)](#setCreator-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getCreator()](../../com.aspose.diagram/documentproperties\#getCreator--) |
+| [setDesc(String value)](#setDesc-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getDesc()](../../com.aspose.diagram/documentproperties\#getDesc--) |
+| [setHyperlinkBase(String value)](#setHyperlinkBase-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getHyperlinkBase()](../../com.aspose.diagram/documentproperties\#getHyperlinkBase--) |
+| [setKeywords(String value)](#setKeywords-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getKeywords()](../../com.aspose.diagram/documentproperties\#getKeywords--) |
+| [setLanguage(String value)](#setLanguage-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getLanguage()](../../com.aspose.diagram/documentproperties\#getLanguage--) |
+| [setManager(String value)](#setManager-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getManager()](../../com.aspose.diagram/documentproperties\#getManager--) |
+| [setPreviewPicture(byte[] value)](#setPreviewPicture-byte---) | Per la descrizione di questa proprietà, vedere [getPreviewPicture()](../../com.aspose.diagram/documentproperties\#getPreviewPicture--) |
+| [setSubject(String value)](#setSubject-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getSubject()](../../com.aspose.diagram/documentproperties\#getSubject--) |
+| [setTemplate(String value)](#setTemplate-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getTemplate()](../../com.aspose.diagram/documentproperties\#getTemplate--) |
+| [setTimeCreated(DateTime value)](#setTimeCreated-com.aspose.diagram.DateTime-) | Per la descrizione di questa proprietà, vedere [getTimeCreated()](../../com.aspose.diagram/documentproperties\#getTimeCreated--) |
+| [setTimeEdited(DateTime value)](#setTimeEdited-com.aspose.diagram.DateTime-) | Per la descrizione di questa proprietà, consultare [getTimeEdited()](../../com.aspose.diagram/documentproperties\#getTimeEdited--) |
+| [setTimePrinted(DateTime value)](#setTimePrinted-com.aspose.diagram.DateTime-) | Per la descrizione di questa proprietà, consultare [getTimePrinted()](../../com.aspose.diagram/documentproperties\#getTimePrinted--) |
+| [setTimeSaved(DateTime value)](#setTimeSaved-com.aspose.diagram.DateTime-) | Per la descrizione di questa proprietà, consultare [getTimeSaved()](../../com.aspose.diagram/documentproperties\#getTimeSaved--) |
+| [setTitle(String value)](#setTitle-java.lang.String-) | Per la descrizione di questa proprietà, consultare [getTitle()](../../com.aspose.diagram/documentproperties\#getTitle--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAlternateNames() {#getAlternateNames--}
+```
+public String getAlternateNames()
+```
+
+
+Specifica i nomi alternativi per un documento.
+
+**Returns:**
+java.lang.String
+### getBuildNumberCreated() {#getBuildNumberCreated--}
+```
+public String getBuildNumberCreated()
+```
+
+
+Contiene il numero di build completo dell'istanza usata per creare il documento.
+
+**Returns:**
+java.lang.String
+### getBuildNumberEdited() {#getBuildNumberEdited--}
+```
+public String getBuildNumberEdited()
+```
+
+
+Contiene il numero di build dell'istanza usata per l'ultima modifica del documento.
+
+**Returns:**
+java.lang.String
+### getCategory() {#getCategory--}
+```
+public String getCategory()
+```
+
+
+Specifica il testo descrittivo per il tipo di disegno, come diagramma di flusso o layout per ufficio. Questo testo può anche essere inserito nell'interfaccia utente di Microsoft Visio nella casella Categoria nella finestra di dialogo Proprietà.
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCompany() {#getCompany--}
+```
+public String getCompany()
+```
+
+
+Contiene informazioni inserite dall'utente che identificano l'azienda che crea il disegno o l'azienda per cui il disegno è stato creato. La lunghezza massima è di 63 caratteri.
+
+**Returns:**
+java.lang.String
+### getCreator() {#getCreator--}
+```
+public String getCreator()
+```
+
+
+Identifica chi ha creato o aggiornato per ultimo il file. La lunghezza massima è di 63 caratteri.
+
+**Returns:**
+java.lang.String
+### getCustomProps() {#getCustomProps--}
+```
+public CustomPropCollection getCustomProps()
+```
+
+
+Raccolta di CustomProp.
+
+**Returns:**
+[CustomPropCollection](../../com.aspose.diagram/custompropcollection)
+### getDesc() {#getDesc--}
+```
+public String getDesc()
+```
+
+
+Contiene una stringa di testo descrittiva per un documento. Utilizzare questo elemento per memorizzare informazioni importanti sul documento, come lo scopo, le modifiche recenti o le modifiche in sospeso. Il massimo è di 191 caratteri.
+
+**Returns:**
+java.lang.String
+### getHyperlinkBase() {#getHyperlinkBase--}
+```
+public String getHyperlinkBase()
+```
+
+
+Contiene il percorso da utilizzare per collegamenti ipertestuali relativi (collegamenti ipertestuali per i quali la posizione del file collegato è descritta in relazione al diagramma Microsoft Visio). Per impostazione predefinita, un percorso di collegamento ipertestuale è relativo al documento corrente, a meno che non venga specificato un percorso diverso in questo elemento. La lunghezza massima è di 256 caratteri.
+
+**Returns:**
+java.lang.String
+### getKeywords() {#getKeywords--}
+```
+public String getKeywords()
+```
+
+
+Contiene una stringa di testo che identifica argomenti o altre informazioni importanti sul file, come il nome del progetto, il nome del cliente o il numero di versione. La lunghezza massima della stringa è di 63 caratteri.
+
+**Returns:**
+java.lang.String
+### getLanguage() {#getLanguage--}
+```
+public String getLanguage()
+```
+
+
+Specifica la lingua
+
+```
+setLanguage("en-GB");
+         setLanguage("en-US");
+```
+
+**Returns:**
+java.lang.String
+### getManager() {#getManager--}
+```
+public String getManager()
+```
+
+
+Contiene una stringa di testo inserita dall'utente che identifica la persona responsabile del progetto o del dipartimento. La lunghezza massima è di 63 caratteri.
+
+**Returns:**
+java.lang.String
+### getPreviewPicture() {#getPreviewPicture--}
+```
+public byte[] getPreviewPicture()
+```
+
+
+Contiene un flusso metafile che funge da anteprima del documento.
+
+**Returns:**
+byte[]
+### getSubject() {#getSubject--}
+```
+public String getSubject()
+```
+
+
+Contiene una stringa di testo definita dall'utente che descrive il contenuto del documento. La lunghezza massima è di 63 caratteri.
+
+**Returns:**
+java.lang.String
+### getTemplate() {#getTemplate--}
+```
+public String getTemplate()
+```
+
+
+Contiene un valore stringa che specifica il nome file del modello da cui è stato creato il documento.
+
+**Returns:**
+java.lang.String
+### getTimeCreated() {#getTimeCreated--}
+```
+public DateTime getTimeCreated()
+```
+
+
+Contiene il valore di data e ora che indica quando il documento è stato creato.
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### getTimeEdited() {#getTimeEdited--}
+```
+public DateTime getTimeEdited()
+```
+
+
+Contiene il valore di data e ora che indica quando il documento è stato modificato l'ultima volta.
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### getTimePrinted() {#getTimePrinted--}
+```
+public DateTime getTimePrinted()
+```
+
+
+Contiene il valore di data e ora che indica quando il documento è stato stampato l'ultima volta.
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### getTimeSaved() {#getTimeSaved--}
+```
+public DateTime getTimeSaved()
+```
+
+
+Contiene il valore di data e ora che indica quando il documento è stato salvato l'ultima volta.
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### getTitle() {#getTitle--}
+```
+public String getTitle()
+```
+
+
+Contiene una stringa di testo definita dall'utente che funge da titolo descrittivo per il documento. La lunghezza massima è di 63 caratteri.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAlternateNames(String value) {#setAlternateNames-java.lang.String-}
+```
+public void setAlternateNames(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getAlternateNames()](../../com.aspose.diagram/documentproperties\#getAlternateNames--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setBuildNumberCreated(String value) {#setBuildNumberCreated-java.lang.String-}
+```
+public void setBuildNumberCreated(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getBuildNumberCreated()](../../com.aspose.diagram/documentproperties\#getBuildNumberCreated--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setBuildNumberEdited(String value) {#setBuildNumberEdited-java.lang.String-}
+```
+public void setBuildNumberEdited(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getBuildNumberEdited()](../../com.aspose.diagram/documentproperties\#getBuildNumberEdited--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setCategory(String value) {#setCategory-java.lang.String-}
+```
+public void setCategory(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getCategory()](../../com.aspose.diagram/documentproperties\#getCategory--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setCompany(String value) {#setCompany-java.lang.String-}
+```
+public void setCompany(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getCompany()](../../com.aspose.diagram/documentproperties\#getCompany--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setCreator(String value) {#setCreator-java.lang.String-}
+```
+public void setCreator(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getCreator()](../../com.aspose.diagram/documentproperties\#getCreator--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setDesc(String value) {#setDesc-java.lang.String-}
+```
+public void setDesc(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDesc()](../../com.aspose.diagram/documentproperties\#getDesc--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setHyperlinkBase(String value) {#setHyperlinkBase-java.lang.String-}
+```
+public void setHyperlinkBase(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getHyperlinkBase()](../../com.aspose.diagram/documentproperties\#getHyperlinkBase--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setKeywords(String value) {#setKeywords-java.lang.String-}
+```
+public void setKeywords(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getKeywords()](../../com.aspose.diagram/documentproperties\#getKeywords--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setLanguage(String value) {#setLanguage-java.lang.String-}
+```
+public void setLanguage(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getLanguage()](../../com.aspose.diagram/documentproperties\#getLanguage--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setManager(String value) {#setManager-java.lang.String-}
+```
+public void setManager(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getManager()](../../com.aspose.diagram/documentproperties\#getManager--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setPreviewPicture(byte[] value) {#setPreviewPicture-byte---}
+```
+public void setPreviewPicture(byte[] value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getPreviewPicture()](../../com.aspose.diagram/documentproperties\#getPreviewPicture--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | byte[] |  |
+
+### setSubject(String value) {#setSubject-java.lang.String-}
+```
+public void setSubject(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getSubject()](../../com.aspose.diagram/documentproperties\#getSubject--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setTemplate(String value) {#setTemplate-java.lang.String-}
+```
+public void setTemplate(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getTemplate()](../../com.aspose.diagram/documentproperties\#getTemplate--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setTimeCreated(DateTime value) {#setTimeCreated-com.aspose.diagram.DateTime-}
+```
+public void setTimeCreated(DateTime value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getTimeCreated()](../../com.aspose.diagram/documentproperties\#getTimeCreated--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setTimeEdited(DateTime value) {#setTimeEdited-com.aspose.diagram.DateTime-}
+```
+public void setTimeEdited(DateTime value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getTimeEdited()](../../com.aspose.diagram/documentproperties\#getTimeEdited--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setTimePrinted(DateTime value) {#setTimePrinted-com.aspose.diagram.DateTime-}
+```
+public void setTimePrinted(DateTime value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getTimePrinted()](../../com.aspose.diagram/documentproperties\#getTimePrinted--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setTimeSaved(DateTime value) {#setTimeSaved-com.aspose.diagram.DateTime-}
+```
+public void setTimeSaved(DateTime value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getTimeSaved()](../../com.aspose.diagram/documentproperties\#getTimeSaved--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setTitle(String value) {#setTitle-java.lang.String-}
+```
+public void setTitle(String value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getTitle()](../../com.aspose.diagram/documentproperties\#getTitle--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/documentsettings/_index.md
+++ b/italian/java/com.aspose.diagram/documentsettings/_index.md
@@ -1,0 +1,550 @@
+---
+title: DocumentSettings
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene elementi che specificano le impostazioni del documento.
+type: docs
+weight: 126
+url: /it/java/com.aspose.diagram/documentsettings/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DocumentSettings
+```
+
+Contiene elementi che specificano le impostazioni del documento.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAttachedToolbars()](#getAttachedToolbars--) | Un file di interfaccia utente Microsoft Visio (VSU) codificato MIME (Multipurpose Internet Mail Extensions) che rappresenta barre degli strumenti personalizzate. |
+| [getClass()](#getClass--) |  |
+| [getCustomMenusFile()](#getCustomMenusFile--) | Contiene il nome del file di interfaccia utente Microsoft Visio (.vsu) che definisce menu personalizzati e acceleratori per un documento. |
+| [getCustomToolbarsFile()](#getCustomToolbarsFile--) | Contiene il nome del file di interfaccia utente Microsoft Visio (.vsu) che definisce barre degli strumenti e barre di stato personalizzate per un documento. |
+| [getDefaultFillStyle()](#getDefaultFillStyle--) | Specifica l'ID di un elemento StyleSheet. |
+| [getDefaultGuideStyle()](#getDefaultGuideStyle--) | Specifica l'ID di un elemento StyleSheet. |
+| [getDefaultLineStyle()](#getDefaultLineStyle--) | Specifica l'ID di un elemento StyleSheet. |
+| [getDefaultTextStyle()](#getDefaultTextStyle--) | Specifica l'ID di un elemento StyleSheet. |
+| [getDynamicGridEnabled()](#getDynamicGridEnabled--) | Specifica se la funzionalità griglia dinamica è abilitata per un documento o una finestra. |
+| [getGlueSettings()](#getGlueSettings--) | Specifica gli oggetti a cui le forme si incollano quando la colla è abilitata nel documento. |
+| [getProtectBkgnds()](#getProtectBkgnds--) | Specifica se all'utente è impedito di eliminare o modificare le pagine di sfondo. |
+| [getProtectMasters()](#getProtectMasters--) | Specifica se all'utente è impedito di creare, modificare o eliminare i master. |
+| [getProtectShapes()](#getProtectShapes--) | Specifica se l'utente è impedito di selezionare forme che hanno l'elemento LockSelect impostato a 1. |
+| [getProtectStyles()](#getProtectStyles--) | Specifica se l'utente è impedito di creare o modificare stili. |
+| [getSnapAngles()](#getSnapAngles--) | Contiene una raccolta di elementi SnapAngle. |
+| [getSnapExtensions()](#getSnapExtensions--) | Specifica se un'impostazione specifica di estensione snap è abilitata o disabilitata per la finestra attiva. |
+| [getSnapSettings()](#getSnapSettings--) | Specifica gli oggetti a cui le forme si agganciano quando lo snap è attivo nella finestra. |
+| [getTopPage()](#getTopPage--) | Specifica l'ID della pagina che dovrebbe essere visualizzata quando il documento è aperto da Microsoft Visio. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAttachedToolbars(byte[] value)](#setAttachedToolbars-byte---) | Per la descrizione di questa proprietà, vedere [getAttachedToolbars()](../../com.aspose.diagram/documentsettings\#getAttachedToolbars--) |
+| [setCustomMenusFile(String value)](#setCustomMenusFile-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getCustomMenusFile()](../../com.aspose.diagram/documentsettings\#getCustomMenusFile--) |
+| [setCustomToolbarsFile(String value)](#setCustomToolbarsFile-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getCustomToolbarsFile()](../../com.aspose.diagram/documentsettings\#getCustomToolbarsFile--) |
+| [setDefaultFillStyle(int value)](#setDefaultFillStyle-int-) | Per la descrizione di questa proprietà, vedere [getDefaultFillStyle()](../../com.aspose.diagram/documentsettings\#getDefaultFillStyle--) |
+| [setDefaultGuideStyle(int value)](#setDefaultGuideStyle-int-) | Per la descrizione di questa proprietà, vedere [getDefaultGuideStyle()](../../com.aspose.diagram/documentsettings\#getDefaultGuideStyle--) |
+| [setDefaultLineStyle(int value)](#setDefaultLineStyle-int-) | Per la descrizione di questa proprietà, vedere [getDefaultLineStyle()](../../com.aspose.diagram/documentsettings\#getDefaultLineStyle--) |
+| [setDefaultTextStyle(int value)](#setDefaultTextStyle-int-) | Per la descrizione di questa proprietà, vedere [getDefaultTextStyle()](../../com.aspose.diagram/documentsettings\#getDefaultTextStyle--) |
+| [setDynamicGridEnabled(int value)](#setDynamicGridEnabled-int-) | Per la descrizione di questa proprietà, vedere [getDynamicGridEnabled()](../../com.aspose.diagram/documentsettings\#getDynamicGridEnabled--) |
+| [setGlueSettings(int value)](#setGlueSettings-int-) | Per la descrizione di questa proprietà, vedere [getGlueSettings()](../../com.aspose.diagram/documentsettings\#getGlueSettings--) |
+| [setProtectBkgnds(int value)](#setProtectBkgnds-int-) | Per la descrizione di questa proprietà, vedere [getProtectBkgnds()](../../com.aspose.diagram/documentsettings\#getProtectBkgnds--) |
+| [setProtectMasters(int value)](#setProtectMasters-int-) | Per la descrizione di questa proprietà, vedere [getProtectMasters()](../../com.aspose.diagram/documentsettings\#getProtectMasters--) |
+| [setProtectShapes(int value)](#setProtectShapes-int-) | Per la descrizione di questa proprietà, vedere [getProtectShapes()](../../com.aspose.diagram/documentsettings\#getProtectShapes--) |
+| [setProtectStyles(int value)](#setProtectStyles-int-) | Per la descrizione di questa proprietà, vedere [getProtectStyles()](../../com.aspose.diagram/documentsettings\#getProtectStyles--) |
+| [setSnapAngles(FloatPointNumCollection value)](#setSnapAngles-com.aspose.diagram.FloatPointNumCollection-) | Per la descrizione di questa proprietà, vedere [getSnapAngles()](../../com.aspose.diagram/documentsettings\#getSnapAngles--) |
+| [setSnapExtensions(int value)](#setSnapExtensions-int-) | Per la descrizione di questa proprietà, vedere [getSnapExtensions()](../../com.aspose.diagram/documentsettings\#getSnapExtensions--) |
+| [setSnapSettings(int value)](#setSnapSettings-int-) | Per la descrizione di questa proprietà, vedere [getSnapSettings()](../../com.aspose.diagram/documentsettings\#getSnapSettings--) |
+| [setTopPage(int value)](#setTopPage-int-) | Per la descrizione di questa proprietà, vedere [getTopPage()](../../com.aspose.diagram/documentsettings\#getTopPage--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAttachedToolbars() {#getAttachedToolbars--}
+```
+public byte[] getAttachedToolbars()
+```
+
+
+Un file di interfaccia utente Microsoft Visio (VSU) codificato MIME (Multipurpose Internet Mail Extensions) che rappresenta barre degli strumenti personalizzate.
+
+**Returns:**
+byte[]
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCustomMenusFile() {#getCustomMenusFile--}
+```
+public String getCustomMenusFile()
+```
+
+
+Contiene il nome del file di interfaccia utente Microsoft Visio (.vsu) che definisce menu personalizzati e acceleratori per un documento.
+
+**Returns:**
+java.lang.String
+### getCustomToolbarsFile() {#getCustomToolbarsFile--}
+```
+public String getCustomToolbarsFile()
+```
+
+
+Contiene il nome del file di interfaccia utente Microsoft Visio (.vsu) che definisce barre degli strumenti e barre di stato personalizzate per un documento.
+
+**Returns:**
+java.lang.String
+### getDefaultFillStyle() {#getDefaultFillStyle--}
+```
+public int getDefaultFillStyle()
+```
+
+
+Specifica l'ID di un elemento StyleSheet. La prossima volta che l'utente crea una forma usando uno strumento di disegno, la forma eredita il suo stile di riempimento dall'elemento StyleSheet specificato.
+
+**Returns:**
+int
+### getDefaultGuideStyle() {#getDefaultGuideStyle--}
+```
+public int getDefaultGuideStyle()
+```
+
+
+Specifica l'ID di un elemento StyleSheet. La prossima volta che l'utente crea una guida, la guida eredita il suo stile guida dall'elemento StyleSheet specificato.
+
+**Returns:**
+int
+### getDefaultLineStyle() {#getDefaultLineStyle--}
+```
+public int getDefaultLineStyle()
+```
+
+
+Specifica l'ID di un elemento StyleSheet. La prossima volta che l'utente crea una forma usando uno strumento di disegno, la forma eredita il suo stile di linea dall'elemento StyleSheet specificato.
+
+**Returns:**
+int
+### getDefaultTextStyle() {#getDefaultTextStyle--}
+```
+public int getDefaultTextStyle()
+```
+
+
+Specifica l'ID di un elemento StyleSheet. La prossima volta che l'utente crea una forma usando uno strumento di disegno, la forma eredita il suo stile di testo dall'elemento StyleSheet specificato.
+
+**Returns:**
+int
+### getDynamicGridEnabled() {#getDynamicGridEnabled--}
+```
+public int getDynamicGridEnabled()
+```
+
+
+Specifica se la funzionalità griglia dinamica è abilitata per un documento o una finestra.
+
+**Returns:**
+int
+### getGlueSettings() {#getGlueSettings--}
+```
+public int getGlueSettings()
+```
+
+
+Specifica gli oggetti a cui le forme si incollano quando la colla è abilitata nel documento.
+
+**Returns:**
+int
+### getProtectBkgnds() {#getProtectBkgnds--}
+```
+public int getProtectBkgnds()
+```
+
+
+Specifica se all'utente è impedito di eliminare o modificare le pagine di sfondo.
+
+**Returns:**
+int
+### getProtectMasters() {#getProtectMasters--}
+```
+public int getProtectMasters()
+```
+
+
+Specifica se l'utente è impedito dal creare, modificare o eliminare i master. Indipendentemente da questa impostazione, l'utente può comunque creare istanze dei master.
+
+**Returns:**
+int
+### getProtectShapes() {#getProtectShapes--}
+```
+public int getProtectShapes()
+```
+
+
+Specifica se l'utente è impedito di selezionare forme che hanno l'elemento LockSelect impostato a 1.
+
+**Returns:**
+int
+### getProtectStyles() {#getProtectStyles--}
+```
+public int getProtectStyles()
+```
+
+
+Specifica se l'utente è impedito dal creare o modificare gli stili. Tuttavia, indipendentemente da questa impostazione, l'utente può comunque applicare gli stili.
+
+**Returns:**
+int
+### getSnapAngles() {#getSnapAngles--}
+```
+public FloatPointNumCollection getSnapAngles()
+```
+
+
+Contiene una raccolta di elementi SnapAngle.
+
+**Returns:**
+[FloatPointNumCollection](../../com.aspose.diagram/floatpointnumcollection)
+### getSnapExtensions() {#getSnapExtensions--}
+```
+public int getSnapExtensions()
+```
+
+
+Specifica se un'impostazione specifica di estensione snap è abilitata o disabilitata per la finestra attiva.
+
+**Returns:**
+int
+### getSnapSettings() {#getSnapSettings--}
+```
+public int getSnapSettings()
+```
+
+
+Specifica gli oggetti a cui le forme si agganciano quando lo snap è attivo nella finestra.
+
+**Returns:**
+int
+### getTopPage() {#getTopPage--}
+```
+public int getTopPage()
+```
+
+
+Specifica l'ID della pagina che dovrebbe essere visualizzata quando il documento è aperto da Microsoft Visio.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAttachedToolbars(byte[] value) {#setAttachedToolbars-byte---}
+```
+public void setAttachedToolbars(byte[] value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getAttachedToolbars()](../../com.aspose.diagram/documentsettings\#getAttachedToolbars--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | byte[] |  |
+
+### setCustomMenusFile(String value) {#setCustomMenusFile-java.lang.String-}
+```
+public void setCustomMenusFile(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getCustomMenusFile()](../../com.aspose.diagram/documentsettings\#getCustomMenusFile--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setCustomToolbarsFile(String value) {#setCustomToolbarsFile-java.lang.String-}
+```
+public void setCustomToolbarsFile(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getCustomToolbarsFile()](../../com.aspose.diagram/documentsettings\#getCustomToolbarsFile--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setDefaultFillStyle(int value) {#setDefaultFillStyle-int-}
+```
+public void setDefaultFillStyle(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDefaultFillStyle()](../../com.aspose.diagram/documentsettings\#getDefaultFillStyle--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setDefaultGuideStyle(int value) {#setDefaultGuideStyle-int-}
+```
+public void setDefaultGuideStyle(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDefaultGuideStyle()](../../com.aspose.diagram/documentsettings\#getDefaultGuideStyle--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setDefaultLineStyle(int value) {#setDefaultLineStyle-int-}
+```
+public void setDefaultLineStyle(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDefaultLineStyle()](../../com.aspose.diagram/documentsettings\#getDefaultLineStyle--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setDefaultTextStyle(int value) {#setDefaultTextStyle-int-}
+```
+public void setDefaultTextStyle(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDefaultTextStyle()](../../com.aspose.diagram/documentsettings\#getDefaultTextStyle--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setDynamicGridEnabled(int value) {#setDynamicGridEnabled-int-}
+```
+public void setDynamicGridEnabled(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDynamicGridEnabled()](../../com.aspose.diagram/documentsettings\#getDynamicGridEnabled--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setGlueSettings(int value) {#setGlueSettings-int-}
+```
+public void setGlueSettings(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getGlueSettings()](../../com.aspose.diagram/documentsettings\#getGlueSettings--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setProtectBkgnds(int value) {#setProtectBkgnds-int-}
+```
+public void setProtectBkgnds(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getProtectBkgnds()](../../com.aspose.diagram/documentsettings\#getProtectBkgnds--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setProtectMasters(int value) {#setProtectMasters-int-}
+```
+public void setProtectMasters(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getProtectMasters()](../../com.aspose.diagram/documentsettings\#getProtectMasters--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setProtectShapes(int value) {#setProtectShapes-int-}
+```
+public void setProtectShapes(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getProtectShapes()](../../com.aspose.diagram/documentsettings\#getProtectShapes--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setProtectStyles(int value) {#setProtectStyles-int-}
+```
+public void setProtectStyles(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getProtectStyles()](../../com.aspose.diagram/documentsettings\#getProtectStyles--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setSnapAngles(FloatPointNumCollection value) {#setSnapAngles-com.aspose.diagram.FloatPointNumCollection-}
+```
+public void setSnapAngles(FloatPointNumCollection value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getSnapAngles()](../../com.aspose.diagram/documentsettings\#getSnapAngles--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [FloatPointNumCollection](../../com.aspose.diagram/floatpointnumcollection) |  |
+
+### setSnapExtensions(int value) {#setSnapExtensions-int-}
+```
+public void setSnapExtensions(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getSnapExtensions()](../../com.aspose.diagram/documentsettings\#getSnapExtensions--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setSnapSettings(int value) {#setSnapSettings-int-}
+```
+public void setSnapSettings(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getSnapSettings()](../../com.aspose.diagram/documentsettings\#getSnapSettings--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setTopPage(int value) {#setTopPage-int-}
+```
+public void setTopPage(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getTopPage()](../../com.aspose.diagram/documentsettings\#getTopPage--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/documentsheet/_index.md
+++ b/italian/java/com.aspose.diagram/documentsheet/_index.md
@@ -1,0 +1,396 @@
+---
+title: DocumentSheet
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica una struttura ShapeSheet di un documento.
+type: docs
+weight: 127
+url: /it/java/com.aspose.diagram/documentsheet/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DocumentSheet
+```
+
+Specifica la struttura ShapeSheet di un documento.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAnnotations()](#getAnnotations--) | Contiene elementi che includono informazioni sui commenti inseriti in una pagina del documento. |
+| [getClass()](#getClass--) |  |
+| [getConnectionABCDs()](#getConnectionABCDs--) | Contiene una raccolta di elementi ConnectionABCD. |
+| [getConnections()](#getConnections--) | Contiene una raccolta di elementi Connection. |
+| [getDocProps()](#getDocProps--) | Contiene elementi che controllano la qualità dell'anteprima del documento, l'ambito e il formato di output. |
+| [getFillStyle()](#getFillStyle--) | Elemento StyleSheet da cui questo stile eredita la formattazione di riempimento. |
+| [getForeign()](#getForeign--) | Contiene elementi che specificano la larghezza e l'altezza di un oggetto proveniente da un altro programma utilizzato in un documento Microsoft Visio. |
+| [getForeignData()](#getForeignData--) | Contiene un BLOB codificato MIME (Multipurpose Internet Mail Extensions) di dati immagine, come metafile Windows, bitmap o dati OLE. |
+| [getHyperlinks()](#getHyperlinks--) | Contiene una raccolta di elementi Hyperlink. |
+| [getLineStyle()](#getLineStyle--) | Elemento StyleSheet da cui questo stile eredita la formattazione della linea. |
+| [getName()](#getName--) | Il nome dell'elemento. |
+| [getNameU()](#getNameU--) | Il nome universale dell'elemento. |
+| [getProps()](#getProps--) | Contiene una raccolta di elementi Prop. |
+| [getReviewers()](#getReviewers--) | Contiene elementi che includono informazioni identificative su un revisore di documento. |
+| [getScratchs()](#getScratchs--) | Contiene una raccolta di elementi Scratch. |
+| [getTextStyle()](#getTextStyle--) | Elemento StyleSheet da cui questo stile eredita la formattazione del testo. |
+| [getUniqueID()](#getUniqueID--) | Un GUID (identificatore univoco globale) che identifica la forma. |
+| [getUsers()](#getUsers--) | Contiene una raccolta di elementi Utente. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setFillStyle(StyleSheet value)](#setFillStyle-com.aspose.diagram.StyleSheet-) | Per la descrizione di questa proprietà, vedere [getFillStyle()](../../com.aspose.diagram/documentsheet\#getFillStyle--) |
+| [setLineStyle(StyleSheet value)](#setLineStyle-com.aspose.diagram.StyleSheet-) | Per la descrizione di questa proprietà, vedere [getLineStyle()](../../com.aspose.diagram/documentsheet\#getLineStyle--) |
+| [setName(String value)](#setName-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getName()](../../com.aspose.diagram/documentsheet\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getNameU()](../../com.aspose.diagram/documentsheet\#getNameU--) |
+| [setTextStyle(StyleSheet value)](#setTextStyle-com.aspose.diagram.StyleSheet-) | Per la descrizione di questa proprietà, vedere [getTextStyle()](../../com.aspose.diagram/documentsheet\#getTextStyle--) |
+| [setUniqueID(UUID value)](#setUniqueID-java.util.UUID-) | Per la descrizione di questa proprietà, vedere [getUniqueID()](../../com.aspose.diagram/documentsheet\#getUniqueID--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAnnotations() {#getAnnotations--}
+```
+public AnnotationCollection getAnnotations()
+```
+
+
+Contiene elementi che includono informazioni sui commenti inseriti in una pagina del documento.
+
+**Returns:**
+[AnnotationCollection](../../com.aspose.diagram/annotationcollection)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConnectionABCDs() {#getConnectionABCDs--}
+```
+public ConnectionABCDCollection getConnectionABCDs()
+```
+
+
+Contiene una raccolta di elementi ConnectionABCD.
+
+**Returns:**
+[ConnectionABCDCollection](../../com.aspose.diagram/connectionabcdcollection)
+### getConnections() {#getConnections--}
+```
+public ConnectionCollection getConnections()
+```
+
+
+Contiene una raccolta di elementi Connection.
+
+**Returns:**
+[ConnectionCollection](../../com.aspose.diagram/connectioncollection)
+### getDocProps() {#getDocProps--}
+```
+public DocProps getDocProps()
+```
+
+
+Contiene elementi che controllano la qualità dell'anteprima del documento, l'ambito e il formato di output.
+
+**Returns:**
+[DocProps](../../com.aspose.diagram/docprops)
+### getFillStyle() {#getFillStyle--}
+```
+public StyleSheet getFillStyle()
+```
+
+
+Elemento StyleSheet da cui questo stile eredita la formattazione di riempimento.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getForeign() {#getForeign--}
+```
+public Foreign getForeign()
+```
+
+
+Contiene elementi che specificano la larghezza e l'altezza di un oggetto proveniente da un altro programma utilizzato in un documento Microsoft Visio. Include anche elementi che specificano la distanza di offset dell'immagine dell'oggetto all'interno dei suoi bordi.
+
+**Returns:**
+[Foreign](../../com.aspose.diagram/foreign)
+### getForeignData() {#getForeignData--}
+```
+public ForeignData getForeignData()
+```
+
+
+Contiene un BLOB codificato MIME (Multipurpose Internet Mail Extensions) di dati immagine, come metafile Windows, bitmap o dati OLE.
+
+**Returns:**
+[ForeignData](../../com.aspose.diagram/foreigndata)
+### getHyperlinks() {#getHyperlinks--}
+```
+public HyperlinkCollection getHyperlinks()
+```
+
+
+Contiene una raccolta di elementi Hyperlink.
+
+**Returns:**
+[HyperlinkCollection](../../com.aspose.diagram/hyperlinkcollection)
+### getLineStyle() {#getLineStyle--}
+```
+public StyleSheet getLineStyle()
+```
+
+
+Elemento StyleSheet da cui questo stile eredita la formattazione della linea.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Il nome dell'elemento.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+Il nome universale dell'elemento.
+
+**Returns:**
+java.lang.String
+### getProps() {#getProps--}
+```
+public PropCollection getProps()
+```
+
+
+Contiene una raccolta di elementi Prop.
+
+**Returns:**
+[PropCollection](../../com.aspose.diagram/propcollection)
+### getReviewers() {#getReviewers--}
+```
+public ReviewerCollection getReviewers()
+```
+
+
+Contiene elementi che includono informazioni identificative su un revisore di documento.
+
+**Returns:**
+[ReviewerCollection](../../com.aspose.diagram/reviewercollection)
+### getScratchs() {#getScratchs--}
+```
+public ScratchCollection getScratchs()
+```
+
+
+Contiene una raccolta di elementi Scratch.
+
+**Returns:**
+[ScratchCollection](../../com.aspose.diagram/scratchcollection)
+### getTextStyle() {#getTextStyle--}
+```
+public StyleSheet getTextStyle()
+```
+
+
+Elemento StyleSheet da cui questo stile eredita la formattazione del testo.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getUniqueID() {#getUniqueID--}
+```
+public UUID getUniqueID()
+```
+
+
+Un GUID (identificatore univoco globale) che identifica la forma.
+
+**Returns:**
+java.util.UUID
+### getUsers() {#getUsers--}
+```
+public UserCollection getUsers()
+```
+
+
+Contiene una raccolta di elementi Utente.
+
+**Returns:**
+[UserCollection](../../com.aspose.diagram/usercollection)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setFillStyle(StyleSheet value) {#setFillStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setFillStyle(StyleSheet value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getFillStyle()](../../com.aspose.diagram/documentsheet\#getFillStyle--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setLineStyle(StyleSheet value) {#setLineStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setLineStyle(StyleSheet value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getLineStyle()](../../com.aspose.diagram/documentsheet\#getLineStyle--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getName()](../../com.aspose.diagram/documentsheet\#getName--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getNameU()](../../com.aspose.diagram/documentsheet\#getNameU--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setTextStyle(StyleSheet value) {#setTextStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setTextStyle(StyleSheet value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getTextStyle()](../../com.aspose.diagram/documentsheet\#getTextStyle--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setUniqueID(UUID value) {#setUniqueID-java.util.UUID-}
+```
+public void setUniqueID(UUID value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getUniqueID()](../../com.aspose.diagram/documentsheet\#getUniqueID--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.util.UUID |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/doublevalue/_index.md
+++ b/italian/java/com.aspose.diagram/doublevalue/_index.md
@@ -1,0 +1,239 @@
+---
+title: DoubleValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Valore double
+type: docs
+weight: 128
+url: /it/java/com.aspose.diagram/doublevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DoubleValue
+```
+
+Valore double
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [DoubleValue(double value, int unit)](#DoubleValue-double-int-) | Costruttore. |
+| [DoubleValue()](#DoubleValue--) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Attributi di un elemento. |
+| [getValue()](#getValue--) | Valore double. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [isThemed()](#isThemed--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setThemed(boolean value)](#setThemed-boolean-) | Per la descrizione di questa proprietà, vedere [isThemed()](../../com.aspose.diagram/doublevalue\#isThemed--) |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | Per la descrizione di questa proprietà, vedere [getUfe()](../../com.aspose.diagram/doublevalue\#getUfe--) |
+| [setValue(double value)](#setValue-double-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/doublevalue\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DoubleValue(double value, int unit) {#DoubleValue-double-int-}
+```
+public DoubleValue(double value, int unit)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double |  |
+| unità | int |  |
+
+### DoubleValue() {#DoubleValue--}
+```
+public DoubleValue()
+```
+
+
+Costruttore.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public double getValue()
+```
+
+
+Valore double.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### isThemed() {#isThemed--}
+```
+public boolean isThemed()
+```
+
+
+
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setThemed(boolean value) {#setThemed-boolean-}
+```
+public void setThemed(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isThemed()](../../com.aspose.diagram/doublevalue\#isThemed--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getUfe()](../../com.aspose.diagram/doublevalue\#getUfe--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(double value) {#setValue-double-}
+```
+public void setValue(double value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/doublevalue\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/drawingresizetype/_index.md
+++ b/italian/java/com.aspose.diagram/drawingresizetype/_index.md
@@ -1,0 +1,179 @@
+---
+title: DrawingResizeType
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Determina se la pagina di disegno si ridimensiona automaticamente per adattarsi al diagramma.
+type: docs
+weight: 129
+url: /it/java/com.aspose.diagram/drawingresizetype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DrawingResizeType
+```
+
+Determina se la pagina di disegno si ridimensiona automaticamente per adattarsi al diagramma.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [DrawingResizeType(int value)](#DrawingResizeType-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Determina se la pagina di disegno si ridimensiona automaticamente per adattarsi al diagramma. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/drawingresizetype\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DrawingResizeType(int value) {#DrawingResizeType-int-}
+```
+public DrawingResizeType(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Determina se la pagina di disegno si ridimensiona automaticamente per adattarsi al diagramma.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/drawingresizetype\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/drawingresizetypevalue/_index.md
+++ b/italian/java/com.aspose.diagram/drawingresizetypevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: DrawingResizeTypeValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Determina se la pagina di disegno si ridimensiona automaticamente per adattarsi al diagramma.
+type: docs
+weight: 130
+url: /it/java/com.aspose.diagram/drawingresizetypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class DrawingResizeTypeValue
+```
+
+Determina se la pagina di disegno si ridimensiona automaticamente per adattarsi al diagramma.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [AUTOMATICALLY](#AUTOMATICALLY) | La pagina del disegno si ridimensiona automaticamente. |
+| [DEPENDS_ON_DRAWING_SIZE_TYPE](#DEPENDS-ON-DRAWING-SIZE-TYPE) | Il fatto che la pagina si ridimensioni automaticamente dipende dal valore della cella DrawingSizeType. |
+| [NOT_AUTOMATICALLY](#NOT-AUTOMATICALLY) | La pagina del disegno non si ridimensiona automaticamente. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AUTOMATICALLY {#AUTOMATICALLY}
+```
+public static final int AUTOMATICALLY
+```
+
+
+La pagina del disegno si ridimensiona automaticamente.
+
+### DEPENDS_ON_DRAWING_SIZE_TYPE {#DEPENDS-ON-DRAWING-SIZE-TYPE}
+```
+public static final int DEPENDS_ON_DRAWING_SIZE_TYPE
+```
+
+
+Il fatto che la pagina si ridimensioni automaticamente dipende dal valore della cella DrawingSizeType. Se DrawingSizeType = 0 (la dimensione della pagina del disegno è la stessa della pagina stampata), la pagina si ridimensiona automaticamente. Se il valore di DrawingSizeType è diverso da zero (0), la pagina non si ridimensiona automaticamente.
+
+### NOT_AUTOMATICALLY {#NOT-AUTOMATICALLY}
+```
+public static final int NOT_AUTOMATICALLY
+```
+
+
+La pagina del disegno non si ridimensiona automaticamente.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/drawingscaletype/_index.md
+++ b/italian/java/com.aspose.diagram/drawingscaletype/_index.md
@@ -1,0 +1,179 @@
+---
+title: DrawingScaleType
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica il tipo di scala di disegno da utilizzare per una pagina.
+type: docs
+weight: 131
+url: /it/java/com.aspose.diagram/drawingscaletype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DrawingScaleType
+```
+
+Specifica il tipo di scala di disegno da utilizzare per una pagina.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [DrawingScaleType(int value)](#DrawingScaleType-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Specifica il tipo di scala di disegno da utilizzare per una pagina. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | For the description of this property, please see [getValue()](../../com.aspose.diagram/drawingscaletype\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DrawingScaleType(int value) {#DrawingScaleType-int-}
+```
+public DrawingScaleType(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specifica il tipo di scala di disegno da utilizzare per una pagina.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+For the description of this property, please see [getValue()](../../com.aspose.diagram/drawingscaletype\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/drawingscaletypevalue/_index.md
+++ b/italian/java/com.aspose.diagram/drawingscaletypevalue/_index.md
@@ -1,0 +1,192 @@
+---
+title: DrawingScaleTypeValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica il tipo di scala di disegno da utilizzare per una pagina.
+type: docs
+weight: 132
+url: /it/java/com.aspose.diagram/drawingscaletypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class DrawingScaleTypeValue
+```
+
+Specifica il tipo di scala di disegno da utilizzare per una pagina.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [ARCHITECTURAL_SCALE](#ARCHITECTURAL-SCALE) | Scala architettonica. |
+| [CIVIL_ENGINEERING_SCALE](#CIVIL-ENGINEERING-SCALE) | Scala di ingegneria civile. |
+| [CUSTOM_SCALE](#CUSTOM-SCALE) | Scala personalizzata. |
+| [MECHANICAL_ENGINEERING_SCALE](#MECHANICAL-ENGINEERING-SCALE) | Scala di ingegneria meccanica. |
+| [METRIC_SCALE](#METRIC-SCALE) | Scala metrico. |
+| [NO_SCALE](#NO-SCALE) | Nessuna scala. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ARCHITECTURAL_SCALE {#ARCHITECTURAL-SCALE}
+```
+public static final int ARCHITECTURAL_SCALE
+```
+
+
+Scala architettonica.
+
+### CIVIL_ENGINEERING_SCALE {#CIVIL-ENGINEERING-SCALE}
+```
+public static final int CIVIL_ENGINEERING_SCALE
+```
+
+
+Scala di ingegneria civile.
+
+### CUSTOM_SCALE {#CUSTOM-SCALE}
+```
+public static final int CUSTOM_SCALE
+```
+
+
+Scala personalizzata.
+
+### MECHANICAL_ENGINEERING_SCALE {#MECHANICAL-ENGINEERING-SCALE}
+```
+public static final int MECHANICAL_ENGINEERING_SCALE
+```
+
+
+Scala di ingegneria meccanica.
+
+### METRIC_SCALE {#METRIC-SCALE}
+```
+public static final int METRIC_SCALE
+```
+
+
+Scala metrico.
+
+### NO_SCALE {#NO-SCALE}
+```
+public static final int NO_SCALE
+```
+
+
+Nessuna scala.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/drawingsizetype/_index.md
+++ b/italian/java/com.aspose.diagram/drawingsizetype/_index.md
@@ -1,0 +1,179 @@
+---
+title: DrawingSizeType
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica le dimensioni di disegno di una pagina.
+type: docs
+weight: 133
+url: /it/java/com.aspose.diagram/drawingsizetype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DrawingSizeType
+```
+
+Specifica le dimensioni di disegno di una pagina.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [DrawingSizeType(int value)](#DrawingSizeType-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Specifica le dimensioni di disegno di una pagina. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/drawingsizetype\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DrawingSizeType(int value) {#DrawingSizeType-int-}
+```
+public DrawingSizeType(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specifica le dimensioni di disegno di una pagina.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/drawingsizetype\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/drawingsizetypevalue/_index.md
+++ b/italian/java/com.aspose.diagram/drawingsizetypevalue/_index.md
@@ -1,0 +1,210 @@
+---
+title: DrawingSizeTypeValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica le dimensioni di disegno di una pagina.
+type: docs
+weight: 134
+url: /it/java/com.aspose.diagram/drawingsizetypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class DrawingSizeTypeValue
+```
+
+Specifica le dimensioni di disegno di una pagina.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [ANSI_ARCHITECTURAL](#ANSI-ARCHITECTURAL) | ANSI architectural. |
+| [ANSI_ENGINEERING](#ANSI-ENGINEERING) | ANSI engineering. |
+| [CUSTOM_PAGE_SIZE](#CUSTOM-PAGE-SIZE) | Custom page size. |
+| [CUSTOM_SCALED_DRAW_SIZE](#CUSTOM-SCALED-DRAW-SIZE) | Custom scaled drawing size. |
+| [FIT_PAGE_DRAW_CONTENTS](#FIT-PAGE-DRAW-CONTENTS) | Fit page to drawing contents. |
+| [METRIC_ISO](#METRIC-ISO) | Metric (ISO). |
+| [SAME_AS_PRINTER](#SAME-AS-PRINTER) | Stesso della stampante. |
+| [STANDARD](#STANDARD) | Standard. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ANSI_ARCHITECTURAL {#ANSI-ARCHITECTURAL}
+```
+public static final int ANSI_ARCHITECTURAL
+```
+
+
+ANSI architectural.
+
+### ANSI_ENGINEERING {#ANSI-ENGINEERING}
+```
+public static final int ANSI_ENGINEERING
+```
+
+
+ANSI engineering.
+
+### CUSTOM_PAGE_SIZE {#CUSTOM-PAGE-SIZE}
+```
+public static final int CUSTOM_PAGE_SIZE
+```
+
+
+Custom page size.
+
+### CUSTOM_SCALED_DRAW_SIZE {#CUSTOM-SCALED-DRAW-SIZE}
+```
+public static final int CUSTOM_SCALED_DRAW_SIZE
+```
+
+
+Custom scaled drawing size.
+
+### FIT_PAGE_DRAW_CONTENTS {#FIT-PAGE-DRAW-CONTENTS}
+```
+public static final int FIT_PAGE_DRAW_CONTENTS
+```
+
+
+Fit page to drawing contents.
+
+### METRIC_ISO {#METRIC-ISO}
+```
+public static final int METRIC_ISO
+```
+
+
+Metric (ISO).
+
+### SAME_AS_PRINTER {#SAME-AS-PRINTER}
+```
+public static final int SAME_AS_PRINTER
+```
+
+
+Stesso della stampante.
+
+### STANDARD {#STANDARD}
+```
+public static final int STANDARD
+```
+
+
+Standard.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/dropbuttonstyle/_index.md
+++ b/italian/java/com.aspose.diagram/dropbuttonstyle/_index.md
@@ -1,0 +1,165 @@
+---
+title: DropButtonStyle
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta il simbolo visualizzato sul pulsante a discesa.
+type: docs
+weight: 135
+url: /it/java/com.aspose.diagram/dropbuttonstyle/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class DropButtonStyle
+```
+
+Rappresenta il simbolo visualizzato sul pulsante a discesa.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [ARROW](#ARROW) | Visualizza un pulsante con una freccia verso il basso. |
+| [ELLIPSIS](#ELLIPSIS) | Visualizza un pulsante con i puntini di sospensione (...). |
+| [PLAIN](#PLAIN) | Visualizza un pulsante senza simbolo. |
+| [REDUCE](#REDUCE) | Visualizza un pulsante con una linea orizzontale simile al carattere di sottolineatura. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ARROW {#ARROW}
+```
+public static final int ARROW
+```
+
+
+Visualizza un pulsante con una freccia verso il basso.
+
+### ELLIPSIS {#ELLIPSIS}
+```
+public static final int ELLIPSIS
+```
+
+
+Visualizza un pulsante con i puntini di sospensione (...).
+
+### PLAIN {#PLAIN}
+```
+public static final int PLAIN
+```
+
+
+Visualizza un pulsante senza simbolo.
+
+### REDUCE {#REDUCE}
+```
+public static final int REDUCE
+```
+
+
+Visualizza un pulsante con una linea orizzontale simile al carattere di sottolineatura.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/dynfeedback/_index.md
+++ b/italian/java/com.aspose.diagram/dynfeedback/_index.md
@@ -1,0 +1,179 @@
+---
+title: DynFeedback
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica il tipo di feedback visivo fornito agli utenti quando trascinano un connettore.
+type: docs
+weight: 136
+url: /it/java/com.aspose.diagram/dynfeedback/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DynFeedback
+```
+
+Specifica il tipo di feedback visivo fornito agli utenti quando trascinano un connettore. Quando il pulsante del mouse viene rilasciato, la forma del connettore risultante non è influenzata da questa impostazione. Questo elemento non si applica ai connettori instradabili.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [DynFeedback(int value)](#DynFeedback-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Specifica il tipo di feedback visivo fornito agli utenti quando trascinano un connettore. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, consultare [getValue()](../../com.aspose.diagram/dynfeedback\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DynFeedback(int value) {#DynFeedback-int-}
+```
+public DynFeedback(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specifica il tipo di feedback visivo fornito agli utenti quando trascinano un connettore. Quando il pulsante del mouse viene rilasciato, la forma del connettore risultante non è influenzata da questa impostazione. Questo elemento non si applica ai connettori instradabili.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getValue()](../../com.aspose.diagram/dynfeedback\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/dynfeedbackvalue/_index.md
+++ b/italian/java/com.aspose.diagram/dynfeedbackvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: DynFeedbackValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica il tipo di feedback visivo fornito agli utenti quando trascinano un connettore.
+type: docs
+weight: 137
+url: /it/java/com.aspose.diagram/dynfeedbackvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class DynFeedbackValue
+```
+
+Specifica il tipo di feedback visivo fornito agli utenti quando trascinano un connettore. Quando il pulsante del mouse viene rilasciato, la forma del connettore risultante non è influenzata da questa impostazione. Questo elemento non si applica ai connettori instradabili.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [REMAIN_STRAIGHT](#REMAIN-STRAIGHT) | Rimani dritto (senza gambe). |
+| [SHOW_FIVE_LEGS](#SHOW-FIVE-LEGS) | Mostra cinque gambe quando trascinato. |
+| [SHOW_THREE_LEGS](#SHOW-THREE-LEGS) | Mostra tre gambe quando trascinato. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### REMAIN_STRAIGHT {#REMAIN-STRAIGHT}
+```
+public static final int REMAIN_STRAIGHT
+```
+
+
+Rimani dritto (senza gambe).
+
+### SHOW_FIVE_LEGS {#SHOW-FIVE-LEGS}
+```
+public static final int SHOW_FIVE_LEGS
+```
+
+
+Mostra cinque gambe quando trascinato.
+
+### SHOW_THREE_LEGS {#SHOW-THREE-LEGS}
+```
+public static final int SHOW_THREE_LEGS
+```
+
+
+Mostra tre gambe quando trascinato.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/ellipse/_index.md
+++ b/italian/java/com.aspose.diagram/ellipse/_index.md
@@ -1,0 +1,349 @@
+---
+title: Ellisse
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene elementi che specificano le coordinate x e y del punto centrale dell'ellisse e due punti sull'ellisse.
+type: docs
+weight: 138
+url: /it/java/com.aspose.diagram/ellipse/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class Ellipse extends Coordinate
+```
+
+Contiene elementi che specificano le coordinate x e y del punto centrale dell'ellisse e due punti sull'ellisse.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [Ellipse()](#Ellipse--) | Crea un'istanza della classe [Ellipse](../../com.aspose.diagram/ellipse). |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | Una coordinata x di un punto sull'ellisse associata alla coordinata y rappresentata dall'elemento B. |
+| [getB()](#getB--) | Una coordinata y di un punto sull'ellisse associata a una coordinata x rappresentata dall'elemento A. |
+| [getC()](#getC--) | Una coordinata x di un punto sull'ellisse associata alla coordinata y rappresentata dall'elemento D. |
+| [getClass()](#getClass--) |  |
+| [getD()](#getD--) | Una coordinata y di un punto sull'ellisse associata alla coordinata x rappresentata dall'elemento C. |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getIX()](#getIX--) | L'indice basato su zero dell'elemento all'interno del suo elemento genitore. |
+| [getX()](#getX--) | La coordinata x del centro dell'ellisse. |
+| [getY()](#getY--) | La coordinata y del centro dell'ellisse. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getA()](../../com.aspose.diagram/ellipse\#getA--) |
+| [setB(DoubleValue value)](#setB-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getB()](../../com.aspose.diagram/ellipse\#getB--) |
+| [setC(DoubleValue value)](#setC-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getC()](../../com.aspose.diagram/ellipse\#getC--) |
+| [setD(DoubleValue value)](#setD-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getD()](../../com.aspose.diagram/ellipse\#getD--) |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/ellipse\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Per la descrizione di questa proprietà, vedere [getIX()](../../com.aspose.diagram/ellipse\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getX()](../../com.aspose.diagram/ellipse\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getY()](../../com.aspose.diagram/ellipse\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Ellipse() {#Ellipse--}
+```
+public Ellipse()
+```
+
+
+Crea un'istanza della classe [Ellipse](../../com.aspose.diagram/ellipse).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+Una coordinata x di un punto sull'ellisse associata alla coordinata y rappresentata dall'elemento B.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getB() {#getB--}
+```
+public DoubleValue getB()
+```
+
+
+Una coordinata y di un punto sull'ellisse associata a una coordinata x rappresentata dall'elemento A.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getC() {#getC--}
+```
+public DoubleValue getC()
+```
+
+
+Una coordinata x di un punto sull'ellisse associata alla coordinata y rappresentata dall'elemento D.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getD() {#getD--}
+```
+public DoubleValue getD()
+```
+
+
+Una coordinata y di un punto sull'ellisse associata alla coordinata x rappresentata dall'elemento C.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+L'indice basato su zero dell'elemento all'interno del suo elemento genitore.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+La coordinata x del centro dell'ellisse.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+La coordinata y del centro dell'ellisse.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getA()](../../com.aspose.diagram/ellipse\#getA--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setB(DoubleValue value) {#setB-com.aspose.diagram.DoubleValue-}
+```
+public void setB(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getB()](../../com.aspose.diagram/ellipse\#getB--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setC(DoubleValue value) {#setC-com.aspose.diagram.DoubleValue-}
+```
+public void setC(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getC()](../../com.aspose.diagram/ellipse\#getC--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setD(DoubleValue value) {#setD-com.aspose.diagram.DoubleValue-}
+```
+public void setD(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getD()](../../com.aspose.diagram/ellipse\#getD--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/ellipse\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getIX()](../../com.aspose.diagram/ellipse\#getIX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getX()](../../com.aspose.diagram/ellipse\#getX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getY()](../../com.aspose.diagram/ellipse\#getY--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/ellipsecollection/_index.md
+++ b/italian/java/com.aspose.diagram/ellipsecollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: EllipseCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Raccolta di ellissi.
+type: docs
+weight: 139
+url: /it/java/com.aspose.diagram/ellipsecollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class EllipseCollection extends Collection
+```
+
+Raccolta di ellissi.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Ellipse get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[Ellipse](../../com.aspose.diagram/ellipse) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/ellipticalarcto/_index.md
+++ b/italian/java/com.aspose.diagram/ellipticalarcto/_index.md
@@ -1,0 +1,349 @@
+---
+title: EllipticalArcTo
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene elementi che specificano informazioni su un arco ellittico.
+type: docs
+weight: 140
+url: /it/java/com.aspose.diagram/ellipticalarcto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class EllipticalArcTo extends Coordinate
+```
+
+Contiene elementi che specificano informazioni su un arco ellittico.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [EllipticalArcTo()](#EllipticalArcTo--) | Crea un'istanza della classe [EllipticalArcTo](../../com.aspose.diagram/ellipticalarcto). |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | La coordinata x del punto di controllo dell'arco. |
+| [getB()](#getB--) | La coordinata y del punto di controllo di un arco. |
+| [getC()](#getC--) | L'angolo dell'asse maggiore di un arco rispetto all'asse x del suo genitore. |
+| [getClass()](#getClass--) |  |
+| [getD()](#getD--) | Il rapporto tra l'asse maggiore e l'asse minore di un arco. |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getIX()](#getIX--) | L'indice basato su zero dell'elemento all'interno del suo elemento genitore. |
+| [getX()](#getX--) | La coordinata x del vertice finale di un arco ellittico. |
+| [getY()](#getY--) | La coordinata y del vertice finale di un arco ellittico. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, consultare [getA()](../../com.aspose.diagram/ellipticalarcto\#getA--) |
+| [setB(DoubleValue value)](#setB-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, consultare [getB()](../../com.aspose.diagram/ellipticalarcto\#getB--) |
+| [setC(DoubleValue value)](#setC-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, consultare [getC()](../../com.aspose.diagram/ellipticalarcto\#getC--) |
+| [setD(DoubleValue value)](#setD-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, consultare [getD()](../../com.aspose.diagram/ellipticalarcto\#getD--) |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, consultare [getDel()](../../com.aspose.diagram/ellipticalarcto\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Per la descrizione di questa proprietà, consultare [getIX()](../../com.aspose.diagram/ellipticalarcto\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, consultare [getX()](../../com.aspose.diagram/ellipticalarcto\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getY()](../../com.aspose.diagram/ellipticalarcto\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### EllipticalArcTo() {#EllipticalArcTo--}
+```
+public EllipticalArcTo()
+```
+
+
+Crea un'istanza della classe [EllipticalArcTo](../../com.aspose.diagram/ellipticalarcto).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+La coordinata x del punto di controllo dell'arco. Il punto di controllo è meglio posizionato circa a metà tra i vertici iniziale e finale dell'arco. Altrimenti, l'arco potrebbe ingrandirsi in modo estremo per passare attraverso il punto di controllo, con risultati imprevedibili.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getB() {#getB--}
+```
+public DoubleValue getB()
+```
+
+
+La coordinata y del punto di controllo di un arco.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getC() {#getC--}
+```
+public DoubleValue getC()
+```
+
+
+L'angolo dell'asse maggiore di un arco rispetto all'asse x del suo genitore.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getD() {#getD--}
+```
+public DoubleValue getD()
+```
+
+
+Il rapporto tra l'asse maggiore e l'asse minore di un arco. Nonostante il significato comune di questi termini, l'asse maggiore non deve necessariamente essere più grande dell'asse minore, quindi questo rapporto non deve necessariamente superare 1. Impostare questo elemento su un valore minore o uguale a 0 o maggiore di 1000 può portare a risultati imprevedibili.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+L'indice basato su zero dell'elemento all'interno del suo elemento genitore.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+La coordinata x del vertice finale di un arco ellittico.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+La coordinata y del vertice finale di un arco ellittico.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getA()](../../com.aspose.diagram/ellipticalarcto\#getA--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setB(DoubleValue value) {#setB-com.aspose.diagram.DoubleValue-}
+```
+public void setB(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getB()](../../com.aspose.diagram/ellipticalarcto\#getB--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setC(DoubleValue value) {#setC-com.aspose.diagram.DoubleValue-}
+```
+public void setC(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getC()](../../com.aspose.diagram/ellipticalarcto\#getC--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setD(DoubleValue value) {#setD-com.aspose.diagram.DoubleValue-}
+```
+public void setD(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getD()](../../com.aspose.diagram/ellipticalarcto\#getD--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getDel()](../../com.aspose.diagram/ellipticalarcto\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getIX()](../../com.aspose.diagram/ellipticalarcto\#getIX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getX()](../../com.aspose.diagram/ellipticalarcto\#getX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getY()](../../com.aspose.diagram/ellipticalarcto\#getY--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/ellipticalarctocollection/_index.md
+++ b/italian/java/com.aspose.diagram/ellipticalarctocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: EllipticalArcToCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: EllipticalArcTo  collection.
+type: docs
+weight: 141
+url: /it/java/com.aspose.diagram/ellipticalarctocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class EllipticalArcToCollection extends Collection
+```
+
+Raccolta EllipticalArcTo.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public EllipticalArcTo get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[EllipticalArcTo](../../com.aspose.diagram/ellipticalarcto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/emfrendersetting/_index.md
+++ b/italian/java/com.aspose.diagram/emfrendersetting/_index.md
@@ -1,0 +1,147 @@
+---
+title: EmfRenderSetting
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Impostazione per il rendering del metafile Emf.
+type: docs
+weight: 142
+url: /it/java/com.aspose.diagram/emfrendersetting/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class EmfRenderSetting
+```
+
+Impostazione per il rendering del metafile Emf.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [EMF_ONLY](#EMF-ONLY) | Solo il rendering dei record Emf. |
+| [EMF_PLUS_PREFER](#EMF-PLUS-PREFER) | Preferisci il rendering dei record EmfPlus. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### EMF_ONLY {#EMF-ONLY}
+```
+public static final int EMF_ONLY
+```
+
+
+Solo il rendering dei record Emf.
+
+### EMF_PLUS_PREFER {#EMF-PLUS-PREFER}
+```
+public static final int EMF_PLUS_PREFER
+```
+
+
+Preferisci il rendering dei record EmfPlus.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/encoding/_index.md
+++ b/italian/java/com.aspose.diagram/encoding/_index.md
@@ -1,0 +1,277 @@
+---
+title: Encoding
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta una codifica dei caratteri.
+type: docs
+weight: 143
+url: /it/java/com.aspose.diagram/encoding/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Encoding
+```
+
+Rappresenta una codifica dei caratteri.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [Encoding()](#Encoding--) |  |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Encoding other)](#equals-com.aspose.diagram.Encoding-) | Determina se l'oggetto Encoding specificato è uguale all'istanza corrente. |
+| [equals(Object o)](#equals-java.lang.Object-) | Determina se l'oggetto specificato è uguale all'istanza corrente. |
+| [getASCII()](#getASCII--) | Ottiene una codifica per il set di caratteri ASCII (7 bit). |
+| [getBigEndianUnicode()](#getBigEndianUnicode--) | Ottiene una codifica per il formato UTF-16 usando l'ordine dei byte big endian. |
+| [getClass()](#getClass--) |  |
+| [getDefault()](#getDefault--) | Ottiene una codifica per la pagina di codice ANSI corrente del sistema operativo. |
+| [getEncoding(int codePage)](#getEncoding-int-) | Restituisce la codifica associata all'identificatore di pagina di codice specificato. |
+| [getEncoding(String charsetName)](#getEncoding-java.lang.String-) | Restituisce una codifica associata al nome del set di caratteri specificato. |
+| [getEncoding(Charset charset)](#getEncoding-java.nio.charset.Charset-) | Restituisce una codifica associata all'oggetto charset specificato. |
+| [getUTF7()](#getUTF7--) | Ottiene una codifica per il formato UTF-7. |
+| [getUTF8()](#getUTF8--) | Ottiene una codifica per il formato UTF-8. |
+| [getUTF8NoBOM()](#getUTF8NoBOM--) | Ottiene una codifica per il formato UTF-8 senza l'identificatore UTF-8. |
+| [getUnicode()](#getUnicode--) | Ottiene una codifica per il formato UTF-16 usando l'ordine dei byte little endian. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Encoding() {#Encoding--}
+```
+public Encoding()
+```
+
+
+### equals(Encoding other) {#equals-com.aspose.diagram.Encoding-}
+```
+public boolean equals(Encoding other)
+```
+
+
+Determina se l'oggetto Encoding specificato è uguale all'istanza corrente.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| other | [Encoding](../../com.aspose.diagram/encoding) | L'oggetto Encoding da confrontare con l'istanza corrente. |
+
+**Returns:**
+boolean - true se il valore è uguale all'istanza corrente; altrimenti, false.
+### equals(Object o) {#equals-java.lang.Object-}
+```
+public boolean equals(Object o)
+```
+
+
+Determina se l'oggetto specificato è uguale all'istanza corrente.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| o | java.lang.Object | L'oggetto da confrontare con l'istanza corrente. |
+
+**Returns:**
+boolean - true se il valore è un'istanza di Encoding ed è uguale all'istanza corrente; altrimenti, false.
+### getASCII() {#getASCII--}
+```
+public static Encoding getASCII()
+```
+
+
+Ottiene una codifica per il set di caratteri ASCII (7 bit).
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - A Encoding object for the ASCII (7-bit) character set.
+### getBigEndianUnicode() {#getBigEndianUnicode--}
+```
+public static Encoding getBigEndianUnicode()
+```
+
+
+Ottiene una codifica per il formato UTF-16 usando l'ordine dei byte big endian.
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - A Encoding object for the UTF-16 format using the big endian byte
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefault() {#getDefault--}
+```
+public static Encoding getDefault()
+```
+
+
+Ottiene una codifica per la pagina di codice ANSI corrente del sistema operativo.
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - An encoding for the operating system's current ANSI code page.
+### getEncoding(int codePage) {#getEncoding-int-}
+```
+public static Encoding getEncoding(int codePage)
+```
+
+
+Restituisce la codifica associata all'identificatore di pagina di codice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| codePage | int | L'identificatore della pagina di codice della codifica preferita. -or- 0, per utilizzare la codifica predefinita. |
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - The Encoding object associated with the specified code page.
+### getEncoding(String charsetName) {#getEncoding-java.lang.String-}
+```
+public static Encoding getEncoding(String charsetName)
+```
+
+
+Restituisce una codifica associata al nome del set di caratteri specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| charsetName | java.lang.String | nome del set di caratteri specificato |
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - The Encoding object associated with the specified charset name.
+### getEncoding(Charset charset) {#getEncoding-java.nio.charset.Charset-}
+```
+public static Encoding getEncoding(Charset charset)
+```
+
+
+Restituisce una codifica associata all'oggetto charset specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| charset | java.nio.charset.Charset | oggetto del set di caratteri specificato |
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - The Encoding object associated with the specified charset object.
+### getUTF7() {#getUTF7--}
+```
+public static Encoding getUTF7()
+```
+
+
+Ottiene una codifica per il formato UTF-7.
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - A Encoding object for the UTF-7 format.
+### getUTF8() {#getUTF8--}
+```
+public static Encoding getUTF8()
+```
+
+
+Ottiene una codifica per il formato UTF-8.
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - A Encoding object for the UTF-8 format.
+### getUTF8NoBOM() {#getUTF8NoBOM--}
+```
+public static Encoding getUTF8NoBOM()
+```
+
+
+Ottiene una codifica per il formato UTF-8 senza l'identificatore UTF-8.
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - A Encoding object for the UTF-8 format without UTF-8 identifier.
+### getUnicode() {#getUnicode--}
+```
+public static Encoding getUnicode()
+```
+
+
+Ottiene una codifica per il formato UTF-16 usando l'ordine dei byte little endian.
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - A Encoding object for the UTF-16 format using the little endian byte
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/event/_index.md
+++ b/italian/java/com.aspose.diagram/event/_index.md
@@ -1,0 +1,311 @@
+---
+title: Evento
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene elementi che specificano formule che controllano gli eventi della forma.
+type: docs
+weight: 144
+url: /it/java/com.aspose.diagram/event/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Event
+```
+
+Contiene elementi che specificano formule che controllano gli eventi della forma.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getEventDblClick()](#getEventDblClick--) | Un elemento evento che viene valutato quando una forma viene doppio-cliccata. |
+| [getEventDrop()](#getEventDrop--) | Un elemento evento che viene valutato quando una forma viene rilasciata sulla pagina di disegno, sia come istanza sia quando una forma è duplicata o incollata. |
+| [getEventMultiDrop()](#getEventMultiDrop--) | EventMultiDrop. |
+| [getEventXFMod()](#getEventXFMod--) | Un elemento evento che viene valutato quando la posizione o l'orientamento di una forma sulla pagina viene trasformato. |
+| [getTheData()](#getTheData--) | Riservato per uso futuro. |
+| [getTheText()](#getTheText--) | Un elemento evento che viene valutato quando il testo o la composizione del testo di una forma cambia. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/event\#getDel--) |
+| [setEventDblClick(DoubleValue value)](#setEventDblClick-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getEventDblClick()](../../com.aspose.diagram/event\#getEventDblClick--) |
+| [setEventDrop(DoubleValue value)](#setEventDrop-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getEventDrop()](../../com.aspose.diagram/event\#getEventDrop--) |
+| [setEventMultiDrop(DoubleValue value)](#setEventMultiDrop-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getEventMultiDrop()](../../com.aspose.diagram/event\#getEventMultiDrop--) |
+| [setEventXFMod(DoubleValue value)](#setEventXFMod-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getEventXFMod()](../../com.aspose.diagram/event\#getEventXFMod--) |
+| [setTheData(DoubleValue value)](#setTheData-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getTheData()](../../com.aspose.diagram/event\#getTheData--) |
+| [setTheText(DoubleValue value)](#setTheText-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getTheText()](../../com.aspose.diagram/event\#getTheText--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getEventDblClick() {#getEventDblClick--}
+```
+public DoubleValue getEventDblClick()
+```
+
+
+Un elemento evento che viene valutato quando una forma viene doppio-cliccata.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getEventDrop() {#getEventDrop--}
+```
+public DoubleValue getEventDrop()
+```
+
+
+Un elemento evento che viene valutato quando una forma viene rilasciata sulla pagina di disegno, sia come istanza sia quando una forma è duplicata o incollata.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getEventMultiDrop() {#getEventMultiDrop--}
+```
+public DoubleValue getEventMultiDrop()
+```
+
+
+EventMultiDrop.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getEventXFMod() {#getEventXFMod--}
+```
+public DoubleValue getEventXFMod()
+```
+
+
+Un elemento evento che viene valutato quando la posizione o l'orientamento di una forma sulla pagina viene trasformato.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTheData() {#getTheData--}
+```
+public DoubleValue getTheData()
+```
+
+
+Riservato per uso futuro.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTheText() {#getTheText--}
+```
+public DoubleValue getTheText()
+```
+
+
+Un elemento evento che viene valutato quando il testo o la composizione del testo di una forma cambia.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/event\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setEventDblClick(DoubleValue value) {#setEventDblClick-com.aspose.diagram.DoubleValue-}
+```
+public void setEventDblClick(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getEventDblClick()](../../com.aspose.diagram/event\#getEventDblClick--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setEventDrop(DoubleValue value) {#setEventDrop-com.aspose.diagram.DoubleValue-}
+```
+public void setEventDrop(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getEventDrop()](../../com.aspose.diagram/event\#getEventDrop--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setEventMultiDrop(DoubleValue value) {#setEventMultiDrop-com.aspose.diagram.DoubleValue-}
+```
+public void setEventMultiDrop(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getEventMultiDrop()](../../com.aspose.diagram/event\#getEventMultiDrop--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setEventXFMod(DoubleValue value) {#setEventXFMod-com.aspose.diagram.DoubleValue-}
+```
+public void setEventXFMod(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getEventXFMod()](../../com.aspose.diagram/event\#getEventXFMod--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTheData(DoubleValue value) {#setTheData-com.aspose.diagram.DoubleValue-}
+```
+public void setTheData(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getTheData()](../../com.aspose.diagram/event\#getTheData--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTheText(DoubleValue value) {#setTheText-com.aspose.diagram.DoubleValue-}
+```
+public void setTheText(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getTheText()](../../com.aspose.diagram/event\#getTheText--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/eventitem/_index.md
+++ b/italian/java/com.aspose.diagram/eventitem/_index.md
@@ -1,0 +1,288 @@
+---
+title: EventItem
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Incapsula un codice evento.
+type: docs
+weight: 145
+url: /it/java/com.aspose.diagram/eventitem/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class EventItem
+```
+
+Incapsula un codice evento. Un elemento EventItem può attivare due tipi di azioni: può eseguire un componente aggiuntivo, oppure può inviare una notifica dell'evento al programma chiamante.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [EventItem()](#EventItem--) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAction()](#getAction--) | Specifica il codice azione dell'elemento EventItem padre. Perché un elemento EventItem venga salvato in un file DatadiagramML, deve essere persistente. |
+| [getClass()](#getClass--) |  |
+| [getEnabled()](#getEnabled--) | Rappresenta un flag che indica se l'evento è abilitato o disabilitato. |
+| [getEventCode()](#getEventCode--) | Un codice che indica l'evento che attiva il componente aggiuntivo. |
+| [getID()](#getID--) | L'ID dell'evento. |
+| [getTarget()](#getTarget--) | Specifica la destinazione di un evento. |
+| [getTargetArgs()](#getTargetArgs--) | Specifica una stringa contenente gli argomenti da inviare alla destinazione di un evento. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAction(int value)](#setAction-int-) | Per la descrizione di questa proprietà, vedere [getAction()](../../com.aspose.diagram/eventitem\#getAction--) |
+| [setEnabled(int value)](#setEnabled-int-) | Per la descrizione di questa proprietà, vedere [getEnabled()](../../com.aspose.diagram/eventitem\#getEnabled--) |
+| [setEventCode(int value)](#setEventCode-int-) | Per la descrizione di questa proprietà, vedere [getEventCode()](../../com.aspose.diagram/eventitem\#getEventCode--) |
+| [setID(int value)](#setID-int-) | Per la descrizione di questa proprietà, vedere [getID()](../../com.aspose.diagram/eventitem\#getID--) |
+| [setTarget(String value)](#setTarget-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getTarget()](../../com.aspose.diagram/eventitem\#getTarget--) |
+| [setTargetArgs(String value)](#setTargetArgs-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getTargetArgs()](../../com.aspose.diagram/eventitem\#getTargetArgs--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### EventItem() {#EventItem--}
+```
+public EventItem()
+```
+
+
+Costruttore.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAction() {#getAction--}
+```
+public int getAction()
+```
+
+
+Specifica il codice azione dell'elemento EventItem padre. Perché un elemento EventItem venga salvato in un file DatadiagramML, deve essere persistente. Attualmente, l'unico codice azione valido che un evento persistente può avere è 1 (ONEVENT\_ACT\_RUNADDON).
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getEnabled() {#getEnabled--}
+```
+public int getEnabled()
+```
+
+
+Rappresenta un flag che indica se l'evento è abilitato o disabilitato.
+
+**Returns:**
+int
+### getEventCode() {#getEventCode--}
+```
+public int getEventCode()
+```
+
+
+Un codice che indica l'evento che attiva il componente aggiuntivo. Per ulteriori informazioni sui codici evento, vedere Codici Evento nella Riferimento di Automazione di Microsoft Visio 2007.
+
+**Returns:**
+int
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+L'ID dell'evento.
+
+**Returns:**
+int
+### getTarget() {#getTarget--}
+```
+public String getTarget()
+```
+
+
+Specifica la destinazione di un evento.
+
+**Returns:**
+java.lang.String
+### getTargetArgs() {#getTargetArgs--}
+```
+public String getTargetArgs()
+```
+
+
+Specifica una stringa contenente gli argomenti da inviare alla destinazione di un evento.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAction(int value) {#setAction-int-}
+```
+public void setAction(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getAction()](../../com.aspose.diagram/eventitem\#getAction--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setEnabled(int value) {#setEnabled-int-}
+```
+public void setEnabled(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getEnabled()](../../com.aspose.diagram/eventitem\#getEnabled--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setEventCode(int value) {#setEventCode-int-}
+```
+public void setEventCode(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getEventCode()](../../com.aspose.diagram/eventitem\#getEventCode--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getID()](../../com.aspose.diagram/eventitem\#getID--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setTarget(String value) {#setTarget-java.lang.String-}
+```
+public void setTarget(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getTarget()](../../com.aspose.diagram/eventitem\#getTarget--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setTargetArgs(String value) {#setTargetArgs-java.lang.String-}
+```
+public void setTargetArgs(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getTargetArgs()](../../com.aspose.diagram/eventitem\#getTargetArgs--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/eventitemcollection/_index.md
+++ b/italian/java/com.aspose.diagram/eventitemcollection/_index.md
@@ -1,0 +1,231 @@
+---
+title: EventItemCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Raccolta EventItem.
+type: docs
+weight: 146
+url: /it/java/com.aspose.diagram/eventitemcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class EventItemCollection extends Collection
+```
+
+Raccolta EventItem.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [EventItemCollection()](#EventItemCollection--) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [add(EventItem eventItem)](#add-com.aspose.diagram.EventItem-) | Aggiungi l'eventItem nella collezione. |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(EventItem eventItem)](#remove-com.aspose.diagram.EventItem-) | Rimuovi l'eventItem dalla collezione. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### EventItemCollection() {#EventItemCollection--}
+```
+public EventItemCollection()
+```
+
+
+Costruttore.
+
+### add(EventItem eventItem) {#add-com.aspose.diagram.EventItem-}
+```
+public int add(EventItem eventItem)
+```
+
+
+Aggiungi l'eventItem nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| eventItem | [EventItem](../../com.aspose.diagram/eventitem) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public EventItem get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[EventItem](../../com.aspose.diagram/eventitem) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(EventItem eventItem) {#remove-com.aspose.diagram.EventItem-}
+```
+public void remove(EventItem eventItem)
+```
+
+
+Rimuovi l'eventItem dalla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| eventItem | [EventItem](../../com.aspose.diagram/eventitem) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/field/_index.md
+++ b/italian/java/com.aspose.diagram/field/_index.md
@@ -1,0 +1,309 @@
+---
+title: Campo
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene elementi che specificano funzioni e formule inserite nel testo delle forme.
+type: docs
+weight: 147
+url: /it/java/com.aspose.diagram/field/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Field
+```
+
+Contiene elementi che specificano funzioni e formule inserite nel testo della forma.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [Field()](#Field--) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCalendar()](#getCalendar--) | Determina il calendario utilizzato per le proprietà personalizzate, i campi di testo e le formule degli elementi. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getDisplayValue()](#getDisplayValue--) | Ottiene il valore stringa formattato di questo campo. |
+| [getEditMode()](#getEditMode--) | Riservato per uso futuro. |
+| [getFormat()](#getFormat--) | L'elemento Format specifica la formattazione per un campo di testo che è una stringa, numero, data o ora, durata o valuta. |
+| [getIX()](#getIX--) | L'indice basato su zero dell'elemento all'interno del suo elemento genitore. |
+| [getObjectKind()](#getObjectKind--) | Indica il tipo di campo di testo. |
+| [getType()](#getType--) | Tipo specifica un tipo di dati per il valore del campo di testo. |
+| [getUICat()](#getUICat--) | Specifica la categoria di un campo inserito nelle versioni di Microsoft Visio precedenti a Visio 2000. |
+| [getUICod()](#getUICod--) | Specifica il codice di un campo inserito nelle versioni di Microsoft Visio precedenti a Visio 2000. |
+| [getUIFmt()](#getUIFmt--) | Specifica il formato di un campo inserito nelle versioni di Microsoft Visio precedenti a Visio 2000. |
+| [getValue()](#getValue--) | Contiene il valore per un campo di testo. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/field\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Per la descrizione di questa proprietà, vedere [getIX()](../../com.aspose.diagram/field\#getIX--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Field() {#Field--}
+```
+public Field()
+```
+
+
+Costruttore.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCalendar() {#getCalendar--}
+```
+public Calendar getCalendar()
+```
+
+
+Determina il calendario utilizzato per le proprietà personalizzate, i campi di testo e le formule degli elementi.
+
+**Returns:**
+[Calendar](../../com.aspose.diagram/calendar)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getDisplayValue() {#getDisplayValue--}
+```
+public String getDisplayValue()
+```
+
+
+Ottiene il valore stringa formattato di questo campo.
+
+**Returns:**
+java.lang.String
+### getEditMode() {#getEditMode--}
+```
+public DoubleValue getEditMode()
+```
+
+
+Riservato per uso futuro.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getFormat() {#getFormat--}
+```
+public Value getFormat()
+```
+
+
+L'elemento Format specifica la formattazione per un campo di testo che è una stringa, un numero, una data o ora, una durata o una valuta. Il tipo di campo di testo è specificato nell'elemento Type corrispondente.
+
+**Returns:**
+[Value](../../com.aspose.diagram/value)
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+L'indice basato su zero dell'elemento all'interno del suo elemento genitore.
+
+**Returns:**
+int
+### getObjectKind() {#getObjectKind--}
+```
+public ObjectKind getObjectKind()
+```
+
+
+Indica il tipo di campo di testo.
+
+**Returns:**
+[ObjectKind](../../com.aspose.diagram/objectkind)
+### getType() {#getType--}
+```
+public TypeField getType()
+```
+
+
+Tipo specifica un tipo di dati per il valore del campo di testo.
+
+**Returns:**
+[TypeField](../../com.aspose.diagram/typefield)
+### getUICat() {#getUICat--}
+```
+public DoubleValue getUICat()
+```
+
+
+Specifica la categoria di un campo inserito nelle versioni di Microsoft Visio precedenti a Visio 2000.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getUICod() {#getUICod--}
+```
+public DoubleValue getUICod()
+```
+
+
+Specifica il codice di un campo inserito nelle versioni di Microsoft Visio precedenti a Visio 2000.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getUIFmt() {#getUIFmt--}
+```
+public DoubleValue getUIFmt()
+```
+
+
+Specifica il formato di un campo inserito nelle versioni di Microsoft Visio precedenti a Visio 2000.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getValue() {#getValue--}
+```
+public Value getValue()
+```
+
+
+Contiene il valore per un campo di testo.
+
+**Returns:**
+[Value](../../com.aspose.diagram/value)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/field\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getIX()](../../com.aspose.diagram/field\#getIX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/fieldcollection/_index.md
+++ b/italian/java/com.aspose.diagram/fieldcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: FieldCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Raccolta di campi.
+type: docs
+weight: 148
+url: /it/java/com.aspose.diagram/fieldcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class FieldCollection extends Collection
+```
+
+Raccolta di campi.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [add(Field item)](#add-com.aspose.diagram.Field-) | Aggiungi l'oggetto Field nella collezione. |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Field item)](#remove-com.aspose.diagram.Field-) | Rimuovi l'oggetto Field dalla collezione. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Field item) {#add-com.aspose.diagram.Field-}
+```
+public int add(Field item)
+```
+
+
+Aggiungi l'oggetto Field nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [Field](../../com.aspose.diagram/field) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Field get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[Field](../../com.aspose.diagram/field) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Field item) {#remove-com.aspose.diagram.Field-}
+```
+public void remove(Field item)
+```
+
+
+Rimuovi l'oggetto Field dalla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [Field](../../com.aspose.diagram/field) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/filefontsource/_index.md
+++ b/italian/java/com.aspose.diagram/filefontsource/_index.md
@@ -1,0 +1,165 @@
+---
+title: FileFontSource
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta il singolo file di font TrueType memorizzato nel file system.
+type: docs
+weight: 149
+url: /it/java/com.aspose.diagram/filefontsource/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.FontSourceBase](../../com.aspose.diagram/fontsourcebase)
+```
+public class FileFontSource extends FontSourceBase
+```
+
+Rappresenta il singolo file di font TrueType memorizzato nel file system.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [FileFontSource(String filePath)](#FileFontSource-java.lang.String-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFilePath()](#getFilePath--) | Percorso al file del font. |
+| [getType()](#getType--) | Restituisce il tipo della fonte dei font. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FileFontSource(String filePath) {#FileFontSource-java.lang.String-}
+```
+public FileFontSource(String filePath)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| filePath | java.lang.String | percorso al file del font |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFilePath() {#getFilePath--}
+```
+public String getFilePath()
+```
+
+
+Percorso al file del font.
+
+**Returns:**
+java.lang.String
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Restituisce il tipo della fonte dei font.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/fileformatinfo/_index.md
+++ b/italian/java/com.aspose.diagram/fileformatinfo/_index.md
@@ -1,0 +1,158 @@
+---
+title: FileFormatInfo
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene i dati restituiti dai metodi di rilevamento del formato file.
+type: docs
+weight: 150
+url: /it/java/com.aspose.diagram/fileformatinfo/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class FileFormatInfo
+```
+
+Contiene i dati restituiti dai metodi di rilevamento del formato file di [FileFormatUtil](../../com.aspose.diagram/fileformatutil).
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [FileFormatInfo()](#FileFormatInfo--) |  |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFileFormatType()](#getFileFormatType--) | Restituisce il formato file rilevato. |
+| [getLoadFormat()](#getLoadFormat--) | Restituisce il formato di caricamento rilevato. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FileFormatInfo() {#FileFormatInfo--}
+```
+public FileFormatInfo()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFileFormatType() {#getFileFormatType--}
+```
+public int getFileFormatType()
+```
+
+
+Restituisce il formato file rilevato.
+
+**Returns:**
+int
+### getLoadFormat() {#getLoadFormat--}
+```
+public int getLoadFormat()
+```
+
+
+Restituisce il formato di caricamento rilevato.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/fileformattype/_index.md
+++ b/italian/java/com.aspose.diagram/fileformattype/_index.md
@@ -1,0 +1,570 @@
+---
+title: FileFormatType
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Enumera i tipi di formato file dei fogli di calcolo
+type: docs
+weight: 151
+url: /it/java/com.aspose.diagram/fileformattype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class FileFormatType
+```
+
+Enumera i tipi di formato file dei fogli di calcolo
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [CSV](#CSV) | Rappresenta un file CSV. |
+| [DIF](#DIF) | Formato di scambio dati. |
+| [DOC](#DOC) | Rappresenta un file doc. |
+| [DOCM](#DOCM) | Rappresenta un file docm. |
+| [DOCX](#DOCX) | Rappresenta un file docx. |
+| [DOTM](#DOTM) | Rappresenta un file dotm. |
+| [DOTX](#DOTX) | Rappresenta un file dotx. |
+| [EXCEL_2003_XML](#EXCEL-2003-XML) | Rappresenta un file xml di Excel 2003. |
+| [EXCEL_97_TO_2003](#EXCEL-97-TO-2003) | Rappresenta un file xls di Excel97-2003. |
+| [HTML](#HTML) | Rappresenta un file html. |
+| [MAPI_MESSAGE](#MAPI-MESSAGE) | Rappresenta un file email. |
+| [MS_EQUATION](#MS-EQUATION) | Rappresenta l'oggetto MS Equation 3.0. |
+| [ODS](#ODS) | Rappresenta un file ods. |
+| [OLE_10_NATIVE](#OLE-10-NATIVE) | Rappresenta l'oggetto nativo incorporato. |
+| [OOXML](#OOXML) | Rappresenta un file Office Open XML (come xlsx, docx, pptx, ecc). |
+| [PDF](#PDF) | Rappresenta un file PDF. |
+| [POTM](#POTM) | Rappresenta un file Potm. |
+| [POTX](#POTX) | Rappresenta un file Potx. |
+| [PPSM](#PPSM) | Rappresenta un file ppsm. |
+| [PPSX](#PPSX) | Rappresenta un file ppsx. |
+| [PPT](#PPT) | Rappresenta un file ppt. |
+| [PPTM](#PPTM) | Rappresenta un file pptm. |
+| [PPTX](#PPTX) | Rappresenta un file pptx. |
+| [SLDX](#SLDX) | Rappresenta un file sldx. |
+| [SVG](#SVG) | Rappresenta un file svg. |
+| [TAB_DELIMITED](#TAB-DELIMITED) | Rappresenta un file di testo delimitato da tabulazioni. |
+| [TIFF](#TIFF) | Rappresenta un file TIFF. |
+| [UNKNOWN](#UNKNOWN) | Rappresenta un formato non riconosciuto, impossibile da caricare. |
+| [VDW](#VDW) | Formato di disegno web VDW di MS Visio. |
+| [VDX](#VDX) | Formato XML VDX di MS Visio. |
+| [VSD](#VSD) | Formato binario VSD di MS Visio. |
+| [VSDM](#VSDM) | Formato file VSDM di MS Visio 2013. |
+| [VSDX](#VSDX) | Formato file VSDX di MS Visio 2013. |
+| [VSS](#VSS) | Formato stencil binario VSS di MS Visio. |
+| [VSSM](#VSSM) | Formato file VSSM di MS Visio 2013. |
+| [VSSX](#VSSX) | Formato file VSSX di MS Visio 2013. |
+| [VST](#VST) | Formato modello binario VST di MS Visio. |
+| [VSTM](#VSTM) | Formato file VSTM di MS Visio 2013. |
+| [VSTX](#VSTX) | Formato file modello VSTX di MS Visio 2013. |
+| [VSX](#VSX) | Formato stencil xml VSX di MS Visio. |
+| [VTX](#VTX) | Formato modello xml VTX di MS Visio. |
+| [XLAM](#XLAM) | Rappresenta un file modello xltm abilitato per macro add-in. |
+| [XLSB](#XLSB) | Rappresenta un file xlsb. |
+| [XLSM](#XLSM) | Rappresenta un file xlsm che abilita le macro. |
+| [XLSX](#XLSX) | Rappresenta un file xlsx. |
+| [XLTM](#XLTM) | Rappresenta un file modello xltm abilitato per macro. |
+| [XLTX](#XLTX) | Rappresenta un file modello xltx. |
+| [XML](#XML) | Rappresenta un semplice file xml. |
+| [XPS](#XPS) | Rappresenta un file XPS. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CSV {#CSV}
+```
+public static final int CSV
+```
+
+
+Rappresenta un file CSV.  Il formato file non è supportato. Solo per rilevare il tipo di file.
+
+### DIF {#DIF}
+```
+public static final int DIF
+```
+
+
+Formato di scambio dati.
+
+### DOC {#DOC}
+```
+public static final int DOC
+```
+
+
+Rappresenta un file doc. Il formato file non è supportato. Solo per rilevare il tipo di file.
+
+### DOCM {#DOCM}
+```
+public static final int DOCM
+```
+
+
+Rappresenta un file docm. Il formato file non è supportato. Solo per rilevare il tipo di file.
+
+### DOCX {#DOCX}
+```
+public static final int DOCX
+```
+
+
+Rappresenta un file docx. Il formato file non è supportato. Solo per rilevare il tipo di file.
+
+### DOTM {#DOTM}
+```
+public static final int DOTM
+```
+
+
+Rappresenta un file dotm. Il formato file non è supportato. Solo per rilevare il tipo di file.
+
+### DOTX {#DOTX}
+```
+public static final int DOTX
+```
+
+
+Rappresenta un file dotx. Il formato file non è supportato. Solo per rilevare il tipo di file.
+
+### EXCEL_2003_XML {#EXCEL-2003-XML}
+```
+public static final int EXCEL_2003_XML
+```
+
+
+Rappresenta un file xml Excel 2003. Il formato file non è supportato. Solo per rilevare il tipo di file.
+
+### EXCEL_97_TO_2003 {#EXCEL-97-TO-2003}
+```
+public static final int EXCEL_97_TO_2003
+```
+
+
+Rappresenta un file Excel97-2003 xls. Il formato del file non è supportato Solo per il rilevamento del tipo di file.
+
+### HTML {#HTML}
+```
+public static final int HTML
+```
+
+
+Rappresenta un file html.
+
+### MAPI_MESSAGE {#MAPI-MESSAGE}
+```
+public static final int MAPI_MESSAGE
+```
+
+
+Rappresenta un file email. Il formato del file non è supportato Solo per il rilevamento del tipo di file.
+
+### MS_EQUATION {#MS-EQUATION}
+```
+public static final int MS_EQUATION
+```
+
+
+Rappresenta l'oggetto MS Equation 3.0. Il formato del file non è supportato Solo per il rilevamento del tipo di file.
+
+### ODS {#ODS}
+```
+public static final int ODS
+```
+
+
+Rappresenta un file ods. Il formato del file non è supportato Solo per il rilevamento del tipo di file.
+
+### OLE_10_NATIVE {#OLE-10-NATIVE}
+```
+public static final int OLE_10_NATIVE
+```
+
+
+Rappresenta l'oggetto nativo incorporato. Il formato del file non è supportato Solo per il rilevamento del tipo di file.
+
+### OOXML {#OOXML}
+```
+public static final int OOXML
+```
+
+
+Rappresenta un file Office Open XML (come xlsx, docx, pptx, ecc). Il formato del file non è supportato Solo per il rilevamento del tipo di file. Se il file Office Open XML è crittografato, non può essere rilevato come xlsx, docx, pptx, ecc.
+
+### PDF {#PDF}
+```
+public static final int PDF
+```
+
+
+Rappresenta un file PDF.
+
+### POTM {#POTM}
+```
+public static final int POTM
+```
+
+
+Rappresenta un file Potm. Il formato del file non è supportato Solo per il rilevamento del tipo di file.
+
+### POTX {#POTX}
+```
+public static final int POTX
+```
+
+
+Rappresenta un file Potx. Il formato del file non è supportato Solo per il rilevamento del tipo di file.
+
+### PPSM {#PPSM}
+```
+public static final int PPSM
+```
+
+
+Rappresenta un file ppsm. Il formato del file non è supportato Solo per il rilevamento del tipo di file.
+
+### PPSX {#PPSX}
+```
+public static final int PPSX
+```
+
+
+Rappresenta un file ppsx. Il formato del file non è supportato Solo per il rilevamento del tipo di file.
+
+### PPT {#PPT}
+```
+public static final int PPT
+```
+
+
+Rappresenta un file ppt. Il formato del file non è supportato Solo per il rilevamento del tipo di file.
+
+### PPTM {#PPTM}
+```
+public static final int PPTM
+```
+
+
+Rappresenta un file pptm. Il formato del file non è supportato Solo per il rilevamento del tipo di file.
+
+### PPTX {#PPTX}
+```
+public static final int PPTX
+```
+
+
+Rappresenta un file pptx. Il formato del file non è supportato Solo per il rilevamento del tipo di file.
+
+### SLDX {#SLDX}
+```
+public static final int SLDX
+```
+
+
+Rappresenta un file sldx. Il formato del file non è supportato Solo per il rilevamento del tipo di file.
+
+### SVG {#SVG}
+```
+public static final int SVG
+```
+
+
+Rappresenta un file svg.
+
+### TAB_DELIMITED {#TAB-DELIMITED}
+```
+public static final int TAB_DELIMITED
+```
+
+
+Rappresenta un file di testo delimitato da tabulazioni. Il formato del file non è supportato Solo per il rilevamento del tipo di file.
+
+### TIFF {#TIFF}
+```
+public static final int TIFF
+```
+
+
+Rappresenta un file TIFF.
+
+### UNKNOWN {#UNKNOWN}
+```
+public static final int UNKNOWN
+```
+
+
+Rappresenta un formato non riconosciuto, impossibile da caricare.
+
+### VDW {#VDW}
+```
+public static final int VDW
+```
+
+
+Formato di disegno web VDW di MS Visio.
+
+### VDX {#VDX}
+```
+public static final int VDX
+```
+
+
+Formato XML VDX di MS Visio.
+
+### VSD {#VSD}
+```
+public static final int VSD
+```
+
+
+Formato binario VSD di MS Visio.
+
+### VSDM {#VSDM}
+```
+public static final int VSDM
+```
+
+
+Formato file VSDM di MS Visio 2013.
+
+### VSDX {#VSDX}
+```
+public static final int VSDX
+```
+
+
+Formato file VSDX di MS Visio 2013.
+
+### VSS {#VSS}
+```
+public static final int VSS
+```
+
+
+Formato stencil binario VSS di MS Visio.
+
+### VSSM {#VSSM}
+```
+public static final int VSSM
+```
+
+
+Formato file VSSM di MS Visio 2013.
+
+### VSSX {#VSSX}
+```
+public static final int VSSX
+```
+
+
+Formato file VSSX di MS Visio 2013.
+
+### VST {#VST}
+```
+public static final int VST
+```
+
+
+Formato modello binario VST di MS Visio.
+
+### VSTM {#VSTM}
+```
+public static final int VSTM
+```
+
+
+Formato file VSTM di MS Visio 2013.
+
+### VSTX {#VSTX}
+```
+public static final int VSTX
+```
+
+
+Formato file modello VSTX di MS Visio 2013.
+
+### VSX {#VSX}
+```
+public static final int VSX
+```
+
+
+Formato stencil xml VSX di MS Visio.
+
+### VTX {#VTX}
+```
+public static final int VTX
+```
+
+
+Formato modello xml VTX di MS Visio.
+
+### XLAM {#XLAM}
+```
+public static final int XLAM
+```
+
+
+Rappresenta un file modello xltm abilitato per addinMacro. Il formato del file non è supportato Solo per il rilevamento del tipo di file.
+
+### XLSB {#XLSB}
+```
+public static final int XLSB
+```
+
+
+Rappresenta un file xlsb. Il formato del file non è supportato Solo per il rilevamento del tipo di file.
+
+### XLSM {#XLSM}
+```
+public static final int XLSM
+```
+
+
+Rappresenta un file xlsm che abilita le macro. Il formato del file non è supportato Solo per il rilevamento del tipo di file.
+
+### XLSX {#XLSX}
+```
+public static final int XLSX
+```
+
+
+Rappresenta un file xlsx. Il formato del file non è supportato Solo per il rilevamento del tipo di file.
+
+### XLTM {#XLTM}
+```
+public static final int XLTM
+```
+
+
+Rappresenta un file modello xltm abilitato per macro. Il formato del file non è supportato Solo per il rilevamento del tipo di file.
+
+### XLTX {#XLTX}
+```
+public static final int XLTX
+```
+
+
+Rappresenta un file modello xltx. Il formato del file non è supportato Solo per il rilevamento del tipo di file.
+
+### XML {#XML}
+```
+public static final int XML
+```
+
+
+Rappresenta un file XML semplice. Il formato del file non è supportato Solo per il rilevamento del tipo di file.
+
+### XPS {#XPS}
+```
+public static final int XPS
+```
+
+
+Rappresenta un file XPS.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/fileformatutil/_index.md
+++ b/italian/java/com.aspose.diagram/fileformatutil/_index.md
@@ -1,0 +1,168 @@
+---
+title: FileFormatUtil
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Fornisce metodi di utilità per convertire le enumerazioni di formato file in stringhe o estensioni di file e viceversa.
+type: docs
+weight: 152
+url: /it/java/com.aspose.diagram/fileformatutil/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class FileFormatUtil
+```
+
+Fornisce metodi di utilità per convertire le enumerazioni di formato file in stringhe o estensioni di file e viceversa.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [FileFormatUtil()](#FileFormatUtil--) |  |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [detectFileFormat(InputStream stream)](#detectFileFormat-java.io.InputStream-) | Rileva e restituisce le informazioni sul formato di un Visio memorizzato in uno stream. |
+| [detectFileFormat(String filePath)](#detectFileFormat-java.lang.String-) | Rileva e restituisce le informazioni sul formato di un Visio memorizzato in un file. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FileFormatUtil() {#FileFormatUtil--}
+```
+public FileFormatUtil()
+```
+
+
+### detectFileFormat(InputStream stream) {#detectFileFormat-java.io.InputStream-}
+```
+public static FileFormatInfo detectFileFormat(InputStream stream)
+```
+
+
+Rileva e restituisce le informazioni sul formato di un Visio memorizzato in uno stream.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| flusso | java.io.InputStream | Il flusso |
+
+**Returns:**
+[FileFormatInfo](../../com.aspose.diagram/fileformatinfo) - A [FileFormatInfo](../../com.aspose.diagram/fileformatinfo) object that contains the detected information.
+### detectFileFormat(String filePath) {#detectFileFormat-java.lang.String-}
+```
+public static FileFormatInfo detectFileFormat(String filePath)
+```
+
+
+Rileva e restituisce le informazioni sul formato di un Visio memorizzato in un file.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| filePath | java.lang.String | Il percorso del file. |
+
+**Returns:**
+[FileFormatInfo](../../com.aspose.diagram/fileformatinfo) - A [FileFormatInfo](../../com.aspose.diagram/fileformatinfo) object that contains the detected information.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/fill/_index.md
+++ b/italian/java/com.aspose.diagram/fill/_index.md
@@ -1,0 +1,597 @@
+---
+title: Riempimento
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene i valori di formattazione di riempimento attuali per la forma e l'ombra proiettata della forma, inclusi il colore di primo piano del modello e il colore di sfondo.
+type: docs
+weight: 153
+url: /it/java/com.aspose.diagram/fill/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Fill
+```
+
+Contiene i valori di formattazione di riempimento attuali per la forma e l'ombra della forma, inclusi modello, colore di primo piano e colore di sfondo.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getFillBkgnd()](#getFillBkgnd--) | Specifica il colore usato per lo sfondo del modello di riempimento della forma. |
+| [getFillBkgndTrans()](#getFillBkgndTrans--) | Specifica il livello di trasparenza per il colore di sfondo (riempimento) del modello di riempimento della forma, da 0 (completamente opaco) a 1 (completamente trasparente). |
+| [getFillForegnd()](#getFillForegnd--) | Specifica il colore usato per il primo piano (tratto) del modello di riempimento della forma. |
+| [getFillForegndTrans()](#getFillForegndTrans--) | Specifica il livello di trasparenza per il colore di primo piano (riempimento) del modello di riempimento della forma, da 0 (completamente opaco) a 1 (completamente trasparente). |
+| [getFillPattern()](#getFillPattern--) | Specifica il modello di riempimento per la forma. |
+| [getGradientFill()](#getGradientFill--) | Contiene i valori di formattazione del riempimento gradiente attuali per la forma |
+| [getShapeShdwBlur()](#getShapeShdwBlur--) | Specifica la dimensione della sfocatura dell'ombra di una forma. |
+| [getShapeShdwObliqueAngle()](#getShapeShdwObliqueAngle--) | Specifica l'angolo della direzione obliqua dell'ombra di una forma. |
+| [getShapeShdwOffsetX()](#getShapeShdwOffsetX--) | Determina la distanza, in unità di pagina, con cui l'ombra di una forma è spostata orizzontalmente dalla forma. |
+| [getShapeShdwOffsetY()](#getShapeShdwOffsetY--) | Determina la distanza, in unità di pagina, con cui l'ombra di una forma è spostata verticalmente dalla forma. |
+| [getShapeShdwScaleFactor()](#getShapeShdwScaleFactor--) | Specifica la percentuale con cui l'ombra di una forma può essere ingrandita o ridotta. |
+| [getShapeShdwShow()](#getShapeShdwShow--) | Specifica il tipo di ombra per una forma. |
+| [getShapeShdwType()](#getShapeShdwType--) | Specifica il tipo di ombra per una forma. |
+| [getShdwBkgnd()](#getShdwBkgnd--) | Specifica il colore usato per lo sfondo (riempimento) del modello di riempimento dell'ombra proiettata della forma. |
+| [getShdwBkgndTrans()](#getShdwBkgndTrans--) | Specifica il livello di trasparenza per lo sfondo (riempimento) del modello di riempimento dell'ombra proiettata della forma, da 0.0 (completamente opaco) a 1.0 (completamente trasparente). |
+| [getShdwForegnd()](#getShdwForegnd--) | Specifica il colore usato per il primo piano (tratto) del modello di riempimento dell'ombra proiettata della forma. |
+| [getShdwForegndTrans()](#getShdwForegndTrans--) | Specifica il livello di trasparenza per il primo piano (tratto) del modello di riempimento dell'ombra proiettata della forma, da 0.0 (completamente opaco) a 1.0 (completamente trasparente). |
+| [getShdwPattern()](#getShdwPattern--) | Specifica il modello di riempimento per l'ombra di una forma. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/fill\#getDel--) |
+| [setFillBkgnd(ColorValue value)](#setFillBkgnd-com.aspose.diagram.ColorValue-) | Per la descrizione di questa proprietà, vedere [getFillBkgnd()](../../com.aspose.diagram/fill\#getFillBkgnd--) |
+| [setFillBkgndTrans(DoubleValue value)](#setFillBkgndTrans-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getFillBkgndTrans()](../../com.aspose.diagram/fill\#getFillBkgndTrans--) |
+| [setFillForegnd(ColorValue value)](#setFillForegnd-com.aspose.diagram.ColorValue-) | Per la descrizione di questa proprietà, vedere [getFillForegnd()](../../com.aspose.diagram/fill\#getFillForegnd--) |
+| [setFillForegndTrans(DoubleValue value)](#setFillForegndTrans-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getFillForegndTrans()](../../com.aspose.diagram/fill\#getFillForegndTrans--) |
+| [setFillPattern(IntValue value)](#setFillPattern-com.aspose.diagram.IntValue-) | Per la descrizione di questa proprietà, vedere [getFillPattern()](../../com.aspose.diagram/fill\#getFillPattern--) |
+| [setShapeShdwBlur(DoubleValue value)](#setShapeShdwBlur-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getShapeShdwBlur()](../../com.aspose.diagram/fill\#getShapeShdwBlur--) |
+| [setShapeShdwObliqueAngle(DoubleValue value)](#setShapeShdwObliqueAngle-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getShapeShdwObliqueAngle()](../../com.aspose.diagram/fill\#getShapeShdwObliqueAngle--) |
+| [setShapeShdwOffsetX(DoubleValue value)](#setShapeShdwOffsetX-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getShapeShdwOffsetX()](../../com.aspose.diagram/fill\#getShapeShdwOffsetX--) |
+| [setShapeShdwOffsetY(DoubleValue value)](#setShapeShdwOffsetY-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getShapeShdwOffsetY()](../../com.aspose.diagram/fill\#getShapeShdwOffsetY--) |
+| [setShapeShdwScaleFactor(DoubleValue value)](#setShapeShdwScaleFactor-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getShapeShdwScaleFactor()](../../com.aspose.diagram/fill\#getShapeShdwScaleFactor--) |
+| [setShapeShdwShow(ShapeShdwShow value)](#setShapeShdwShow-com.aspose.diagram.ShapeShdwShow-) | Per la descrizione di questa proprietà, vedere [getShapeShdwShow()](../../com.aspose.diagram/fill\#getShapeShdwShow--) |
+| [setShapeShdwType(ShapeShdwType value)](#setShapeShdwType-com.aspose.diagram.ShapeShdwType-) | Per la descrizione di questa proprietà, vedere [getShapeShdwType()](../../com.aspose.diagram/fill\#getShapeShdwType--) |
+| [setShdwBkgnd(ColorValue value)](#setShdwBkgnd-com.aspose.diagram.ColorValue-) | Per la descrizione di questa proprietà, vedere [getShdwBkgnd()](../../com.aspose.diagram/fill\#getShdwBkgnd--) |
+| [setShdwBkgndTrans(DoubleValue value)](#setShdwBkgndTrans-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getShdwBkgndTrans()](../../com.aspose.diagram/fill\#getShdwBkgndTrans--) |
+| [setShdwForegnd(ColorValue value)](#setShdwForegnd-com.aspose.diagram.ColorValue-) | Per la descrizione di questa proprietà, vedere [getShdwForegnd()](../../com.aspose.diagram/fill\#getShdwForegnd--) |
+| [setShdwForegndTrans(DoubleValue value)](#setShdwForegndTrans-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getShdwForegndTrans()](../../com.aspose.diagram/fill\#getShdwForegndTrans--) |
+| [setShdwPattern(IntValue value)](#setShdwPattern-com.aspose.diagram.IntValue-) | Per la descrizione di questa proprietà, vedere [getShdwPattern()](../../com.aspose.diagram/fill\#getShdwPattern--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getFillBkgnd() {#getFillBkgnd--}
+```
+public ColorValue getFillBkgnd()
+```
+
+
+Specifica il colore usato per lo sfondo del modello di riempimento della forma.
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getFillBkgndTrans() {#getFillBkgndTrans--}
+```
+public DoubleValue getFillBkgndTrans()
+```
+
+
+Specifica il livello di trasparenza per il colore di sfondo (riempimento) del modello di riempimento della forma, da 0 (completamente opaco) a 1 (completamente trasparente).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getFillForegnd() {#getFillForegnd--}
+```
+public ColorValue getFillForegnd()
+```
+
+
+Specifica il colore usato per il primo piano (tratto) del modello di riempimento della forma.
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getFillForegndTrans() {#getFillForegndTrans--}
+```
+public DoubleValue getFillForegndTrans()
+```
+
+
+Specifica il livello di trasparenza per il colore di primo piano (riempimento) del modello di riempimento della forma, da 0 (completamente opaco) a 1 (completamente trasparente).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getFillPattern() {#getFillPattern--}
+```
+public IntValue getFillPattern()
+```
+
+
+Specifica il modello di riempimento per la forma.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getGradientFill() {#getGradientFill--}
+```
+public GradientFill getGradientFill()
+```
+
+
+Contiene i valori di formattazione del riempimento gradiente attuali per la forma
+
+**Returns:**
+[GradientFill](../../com.aspose.diagram/gradientfill)
+### getShapeShdwBlur() {#getShapeShdwBlur--}
+```
+public DoubleValue getShapeShdwBlur()
+```
+
+
+Specifica la dimensione della sfocatura dell'ombra di una forma. non è possibile disegnare la sfocatura ora, ma è possibile analizzarla da vsdx ora.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShapeShdwObliqueAngle() {#getShapeShdwObliqueAngle--}
+```
+public DoubleValue getShapeShdwObliqueAngle()
+```
+
+
+Specifica l'angolo della direzione obliqua dell'ombra di una forma.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShapeShdwOffsetX() {#getShapeShdwOffsetX--}
+```
+public DoubleValue getShapeShdwOffsetX()
+```
+
+
+Determina la distanza, in unità di pagina, con cui l'ombra di una forma è spostata orizzontalmente dalla forma.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShapeShdwOffsetY() {#getShapeShdwOffsetY--}
+```
+public DoubleValue getShapeShdwOffsetY()
+```
+
+
+Determina la distanza, in unità di pagina, con cui l'ombra di una forma è spostata verticalmente dalla forma.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShapeShdwScaleFactor() {#getShapeShdwScaleFactor--}
+```
+public DoubleValue getShapeShdwScaleFactor()
+```
+
+
+Specifica la percentuale con cui l'ombra di una forma può essere ingrandita o ridotta.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShapeShdwShow() {#getShapeShdwShow--}
+```
+public ShapeShdwShow getShapeShdwShow()
+```
+
+
+Specifica il tipo di ombra per una forma.
+
+**Returns:**
+[ShapeShdwShow](../../com.aspose.diagram/shapeshdwshow)
+### getShapeShdwType() {#getShapeShdwType--}
+```
+public ShapeShdwType getShapeShdwType()
+```
+
+
+Specifica il tipo di ombra per una forma.
+
+**Returns:**
+[ShapeShdwType](../../com.aspose.diagram/shapeshdwtype)
+### getShdwBkgnd() {#getShdwBkgnd--}
+```
+public ColorValue getShdwBkgnd()
+```
+
+
+Specifica il colore usato per lo sfondo (riempimento) del modello di riempimento dell'ombra proiettata della forma.
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getShdwBkgndTrans() {#getShdwBkgndTrans--}
+```
+public DoubleValue getShdwBkgndTrans()
+```
+
+
+Specifica il livello di trasparenza per lo sfondo (riempimento) del modello di riempimento dell'ombra proiettata della forma, da 0.0 (completamente opaco) a 1.0 (completamente trasparente).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShdwForegnd() {#getShdwForegnd--}
+```
+public ColorValue getShdwForegnd()
+```
+
+
+Specifica il colore usato per il primo piano (tratto) del modello di riempimento dell'ombra proiettata della forma.
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getShdwForegndTrans() {#getShdwForegndTrans--}
+```
+public DoubleValue getShdwForegndTrans()
+```
+
+
+Specifica il livello di trasparenza per il primo piano (tratto) del modello di riempimento dell'ombra proiettata della forma, da 0.0 (completamente opaco) a 1.0 (completamente trasparente).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShdwPattern() {#getShdwPattern--}
+```
+public IntValue getShdwPattern()
+```
+
+
+Specifica il modello di riempimento per l'ombra di una forma.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/fill\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setFillBkgnd(ColorValue value) {#setFillBkgnd-com.aspose.diagram.ColorValue-}
+```
+public void setFillBkgnd(ColorValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getFillBkgnd()](../../com.aspose.diagram/fill\#getFillBkgnd--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setFillBkgndTrans(DoubleValue value) {#setFillBkgndTrans-com.aspose.diagram.DoubleValue-}
+```
+public void setFillBkgndTrans(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getFillBkgndTrans()](../../com.aspose.diagram/fill\#getFillBkgndTrans--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setFillForegnd(ColorValue value) {#setFillForegnd-com.aspose.diagram.ColorValue-}
+```
+public void setFillForegnd(ColorValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getFillForegnd()](../../com.aspose.diagram/fill\#getFillForegnd--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setFillForegndTrans(DoubleValue value) {#setFillForegndTrans-com.aspose.diagram.DoubleValue-}
+```
+public void setFillForegndTrans(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getFillForegndTrans()](../../com.aspose.diagram/fill\#getFillForegndTrans--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setFillPattern(IntValue value) {#setFillPattern-com.aspose.diagram.IntValue-}
+```
+public void setFillPattern(IntValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getFillPattern()](../../com.aspose.diagram/fill\#getFillPattern--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setShapeShdwBlur(DoubleValue value) {#setShapeShdwBlur-com.aspose.diagram.DoubleValue-}
+```
+public void setShapeShdwBlur(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getShapeShdwBlur()](../../com.aspose.diagram/fill\#getShapeShdwBlur--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setShapeShdwObliqueAngle(DoubleValue value) {#setShapeShdwObliqueAngle-com.aspose.diagram.DoubleValue-}
+```
+public void setShapeShdwObliqueAngle(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getShapeShdwObliqueAngle()](../../com.aspose.diagram/fill\#getShapeShdwObliqueAngle--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setShapeShdwOffsetX(DoubleValue value) {#setShapeShdwOffsetX-com.aspose.diagram.DoubleValue-}
+```
+public void setShapeShdwOffsetX(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getShapeShdwOffsetX()](../../com.aspose.diagram/fill\#getShapeShdwOffsetX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setShapeShdwOffsetY(DoubleValue value) {#setShapeShdwOffsetY-com.aspose.diagram.DoubleValue-}
+```
+public void setShapeShdwOffsetY(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getShapeShdwOffsetY()](../../com.aspose.diagram/fill\#getShapeShdwOffsetY--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setShapeShdwScaleFactor(DoubleValue value) {#setShapeShdwScaleFactor-com.aspose.diagram.DoubleValue-}
+```
+public void setShapeShdwScaleFactor(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getShapeShdwScaleFactor()](../../com.aspose.diagram/fill\#getShapeShdwScaleFactor--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setShapeShdwShow(ShapeShdwShow value) {#setShapeShdwShow-com.aspose.diagram.ShapeShdwShow-}
+```
+public void setShapeShdwShow(ShapeShdwShow value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getShapeShdwShow()](../../com.aspose.diagram/fill\#getShapeShdwShow--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [ShapeShdwShow](../../com.aspose.diagram/shapeshdwshow) |  |
+
+### setShapeShdwType(ShapeShdwType value) {#setShapeShdwType-com.aspose.diagram.ShapeShdwType-}
+```
+public void setShapeShdwType(ShapeShdwType value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getShapeShdwType()](../../com.aspose.diagram/fill\#getShapeShdwType--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [ShapeShdwType](../../com.aspose.diagram/shapeshdwtype) |  |
+
+### setShdwBkgnd(ColorValue value) {#setShdwBkgnd-com.aspose.diagram.ColorValue-}
+```
+public void setShdwBkgnd(ColorValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getShdwBkgnd()](../../com.aspose.diagram/fill\#getShdwBkgnd--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setShdwBkgndTrans(DoubleValue value) {#setShdwBkgndTrans-com.aspose.diagram.DoubleValue-}
+```
+public void setShdwBkgndTrans(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getShdwBkgndTrans()](../../com.aspose.diagram/fill\#getShdwBkgndTrans--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setShdwForegnd(ColorValue value) {#setShdwForegnd-com.aspose.diagram.ColorValue-}
+```
+public void setShdwForegnd(ColorValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getShdwForegnd()](../../com.aspose.diagram/fill\#getShdwForegnd--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setShdwForegndTrans(DoubleValue value) {#setShdwForegndTrans-com.aspose.diagram.DoubleValue-}
+```
+public void setShdwForegndTrans(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getShdwForegndTrans()](../../com.aspose.diagram/fill\#getShdwForegndTrans--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setShdwPattern(IntValue value) {#setShdwPattern-com.aspose.diagram.IntValue-}
+```
+public void setShdwPattern(IntValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getShdwPattern()](../../com.aspose.diagram/fill\#getShdwPattern--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/filltype/_index.md
+++ b/italian/java/com.aspose.diagram/filltype/_index.md
@@ -1,0 +1,183 @@
+---
+title: FillType
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Tipo di formato di riempimento.
+type: docs
+weight: 154
+url: /it/java/com.aspose.diagram/filltype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class FillType
+```
+
+Tipo di formato di riempimento.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [AUTOMATIC](#AUTOMATIC) | Rappresenta il tipo di formattazione automatico. |
+| [GRADIENT](#GRADIENT) | Formato di riempimento gradiente. |
+| [NONE](#NONE) | Rappresenta il tipo di formattazione nessuno. |
+| [PATTERN](#PATTERN) | Formato di riempimento a pattern. |
+| [SOLID](#SOLID) | Formato di riempimento solido. |
+| [TEXTURE](#TEXTURE) | Formato di riempimento texture. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AUTOMATIC {#AUTOMATIC}
+```
+public static final int AUTOMATIC
+```
+
+
+Rappresenta il tipo di formattazione automatico.
+
+### GRADIENT {#GRADIENT}
+```
+public static final int GRADIENT
+```
+
+
+Formato di riempimento gradiente.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Rappresenta il tipo di formattazione nessuno.
+
+### PATTERN {#PATTERN}
+```
+public static final int PATTERN
+```
+
+
+Formato di riempimento a pattern.
+
+### SOLID {#SOLID}
+```
+public static final int SOLID
+```
+
+
+Formato di riempimento solido.
+
+### TEXTURE {#TEXTURE}
+```
+public static final int TEXTURE
+```
+
+
+Formato di riempimento texture.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/fld/_index.md
+++ b/italian/java/com.aspose.diagram/fld/_index.md
@@ -1,0 +1,155 @@
+---
+title: Fld
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Indica un punto di inserimento del campo di testo per l'elemento Field corrispondente.
+type: docs
+weight: 155
+url: /it/java/com.aspose.diagram/fld/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.FormatTxt](../../com.aspose.diagram/formattxt)
+```
+public class Fld extends FormatTxt
+```
+
+Indica un punto di inserimento del campo di testo per l'elemento Field corrispondente.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [Fld(int IX, Shape shape)](#Fld-int-com.aspose.diagram.Shape-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getValue()](#getValue--) | Valore |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Fld(int IX, Shape shape) {#Fld-int-com.aspose.diagram.Shape-}
+```
+public Fld(int IX, Shape shape)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| IX | int | L'indice basato su zero dell'elemento Field all'interno del suo elemento padre Shape. |
+| shape | [Shape](../../com.aspose.diagram/shape) | Forma. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+Valore
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/floatpointnumcollection/_index.md
+++ b/italian/java/com.aspose.diagram/floatpointnumcollection/_index.md
@@ -1,0 +1,231 @@
+---
+title: FloatPointNumCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene una raccolta di numeri di punti doppi
+type: docs
+weight: 156
+url: /it/java/com.aspose.diagram/floatpointnumcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class FloatPointNumCollection extends Collection
+```
+
+Contiene una raccolta di numeri di punti doppi
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [FloatPointNumCollection()](#FloatPointNumCollection--) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [add(double number)](#add-double-) | Aggiungi il numero del punto di raddoppio nella collezione. |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(double number)](#remove-double-) | Rimuovi il numero del punto di raddoppio dalla collezione. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FloatPointNumCollection() {#FloatPointNumCollection--}
+```
+public FloatPointNumCollection()
+```
+
+
+Costruttore.
+
+### add(double number) {#add-double-}
+```
+public int add(double number)
+```
+
+
+Aggiungi il numero del punto di raddoppio nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| number | double |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public double get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+double -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(double number) {#remove-double-}
+```
+public void remove(double number)
+```
+
+
+Rimuovi il numero del punto di raddoppio dalla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| number | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/folderfontsource/_index.md
+++ b/italian/java/com.aspose.diagram/folderfontsource/_index.md
@@ -1,0 +1,177 @@
+---
+title: FolderFontSource
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta la cartella che contiene i file di font TrueType.
+type: docs
+weight: 157
+url: /it/java/com.aspose.diagram/folderfontsource/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.FontSourceBase](../../com.aspose.diagram/fontsourcebase)
+```
+public class FolderFontSource extends FontSourceBase
+```
+
+Rappresenta la cartella che contiene i file di font TrueType.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [FolderFontSource(String folderPath, boolean scanSubfolders)](#FolderFontSource-java.lang.String-boolean-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFolderPath()](#getFolderPath--) | Percorso alla cartella dei font. |
+| [getScanSubFolders()](#getScanSubFolders--) | Determina se eseguire o meno la scansione delle sottocartelle. |
+| [getType()](#getType--) | Restituisce il tipo della fonte dei font. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FolderFontSource(String folderPath, boolean scanSubfolders) {#FolderFontSource-java.lang.String-boolean-}
+```
+public FolderFontSource(String folderPath, boolean scanSubfolders)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| folderPath | java.lang.String | percorso alla cartella dei font |
+| scanSubfolders | boolean | Determina se eseguire o meno la scansione delle sottocartelle. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFolderPath() {#getFolderPath--}
+```
+public String getFolderPath()
+```
+
+
+Percorso alla cartella dei font.
+
+**Returns:**
+java.lang.String
+### getScanSubFolders() {#getScanSubFolders--}
+```
+public boolean getScanSubFolders()
+```
+
+
+Determina se eseguire o meno la scansione delle sottocartelle.
+
+**Returns:**
+boolean
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Restituisce il tipo della fonte dei font.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/font/_index.md
+++ b/italian/java/com.aspose.diagram/font/_index.md
@@ -1,0 +1,288 @@
+---
+title: Carattere
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene informazioni su un font.
+type: docs
+weight: 158
+url: /it/java/com.aspose.diagram/font/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Font
+```
+
+Contiene informazioni su un font.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [Font()](#Font--) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCharSets()](#getCharSets--) | I set di caratteri supportati del carattere. |
+| [getClass()](#getClass--) |  |
+| [getFlags()](#getFlags--) | Flag che indicano quanto segue: carattere mancante, carattere predefinito, carattere asiatico, carattere complesso, carattere verticale e tipo di carattere. |
+| [getID()](#getID--) | L'ID dell'elemento all'interno del suo elemento padre. |
+| [getName()](#getName--) | Il nome del carattere come stringa Unicode UTF-16. |
+| [getPanos()](#getPanos--) | La firma Panose per il carattere. |
+| [getUnicodeRanges()](#getUnicodeRanges--) | Gli intervalli Unicode supportati del carattere. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCharSets(String value)](#setCharSets-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getCharSets()](../../com.aspose.diagram/font\#getCharSets--) |
+| [setFlags(int value)](#setFlags-int-) | Per la descrizione di questa proprietà, vedere [getFlags()](../../com.aspose.diagram/font\#getFlags--) |
+| [setID(int value)](#setID-int-) | Per la descrizione di questa proprietà, vedere [getID()](../../com.aspose.diagram/font\#getID--) |
+| [setName(String value)](#setName-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getName()](../../com.aspose.diagram/font\#getName--) |
+| [setPanos(String value)](#setPanos-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getPanos()](../../com.aspose.diagram/font\#getPanos--) |
+| [setUnicodeRanges(String value)](#setUnicodeRanges-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getUnicodeRanges()](../../com.aspose.diagram/font\#getUnicodeRanges--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Font() {#Font--}
+```
+public Font()
+```
+
+
+Costruttore.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCharSets() {#getCharSets--}
+```
+public String getCharSets()
+```
+
+
+I set di caratteri supportati del carattere.
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFlags() {#getFlags--}
+```
+public int getFlags()
+```
+
+
+Flag che indicano quanto segue: carattere mancante, carattere predefinito, carattere asiatico, carattere complesso, carattere verticale e tipo di carattere.
+
+**Returns:**
+int
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+L'ID dell'elemento all'interno del suo elemento padre.
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Il nome del carattere come stringa Unicode UTF-16.
+
+**Returns:**
+java.lang.String
+### getPanos() {#getPanos--}
+```
+public String getPanos()
+```
+
+
+La firma Panose per il carattere. Panose è un sistema di classificazione per i tipi di carattere che li categorizza in base alle loro caratteristiche visive.
+
+**Returns:**
+java.lang.String
+### getUnicodeRanges() {#getUnicodeRanges--}
+```
+public String getUnicodeRanges()
+```
+
+
+Gli intervalli Unicode supportati del carattere.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCharSets(String value) {#setCharSets-java.lang.String-}
+```
+public void setCharSets(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getCharSets()](../../com.aspose.diagram/font\#getCharSets--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setFlags(int value) {#setFlags-int-}
+```
+public void setFlags(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getFlags()](../../com.aspose.diagram/font\#getFlags--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getID()](../../com.aspose.diagram/font\#getID--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getName()](../../com.aspose.diagram/font\#getName--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setPanos(String value) {#setPanos-java.lang.String-}
+```
+public void setPanos(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getPanos()](../../com.aspose.diagram/font\#getPanos--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setUnicodeRanges(String value) {#setUnicodeRanges-java.lang.String-}
+```
+public void setUnicodeRanges(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getUnicodeRanges()](../../com.aspose.diagram/font\#getUnicodeRanges--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/fontcollection/_index.md
+++ b/italian/java/com.aspose.diagram/fontcollection/_index.md
@@ -1,0 +1,247 @@
+---
+title: FontCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene una raccolta di elementi Font.
+type: docs
+weight: 159
+url: /it/java/com.aspose.diagram/fontcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class FontCollection extends Collection
+```
+
+Contiene una raccolta di elementi Font.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [FontCollection()](#FontCollection--) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [add(Font font)](#add-com.aspose.diagram.Font-) | Aggiungi l'oggetto Font nella collezione. |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [getFont(int ID)](#getFont-int-) | Restituisce l'elemento con l'ID specificato. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Font font)](#remove-com.aspose.diagram.Font-) | Rimuovi l'oggetto Font dalla collezione. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FontCollection() {#FontCollection--}
+```
+public FontCollection()
+```
+
+
+Costruttore.
+
+### add(Font font) {#add-com.aspose.diagram.Font-}
+```
+public int add(Font font)
+```
+
+
+Aggiungi l'oggetto Font nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| font | [Font](../../com.aspose.diagram/font) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Font get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[Font](../../com.aspose.diagram/font) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### getFont(int ID) {#getFont-int-}
+```
+public Font getFont(int ID)
+```
+
+
+Restituisce l'elemento con l'ID specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| ID | int | intThe ID dell'elemento all'interno del suo elemento genitore. |
+
+**Returns:**
+[Font](../../com.aspose.diagram/font) - [Font](../../com.aspose.diagram/font)Font.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Font font) {#remove-com.aspose.diagram.Font-}
+```
+public void remove(Font font)
+```
+
+
+Rimuovi l'oggetto Font dalla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| font | [Font](../../com.aspose.diagram/font) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/fontconfigs/_index.md
+++ b/italian/java/com.aspose.diagram/fontconfigs/_index.md
@@ -1,0 +1,272 @@
+---
+title: FontConfigs
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica le impostazioni del font
+type: docs
+weight: 160
+url: /it/java/com.aspose.diagram/fontconfigs/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class FontConfigs
+```
+
+Specifica le impostazioni del font
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [FontConfigs()](#FontConfigs--) |  |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDefaultFontName()](#getDefaultFontName--) | il nome del carattere predefinito. |
+| [getFontSources()](#getFontSources--) | Ottiene una copia dell'array che contiene l'elenco delle origini |
+| [getFontSubstitutes(String originalFontName)](#getFontSubstitutes-java.lang.String-) | Restituisce un array contenente i nomi dei caratteri sostitutivi da utilizzare se il carattere originale non è presente. |
+| [getPreferSystemFontSubstitutes()](#getPreferSystemFontSubstitutes--) | Indica se utilizzare prima i sostituti di caratteri di sistema o meno quando un carattere non è presente e il sostituto di questo carattere non è impostato. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDefaultFontName(String value)](#setDefaultFontName-java.lang.String-) | Per la descrizione di questa proprietà, consultare [getDefaultFontName()](../../com.aspose.diagram/fontconfigs\#getDefaultFontName--) |
+| [setFontFolder(String fontFolder, boolean recursive)](#setFontFolder-java.lang.String-boolean-) | Imposta la cartella dei caratteri |
+| [setFontFolders(String[] fontFolders, boolean recursive)](#setFontFolders-java.lang.String---boolean-) | Imposta le cartelle dei caratteri |
+| [setFontSources(FontSourceBase[] sources)](#setFontSources-com.aspose.diagram.FontSourceBase---) | Imposta le origini dei caratteri. |
+| [setFontSubstitutes(String originalFontName, String[] substituteFontNames)](#setFontSubstitutes-java.lang.String-java.lang.String---) | Nomi dei caratteri sostitutivi per il nome del carattere originale fornito. |
+| [setPreferSystemFontSubstitutes(boolean value)](#setPreferSystemFontSubstitutes-boolean-) | Per la descrizione di questa proprietà, consultare [getPreferSystemFontSubstitutes()](../../com.aspose.diagram/fontconfigs\#getPreferSystemFontSubstitutes--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FontConfigs() {#FontConfigs--}
+```
+public FontConfigs()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultFontName() {#getDefaultFontName--}
+```
+public static String getDefaultFontName()
+```
+
+
+il nome del carattere predefinito.
+
+**Returns:**
+java.lang.String
+### getFontSources() {#getFontSources--}
+```
+public static FontSourceBase[] getFontSources()
+```
+
+
+Ottiene una copia dell'array che contiene l'elenco delle origini
+
+**Returns:**
+com.aspose.diagram.FontSourceBase[] -
+### getFontSubstitutes(String originalFontName) {#getFontSubstitutes-java.lang.String-}
+```
+public static String[] getFontSubstitutes(String originalFontName)
+```
+
+
+Restituisce un array contenente i nomi dei caratteri sostitutivi da utilizzare se il carattere originale non è presente.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| originalFontName | java.lang.String | originalFontName |
+
+**Returns:**
+java.lang.String[] - Un array contenente i nomi dei sostituti di carattere da utilizzare se il carattere originale non è presente.
+### getPreferSystemFontSubstitutes() {#getPreferSystemFontSubstitutes--}
+```
+public static boolean getPreferSystemFontSubstitutes()
+```
+
+
+Indicare se utilizzare prima i sostituti di carattere di sistema o meno quando un carattere non è presente e il sostituto di questo carattere non è impostato. ad es. su Ubuntu, il carattere "Arial" è generalmente sostituito da "Liberation Sans". Il valore predefinito è false.
+
+**Returns:**
+boolean
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDefaultFontName(String value) {#setDefaultFontName-java.lang.String-}
+```
+public static void setDefaultFontName(String value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getDefaultFontName()](../../com.aspose.diagram/fontconfigs\#getDefaultFontName--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setFontFolder(String fontFolder, boolean recursive) {#setFontFolder-java.lang.String-boolean-}
+```
+public static void setFontFolder(String fontFolder, boolean recursive)
+```
+
+
+Imposta la cartella dei caratteri
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontFolder | java.lang.String | La cartella che contiene i caratteri TrueType. |
+| recursive | boolean | Determina se eseguire o meno la scansione delle sottocartelle. |
+
+### setFontFolders(String[] fontFolders, boolean recursive) {#setFontFolders-java.lang.String---boolean-}
+```
+public static void setFontFolders(String[] fontFolders, boolean recursive)
+```
+
+
+Imposta le cartelle dei caratteri
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontFolders | java.lang.String[] | Le cartelle che contengono i caratteri TrueType. |
+| recursive | boolean | Determina se eseguire o meno la scansione delle sottocartelle. |
+
+### setFontSources(FontSourceBase[] sources) {#setFontSources-com.aspose.diagram.FontSourceBase---}
+```
+public static void setFontSources(FontSourceBase[] sources)
+```
+
+
+Imposta le origini dei caratteri.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| sources | [FontSourceBase\[\]](../../com.aspose.diagram/fontsourcebase) | Un array di sorgenti che contengono i caratteri TrueType. |
+
+### setFontSubstitutes(String originalFontName, String[] substituteFontNames) {#setFontSubstitutes-java.lang.String-java.lang.String---}
+```
+public static void setFontSubstitutes(String originalFontName, String[] substituteFontNames)
+```
+
+
+Nomi dei caratteri sostitutivi per il nome del carattere originale fornito.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| originalFontName | java.lang.String | Nome del carattere originale. |
+| substituteFontNames | java.lang.String[] | Elenco dei nomi dei sostituti di carattere da utilizzare se il carattere originale non è presente. |
+
+### setPreferSystemFontSubstitutes(boolean value) {#setPreferSystemFontSubstitutes-boolean-}
+```
+public static void setPreferSystemFontSubstitutes(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getPreferSystemFontSubstitutes()](../../com.aspose.diagram/fontconfigs\#getPreferSystemFontSubstitutes--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/fontsourcebase/_index.md
+++ b/italian/java/com.aspose.diagram/fontsourcebase/_index.md
@@ -1,0 +1,147 @@
+---
+title: FontSourceBase
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Questa è una classe base astratta per le classi che consentono all'utente di specificare varie font source
+type: docs
+weight: 161
+url: /it/java/com.aspose.diagram/fontsourcebase/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public abstract class FontSourceBase
+```
+
+Questa è una classe base astratta per le classi che consentono all'utente di specificare varie font source
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [FontSourceBase()](#FontSourceBase--) |  |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getType()](#getType--) | Restituisce il tipo della fonte dei font. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FontSourceBase() {#FontSourceBase--}
+```
+public FontSourceBase()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getType() {#getType--}
+```
+public abstract int getType()
+```
+
+
+Restituisce il tipo della fonte dei font.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/fontsourcetype/_index.md
+++ b/italian/java/com.aspose.diagram/fontsourcetype/_index.md
@@ -1,0 +1,156 @@
+---
+title: FontSourceType
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica il tipo di una font source.
+type: docs
+weight: 162
+url: /it/java/com.aspose.diagram/fontsourcetype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class FontSourceType
+```
+
+Specifica il tipo di una font source.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [FONTS_FOLDER](#FONTS-FOLDER) | rappresenta una cartella con file di caratteri. |
+| [FONT_FILE](#FONT-FILE) | rappresenta un singolo file di carattere. |
+| [MEMORY_FONT](#MEMORY-FONT) | rappresenta un singolo carattere in memoria. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FONTS_FOLDER {#FONTS-FOLDER}
+```
+public static final int FONTS_FOLDER
+```
+
+
+rappresenta una cartella con file di caratteri.
+
+### FONT_FILE {#FONT-FILE}
+```
+public static final int FONT_FILE
+```
+
+
+rappresenta un singolo file di carattere.
+
+### MEMORY_FONT {#MEMORY-FONT}
+```
+public static final int MEMORY_FONT
+```
+
+
+rappresenta un singolo carattere in memoria.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/foreign/_index.md
+++ b/italian/java/com.aspose.diagram/foreign/_index.md
@@ -1,0 +1,205 @@
+---
+title: Esterno
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene elementi che specificano la larghezza e l'altezza di un oggetto proveniente da un altro programma utilizzato in un documento Microsoft Visio.
+type: docs
+weight: 163
+url: /it/java/com.aspose.diagram/foreign/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Foreign
+```
+
+Contiene elementi che specificano la larghezza e l'altezza di un oggetto proveniente da un altro programma utilizzato in un documento Microsoft Visio. Include anche elementi che specificano la distanza di offset dell'immagine dell'oggetto all'interno dei suoi bordi.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getImgHeight()](#getImgHeight--) | Determina l'altezza dell'immagine dell'oggetto all'interno del suo bordo. |
+| [getImgOffsetX()](#getImgOffsetX--) | Determina la distanza di spostamento orizzontale dell'oggetto dall'origine del suo bordo. |
+| [getImgOffsetY()](#getImgOffsetY--) | Determina la distanza di spostamento verticale dell'oggetto dall'origine del suo bordo. |
+| [getImgWidth()](#getImgWidth--) | Determina la larghezza dell'immagine dell'oggetto all'interno del suo bordo. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/foreign\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getImgHeight() {#getImgHeight--}
+```
+public DoubleValue getImgHeight()
+```
+
+
+Determina l'altezza dell'immagine dell'oggetto all'interno del suo bordo. La formula predefinita è: F="Height\*1".
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getImgOffsetX() {#getImgOffsetX--}
+```
+public DoubleValue getImgOffsetX()
+```
+
+
+Determina la distanza di spostamento orizzontale dell'oggetto rispetto all'origine del bordo dell'oggetto. Il valore predefinito è 0; la formula predefinita è F="ImgWidth\*0".
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getImgOffsetY() {#getImgOffsetY--}
+```
+public DoubleValue getImgOffsetY()
+```
+
+
+Determina la distanza di spostamento verticale dell'oggetto rispetto all'origine del bordo dell'oggetto. Il valore predefinito è 0; la formula predefinita è F="ImgHeight\*0".
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getImgWidth() {#getImgWidth--}
+```
+public DoubleValue getImgWidth()
+```
+
+
+Determina la larghezza dell'immagine dell'oggetto all'interno del suo bordo. La formula predefinita è: F="Width\*1".
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/foreign\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/foreigndata/_index.md
+++ b/italian/java/com.aspose.diagram/foreigndata/_index.md
@@ -1,0 +1,486 @@
+---
+title: ForeignData
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene un BLOB codificato MIME Multipurpose Internet Mail Extensions di dati immagine, come bitmap di metafile Windows o dati OLE.
+type: docs
+weight: 164
+url: /it/java/com.aspose.diagram/foreigndata/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ForeignData
+```
+
+Contiene un BLOB codificato MIME (Multipurpose Internet Mail Extensions) di dati immagine, come metafile Windows, bitmap o dati OLE.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCompressionLevel()](#getCompressionLevel--) | Questo attributo ha senso solo se i dati esterni sono un oggetto esterno basato su raster, come un file DIB, JPG, PNG, TIFF o GIF. |
+| [getCompressionType()](#getCompressionType--) | Questo attributo ha senso solo se i dati esterni sono un oggetto esterno basato su raster, come un file DIB, JPG, PNG, TIFF o GIF. |
+| [getExtentX()](#getExtentX--) | Questo attributo ha senso solo se i dati esterni sono un metafile. |
+| [getExtentY()](#getExtentY--) | Questo attributo ha senso solo se i dati esterni sono un metafile. |
+| [getForeignType()](#getForeignType--) | Tipo di dati. |
+| [getImageData()](#getImageData--) | Rappresenta l'immagine dell'oggetto OLE come array di byte. |
+| [getMappingMode()](#getMappingMode--) | Questo attributo ha senso solo se i dati esterni sono un metafile. |
+| [getObjectData()](#getObjectData--) | Rappresenta i dati dell'oggetto OLE incorporato come array di byte. |
+| [getObjectHeight()](#getObjectHeight--) | Questo attributo ha senso solo se i dati esterni sono un oggetto OLE2 incorporato. |
+| [getObjectSourceFullName()](#getObjectSourceFullName--) | Restituisce il nome completo della sorgente del file di origine per l'oggetto OLE collegato. |
+| [getObjectType()](#getObjectType--) | Se l'attributo ForeignType è "Object", l'elemento ForeignData deve inoltre avere un attributo ObjectType. |
+| [getObjectWidth()](#getObjectWidth--) | Questo attributo ha senso solo se i dati esterni sono un oggetto OLE2 incorporato. |
+| [getShowAsIcon()](#getShowAsIcon--) | Questo attributo ha senso solo se i dati esterni sono un oggetto OLE2 incorporato. |
+| [getValue()](#getValue--) | Contiene un BLOB codificato MIME (Multipurpose Internet Mail Extensions) di dati immagine, come metafile Windows, bitmap o dati OLE. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCompressionLevel(double value)](#setCompressionLevel-double-) | Per la descrizione di questa proprietà, consultare [getCompressionLevel()](../../com.aspose.diagram/foreigndata\#getCompressionLevel--) |
+| [setCompressionType(int value)](#setCompressionType-int-) | Per la descrizione di questa proprietà, consultare [getCompressionType()](../../com.aspose.diagram/foreigndata\#getCompressionType--) |
+| [setExtentX(double value)](#setExtentX-double-) | Per la descrizione di questa proprietà, consultare [getExtentX()](../../com.aspose.diagram/foreigndata\#getExtentX--) |
+| [setExtentY(double value)](#setExtentY-double-) | Per la descrizione di questa proprietà, consultare [getExtentY()](../../com.aspose.diagram/foreigndata\#getExtentY--) |
+| [setForeignType(int value)](#setForeignType-int-) | Per la descrizione di questa proprietà, consultare [getForeignType()](../../com.aspose.diagram/foreigndata\#getForeignType--) |
+| [setImageData(byte[] value)](#setImageData-byte---) | Per la descrizione di questa proprietà, consultare [getImageData()](../../com.aspose.diagram/foreigndata\#getImageData--) |
+| [setMappingMode(int value)](#setMappingMode-int-) | Per la descrizione di questa proprietà, consultare [getMappingMode()](../../com.aspose.diagram/foreigndata\#getMappingMode--) |
+| [setObjectData(byte[] value)](#setObjectData-byte---) | Per la descrizione di questa proprietà, consultare [getObjectData()](../../com.aspose.diagram/foreigndata\#getObjectData--) |
+| [setObjectHeight(double value)](#setObjectHeight-double-) | Per la descrizione di questa proprietà, consultare [getObjectHeight()](../../com.aspose.diagram/foreigndata\#getObjectHeight--) |
+| [setObjectSourceFullName(String value)](#setObjectSourceFullName-java.lang.String-) | Per la descrizione di questa proprietà, consultare [getObjectSourceFullName()](../../com.aspose.diagram/foreigndata\#getObjectSourceFullName--) |
+| [setObjectType(int value)](#setObjectType-int-) | Per la descrizione di questa proprietà, consultare [getObjectType()](../../com.aspose.diagram/foreigndata\#getObjectType--) |
+| [setObjectWidth(double value)](#setObjectWidth-double-) | Per la descrizione di questa proprietà, consultare [getObjectWidth()](../../com.aspose.diagram/foreigndata\#getObjectWidth--) |
+| [setShowAsIcon(int value)](#setShowAsIcon-int-) | Per la descrizione di questa proprietà, consultare [getShowAsIcon()](../../com.aspose.diagram/foreigndata\#getShowAsIcon--) |
+| [setValue(byte[] value)](#setValue-byte---) | Per la descrizione di questa proprietà, consultare [getValue()](../../com.aspose.diagram/foreigndata\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCompressionLevel() {#getCompressionLevel--}
+```
+public double getCompressionLevel()
+```
+
+
+Questo attributo ha senso solo se i dati esterni sono un oggetto esterno basato su raster, come un file DIB, JPG, PNG, TIFF o GIF. Il valore indica il livello di compressione applicato al file. Il livello di compressione è misurato in centinaia di percento.
+
+**Returns:**
+double
+### getCompressionType() {#getCompressionType--}
+```
+public int getCompressionType()
+```
+
+
+Questo attributo ha senso solo se i dati esterni sono un oggetto esterno basato su raster, come un file DIB, JPG, PNG, TIFF o GIF. Il valore indica il tipo di compressione applicato al file.
+
+**Returns:**
+int
+### getExtentX() {#getExtentX--}
+```
+public double getExtentX()
+```
+
+
+Questo attributo ha senso solo se i dati esterni sono un metafile. Il valore indica l'estensione orizzontale del metafile.
+
+**Returns:**
+double
+### getExtentY() {#getExtentY--}
+```
+public double getExtentY()
+```
+
+
+Questo attributo ha senso solo se i dati esterni sono un metafile. Il valore indica l'estensione verticale del metafile.
+
+**Returns:**
+double
+### getForeignType() {#getForeignType--}
+```
+public int getForeignType()
+```
+
+
+Tipo di dati.
+
+**Returns:**
+int
+### getImageData() {#getImageData--}
+```
+public byte[] getImageData()
+```
+
+
+Rappresenta l'immagine dell'oggetto OLE come array di byte.
+
+**Returns:**
+byte[]
+### getMappingMode() {#getMappingMode--}
+```
+public int getMappingMode()
+```
+
+
+Questo attributo ha senso solo se i dati esterni sono un metafile. Il valore indica la modalità di mappatura del metafile.
+
+**Returns:**
+int
+### getObjectData() {#getObjectData--}
+```
+public byte[] getObjectData()
+```
+
+
+Rappresenta i dati dell'oggetto OLE incorporato come array di byte.
+
+**Returns:**
+byte[]
+### getObjectHeight() {#getObjectHeight--}
+```
+public double getObjectHeight()
+```
+
+
+Questo attributo ha senso solo se i dati esterni sono un oggetto OLE2 incorporato. Il valore esprime l'altezza dell'oggetto in unità di pagina.
+
+**Returns:**
+double
+### getObjectSourceFullName() {#getObjectSourceFullName--}
+```
+public String getObjectSourceFullName()
+```
+
+
+Restituisce il nome completo della sorgente del file di origine per l'oggetto OLE collegato. Supporta l'impostazione del nome completo della sorgente solo quando il tipo di file è OleFileType.Unknown. Ad esempio file wav, file avi, ecc.
+
+**Returns:**
+java.lang.String
+### getObjectType() {#getObjectType--}
+```
+public int getObjectType()
+```
+
+
+Se l'attributo ForeignType è "Object", l'elemento ForeignData deve inoltre avere un attributo ObjectType.
+
+**Returns:**
+int
+### getObjectWidth() {#getObjectWidth--}
+```
+public double getObjectWidth()
+```
+
+
+Questo attributo ha senso solo se i dati esterni sono un oggetto OLE2 incorporato. Il valore esprime la larghezza dell'oggetto in unità di pagina.
+
+**Returns:**
+double
+### getShowAsIcon() {#getShowAsIcon--}
+```
+public int getShowAsIcon()
+```
+
+
+Questo attributo ha senso solo se i dati esterni sono un oggetto OLE2 incorporato.
+
+**Returns:**
+int
+### getValue() {#getValue--}
+```
+public byte[] getValue()
+```
+
+
+Contiene un BLOB codificato MIME (Multipurpose Internet Mail Extensions) di dati immagine, come metafile Windows, bitmap o dati OLE.
+
+**Returns:**
+byte[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCompressionLevel(double value) {#setCompressionLevel-double-}
+```
+public void setCompressionLevel(double value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getCompressionLevel()](../../com.aspose.diagram/foreigndata\#getCompressionLevel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double |  |
+
+### setCompressionType(int value) {#setCompressionType-int-}
+```
+public void setCompressionType(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getCompressionType()](../../com.aspose.diagram/foreigndata\#getCompressionType--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setExtentX(double value) {#setExtentX-double-}
+```
+public void setExtentX(double value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getExtentX()](../../com.aspose.diagram/foreigndata\#getExtentX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double |  |
+
+### setExtentY(double value) {#setExtentY-double-}
+```
+public void setExtentY(double value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getExtentY()](../../com.aspose.diagram/foreigndata\#getExtentY--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double |  |
+
+### setForeignType(int value) {#setForeignType-int-}
+```
+public void setForeignType(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getForeignType()](../../com.aspose.diagram/foreigndata\#getForeignType--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setImageData(byte[] value) {#setImageData-byte---}
+```
+public void setImageData(byte[] value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getImageData()](../../com.aspose.diagram/foreigndata\#getImageData--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | byte[] |  |
+
+### setMappingMode(int value) {#setMappingMode-int-}
+```
+public void setMappingMode(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getMappingMode()](../../com.aspose.diagram/foreigndata\#getMappingMode--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setObjectData(byte[] value) {#setObjectData-byte---}
+```
+public void setObjectData(byte[] value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getObjectData()](../../com.aspose.diagram/foreigndata\#getObjectData--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | byte[] |  |
+
+### setObjectHeight(double value) {#setObjectHeight-double-}
+```
+public void setObjectHeight(double value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getObjectHeight()](../../com.aspose.diagram/foreigndata\#getObjectHeight--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double |  |
+
+### setObjectSourceFullName(String value) {#setObjectSourceFullName-java.lang.String-}
+```
+public void setObjectSourceFullName(String value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getObjectSourceFullName()](../../com.aspose.diagram/foreigndata\#getObjectSourceFullName--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setObjectType(int value) {#setObjectType-int-}
+```
+public void setObjectType(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getObjectType()](../../com.aspose.diagram/foreigndata\#getObjectType--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setObjectWidth(double value) {#setObjectWidth-double-}
+```
+public void setObjectWidth(double value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getObjectWidth()](../../com.aspose.diagram/foreigndata\#getObjectWidth--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double |  |
+
+### setShowAsIcon(int value) {#setShowAsIcon-int-}
+```
+public void setShowAsIcon(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getShowAsIcon()](../../com.aspose.diagram/foreigndata\#getShowAsIcon--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setValue(byte[] value) {#setValue-byte---}
+```
+public void setValue(byte[] value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getValue()](../../com.aspose.diagram/foreigndata\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | byte[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/foreigntype/_index.md
+++ b/italian/java/com.aspose.diagram/foreigntype/_index.md
@@ -1,0 +1,183 @@
+---
+title: ForeignType
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Tipo di dati.
+type: docs
+weight: 165
+url: /it/java/com.aspose.diagram/foreigntype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ForeignType
+```
+
+Tipo di dati.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [BITMAP](#BITMAP) | Bitmap. |
+| [ENH_METAFILE](#ENH-METAFILE) | Metafile migliorato. |
+| [INK](#INK) | Inchiostro. |
+| [METAFILE](#METAFILE) | Metafile. |
+| [OBJECT](#OBJECT) | Oggetto. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BITMAP {#BITMAP}
+```
+public static final int BITMAP
+```
+
+
+Bitmap.
+
+### ENH_METAFILE {#ENH-METAFILE}
+```
+public static final int ENH_METAFILE
+```
+
+
+Metafile migliorato.
+
+### INK {#INK}
+```
+public static final int INK
+```
+
+
+Inchiostro.
+
+### METAFILE {#METAFILE}
+```
+public static final int METAFILE
+```
+
+
+Metafile.
+
+### OBJECT {#OBJECT}
+```
+public static final int OBJECT
+```
+
+
+Oggetto.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/formattxt/_index.md
+++ b/italian/java/com.aspose.diagram/formattxt/_index.md
@@ -1,0 +1,147 @@
+---
+title: FormatTxt
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Classe astratta per la formattazione del testo
+type: docs
+weight: 166
+url: /it/java/com.aspose.diagram/formattxt/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public abstract class FormatTxt
+```
+
+Classe astratta per la formattazione del testo
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [FormatTxt()](#FormatTxt--) |  |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getValue()](#getValue--) | Valore |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FormatTxt() {#FormatTxt--}
+```
+public FormatTxt()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getValue() {#getValue--}
+```
+public abstract String getValue()
+```
+
+
+Valore
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/formattxtcollection/_index.md
+++ b/italian/java/com.aspose.diagram/formattxtcollection/_index.md
@@ -1,0 +1,243 @@
+---
+title: FormatTxtCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Raccolta FormatTxt che contiene il testo di una forma.
+type: docs
+weight: 167
+url: /it/java/com.aspose.diagram/formattxtcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class FormatTxtCollection extends Collection
+```
+
+Raccolta FormatTxt che contiene il testo di una forma.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [add(FormatTxt item)](#add-com.aspose.diagram.FormatTxt-) | Aggiungi l'oggetto FormatTxt nella collezione. |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [getText()](#getText--) | Contiene il testo di una forma con formattazione. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(FormatTxt item)](#remove-com.aspose.diagram.FormatTxt-) | Rimuovi l'oggetto FormatTxt dalla collezione. |
+| [setWholeText(String text)](#setWholeText-java.lang.String-) | Imposta il testo di una forma senza formattazione. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(FormatTxt item) {#add-com.aspose.diagram.FormatTxt-}
+```
+public int add(FormatTxt item)
+```
+
+
+Aggiungi l'oggetto FormatTxt nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [FormatTxt](../../com.aspose.diagram/formattxt) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public FormatTxt get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[FormatTxt](../../com.aspose.diagram/formattxt) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### getText() {#getText--}
+```
+public String getText()
+```
+
+
+Contiene il testo di una forma con formattazione.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(FormatTxt item) {#remove-com.aspose.diagram.FormatTxt-}
+```
+public void remove(FormatTxt item)
+```
+
+
+Rimuovi l'oggetto FormatTxt dalla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [FormatTxt](../../com.aspose.diagram/formattxt) |  |
+
+### setWholeText(String text) {#setWholeText-java.lang.String-}
+```
+public void setWholeText(String text)
+```
+
+
+Imposta il testo di una forma senza formattazione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| text | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/frompartvalue/_index.md
+++ b/italian/java/com.aspose.diagram/frompartvalue/_index.md
@@ -1,0 +1,264 @@
+---
+title: FromPartValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: La parte di una forma da cui origina una connessione.
+type: docs
+weight: 168
+url: /it/java/com.aspose.diagram/frompartvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class FromPartValue
+```
+
+La parte di una forma da cui origina una connessione.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [BEGIN_X_CELL](#BEGIN-X-CELL) | cella BeginX. |
+| [BEGIN_X_OR_BEGIN_Y_POINT](#BEGIN-X-OR-BEGIN-Y-POINT) | punto BeginX/BeginY. |
+| [BEGIN_Y_CELL](#BEGIN-Y-CELL) | cella BeginY. |
+| [BOTTOM_EDGE](#BOTTOM-EDGE) | Bordo inferiore. |
+| [CENTER_EDGE](#CENTER-EDGE) | Bordo centrale. |
+| [CONTROL_POINT](#CONTROL-POINT) | Punto di controllo. |
+| [END_X_CELL](#END-X-CELL) | cella EndX. |
+| [END_X_OR_END_Y_POINT](#END-X-OR-END-Y-POINT) | punto EndX/EndY. |
+| [END_Y_CELL](#END-Y-CELL) | EndY cell. |
+| [LEFT_EDGE](#LEFT-EDGE) | Left edge. |
+| [MIDDLE_EDGE](#MIDDLE-EDGE) | Middle Edge. |
+| [NONE](#NONE) | None. |
+| [RIGHT_EDGE](#RIGHT-EDGE) | Right Edge. |
+| [TOP_EDGE](#TOP-EDGE) | Top Edge. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BEGIN_X_CELL {#BEGIN-X-CELL}
+```
+public static final int BEGIN_X_CELL
+```
+
+
+cella BeginX.
+
+### BEGIN_X_OR_BEGIN_Y_POINT {#BEGIN-X-OR-BEGIN-Y-POINT}
+```
+public static final int BEGIN_X_OR_BEGIN_Y_POINT
+```
+
+
+punto BeginX/BeginY.
+
+### BEGIN_Y_CELL {#BEGIN-Y-CELL}
+```
+public static final int BEGIN_Y_CELL
+```
+
+
+cella BeginY.
+
+### BOTTOM_EDGE {#BOTTOM-EDGE}
+```
+public static final int BOTTOM_EDGE
+```
+
+
+Bordo inferiore.
+
+### CENTER_EDGE {#CENTER-EDGE}
+```
+public static final int CENTER_EDGE
+```
+
+
+Bordo centrale.
+
+### CONTROL_POINT {#CONTROL-POINT}
+```
+public static final int CONTROL_POINT
+```
+
+
+Punto di controllo.
+
+### END_X_CELL {#END-X-CELL}
+```
+public static final int END_X_CELL
+```
+
+
+cella EndX.
+
+### END_X_OR_END_Y_POINT {#END-X-OR-END-Y-POINT}
+```
+public static final int END_X_OR_END_Y_POINT
+```
+
+
+punto EndX/EndY.
+
+### END_Y_CELL {#END-Y-CELL}
+```
+public static final int END_Y_CELL
+```
+
+
+EndY cell.
+
+### LEFT_EDGE {#LEFT-EDGE}
+```
+public static final int LEFT_EDGE
+```
+
+
+Left edge.
+
+### MIDDLE_EDGE {#MIDDLE-EDGE}
+```
+public static final int MIDDLE_EDGE
+```
+
+
+Middle Edge.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+None.
+
+### RIGHT_EDGE {#RIGHT-EDGE}
+```
+public static final int RIGHT_EDGE
+```
+
+
+Right Edge.
+
+### TOP_EDGE {#TOP-EDGE}
+```
+public static final int TOP_EDGE
+```
+
+
+Top Edge.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/geom/_index.md
+++ b/italian/java/com.aspose.diagram/geom/_index.md
@@ -1,0 +1,346 @@
+---
+title: Geom
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene elementi che specificano le coordinate dei vertici per le linee e gli archi che compongono la forma.
+type: docs
+weight: 169
+url: /it/java/com.aspose.diagram/geom/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Geom
+```
+
+Contiene elementi che specificano le coordinate dei vertici per le linee e gli archi che compongono la forma. Se la forma ha più di un percorso, esiste un elemento Geom per ciascun percorso.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [Geom()](#Geom--) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCoordinateCol()](#getCoordinateCol--) | Raccolta di coordinate. |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getIX()](#getIX--) | L'indice basato su zero dell'elemento all'interno del suo elemento genitore. |
+| [getNextCoordinateIX()](#getNextCoordinateIX--) | Restituisce il valore IX per il prossimo membro della raccolta di coordinate della forma. |
+| [getNoFill()](#getNoFill--) | Specifica se un percorso può essere riempito. |
+| [getNoLine()](#getNoLine--) | Specifica se una linea è disegnata attorno al contorno del percorso. |
+| [getNoQuickDrag()](#getNoQuickDrag--) | Determina se una forma può essere selezionata o trascinata quando l'utente fa clic sull'area riempita definita dalla sezione Geometry. |
+| [getNoShow()](#getNoShow--) | Specifica se un percorso è visualizzato nella pagina di disegno. |
+| [getNoSnap()](#getNoSnap--) | Specifica se altre forme si agganciano a un percorso. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/geom\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Per la descrizione di questa proprietà, vedere [getIX()](../../com.aspose.diagram/geom\#getIX--) |
+| [setNoFill(BoolValue value)](#setNoFill-com.aspose.diagram.BoolValue-) | Per la descrizione di questa proprietà, vedere [getNoFill()](../../com.aspose.diagram/geom\#getNoFill--) |
+| [setNoLine(BoolValue value)](#setNoLine-com.aspose.diagram.BoolValue-) | Per la descrizione di questa proprietà, vedere [getNoLine()](../../com.aspose.diagram/geom\#getNoLine--) |
+| [setNoQuickDrag(BoolValue value)](#setNoQuickDrag-com.aspose.diagram.BoolValue-) | Per la descrizione di questa proprietà, vedere [getNoQuickDrag()](../../com.aspose.diagram/geom\#getNoQuickDrag--) |
+| [setNoShow(BoolValue value)](#setNoShow-com.aspose.diagram.BoolValue-) | Per la descrizione di questa proprietà, vedere [getNoShow()](../../com.aspose.diagram/geom\#getNoShow--) |
+| [setNoSnap(BoolValue value)](#setNoSnap-com.aspose.diagram.BoolValue-) | Per la descrizione di questa proprietà, vedere [getNoSnap()](../../com.aspose.diagram/geom\#getNoSnap--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Geom() {#Geom--}
+```
+public Geom()
+```
+
+
+Costruttore.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCoordinateCol() {#getCoordinateCol--}
+```
+public CoordinateCollection getCoordinateCol()
+```
+
+
+Raccolta di coordinate. Mostra la sequenza di coordinate.
+
+**Returns:**
+[CoordinateCollection](../../com.aspose.diagram/coordinatecollection)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+L'indice basato su zero dell'elemento all'interno del suo elemento genitore.
+
+**Returns:**
+int
+### getNextCoordinateIX() {#getNextCoordinateIX--}
+```
+public int getNextCoordinateIX()
+```
+
+
+Restituisce il valore IX per il prossimo membro della raccolta di coordinate della forma.
+
+**Returns:**
+int
+### getNoFill() {#getNoFill--}
+```
+public BoolValue getNoFill()
+```
+
+
+Specifica se un percorso può essere riempito.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getNoLine() {#getNoLine--}
+```
+public BoolValue getNoLine()
+```
+
+
+Specifica se una linea è disegnata attorno al contorno del percorso.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getNoQuickDrag() {#getNoQuickDrag--}
+```
+public BoolValue getNoQuickDrag()
+```
+
+
+Determina se una forma può essere selezionata o trascinata quando l'utente fa clic sull'area riempita definita dalla sezione Geometry.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getNoShow() {#getNoShow--}
+```
+public BoolValue getNoShow()
+```
+
+
+Specifica se un percorso è visualizzato nella pagina di disegno.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getNoSnap() {#getNoSnap--}
+```
+public BoolValue getNoSnap()
+```
+
+
+Specifica se altre forme si agganciano a un percorso.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/geom\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getIX()](../../com.aspose.diagram/geom\#getIX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setNoFill(BoolValue value) {#setNoFill-com.aspose.diagram.BoolValue-}
+```
+public void setNoFill(BoolValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getNoFill()](../../com.aspose.diagram/geom\#getNoFill--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setNoLine(BoolValue value) {#setNoLine-com.aspose.diagram.BoolValue-}
+```
+public void setNoLine(BoolValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getNoLine()](../../com.aspose.diagram/geom\#getNoLine--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setNoQuickDrag(BoolValue value) {#setNoQuickDrag-com.aspose.diagram.BoolValue-}
+```
+public void setNoQuickDrag(BoolValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getNoQuickDrag()](../../com.aspose.diagram/geom\#getNoQuickDrag--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setNoShow(BoolValue value) {#setNoShow-com.aspose.diagram.BoolValue-}
+```
+public void setNoShow(BoolValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getNoShow()](../../com.aspose.diagram/geom\#getNoShow--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setNoSnap(BoolValue value) {#setNoSnap-com.aspose.diagram.BoolValue-}
+```
+public void setNoSnap(BoolValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getNoSnap()](../../com.aspose.diagram/geom\#getNoSnap--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/geomcollection/_index.md
+++ b/italian/java/com.aspose.diagram/geomcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: GeomCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Raccolta Geom.
+type: docs
+weight: 170
+url: /it/java/com.aspose.diagram/geomcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class GeomCollection extends Collection
+```
+
+Raccolta Geom.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [add(Geom item)](#add-com.aspose.diagram.Geom-) | Aggiungi l'oggetto Geom nella collezione. |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Geom item)](#remove-com.aspose.diagram.Geom-) | Rimuovi l'oggetto Geom dalla collezione. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Geom item) {#add-com.aspose.diagram.Geom-}
+```
+public int add(Geom item)
+```
+
+
+Aggiungi l'oggetto Geom nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [Geom](../../com.aspose.diagram/geom) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Geom get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[Geom](../../com.aspose.diagram/geom) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Geom item) {#remove-com.aspose.diagram.Geom-}
+```
+public void remove(Geom item)
+```
+
+
+Rimuovi l'oggetto Geom dalla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [Geom](../../com.aspose.diagram/geom) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/gloweffect/_index.md
+++ b/italian/java/com.aspose.diagram/gloweffect/_index.md
@@ -1,0 +1,150 @@
+---
+title: GlowEffect
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Questa classe specifica un effetto bagliore in cui un contorno sfocato colorato viene aggiunto al di fuori dei bordi dell'oggetto.
+type: docs
+weight: 171
+url: /it/java/com.aspose.diagram/gloweffect/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class GlowEffect
+```
+
+Questa classe specifica un effetto bagliore, in cui un contorno sfocato di colore viene aggiunto al di fuori dei bordi dell'oggetto.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getSize()](#getSize--) | Il raggio del bagliore, in unità di punti. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setSize(double value)](#setSize-double-) | Per la descrizione di questa proprietà, vedere [getSize()](../../com.aspose.diagram/gloweffect\#getSize--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getSize() {#getSize--}
+```
+public double getSize()
+```
+
+
+Il raggio del bagliore, in unità di punti.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setSize(double value) {#setSize-double-}
+```
+public void setSize(double value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getSize()](../../com.aspose.diagram/gloweffect\#getSize--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/gluedshapesflags/_index.md
+++ b/italian/java/com.aspose.diagram/gluedshapesflags/_index.md
@@ -1,0 +1,183 @@
+---
+title: GluedShapesFlags
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica le costanti che identificano quali forme restituire in base alla dimensionalità e alla direzionalità dei punti di connessione incollati a una forma particolare passata al metodo Shape.GluedShapes.
+type: docs
+weight: 176
+url: /it/java/com.aspose.diagram/gluedshapesflags/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class GluedShapesFlags
+```
+
+Specifica le costanti che identificano quali forme restituire, in base alla dimensionalità e alla direzionalità dei punti di connessione incollati a una forma particolare; passate al metodo Shape.GluedShapes.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [GLUED_SHAPES_ALL_1_D](#GLUED-SHAPES-ALL-1-D) | Restituisce gli ID di tutte le forme 1-D incollate a questa forma. |
+| [GLUED_SHAPES_ALL_2_D](#GLUED-SHAPES-ALL-2-D) | Restituisce tutte le forme 2-D incollate a questa forma e tutte le forme 2-D a cui questa forma è incollata. |
+| [GLUED_SHAPES_INCOMING_1_D](#GLUED-SHAPES-INCOMING-1-D) | Restituisce gli ID delle forme 1-D i cui punti finali sono incollati a questa forma. |
+| [GLUED_SHAPES_INCOMING_2_D](#GLUED-SHAPES-INCOMING-2-D) | Se l'oggetto sorgente è una forma 1-D, restituisce gli ID della forma 2-D a cui il punto di inizio è incollato. |
+| [GLUED_SHAPES_OUTGOING_1_D](#GLUED-SHAPES-OUTGOING-1-D) | Restituisci gli ID delle forme 1-D i cui punti di inizio sono incollati a questa forma. |
+| [GLUED_SHAPES_OUTGOING_2_D](#GLUED-SHAPES-OUTGOING-2-D) | Se l'oggetto di origine è una forma 1-D, restituisci gli ID della forma 2-D a cui è incollato il punto finale. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GLUED_SHAPES_ALL_1_D {#GLUED-SHAPES-ALL-1-D}
+```
+public static final int GLUED_SHAPES_ALL_1_D
+```
+
+
+Restituisce gli ID di tutte le forme 1-D incollate a questa forma.
+
+### GLUED_SHAPES_ALL_2_D {#GLUED-SHAPES-ALL-2-D}
+```
+public static final int GLUED_SHAPES_ALL_2_D
+```
+
+
+Restituisce tutte le forme 2-D incollate a questa forma e tutte le forme 2-D a cui questa forma è incollata.
+
+### GLUED_SHAPES_INCOMING_1_D {#GLUED-SHAPES-INCOMING-1-D}
+```
+public static final int GLUED_SHAPES_INCOMING_1_D
+```
+
+
+Restituisce gli ID delle forme 1-D i cui punti finali sono incollati a questa forma.
+
+### GLUED_SHAPES_INCOMING_2_D {#GLUED-SHAPES-INCOMING-2-D}
+```
+public static final int GLUED_SHAPES_INCOMING_2_D
+```
+
+
+Se l'oggetto di origine è una forma 1-D, restituisci gli ID della forma 2-D a cui è incollato il punto di inizio. Se l'oggetto di origine è una forma 2-D, restituisci gli ID delle forme 2-D che sono incollate a questa forma.
+
+### GLUED_SHAPES_OUTGOING_1_D {#GLUED-SHAPES-OUTGOING-1-D}
+```
+public static final int GLUED_SHAPES_OUTGOING_1_D
+```
+
+
+Restituisci gli ID delle forme 1-D i cui punti di inizio sono incollati a questa forma.
+
+### GLUED_SHAPES_OUTGOING_2_D {#GLUED-SHAPES-OUTGOING-2-D}
+```
+public static final int GLUED_SHAPES_OUTGOING_2_D
+```
+
+
+Se l'oggetto di origine è una forma 1-D, restituisci gli ID della forma 2-D a cui è incollato il punto finale. Se l'oggetto di origine è una forma 2-D, restituisci gli ID delle forme 2-D a cui è incollata questa forma.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/gluesettings/_index.md
+++ b/italian/java/com.aspose.diagram/gluesettings/_index.md
@@ -1,0 +1,201 @@
+---
+title: GlueSettings
+second_title: Riferimento API di Aspose.Diagram per Java
+description: I valori dei bit indicano che una specifica impostazione di incollaggio è attiva o disattiva.
+type: docs
+weight: 172
+url: /it/java/com.aspose.diagram/gluesettings/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class GlueSettings
+```
+
+I valori dei bit indicano che una specifica impostazione di incollaggio è attiva o disattiva. Il valore può essere una somma dei valori:
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [CONNECTION_POINTS](#CONNECTION-POINTS) | Incolla ai punti di connessione. |
+| [DISABLED](#DISABLED) | L'incollaggio è disabilitato |
+| [GEOMETRY](#GEOMETRY) | Incolla alla geometria. |
+| [GUIDES](#GUIDES) | Incolla alle guide. |
+| [HANDLES](#HANDLES) | Incolla alle maniglie. |
+| [NONE](#NONE) | L'incollaggio è abilitato, ma nessun'altra impostazione di incollaggio è abilitata. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+| [VERTICES](#VERTICES) | Incolla ai vertici. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CONNECTION_POINTS {#CONNECTION-POINTS}
+```
+public static final int CONNECTION_POINTS
+```
+
+
+Incolla ai punti di connessione.
+
+### DISABLED {#DISABLED}
+```
+public static final int DISABLED
+```
+
+
+L'incollaggio è disabilitato
+
+### GEOMETRY {#GEOMETRY}
+```
+public static final int GEOMETRY
+```
+
+
+Incolla alla geometria.
+
+### GUIDES {#GUIDES}
+```
+public static final int GUIDES
+```
+
+
+Incolla alle guide.
+
+### HANDLES {#HANDLES}
+```
+public static final int HANDLES
+```
+
+
+Incolla alle maniglie.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+L'incollaggio è abilitato, ma nessun'altra impostazione di incollaggio è abilitata.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### VERTICES {#VERTICES}
+```
+public static final int VERTICES
+```
+
+
+Incolla ai vertici.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/gluesettingsvalue/_index.md
+++ b/italian/java/com.aspose.diagram/gluesettingsvalue/_index.md
@@ -1,0 +1,201 @@
+---
+title: GlueSettingsValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica gli oggetti a cui le forme si incollano quando la colla è abilitata nel documento.
+type: docs
+weight: 173
+url: /it/java/com.aspose.diagram/gluesettingsvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class GlueSettingsValue
+```
+
+Specifica gli oggetti a cui le forme si incollano quando la colla è abilitata nel documento.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [GLUE_IS_DISABLED](#GLUE-IS-DISABLED) | L'incollaggio è disabilitato. |
+| [GLUE_IS_ENABLED](#GLUE-IS-ENABLED) | L'incollaggio è abilitato, ma nessun'altra impostazione di incollaggio è abilitata. |
+| [GLUE_TO_CONNECTION_POINTS](#GLUE-TO-CONNECTION-POINTS) | Incolla ai punti di connessione. |
+| [GLUE_TO_GEOMETRY](#GLUE-TO-GEOMETRY) | Incolla alla geometria. |
+| [GLUE_TO_GUIDES](#GLUE-TO-GUIDES) | Incolla alle guide. |
+| [GLUE_TO_HANDLES](#GLUE-TO-HANDLES) | Incolla alle maniglie. |
+| [GLUE_TO_VERTICES](#GLUE-TO-VERTICES) | Incolla ai vertici. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GLUE_IS_DISABLED {#GLUE-IS-DISABLED}
+```
+public static final int GLUE_IS_DISABLED
+```
+
+
+L'incollaggio è disabilitato.
+
+### GLUE_IS_ENABLED {#GLUE-IS-ENABLED}
+```
+public static final int GLUE_IS_ENABLED
+```
+
+
+L'incollaggio è abilitato, ma nessun'altra impostazione di incollaggio è abilitata.
+
+### GLUE_TO_CONNECTION_POINTS {#GLUE-TO-CONNECTION-POINTS}
+```
+public static final int GLUE_TO_CONNECTION_POINTS
+```
+
+
+Incolla ai punti di connessione.
+
+### GLUE_TO_GEOMETRY {#GLUE-TO-GEOMETRY}
+```
+public static final int GLUE_TO_GEOMETRY
+```
+
+
+Incolla alla geometria.
+
+### GLUE_TO_GUIDES {#GLUE-TO-GUIDES}
+```
+public static final int GLUE_TO_GUIDES
+```
+
+
+Incolla alle guide.
+
+### GLUE_TO_HANDLES {#GLUE-TO-HANDLES}
+```
+public static final int GLUE_TO_HANDLES
+```
+
+
+Incolla alle maniglie.
+
+### GLUE_TO_VERTICES {#GLUE-TO-VERTICES}
+```
+public static final int GLUE_TO_VERTICES
+```
+
+
+Incolla ai vertici.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/gluetype/_index.md
+++ b/italian/java/com.aspose.diagram/gluetype/_index.md
@@ -1,0 +1,179 @@
+---
+title: GlueType
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica se è consentita la colla dinamica forma‑a‑forma durante il collegamento a una forma.
+type: docs
+weight: 174
+url: /it/java/com.aspose.diagram/gluetype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class GlueType
+```
+
+Specifica se è consentita la colla dinamica (forma‑a‑forma) quando si collega a una forma.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [GlueType(int value)](#GlueType-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Specifica se è consentita la colla dinamica (forma‑a‑forma) quando si collega a una forma. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/gluetype\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GlueType(int value) {#GlueType-int-}
+```
+public GlueType(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specifica se è consentita la colla dinamica (forma‑a‑forma) quando si collega a una forma.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/gluetype\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/gluetypevalue/_index.md
+++ b/italian/java/com.aspose.diagram/gluetypevalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: GlueTypeValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica se è consentita la colla dinamica forma‑a‑forma durante il collegamento a una forma.
+type: docs
+weight: 175
+url: /it/java/com.aspose.diagram/gluetypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class GlueTypeValue
+```
+
+Specifica se è consentita la colla dinamica (forma‑a‑forma) quando si collega a una forma.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [ALLOW_DYNAMIC_GLUE](#ALLOW-DYNAMIC-GLUE) | Consenti colla dinamica. |
+| [ALLOW_DYNAMIC_GLUE_2002](#ALLOW-DYNAMIC-GLUE-2002) | Consenti colla dinamica (obsoleta in Microsoft Visio 2002). |
+| [ALLOW_DYNAMIC_GLUE_FOR_DYNAMIC_CONNECTOR](#ALLOW-DYNAMIC-GLUE-FOR-DYNAMIC-CONNECTOR) | Predefinito. |
+| [NO_ALLOW_2_D_SHAPE](#NO-ALLOW-2-D-SHAPE) | Non consentire a questa forma 2‑D di essere collegata usando la colla dinamica. |
+| [NO_ALLOW_DYNAMIC_GLUE](#NO-ALLOW-DYNAMIC-GLUE) | Non consentire colla dinamica. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALLOW_DYNAMIC_GLUE {#ALLOW-DYNAMIC-GLUE}
+```
+public static final int ALLOW_DYNAMIC_GLUE
+```
+
+
+Consenti colla dinamica.
+
+### ALLOW_DYNAMIC_GLUE_2002 {#ALLOW-DYNAMIC-GLUE-2002}
+```
+public static final int ALLOW_DYNAMIC_GLUE_2002
+```
+
+
+Consenti colla dinamica (obsoleta in Microsoft Visio 2002).
+
+### ALLOW_DYNAMIC_GLUE_FOR_DYNAMIC_CONNECTOR {#ALLOW-DYNAMIC-GLUE-FOR-DYNAMIC-CONNECTOR}
+```
+public static final int ALLOW_DYNAMIC_GLUE_FOR_DYNAMIC_CONNECTOR
+```
+
+
+Predefinito. Consenti la colla dinamica solo per il connettore dinamico; altrimenti, usa la colla statica.
+
+### NO_ALLOW_2_D_SHAPE {#NO-ALLOW-2-D-SHAPE}
+```
+public static final int NO_ALLOW_2_D_SHAPE
+```
+
+
+Non consentire a questa forma 2‑D di essere collegata usando la colla dinamica.
+
+### NO_ALLOW_DYNAMIC_GLUE {#NO-ALLOW-DYNAMIC-GLUE}
+```
+public static final int NO_ALLOW_DYNAMIC_GLUE
+```
+
+
+Non consentire colla dinamica.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/gradientdirectiontype/_index.md
+++ b/italian/java/com.aspose.diagram/gradientdirectiontype/_index.md
@@ -1,0 +1,183 @@
+---
+title: GradientDirectionType
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta tutti i tipi di direzione del gradiente.
+type: docs
+weight: 177
+url: /it/java/com.aspose.diagram/gradientdirectiontype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class GradientDirectionType
+```
+
+Rappresenta tutti i tipi di direzione del gradiente.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [FROM_CENTER](#FROM-CENTER) | FromCenter |
+| [FROM_LOWER_LEFT_CORNER](#FROM-LOWER-LEFT-CORNER) | FromLowerLeftCorner |
+| [FROM_LOWER_RIGHT_CORNER](#FROM-LOWER-RIGHT-CORNER) | FromLowerRightCorner |
+| [FROM_UPPER_LEFT_CORNER](#FROM-UPPER-LEFT-CORNER) | FromUpperLeftCorner |
+| [FROM_UPPER_RIGHT_CORNER](#FROM-UPPER-RIGHT-CORNER) | FromUpperRightCorner |
+| [UNKNOWN](#UNKNOWN) | Unknown |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FROM_CENTER {#FROM-CENTER}
+```
+public static final int FROM_CENTER
+```
+
+
+FromCenter
+
+### FROM_LOWER_LEFT_CORNER {#FROM-LOWER-LEFT-CORNER}
+```
+public static final int FROM_LOWER_LEFT_CORNER
+```
+
+
+FromLowerLeftCorner
+
+### FROM_LOWER_RIGHT_CORNER {#FROM-LOWER-RIGHT-CORNER}
+```
+public static final int FROM_LOWER_RIGHT_CORNER
+```
+
+
+FromLowerRightCorner
+
+### FROM_UPPER_LEFT_CORNER {#FROM-UPPER-LEFT-CORNER}
+```
+public static final int FROM_UPPER_LEFT_CORNER
+```
+
+
+FromUpperLeftCorner
+
+### FROM_UPPER_RIGHT_CORNER {#FROM-UPPER-RIGHT-CORNER}
+```
+public static final int FROM_UPPER_RIGHT_CORNER
+```
+
+
+FromUpperRightCorner
+
+### UNKNOWN {#UNKNOWN}
+```
+public static final int UNKNOWN
+```
+
+
+Unknown
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/gradientfill/_index.md
+++ b/italian/java/com.aspose.diagram/gradientfill/_index.md
@@ -1,0 +1,211 @@
+---
+title: GradientFill
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta il riempimento a gradiente.
+type: docs
+weight: 178
+url: /it/java/com.aspose.diagram/gradientfill/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class GradientFill
+```
+
+Rappresenta il riempimento a gradiente.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getGradientAngle()](#getGradientAngle--) | Specifica l'orientamento del gradiente di colore di riempimento |
+| [getGradientDir()](#getGradientDir--) | Specifica il tipo di gradiente di colore di riempimento |
+| [getGradientEnabled()](#getGradientEnabled--) | Specifica se il gradiente di colore di riempimento è visibile. |
+| [getGradientStops()](#getGradientStops--) | Rappresenta la raccolta dei punti di arresto del gradiente. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setGradientAngle(DoubleValue value)](#setGradientAngle-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getGradientAngle()](../../com.aspose.diagram/gradientfill\#getGradientAngle--) |
+| [setGradientDir(IntValue value)](#setGradientDir-com.aspose.diagram.IntValue-) | Per la descrizione di questa proprietà, vedere [getGradientDir()](../../com.aspose.diagram/gradientfill\#getGradientDir--) |
+| [setGradientEnabled(BoolValue value)](#setGradientEnabled-com.aspose.diagram.BoolValue-) | Per la descrizione di questa proprietà, vedere [getGradientEnabled()](../../com.aspose.diagram/gradientfill\#getGradientEnabled--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getGradientAngle() {#getGradientAngle--}
+```
+public DoubleValue getGradientAngle()
+```
+
+
+Specifica l'orientamento del gradiente di colore di riempimento
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getGradientDir() {#getGradientDir--}
+```
+public IntValue getGradientDir()
+```
+
+
+Specifica il tipo di gradiente di colore di riempimento
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getGradientEnabled() {#getGradientEnabled--}
+```
+public BoolValue getGradientEnabled()
+```
+
+
+Specifica se il gradiente di colore di riempimento è visibile.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getGradientStops() {#getGradientStops--}
+```
+public GradientStopCollection getGradientStops()
+```
+
+
+Rappresenta la raccolta dei punti di arresto del gradiente.
+
+**Returns:**
+[GradientStopCollection](../../com.aspose.diagram/gradientstopcollection)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setGradientAngle(DoubleValue value) {#setGradientAngle-com.aspose.diagram.DoubleValue-}
+```
+public void setGradientAngle(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getGradientAngle()](../../com.aspose.diagram/gradientfill\#getGradientAngle--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setGradientDir(IntValue value) {#setGradientDir-com.aspose.diagram.IntValue-}
+```
+public void setGradientDir(IntValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getGradientDir()](../../com.aspose.diagram/gradientfill\#getGradientDir--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setGradientEnabled(BoolValue value) {#setGradientEnabled-com.aspose.diagram.BoolValue-}
+```
+public void setGradientEnabled(BoolValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getGradientEnabled()](../../com.aspose.diagram/gradientfill\#getGradientEnabled--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/gradientfilldir/_index.md
+++ b/italian/java/com.aspose.diagram/gradientfilldir/_index.md
@@ -1,0 +1,255 @@
+---
+title: GradientFillDir
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica il tipo di gradiente di colore di riempimento di una forma
+type: docs
+weight: 179
+url: /it/java/com.aspose.diagram/gradientfilldir/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class GradientFillDir
+```
+
+Specifica il tipo di gradiente di colore di riempimento di una forma
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [LINEAR](#LINEAR) | Specifica un gradiente di colore di riempimento lineare. |
+| [PATH](#PATH) | Specifica che il gradiente di colore di riempimento della forma è in modalità percorso |
+| [RADIAL_FROM_BOTTOM_LEFT](#RADIAL-FROM-BOTTOM-LEFT) | Specifica che il gradiente di colore di riempimento della forma è in modalità radiale dall'angolo inferiore sinistro della forma |
+| [RADIAL_FROM_BOTTOM_RIGHT](#RADIAL-FROM-BOTTOM-RIGHT) | Specifica che il gradiente di colore di riempimento della forma è in modalità radiale dall'angolo inferiore destro della forma |
+| [RADIAL_FROM_CENTER](#RADIAL-FROM-CENTER) | Specifica che il gradiente di colore di riempimento della forma è in modalità radiale dal centro della forma. |
+| [RADIAL_FROM_CENTER_BOTTOM](#RADIAL-FROM-CENTER-BOTTOM) | Specifica che il gradiente di colore di riempimento della forma è in modalità radiale dal centro del bordo inferiore della forma. |
+| [RADIAL_FROM_CENTER_TOP](#RADIAL-FROM-CENTER-TOP) | Specifica che il gradiente di colore di riempimento della forma è in modalità radiale dal centro del bordo superiore della forma |
+| [RADIAL_FROM_TOP_LEFT](#RADIAL-FROM-TOP-LEFT) | Specifica che il gradiente di colore di riempimento della forma è in modalità radiale dall'angolo superiore sinistro della forma |
+| [RADIAL_FROM_TOP_RIGHT](#RADIAL-FROM-TOP-RIGHT) | Specifica che il gradiente di colore di riempimento della forma è in modalità radiale dall'angolo superiore destro della forma |
+| [RECTANGLE_FROM_BOTTOM_LEFT](#RECTANGLE-FROM-BOTTOM-LEFT) | Specifica che il gradiente di colore di riempimento della forma è in modalità rettangolare dall'angolo inferiore sinistro della forma |
+| [RECTANGLE_FROM_BOTTOM_RIGHT](#RECTANGLE-FROM-BOTTOM-RIGHT) | Specifica che il gradiente di colore di riempimento della forma è in modalità rettangolare dall'angolo inferiore destro della forma |
+| [RECTANGLE_FROM_CENTER](#RECTANGLE-FROM-CENTER) | Specifica che il gradiente di colore di riempimento della forma è in modalità rettangolare dal centro della forma. |
+| [RECTANGLE_FROM_TOP_LEFT](#RECTANGLE-FROM-TOP-LEFT) | Specifica che il gradiente di colore di riempimento della forma è in modalità rettangolare dall'angolo superiore sinistro della forma |
+| [RECTANGLE_FROM_TOP_RIGHT](#RECTANGLE-FROM-TOP-RIGHT) | Specifica che il gradiente di colore di riempimento della forma è in modalità rettangolare dall'angolo superiore destro della forma |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LINEAR {#LINEAR}
+```
+public static final int LINEAR
+```
+
+
+Specifica un gradiente di colore di riempimento lineare.
+
+### PATH {#PATH}
+```
+public static final int PATH
+```
+
+
+Specifica che il gradiente di colore di riempimento della forma è in modalità percorso
+
+### RADIAL_FROM_BOTTOM_LEFT {#RADIAL-FROM-BOTTOM-LEFT}
+```
+public static final int RADIAL_FROM_BOTTOM_LEFT
+```
+
+
+Specifica che il gradiente di colore di riempimento della forma è in modalità radiale dall'angolo inferiore sinistro della forma
+
+### RADIAL_FROM_BOTTOM_RIGHT {#RADIAL-FROM-BOTTOM-RIGHT}
+```
+public static final int RADIAL_FROM_BOTTOM_RIGHT
+```
+
+
+Specifica che il gradiente di colore di riempimento della forma è in modalità radiale dall'angolo inferiore destro della forma
+
+### RADIAL_FROM_CENTER {#RADIAL-FROM-CENTER}
+```
+public static final int RADIAL_FROM_CENTER
+```
+
+
+Specifica che il gradiente di colore di riempimento della forma è in modalità radiale dal centro della forma.
+
+### RADIAL_FROM_CENTER_BOTTOM {#RADIAL-FROM-CENTER-BOTTOM}
+```
+public static final int RADIAL_FROM_CENTER_BOTTOM
+```
+
+
+Specifica che il gradiente di colore di riempimento della forma è in modalità radiale dal centro del bordo inferiore della forma.
+
+### RADIAL_FROM_CENTER_TOP {#RADIAL-FROM-CENTER-TOP}
+```
+public static final int RADIAL_FROM_CENTER_TOP
+```
+
+
+Specifica che il gradiente di colore di riempimento della forma è in modalità radiale dal centro del bordo superiore della forma
+
+### RADIAL_FROM_TOP_LEFT {#RADIAL-FROM-TOP-LEFT}
+```
+public static final int RADIAL_FROM_TOP_LEFT
+```
+
+
+Specifica che il gradiente di colore di riempimento della forma è in modalità radiale dall'angolo superiore sinistro della forma
+
+### RADIAL_FROM_TOP_RIGHT {#RADIAL-FROM-TOP-RIGHT}
+```
+public static final int RADIAL_FROM_TOP_RIGHT
+```
+
+
+Specifica che il gradiente di colore di riempimento della forma è in modalità radiale dall'angolo superiore destro della forma
+
+### RECTANGLE_FROM_BOTTOM_LEFT {#RECTANGLE-FROM-BOTTOM-LEFT}
+```
+public static final int RECTANGLE_FROM_BOTTOM_LEFT
+```
+
+
+Specifica che il gradiente di colore di riempimento della forma è in modalità rettangolare dall'angolo inferiore sinistro della forma
+
+### RECTANGLE_FROM_BOTTOM_RIGHT {#RECTANGLE-FROM-BOTTOM-RIGHT}
+```
+public static final int RECTANGLE_FROM_BOTTOM_RIGHT
+```
+
+
+Specifica che il gradiente di colore di riempimento della forma è in modalità rettangolare dall'angolo inferiore destro della forma
+
+### RECTANGLE_FROM_CENTER {#RECTANGLE-FROM-CENTER}
+```
+public static final int RECTANGLE_FROM_CENTER
+```
+
+
+Specifica che il gradiente di colore di riempimento della forma è in modalità rettangolare dal centro della forma.
+
+### RECTANGLE_FROM_TOP_LEFT {#RECTANGLE-FROM-TOP-LEFT}
+```
+public static final int RECTANGLE_FROM_TOP_LEFT
+```
+
+
+Specifica che il gradiente di colore di riempimento della forma è in modalità rettangolare dall'angolo superiore sinistro della forma
+
+### RECTANGLE_FROM_TOP_RIGHT {#RECTANGLE-FROM-TOP-RIGHT}
+```
+public static final int RECTANGLE_FROM_TOP_RIGHT
+```
+
+
+Specifica che il gradiente di colore di riempimento della forma è in modalità rettangolare dall'angolo superiore destro della forma
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/gradientfilltype/_index.md
+++ b/italian/java/com.aspose.diagram/gradientfilltype/_index.md
@@ -1,0 +1,165 @@
+---
+title: GradientFillType
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta tutti i tipi di riempimento a gradiente.
+type: docs
+weight: 180
+url: /it/java/com.aspose.diagram/gradientfilltype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class GradientFillType
+```
+
+Rappresenta tutti i tipi di riempimento a gradiente.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [LINEAR](#LINEAR) | Lineare |
+| [PATH](#PATH) | Path |
+| [RADIAL](#RADIAL) | Radiale |
+| [RECTANGLE](#RECTANGLE) | Rettangolo |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LINEAR {#LINEAR}
+```
+public static final int LINEAR
+```
+
+
+Lineare
+
+### PATH {#PATH}
+```
+public static final int PATH
+```
+
+
+Path
+
+### RADIAL {#RADIAL}
+```
+public static final int RADIAL
+```
+
+
+Radiale
+
+### RECTANGLE {#RECTANGLE}
+```
+public static final int RECTANGLE
+```
+
+
+Rettangolo
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/gradientstop/_index.md
+++ b/italian/java/com.aspose.diagram/gradientstop/_index.md
@@ -1,0 +1,222 @@
+---
+title: GradientStop
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta il punto di arresto del gradiente.
+type: docs
+weight: 181
+url: /it/java/com.aspose.diagram/gradientstop/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class GradientStop
+```
+
+Rappresenta il punto di arresto del gradiente.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [GradientStop()](#GradientStop--) |  |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getColor()](#getColor--) | Ottiene il colore di questo punto di gradiente. |
+| [getPosition()](#getPosition--) | La posizione del punto. |
+| [getTransparency()](#getTransparency--) | Restituisce o imposta il grado di trasparenza dell'area come valore da 0.0 (opaco) a 1.0 (trasparente). |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setColor(ColorValue value)](#setColor-com.aspose.diagram.ColorValue-) | Per la descrizione di questa proprietà, vedere [getColor()](../../com.aspose.diagram/gradientstop\#getColor--) |
+| [setPosition(DoubleValue value)](#setPosition-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getPosition()](../../com.aspose.diagram/gradientstop\#getPosition--) |
+| [setTransparency(DoubleValue value)](#setTransparency-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getTransparency()](../../com.aspose.diagram/gradientstop\#getTransparency--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GradientStop() {#GradientStop--}
+```
+public GradientStop()
+```
+
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColor() {#getColor--}
+```
+public ColorValue getColor()
+```
+
+
+Ottiene il colore di questo punto di gradiente.
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getPosition() {#getPosition--}
+```
+public DoubleValue getPosition()
+```
+
+
+La posizione del punto.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTransparency() {#getTransparency--}
+```
+public DoubleValue getTransparency()
+```
+
+
+Restituisce o imposta il grado di trasparenza dell'area come valore da 0.0 (opaco) a 1.0 (trasparente).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setColor(ColorValue value) {#setColor-com.aspose.diagram.ColorValue-}
+```
+public void setColor(ColorValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getColor()](../../com.aspose.diagram/gradientstop\#getColor--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setPosition(DoubleValue value) {#setPosition-com.aspose.diagram.DoubleValue-}
+```
+public void setPosition(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getPosition()](../../com.aspose.diagram/gradientstop\#getPosition--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTransparency(DoubleValue value) {#setTransparency-com.aspose.diagram.DoubleValue-}
+```
+public void setTransparency(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getTransparency()](../../com.aspose.diagram/gradientstop\#getTransparency--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/gradientstopcollection/_index.md
+++ b/italian/java/com.aspose.diagram/gradientstopcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: GradientStopCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta la raccolta dei punti di arresto del gradiente.
+type: docs
+weight: 182
+url: /it/java/com.aspose.diagram/gradientstopcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class GradientStopCollection extends Collection
+```
+
+Rappresenta la raccolta dei punti di arresto del gradiente.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [add(DoubleValue position, ColorValue color)](#add-com.aspose.diagram.DoubleValue-com.aspose.diagram.ColorValue-) | Add a gradient stop. |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gets the gradient stop by the index. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [set(int index, GradientStop value)](#set-int-com.aspose.diagram.GradientStop-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(DoubleValue position, ColorValue color) {#add-com.aspose.diagram.DoubleValue-com.aspose.diagram.ColorValue-}
+```
+public void add(DoubleValue position, ColorValue color)
+```
+
+
+Add a gradient stop.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| position | [DoubleValue](../../com.aspose.diagram/doublevalue) | The position of the stop,in unit of percentage. |
+| color | [ColorValue](../../com.aspose.diagram/colorvalue) | The color of the stop. |
+
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public GradientStop get(int index)
+```
+
+
+Gets the gradient stop by the index.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | The index. |
+
+**Returns:**
+[GradientStop](../../com.aspose.diagram/gradientstop) - The gradient stop.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### set(int index, GradientStop value) {#set-int-com.aspose.diagram.GradientStop-}
+```
+public void set(int index, GradientStop value)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+| value | [GradientStop](../../com.aspose.diagram/gradientstop) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/gradientstyletype/_index.md
+++ b/italian/java/com.aspose.diagram/gradientstyletype/_index.md
@@ -1,0 +1,192 @@
+---
+title: GradientStyleType
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta lo stile di sfumatura del gradiente.
+type: docs
+weight: 183
+url: /it/java/com.aspose.diagram/gradientstyletype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class GradientStyleType
+```
+
+Rappresenta lo stile di sfumatura del gradiente.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [DIAGONAL_DOWN](#DIAGONAL-DOWN) | Stile di sfumatura diagonale verso il basso |
+| [DIAGONAL_UP](#DIAGONAL-UP) | Stile di sfumatura diagonale verso l'alto |
+| [FROM_CENTER](#FROM-CENTER) | Stile di ombreggiatura dal centro |
+| [FROM_CORNER](#FROM-CORNER) | Stile di ombreggiatura dall'angolo |
+| [HORIZONTAL](#HORIZONTAL) | Stile di ombreggiatura orizzontale |
+| [UNKNOWN](#UNKNOWN) | Stile di ombreggiatura sconosciuto. Solo per lo stile di ombreggiatura (che non è per alcun membro di GradientStyleType) nel file modello. |
+| [VERTICAL](#VERTICAL) | Stile di ombreggiatura verticale |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DIAGONAL_DOWN {#DIAGONAL-DOWN}
+```
+public static final int DIAGONAL_DOWN
+```
+
+
+Stile di sfumatura diagonale verso il basso
+
+### DIAGONAL_UP {#DIAGONAL-UP}
+```
+public static final int DIAGONAL_UP
+```
+
+
+Stile di sfumatura diagonale verso l'alto
+
+### FROM_CENTER {#FROM-CENTER}
+```
+public static final int FROM_CENTER
+```
+
+
+Stile di ombreggiatura dal centro
+
+### FROM_CORNER {#FROM-CORNER}
+```
+public static final int FROM_CORNER
+```
+
+
+Stile di ombreggiatura dall'angolo
+
+### HORIZONTAL {#HORIZONTAL}
+```
+public static final int HORIZONTAL
+```
+
+
+Stile di ombreggiatura orizzontale
+
+### UNKNOWN {#UNKNOWN}
+```
+public static final int UNKNOWN
+```
+
+
+Stile di ombreggiatura sconosciuto. Solo per lo stile di ombreggiatura (che non è per alcun membro di GradientStyleType) nel file modello.
+
+### VERTICAL {#VERTICAL}
+```
+public static final int VERTICAL
+```
+
+
+Stile di ombreggiatura verticale
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/griddensity/_index.md
+++ b/italian/java/com.aspose.diagram/griddensity/_index.md
@@ -1,0 +1,179 @@
+---
+title: GridDensity
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica il tipo di griglia orizzontale/verticale da utilizzare per una pagina.
+type: docs
+weight: 184
+url: /it/java/com.aspose.diagram/griddensity/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class GridDensity
+```
+
+Specifica il tipo di griglia orizzontale/verticale da utilizzare per una pagina.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [GridDensity(int value)](#GridDensity-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Specifica il tipo di griglia orizzontale/verticale da utilizzare per una pagina. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, consultare [getValue()](../../com.aspose.diagram/griddensity\\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GridDensity(int value) {#GridDensity-int-}
+```
+public GridDensity(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specifica il tipo di griglia orizzontale/verticale da utilizzare per una pagina.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getValue()](../../com.aspose.diagram/griddensity\\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/griddensityvalue/_index.md
+++ b/italian/java/com.aspose.diagram/griddensityvalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: GridDensityValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica il tipo di griglia orizzontale/verticale da utilizzare per una pagina.
+type: docs
+weight: 185
+url: /it/java/com.aspose.diagram/griddensityvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class GridDensityValue
+```
+
+Specifica il tipo di griglia orizzontale/verticale da utilizzare per una pagina.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [COARSE](#COARSE) | Grossa. |
+| [FINE](#FINE) | Fine |
+| [FIXED](#FIXED) | Fisso. |
+| [NORMAL](#NORMAL) | Normale. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### COARSE {#COARSE}
+```
+public static final int COARSE
+```
+
+
+Grossa.
+
+### FINE {#FINE}
+```
+public static final int FINE
+```
+
+
+Fine
+
+### FIXED {#FIXED}
+```
+public static final int FIXED
+```
+
+
+Fisso.
+
+### NORMAL {#NORMAL}
+```
+public static final int NORMAL
+```
+
+
+Normale. Predefinito.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/group/_index.md
+++ b/italian/java/com.aspose.diagram/group/_index.md
@@ -1,0 +1,216 @@
+---
+title: Gruppo
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene elementi che controllano come aggiungere forme a un gruppo, spostare i membri di un gruppo e selezionare i gruppi.
+type: docs
+weight: 186
+url: /it/java/com.aspose.diagram/group/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Group
+```
+
+Contiene gli elementi che controllano come aggiungere forme a un gruppo, spostare i membri di un gruppo e selezionare i gruppi.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getDisplayMode()](#getDisplayMode--) | Quando è contenuto in un elemento Group, l'elemento DisplayMode specifica come viene visualizzata una forma di gruppo e i suoi membri. |
+| [getDontMoveChildren()](#getDontMoveChildren--) | Specifica se è possibile trascinare le forme in un gruppo usando il mouse. |
+| [getSelectMode()](#getSelectMode--) | Specifica come l'utente seleziona una forma di gruppo e i suoi membri. |
+| [hashCode()](#hashCode--) |  |
+| [isDropTarget()](#isDropTarget--) | Specifica se il gruppo consente di aggiungere una forma quando la forma viene rilasciata sul gruppo. |
+| [isSnapTarget()](#isSnapTarget--) | Specifica se l'aggancio a un gruppo o alle forme all'interno del gruppo è abilitato. |
+| [isTextEditTarget()](#isTextEditTarget--) | Specifica come assegnare testo a un gruppo. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/group\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getDisplayMode() {#getDisplayMode--}
+```
+public DisplayMode getDisplayMode()
+```
+
+
+Quando è contenuto in un elemento Group, l'elemento DisplayMode specifica come viene visualizzata una forma di gruppo e i suoi membri.
+
+**Returns:**
+[DisplayMode](../../com.aspose.diagram/displaymode)
+### getDontMoveChildren() {#getDontMoveChildren--}
+```
+public BoolValue getDontMoveChildren()
+```
+
+
+Specifica se è possibile trascinare le forme in un gruppo usando il mouse.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getSelectMode() {#getSelectMode--}
+```
+public SelectMode getSelectMode()
+```
+
+
+Specifica come l'utente seleziona una forma di gruppo e i suoi membri.
+
+**Returns:**
+[SelectMode](../../com.aspose.diagram/selectmode)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isDropTarget() {#isDropTarget--}
+```
+public BoolValue isDropTarget()
+```
+
+
+Specifica se il gruppo consente di aggiungere una forma quando la forma viene rilasciata sul gruppo.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### isSnapTarget() {#isSnapTarget--}
+```
+public BoolValue isSnapTarget()
+```
+
+
+Specifica se l'aggancio a un gruppo o alle forme all'interno del gruppo è abilitato.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### isTextEditTarget() {#isTextEditTarget--}
+```
+public BoolValue isTextEditTarget()
+```
+
+
+Specifica come assegnare testo a un gruppo.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/group\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/headerfooter/_index.md
+++ b/italian/java/com.aspose.diagram/headerfooter/_index.md
@@ -1,0 +1,361 @@
+---
+title: HeaderFooter
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene elementi per l'intestazione e il piè di pagina di un documento.
+type: docs
+weight: 188
+url: /it/java/com.aspose.diagram/headerfooter/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class HeaderFooter
+```
+
+Contiene gli elementi per l'intestazione e il piè di pagina di un documento.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFooterCenter()](#getFooterCenter--) | Contiene la stringa di testo che appare nella parte centrale del piè di pagina di un documento. |
+| [getFooterLeft()](#getFooterLeft--) | Contiene la stringa di testo che appare nella parte sinistra del piè di pagina di un documento. |
+| [getFooterMargin()](#getFooterMargin--) | Specifica il margine del piè di pagina di un documento. |
+| [getFooterRight()](#getFooterRight--) | Contiene la stringa di testo che appare nella parte destra del piè di pagina di un documento. |
+| [getHeaderCenter()](#getHeaderCenter--) | Contiene la stringa di testo che appare nella parte centrale dell'intestazione di un documento. |
+| [getHeaderFooterColor()](#getHeaderFooterColor--) | Il valore RGB del colore del testo per l'intestazione e il piè di pagina. |
+| [getHeaderFooterFont()](#getHeaderFooterFont--) | Specifica il carattere utilizzato per il testo dell'intestazione e del piè di pagina. |
+| [getHeaderLeft()](#getHeaderLeft--) | Contiene la stringa di testo che appare nella parte sinistra dell'intestazione di un documento. |
+| [getHeaderMargin()](#getHeaderMargin--) | Specifica il margine del piè di pagina di un documento. |
+| [getHeaderRight()](#getHeaderRight--) | Contiene la stringa di testo che appare nella parte destra dell'intestazione di un documento. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setFooterCenter(String value)](#setFooterCenter-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getFooterCenter()](../../com.aspose.diagram/headerfooter\#getFooterCenter--) |
+| [setFooterLeft(String value)](#setFooterLeft-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getFooterLeft()](../../com.aspose.diagram/headerfooter\#getFooterLeft--) |
+| [setFooterMargin(Margin value)](#setFooterMargin-com.aspose.diagram.Margin-) | Per la descrizione di questa proprietà, vedere [getFooterMargin()](../../com.aspose.diagram/headerfooter\#getFooterMargin--) |
+| [setFooterRight(String value)](#setFooterRight-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getFooterRight()](../../com.aspose.diagram/headerfooter\#getFooterRight--) |
+| [setHeaderCenter(String value)](#setHeaderCenter-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getHeaderCenter()](../../com.aspose.diagram/headerfooter\#getHeaderCenter--) |
+| [setHeaderFooterColor(Color value)](#setHeaderFooterColor-com.aspose.diagram.Color-) | Per la descrizione di questa proprietà, vedere [getHeaderFooterColor()](../../com.aspose.diagram/headerfooter\#getHeaderFooterColor--) |
+| [setHeaderLeft(String value)](#setHeaderLeft-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getHeaderLeft()](../../com.aspose.diagram/headerfooter\#getHeaderLeft--) |
+| [setHeaderMargin(Margin value)](#setHeaderMargin-com.aspose.diagram.Margin-) | Per la descrizione di questa proprietà, vedere [getHeaderMargin()](../../com.aspose.diagram/headerfooter\#getHeaderMargin--) |
+| [setHeaderRight(String value)](#setHeaderRight-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getHeaderRight()](../../com.aspose.diagram/headerfooter\#getHeaderRight--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFooterCenter() {#getFooterCenter--}
+```
+public String getFooterCenter()
+```
+
+
+Contiene la stringa di testo che appare nella parte centrale del piè di pagina di un documento.
+
+**Returns:**
+java.lang.String
+### getFooterLeft() {#getFooterLeft--}
+```
+public String getFooterLeft()
+```
+
+
+Contiene la stringa di testo che appare nella parte sinistra del piè di pagina di un documento.
+
+**Returns:**
+java.lang.String
+### getFooterMargin() {#getFooterMargin--}
+```
+public Margin getFooterMargin()
+```
+
+
+Specifica il margine del piè di pagina di un documento.
+
+**Returns:**
+[Margin](../../com.aspose.diagram/margin)
+### getFooterRight() {#getFooterRight--}
+```
+public String getFooterRight()
+```
+
+
+Contiene la stringa di testo che appare nella parte destra del piè di pagina di un documento.
+
+**Returns:**
+java.lang.String
+### getHeaderCenter() {#getHeaderCenter--}
+```
+public String getHeaderCenter()
+```
+
+
+Contiene la stringa di testo che appare nella parte centrale dell'intestazione di un documento.
+
+**Returns:**
+java.lang.String
+### getHeaderFooterColor() {#getHeaderFooterColor--}
+```
+public Color getHeaderFooterColor()
+```
+
+
+Il valore RGB del colore del testo per l'intestazione e il piè di pagina.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color)
+### getHeaderFooterFont() {#getHeaderFooterFont--}
+```
+public HeaderFooterFont getHeaderFooterFont()
+```
+
+
+Specifica il carattere utilizzato per il testo dell'intestazione e del piè di pagina.
+
+**Returns:**
+[HeaderFooterFont](../../com.aspose.diagram/headerfooterfont)
+### getHeaderLeft() {#getHeaderLeft--}
+```
+public String getHeaderLeft()
+```
+
+
+Contiene la stringa di testo che appare nella parte sinistra dell'intestazione di un documento.
+
+**Returns:**
+java.lang.String
+### getHeaderMargin() {#getHeaderMargin--}
+```
+public Margin getHeaderMargin()
+```
+
+
+Specifica il margine del piè di pagina di un documento.
+
+**Returns:**
+[Margin](../../com.aspose.diagram/margin)
+### getHeaderRight() {#getHeaderRight--}
+```
+public String getHeaderRight()
+```
+
+
+Contiene la stringa di testo che appare nella parte destra dell'intestazione di un documento.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setFooterCenter(String value) {#setFooterCenter-java.lang.String-}
+```
+public void setFooterCenter(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getFooterCenter()](../../com.aspose.diagram/headerfooter\#getFooterCenter--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setFooterLeft(String value) {#setFooterLeft-java.lang.String-}
+```
+public void setFooterLeft(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getFooterLeft()](../../com.aspose.diagram/headerfooter\#getFooterLeft--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setFooterMargin(Margin value) {#setFooterMargin-com.aspose.diagram.Margin-}
+```
+public void setFooterMargin(Margin value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getFooterMargin()](../../com.aspose.diagram/headerfooter\#getFooterMargin--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [Margin](../../com.aspose.diagram/margin) |  |
+
+### setFooterRight(String value) {#setFooterRight-java.lang.String-}
+```
+public void setFooterRight(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getFooterRight()](../../com.aspose.diagram/headerfooter\#getFooterRight--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setHeaderCenter(String value) {#setHeaderCenter-java.lang.String-}
+```
+public void setHeaderCenter(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getHeaderCenter()](../../com.aspose.diagram/headerfooter\#getHeaderCenter--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setHeaderFooterColor(Color value) {#setHeaderFooterColor-com.aspose.diagram.Color-}
+```
+public void setHeaderFooterColor(Color value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getHeaderFooterColor()](../../com.aspose.diagram/headerfooter\#getHeaderFooterColor--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [Color](../../com.aspose.diagram/color) |  |
+
+### setHeaderLeft(String value) {#setHeaderLeft-java.lang.String-}
+```
+public void setHeaderLeft(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getHeaderLeft()](../../com.aspose.diagram/headerfooter\#getHeaderLeft--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setHeaderMargin(Margin value) {#setHeaderMargin-com.aspose.diagram.Margin-}
+```
+public void setHeaderMargin(Margin value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getHeaderMargin()](../../com.aspose.diagram/headerfooter\#getHeaderMargin--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [Margin](../../com.aspose.diagram/margin) |  |
+
+### setHeaderRight(String value) {#setHeaderRight-java.lang.String-}
+```
+public void setHeaderRight(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getHeaderRight()](../../com.aspose.diagram/headerfooter\#getHeaderRight--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/headerfooterfont/_index.md
+++ b/italian/java/com.aspose.diagram/headerfooterfont/_index.md
@@ -1,0 +1,475 @@
+---
+title: HeaderFooterFont
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica il carattere utilizzato per il testo dell'intestazione e del piè di pagina.
+type: docs
+weight: 189
+url: /it/java/com.aspose.diagram/headerfooterfont/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class HeaderFooterFont
+```
+
+Specifica il carattere utilizzato per il testo dell'intestazione e del piè di pagina.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCharSet()](#getCharSet--) | Specifica il set di caratteri del font. |
+| [getClass()](#getClass--) |  |
+| [getClipPrecision()](#getClipPrecision--) | Specifica la precisione di clipping del font. |
+| [getEscapement()](#getEscapement--) | Specifica l'attributo di escapement del font. |
+| [getFaceName()](#getFaceName--) | Specifica l'attributo del nome del tipo di carattere del font. |
+| [getHeight()](#getHeight--) | Specifica l'altezza del font. |
+| [getItalic()](#getItalic--) | Specifica il peso del font. |
+| [getOrientation()](#getOrientation--) | Specifica l'orientamento del font. |
+| [getOutPrecision()](#getOutPrecision--) | Specifica l'attributo di precisione di output del font. |
+| [getPitchAndFamily()](#getPitchAndFamily--) | Specifica il pitch e la famiglia del font. |
+| [getQuality()](#getQuality--) | Specifica la qualità di output del font. |
+| [getStrikeOut()](#getStrikeOut--) | Specifica se il font è barrato. |
+| [getUnderline()](#getUnderline--) | Specifica se il font è sottolineato. |
+| [getWeight()](#getWeight--) | Specifica il peso del font. |
+| [getWidth()](#getWidth--) | Specifica la larghezza del font. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCharSet(long value)](#setCharSet-long-) | Per la descrizione di questa proprietà, vedere \{@link HeaderFooterFont\#(getCharSet() & 0xFFFFFFFFL)\} |
+| [setClipPrecision(long value)](#setClipPrecision-long-) | Per la descrizione di questa proprietà, vedere \{@link HeaderFooterFont\#(getClipPrecision() & 0xFFFFFFFFL)\} |
+| [setEscapement(int value)](#setEscapement-int-) | Per la descrizione di questa proprietà, vedere [getEscapement()](../../com.aspose.diagram/headerfooterfont\#getEscapement--) |
+| [setFaceName(String value)](#setFaceName-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getFaceName()](../../com.aspose.diagram/headerfooterfont\#getFaceName--) |
+| [setHeight(int value)](#setHeight-int-) | Per la descrizione di questa proprietà, vedere [getHeight()](../../com.aspose.diagram/headerfooterfont\#getHeight--) |
+| [setItalic(int value)](#setItalic-int-) | Per la descrizione di questa proprietà, vedere [getItalic()](../../com.aspose.diagram/headerfooterfont\#getItalic--) |
+| [setOrientation(int value)](#setOrientation-int-) | Per la descrizione di questa proprietà, vedere [getOrientation()](../../com.aspose.diagram/headerfooterfont\#getOrientation--) |
+| [setOutPrecision(long value)](#setOutPrecision-long-) | Per la descrizione di questa proprietà, vedere \{@link HeaderFooterFont\#(getOutPrecision() & 0xFFFFFFFFL)\} |
+| [setPitchAndFamily(long value)](#setPitchAndFamily-long-) | Per la descrizione di questa proprietà, vedere \{@link HeaderFooterFont\#(getPitchAndFamily() & 0xFFFFFFFFL)\} |
+| [setQuality(long value)](#setQuality-long-) | Per la descrizione di questa proprietà, vedere \{@link HeaderFooterFont\#(getQuality() & 0xFFFFFFFFL)\} |
+| [setStrikeOut(int value)](#setStrikeOut-int-) | Per la descrizione di questa proprietà, vedere [getStrikeOut()](../../com.aspose.diagram/headerfooterfont\#getStrikeOut--) |
+| [setUnderline(int value)](#setUnderline-int-) | Per la descrizione di questa proprietà, vedere [getUnderline()](../../com.aspose.diagram/headerfooterfont\#getUnderline--) |
+| [setWeight(int value)](#setWeight-int-) | Per la descrizione di questa proprietà, vedere [getWeight()](../../com.aspose.diagram/headerfooterfont\#getWeight--) |
+| [setWidth(int value)](#setWidth-int-) | Per la descrizione di questa proprietà, vedere [getWidth()](../../com.aspose.diagram/headerfooterfont\#getWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCharSet() {#getCharSet--}
+```
+public long getCharSet()
+```
+
+
+Specifica il set di caratteri del font. Equivalente al campo GDI LOGFONT lfCharSet.
+
+**Returns:**
+long
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getClipPrecision() {#getClipPrecision--}
+```
+public long getClipPrecision()
+```
+
+
+Specifica la precisione di clipping del font. Equivalente al campo GDI LOGFONT lfClipPrecision.
+
+**Returns:**
+long
+### getEscapement() {#getEscapement--}
+```
+public int getEscapement()
+```
+
+
+Specifica l'attributo di escapement del font. Equivalente al campo GDI LOGFONT lfEscapement.
+
+**Returns:**
+int
+### getFaceName() {#getFaceName--}
+```
+public String getFaceName()
+```
+
+
+Specifica l'attributo del nome del tipo di carattere del font. Equivalente al campo GDI LOGFONT lfFaceName.
+
+**Returns:**
+java.lang.String
+### getHeight() {#getHeight--}
+```
+public int getHeight()
+```
+
+
+Specifica l'altezza del font. Equivalente al campo GDI LOGFONT lfHeight.
+
+**Returns:**
+int
+### getItalic() {#getItalic--}
+```
+public int getItalic()
+```
+
+
+Specifica il peso del font. Equivalente al campo GDI LOGFONT lfWeight.
+
+**Returns:**
+int
+### getOrientation() {#getOrientation--}
+```
+public int getOrientation()
+```
+
+
+Specifica l'orientamento del font. Equivalente al campo GDI LOGFONT lfOrientation.
+
+**Returns:**
+int
+### getOutPrecision() {#getOutPrecision--}
+```
+public long getOutPrecision()
+```
+
+
+Specifica l'attributo di precisione di output del font. Equivalente al campo GDI LOGFONT lfOutPrecision.
+
+**Returns:**
+long
+### getPitchAndFamily() {#getPitchAndFamily--}
+```
+public long getPitchAndFamily()
+```
+
+
+Specifica il pitch e la famiglia del font. Equivalente al campo GDI LOGFONT lfPitchAndFamily.
+
+**Returns:**
+long
+### getQuality() {#getQuality--}
+```
+public long getQuality()
+```
+
+
+Specifica la qualità di output del font. Equivalente al campo GDI LOGFONT lfQuality.
+
+**Returns:**
+long
+### getStrikeOut() {#getStrikeOut--}
+```
+public int getStrikeOut()
+```
+
+
+Specifica se il font è barrato. Equivalente al campo GDI LOGFONT lfStrikeOut.
+
+**Returns:**
+int
+### getUnderline() {#getUnderline--}
+```
+public int getUnderline()
+```
+
+
+Specifica se il font è sottolineato. Equivalente al campo GDI LOGFONT lfUnderline.
+
+**Returns:**
+int
+### getWeight() {#getWeight--}
+```
+public int getWeight()
+```
+
+
+Specifica il peso del font. Equivalente al campo GDI LOGFONT lfWeight.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public int getWidth()
+```
+
+
+Specifica la larghezza del font. Equivalente al campo GDI LOGFONT lfWidth.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCharSet(long value) {#setCharSet-long-}
+```
+public void setCharSet(long value)
+```
+
+
+Per la descrizione di questa proprietà, vedere \{@link HeaderFooterFont\#(getCharSet() & 0xFFFFFFFFL)\}
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | long |  |
+
+### setClipPrecision(long value) {#setClipPrecision-long-}
+```
+public void setClipPrecision(long value)
+```
+
+
+Per la descrizione di questa proprietà, vedere \{@link HeaderFooterFont\#(getClipPrecision() & 0xFFFFFFFFL)\}
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | long |  |
+
+### setEscapement(int value) {#setEscapement-int-}
+```
+public void setEscapement(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getEscapement()](../../com.aspose.diagram/headerfooterfont\#getEscapement--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setFaceName(String value) {#setFaceName-java.lang.String-}
+```
+public void setFaceName(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getFaceName()](../../com.aspose.diagram/headerfooterfont\#getFaceName--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setHeight(int value) {#setHeight-int-}
+```
+public void setHeight(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getHeight()](../../com.aspose.diagram/headerfooterfont\#getHeight--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setItalic(int value) {#setItalic-int-}
+```
+public void setItalic(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getItalic()](../../com.aspose.diagram/headerfooterfont\#getItalic--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setOrientation(int value) {#setOrientation-int-}
+```
+public void setOrientation(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getOrientation()](../../com.aspose.diagram/headerfooterfont\#getOrientation--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setOutPrecision(long value) {#setOutPrecision-long-}
+```
+public void setOutPrecision(long value)
+```
+
+
+Per la descrizione di questa proprietà, vedere \{@link HeaderFooterFont\#(getOutPrecision() & 0xFFFFFFFFL)\}
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | long |  |
+
+### setPitchAndFamily(long value) {#setPitchAndFamily-long-}
+```
+public void setPitchAndFamily(long value)
+```
+
+
+Per la descrizione di questa proprietà, vedere \{@link HeaderFooterFont\#(getPitchAndFamily() & 0xFFFFFFFFL)\}
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | long |  |
+
+### setQuality(long value) {#setQuality-long-}
+```
+public void setQuality(long value)
+```
+
+
+Per la descrizione di questa proprietà, vedere \{@link HeaderFooterFont\#(getQuality() & 0xFFFFFFFFL)\}
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | long |  |
+
+### setStrikeOut(int value) {#setStrikeOut-int-}
+```
+public void setStrikeOut(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getStrikeOut()](../../com.aspose.diagram/headerfooterfont\#getStrikeOut--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setUnderline(int value) {#setUnderline-int-}
+```
+public void setUnderline(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getUnderline()](../../com.aspose.diagram/headerfooterfont\#getUnderline--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setWeight(int value) {#setWeight-int-}
+```
+public void setWeight(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getWeight()](../../com.aspose.diagram/headerfooterfont\#getWeight--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setWidth(int value) {#setWidth-int-}
+```
+public void setWidth(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getWidth()](../../com.aspose.diagram/headerfooterfont\#getWidth--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/help/_index.md
+++ b/italian/java/com.aspose.diagram/help/_index.md
@@ -1,0 +1,172 @@
+---
+title: Guida
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene elementi che specificano l'argomento del file di aiuto degli elementi Shape e le informazioni sul copyright.
+type: docs
+weight: 190
+url: /it/java/com.aspose.diagram/help/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Help
+```
+
+Contiene gli elementi che specificano l'argomento del file di aiuto dell'elemento Shape e le informazioni sul copyright.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCopyright()](#getCopyright--) | Contiene una stringa che rappresenta una dichiarazione di copyright leggibile dall'uomo. |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getHelpTopic()](#getHelpTopic--) | Specifica l'ID dell'argomento di aiuto dell'elemento Shape. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/help\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCopyright() {#getCopyright--}
+```
+public Str2Value getCopyright()
+```
+
+
+Contiene una stringa che rappresenta una dichiarazione di copyright leggibile dall'uomo.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getHelpTopic() {#getHelpTopic--}
+```
+public Str2Value getHelpTopic()
+```
+
+
+Specifica l'ID dell'argomento di aiuto dell'elemento Shape.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/help\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/horzalign/_index.md
+++ b/italian/java/com.aspose.diagram/horzalign/_index.md
@@ -1,0 +1,179 @@
+---
+title: HorzAlign
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica l'allineamento orizzontale del testo nel blocco di testo delle forme.
+type: docs
+weight: 191
+url: /it/java/com.aspose.diagram/horzalign/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class HorzAlign
+```
+
+Specifica l'allineamento orizzontale del testo nel blocco di testo della forma.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [HorzAlign(int value)](#HorzAlign-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Specifica l'allineamento orizzontale del testo nel blocco di testo della forma. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, consultare [getValue()](../../com.aspose.diagram/horzalign\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### HorzAlign(int value) {#HorzAlign-int-}
+```
+public HorzAlign(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specifica l'allineamento orizzontale del testo nel blocco di testo della forma.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getValue()](../../com.aspose.diagram/horzalign\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/horzalignvalue/_index.md
+++ b/italian/java/com.aspose.diagram/horzalignvalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: HorzAlignValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica l'allineamento orizzontale del testo nel blocco di testo delle forme.
+type: docs
+weight: 192
+url: /it/java/com.aspose.diagram/horzalignvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class HorzAlignValue
+```
+
+Specifica l'allineamento orizzontale del testo nel blocco di testo della forma.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [CENTER](#CENTER) | Centro. |
+| [FORCE_JUSTIFY](#FORCE-JUSTIFY) | Forza giustificazione. |
+| [JUSTIFY](#JUSTIFY) | Giustifica. |
+| [LEFT_ALIGN](#LEFT-ALIGN) | Allinea a sinistra. |
+| [RIGHT_ALIGN](#RIGHT-ALIGN) | Allinea a destra. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CENTER {#CENTER}
+```
+public static final int CENTER
+```
+
+
+Centro.
+
+### FORCE_JUSTIFY {#FORCE-JUSTIFY}
+```
+public static final int FORCE_JUSTIFY
+```
+
+
+Forza giustificazione.
+
+### JUSTIFY {#JUSTIFY}
+```
+public static final int JUSTIFY
+```
+
+
+Giustifica.
+
+### LEFT_ALIGN {#LEFT-ALIGN}
+```
+public static final int LEFT_ALIGN
+```
+
+
+Allinea a sinistra.
+
+### RIGHT_ALIGN {#RIGHT-ALIGN}
+```
+public static final int RIGHT_ALIGN
+```
+
+
+Allinea a destra.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/htmlsaveoptions/_index.md
+++ b/italian/java/com.aspose.diagram/htmlsaveoptions/_index.md
@@ -1,0 +1,629 @@
+---
+title: HTMLSaveOptions
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Consente di specificare opzioni aggiuntive durante il rendering delle pagine del diagramma in HTML.
+type: docs
+weight: 187
+url: /it/java/com.aspose.diagram/htmlsaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.SaveOptions](../../com.aspose.diagram/saveoptions), [com.aspose.diagram.RenderingSaveOptions](../../com.aspose.diagram/renderingsaveoptions)
+```
+public class HTMLSaveOptions extends RenderingSaveOptions
+```
+
+Consente di specificare opzioni aggiuntive durante il rendering delle pagine del diagramma in HTML.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [HTMLSaveOptions()](#HTMLSaveOptions--) | Inizializza una nuova istanza di questa classe che può essere utilizzata per salvare un documento nel formato Aspose.Diagram.SaveFileFormat. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | Crea un oggetto di opzioni di salvataggio di una classe adatta al formato di salvataggio specificato. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDefaultFont()](#getDefaultFont--) | Quando i caratteri nel diagramma sono Unicode e non vengono impostati con il valore di carattere corretto o il carattere non è installato localmente, possono apparire come blocchi in PDF, immagine o XPS. |
+| [getEmfRenderSetting()](#getEmfRenderSetting--) | Impostazione per il rendering del metafile Emf. |
+| [getEnlargePage()](#getEnlargePage--) | Specifica se ingrandire la pagina. |
+| [getExportGuideShapes()](#getExportGuideShapes--) | Definisce se è necessario esportare le forme guida o meno. |
+| [getExportHiddenPage()](#getExportHiddenPage--) | Definisce se è necessario esportare la pagina nascosta o meno. |
+| [getPageCount()](#getPageCount--) | il numero di pagine da renderizzare in HTML. |
+| [getPageIndex()](#getPageIndex--) | l'indice basato su zero della prima pagina da renderizzare. |
+| [getPageSize()](#getPageSize--) | la dimensione della pagina per le immagini generate. |
+| [getResolution()](#getResolution--) | la risoluzione per l'HTML generato, in punti per pollice. |
+| [getSaveAsSingleFile()](#getSaveAsSingleFile--) | Indica se salvare l'HTML come file unico. |
+| [getSaveForegroundPagesOnly()](#getSaveForegroundPagesOnly--) | Specifica se tutte le pagine saranno salvate come immagine o solo il primo piano. |
+| [getSaveFormat()](#getSaveFormat--) | Specifica il formato in cui le pagine del diagramma renderizzate saranno salvate se viene utilizzato questo oggetto di opzioni di salvataggio. |
+| [getSaveTitle()](#getSaveTitle--) | Definisce se è necessario esportare il titolo o meno. |
+| [getSaveToolBar()](#getSaveToolBar--) | Specifica se salvare la barra degli strumenti. Il valore predefinito è true. |
+| [getShapes()](#getShapes--) | forme da renderizzare. |
+| [getStreamProvider()](#getStreamProvider--) | l'IStreamProvider per l'esportazione degli oggetti. |
+| [getTitle()](#getTitle--) | il titolo del diagramma da renderizzare in HTML. |
+| [getWarningCallback()](#getWarningCallback--) | callback di avviso. |
+| [hashCode()](#hashCode--) |  |
+| [isExportComments()](#isExportComments--) | Definisce se è necessario esportare i commenti o meno. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--) |
+| [setEmfRenderSetting(int value)](#setEmfRenderSetting-int-) | Per la descrizione di questa proprietà, vedere [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--) |
+| [setEnlargePage(boolean value)](#setEnlargePage-boolean-) | Per la descrizione di questa proprietà, vedere [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\\#getEnlargePage--) |
+| [setExportComments(boolean value)](#setExportComments-boolean-) | Per la descrizione di questa proprietà, vedere [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\\#isExportComments--) |
+| [setExportGuideShapes(boolean value)](#setExportGuideShapes-boolean-) | Per la descrizione di questa proprietà, vedere [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\\#getExportGuideShapes--) |
+| [setExportHiddenPage(boolean value)](#setExportHiddenPage-boolean-) | Per la descrizione di questa proprietà, vedere [getExportHiddenPage()](../../com.aspose.diagram/htmlsaveoptions\\#getExportHiddenPage--) |
+| [setPageCount(int value)](#setPageCount-int-) | Per la descrizione di questa proprietà, vedere [getPageCount()](../../com.aspose.diagram/htmlsaveoptions\\#getPageCount--) |
+| [setPageIndex(int value)](#setPageIndex-int-) | Per la descrizione di questa proprietà, vedere [getPageIndex()](../../com.aspose.diagram/htmlsaveoptions\\#getPageIndex--) |
+| [setPageSize(PageSize value)](#setPageSize-com.aspose.diagram.PageSize-) | Per la descrizione di questa proprietà, vedere [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\\#getPageSize--) |
+| [setResolution(int value)](#setResolution-int-) | Per la descrizione di questa proprietà, vedere [getResolution()](../../com.aspose.diagram/htmlsaveoptions\\#getResolution--) |
+| [setSaveAsSingleFile(boolean value)](#setSaveAsSingleFile-boolean-) | Per la descrizione di questa proprietà, vedere [getSaveAsSingleFile()](../../com.aspose.diagram/htmlsaveoptions\\#getSaveAsSingleFile--) |
+| [setSaveForegroundPagesOnly(boolean value)](#setSaveForegroundPagesOnly-boolean-) | Per la descrizione di questa proprietà, vedere [getSaveForegroundPagesOnly()](../../com.aspose.diagram/htmlsaveoptions\\#getSaveForegroundPagesOnly--) |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | Per la descrizione di questa proprietà, vedere [getSaveFormat()](../../com.aspose.diagram/htmlsaveoptions\\#getSaveFormat--) |
+| [setSaveTitle(boolean value)](#setSaveTitle-boolean-) | Per la descrizione di questa proprietà, vedere [getSaveTitle()](../../com.aspose.diagram/htmlsaveoptions\\#getSaveTitle--) |
+| [setSaveToolBar(boolean value)](#setSaveToolBar-boolean-) | Per la descrizione di questa proprietà, vedere [getSaveToolBar()](../../com.aspose.diagram/htmlsaveoptions\\#getSaveToolBar--) |
+| [setShapes(ShapeCollection value)](#setShapes-com.aspose.diagram.ShapeCollection-) | Per la descrizione di questa proprietà, vedere [getShapes()](../../com.aspose.diagram/renderingsaveoptions\\#getShapes--) |
+| [setStreamProvider(IStreamProvider value)](#setStreamProvider-com.aspose.diagram.IStreamProvider-) | Per la descrizione di questa proprietà, vedere [getStreamProvider()](../../com.aspose.diagram/htmlsaveoptions\\#getStreamProvider--) |
+| [setTitle(String value)](#setTitle-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getTitle()](../../com.aspose.diagram/htmlsaveoptions\\#getTitle--) |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### HTMLSaveOptions() {#HTMLSaveOptions--}
+```
+public HTMLSaveOptions()
+```
+
+
+Inizializza una nuova istanza di questa classe che può essere utilizzata per salvare un documento nel formato Aspose.Diagram.SaveFileFormat.
+
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+Crea un oggetto di opzioni di salvataggio di una classe adatta al formato di salvataggio specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| saveFormat | int | Il Aspose.Diagram.SaveFileFormat per il quale creare un oggetto di opzioni di salvataggio. |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+Quando i caratteri nel diagramma sono Unicode e non sono impostati con il valore di font corretto o il font non è installato localmente, possono apparire come blocchi in PDF, immagine o XPS. Impostare il DefaultFont, ad esempio MingLiu o MS Gothic, per visualizzare questi caratteri.
+
+**Returns:**
+java.lang.String
+### getEmfRenderSetting() {#getEmfRenderSetting--}
+```
+public int getEmfRenderSetting()
+```
+
+
+Impostazione per il rendering dei metafile EMF. I metafile EMF identificati come "EMF+ Dual" possono contenere sia record EMF+ sia record EMF. Entrambi i tipi di record possono essere usati per renderizzare l'immagine, solo record EMF+, o solo record EMF. Quando EmfPlusPrefer è impostato, i record EMF+ verranno analizzati, altrimenti verranno analizzati solo i record EMF. Il valore predefinito è EmfOnly"/>.
+
+**Returns:**
+int
+### getEnlargePage() {#getEnlargePage--}
+```
+public boolean getEnlargePage()
+```
+
+
+Specifica se ingrandire la pagina. Se true - ingrandire la pagina. Se false - non ingrandire la pagina. Il valore predefinito è true.
+
+**Returns:**
+boolean
+### getExportGuideShapes() {#getExportGuideShapes--}
+```
+public boolean getExportGuideShapes()
+```
+
+
+Definisce se è necessario esportare le forme guida o meno. Il valore predefinito è true.
+
+**Returns:**
+boolean
+### getExportHiddenPage() {#getExportHiddenPage--}
+```
+public boolean getExportHiddenPage()
+```
+
+
+Definisce se è necessario esportare la pagina nascosta o meno. Il valore predefinito è true.
+
+**Returns:**
+boolean
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+Il numero di pagine da renderizzare in HTML. Il valore predefinito è MaxValue, il che significa che verranno renderizzate tutte le pagine del diagramma.
+
+**Returns:**
+int
+### getPageIndex() {#getPageIndex--}
+```
+public int getPageIndex()
+```
+
+
+L'indice basato su zero della prima pagina da renderizzare. Il valore predefinito è 0.
+
+**Returns:**
+int
+### getPageSize() {#getPageSize--}
+```
+public PageSize getPageSize()
+```
+
+
+la dimensione della pagina per le immagini generate. Può essere [PageSize](../../com.aspose.diagram/pagesize) o null. Il valore predefinito è null. Se PageSize è null, la dimensione della pagina per l'immagine generata viene ottenuta dal diagramma di origine.
+
+**Returns:**
+[PageSize](../../com.aspose.diagram/pagesize)
+### getResolution() {#getResolution--}
+```
+public int getResolution()
+```
+
+
+la risoluzione per l'html generato, in punti per pollice. Questa proprietà ha effetto solo durante il salvataggio in html. Il valore predefinito è 96.
+
+**Returns:**
+int
+### getSaveAsSingleFile() {#getSaveAsSingleFile--}
+```
+public boolean getSaveAsSingleFile()
+```
+
+
+Indica se salvare l'html come file unico. Il valore predefinito è false. Se ci sono più pagine, quelle pagine e le altre risorse devono essere salvate in file separati. In alcuni scenari, l'utente potrebbe aver bisogno di ottenere un solo file risultante, ad esempio per facilitare il trasferimento. In tal caso, l'utente può impostare questa proprietà su true.
+
+**Returns:**
+boolean
+### getSaveForegroundPagesOnly() {#getSaveForegroundPagesOnly--}
+```
+public boolean getSaveForegroundPagesOnly()
+```
+
+
+Specifica se tutte le pagine saranno salvate in immagine o solo il primo piano. Se true - vengono renderizzate solo le pagine di primo piano (con lo sfondo se presente). Se false - vengono renderizzate le pagine di primo piano (con lo sfondo se presente) seguite da pagine di sfondo vuote. Può restituire true solo quando PageCount > 1. Il valore predefinito è false.
+
+**Returns:**
+boolean
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+Specifica il formato in cui le pagine del diagramma renderizzate saranno salvate se viene utilizzato questo oggetto di opzioni di salvataggio. Può essere solo Aspose.Diagram.SaveFileFormat.
+
+**Returns:**
+int
+### getSaveTitle() {#getSaveTitle--}
+```
+public boolean getSaveTitle()
+```
+
+
+Definisce se è necessario esportare il titolo o meno. Il valore predefinito è true.
+
+**Returns:**
+boolean
+### getSaveToolBar() {#getSaveToolBar--}
+```
+public boolean getSaveToolBar()
+```
+
+
+Specifica se salvare la barra degli strumenti. Il valore predefinito è true.
+
+**Returns:**
+boolean
+### getShapes() {#getShapes--}
+```
+public ShapeCollection getShapes()
+```
+
+
+forme da renderizzare. Il conteggio predefinito è 0.
+
+**Returns:**
+[ShapeCollection](../../com.aspose.diagram/shapecollection)
+### getStreamProvider() {#getStreamProvider--}
+```
+public IStreamProvider getStreamProvider()
+```
+
+
+l'IStreamProvider per l'esportazione degli oggetti.
+
+**Returns:**
+[IStreamProvider](../../com.aspose.diagram/istreamprovider)
+### getTitle() {#getTitle--}
+```
+public String getTitle()
+```
+
+
+il titolo del diagramma da renderizzare in HTML. Se Title è null, verrà utilizzato Diagram.DocumentProperties.Title [DocumentProperties](../../com.aspose.diagram/documentproperties) come titolo. Se Diagram.DocumentProperties.Title è null o vuoto, verrà utilizzato il nome file del diagramma come titolo.
+
+**Returns:**
+java.lang.String
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+callback di avviso.
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExportComments() {#isExportComments--}
+```
+public boolean isExportComments()
+```
+
+
+Definisce se è necessario esportare i commenti o meno. Il valore predefinito è false.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setEmfRenderSetting(int value) {#setEmfRenderSetting-int-}
+```
+public void setEmfRenderSetting(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setEnlargePage(boolean value) {#setEnlargePage-boolean-}
+```
+public void setEnlargePage(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\\#getEnlargePage--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setExportComments(boolean value) {#setExportComments-boolean-}
+```
+public void setExportComments(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\\#isExportComments--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setExportGuideShapes(boolean value) {#setExportGuideShapes-boolean-}
+```
+public void setExportGuideShapes(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\\#getExportGuideShapes--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setExportHiddenPage(boolean value) {#setExportHiddenPage-boolean-}
+```
+public void setExportHiddenPage(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getExportHiddenPage()](../../com.aspose.diagram/htmlsaveoptions\\#getExportHiddenPage--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setPageCount(int value) {#setPageCount-int-}
+```
+public void setPageCount(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getPageCount()](../../com.aspose.diagram/htmlsaveoptions\\#getPageCount--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setPageIndex(int value) {#setPageIndex-int-}
+```
+public void setPageIndex(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getPageIndex()](../../com.aspose.diagram/htmlsaveoptions\\#getPageIndex--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setPageSize(PageSize value) {#setPageSize-com.aspose.diagram.PageSize-}
+```
+public void setPageSize(PageSize value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\\#getPageSize--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [PageSize](../../com.aspose.diagram/pagesize) |  |
+
+### setResolution(int value) {#setResolution-int-}
+```
+public void setResolution(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getResolution()](../../com.aspose.diagram/htmlsaveoptions\\#getResolution--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setSaveAsSingleFile(boolean value) {#setSaveAsSingleFile-boolean-}
+```
+public void setSaveAsSingleFile(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getSaveAsSingleFile()](../../com.aspose.diagram/htmlsaveoptions\\#getSaveAsSingleFile--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setSaveForegroundPagesOnly(boolean value) {#setSaveForegroundPagesOnly-boolean-}
+```
+public void setSaveForegroundPagesOnly(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getSaveForegroundPagesOnly()](../../com.aspose.diagram/htmlsaveoptions\\#getSaveForegroundPagesOnly--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getSaveFormat()](../../com.aspose.diagram/htmlsaveoptions\\#getSaveFormat--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setSaveTitle(boolean value) {#setSaveTitle-boolean-}
+```
+public void setSaveTitle(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getSaveTitle()](../../com.aspose.diagram/htmlsaveoptions\\#getSaveTitle--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setSaveToolBar(boolean value) {#setSaveToolBar-boolean-}
+```
+public void setSaveToolBar(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getSaveToolBar()](../../com.aspose.diagram/htmlsaveoptions\\#getSaveToolBar--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setShapes(ShapeCollection value) {#setShapes-com.aspose.diagram.ShapeCollection-}
+```
+public void setShapes(ShapeCollection value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getShapes()](../../com.aspose.diagram/renderingsaveoptions\\#getShapes--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [ShapeCollection](../../com.aspose.diagram/shapecollection) |  |
+
+### setStreamProvider(IStreamProvider value) {#setStreamProvider-com.aspose.diagram.IStreamProvider-}
+```
+public void setStreamProvider(IStreamProvider value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getStreamProvider()](../../com.aspose.diagram/htmlsaveoptions\\#getStreamProvider--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [IStreamProvider](../../com.aspose.diagram/istreamprovider) |  |
+
+### setTitle(String value) {#setTitle-java.lang.String-}
+```
+public void setTitle(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getTitle()](../../com.aspose.diagram/htmlsaveoptions\\#getTitle--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/hyperlink/_index.md
+++ b/italian/java/com.aspose.diagram/hyperlink/_index.md
@@ -1,0 +1,348 @@
+---
+title: Hyperlink
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene elementi per creare più collegamenti tra una forma o pagina di disegno e un'altra pagina di disegno, un altro file o un sito Web.
+type: docs
+weight: 193
+url: /it/java/com.aspose.diagram/hyperlink/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Hyperlink
+```
+
+Contiene gli elementi per creare più collegamenti tra una forma o una pagina di disegno e un'altra pagina di disegno, un altro file o un sito Web.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [Hyperlink()](#Hyperlink--) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAddress()](#getAddress--) | Specifica un indirizzo URL, un nome file DOS o un percorso UNC a cui saltare. |
+| [getClass()](#getClass--) |  |
+| [getDefault()](#getDefault--) | Specifica il collegamento ipertestuale predefinito per una forma o una pagina. |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getDescription()](#getDescription--) | L'elemento Description contiene una stringa di testo che descrive il collegamento ipertestuale. |
+| [getExtraInfo()](#getExtraInfo--) | Contiene informazioni da utilizzare per risolvere un URL, come le coordinate di una mappa immagine. |
+| [getFrame()](#getFrame--) | Contiene il nome di un frame da destinazione quando Microsoft Visio è aperto come documento attivo in un'applicazione contenitore. |
+| [getID()](#getID--) | L'ID univoco dell'elemento all'interno del suo elemento genitore. |
+| [getInvisible()](#getInvisible--) | L'elemento Invisible indica se un collegamento ipertestuale appare nel menu contestuale per una forma o una pagina. |
+| [getName()](#getName--) | Il nome dell'elemento. |
+| [getNameU()](#getNameU--) | Il nome universale dell'elemento. |
+| [getNewWindow()](#getNewWindow--) | Specifica se Microsoft Visio apre una finestra in una nuova posizione quando segue un collegamento ipertestuale per aprire una pagina Web o un altro documento Visio. |
+| [getSortKey()](#getSortKey--) | L'elemento Invisible indica se un collegamento ipertestuale appare nel menu contestuale per una forma o una pagina. |
+| [getSubAddress()](#getSubAddress--) | Specifica una posizione all'interno del documento di destinazione a cui collegarsi. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, consultare [getDel()](../../com.aspose.diagram/hyperlink\#getDel--) |
+| [setID(int value)](#setID-int-) | Per la descrizione di questa proprietà, consultare [getID()](../../com.aspose.diagram/hyperlink\#getID--) |
+| [setName(String value)](#setName-java.lang.String-) | Per la descrizione di questa proprietà, consultare [getName()](../../com.aspose.diagram/hyperlink\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | Per la descrizione di questa proprietà, consultare [getNameU()](../../com.aspose.diagram/hyperlink\#getNameU--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Hyperlink() {#Hyperlink--}
+```
+public Hyperlink()
+```
+
+
+Costruttore.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAddress() {#getAddress--}
+```
+public Str2Value getAddress()
+```
+
+
+Specifica un indirizzo URL, un nome file DOS o un percorso UNC a cui saltare.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefault() {#getDefault--}
+```
+public BoolValue getDefault()
+```
+
+
+Specifica il collegamento ipertestuale predefinito per una forma o una pagina.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getDescription() {#getDescription--}
+```
+public Str2Value getDescription()
+```
+
+
+L'elemento Description contiene una stringa di testo che descrive il collegamento ipertestuale.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getExtraInfo() {#getExtraInfo--}
+```
+public Str2Value getExtraInfo()
+```
+
+
+Contiene informazioni da utilizzare per risolvere un URL, come le coordinate di una mappa immagine. Per esempio, x=41 y=7 specificerebbe le coordinate di una mappa immagine.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getFrame() {#getFrame--}
+```
+public Str2Value getFrame()
+```
+
+
+Contiene il nome di un frame da destinazione quando Microsoft Visio è aperto come documento attivo in un'applicazione contenitore. Il valore predefinito è una stringa vuota.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+L'ID univoco dell'elemento all'interno del suo elemento genitore.
+
+**Returns:**
+int
+### getInvisible() {#getInvisible--}
+```
+public BoolValue getInvisible()
+```
+
+
+L'elemento Invisible indica se un collegamento ipertestuale appare nel menu contestuale per una forma o una pagina.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Il nome dell'elemento.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+Il nome universale dell'elemento.
+
+**Returns:**
+java.lang.String
+### getNewWindow() {#getNewWindow--}
+```
+public BoolValue getNewWindow()
+```
+
+
+Specifica se Microsoft Visio apre una finestra in una nuova posizione quando segue un collegamento ipertestuale per aprire una pagina Web o un altro documento Visio.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getSortKey() {#getSortKey--}
+```
+public Str2Value getSortKey()
+```
+
+
+L'elemento Invisible indica se un collegamento ipertestuale appare nel menu contestuale per una forma o una pagina.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getSubAddress() {#getSubAddress--}
+```
+public Str2Value getSubAddress()
+```
+
+
+Specifica una posizione all'interno del documento di destinazione a cui collegarsi.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getDel()](../../com.aspose.diagram/hyperlink\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getID()](../../com.aspose.diagram/hyperlink\#getID--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getName()](../../com.aspose.diagram/hyperlink\#getName--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getNameU()](../../com.aspose.diagram/hyperlink\#getNameU--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/hyperlinkcollection/_index.md
+++ b/italian/java/com.aspose.diagram/hyperlinkcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: HyperlinkCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Raccolta di collegamenti ipertestuali.
+type: docs
+weight: 194
+url: /it/java/com.aspose.diagram/hyperlinkcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class HyperlinkCollection extends Collection
+```
+
+Raccolta di collegamenti ipertestuali.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [add(Hyperlink item)](#add-com.aspose.diagram.Hyperlink-) | Aggiungi l'oggetto Hyperlink nella collezione. |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Hyperlink item)](#remove-com.aspose.diagram.Hyperlink-) | Rimuovi l'oggetto Hyperlink dalla collezione. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Hyperlink item) {#add-com.aspose.diagram.Hyperlink-}
+```
+public int add(Hyperlink item)
+```
+
+
+Aggiungi l'oggetto Hyperlink nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [Hyperlink](../../com.aspose.diagram/hyperlink) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Hyperlink get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[Hyperlink](../../com.aspose.diagram/hyperlink) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Hyperlink item) {#remove-com.aspose.diagram.Hyperlink-}
+```
+public void remove(Hyperlink item)
+```
+
+
+Rimuovi l'oggetto Hyperlink dalla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [Hyperlink](../../com.aspose.diagram/hyperlink) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/iconsizevalue/_index.md
+++ b/italian/java/com.aspose.diagram/iconsizevalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: IconSizeValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: int opzionale.
+type: docs
+weight: 195
+url: /it/java/com.aspose.diagram/iconsizevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class IconSizeValue
+```
+
+Intero opzionale. La dimensione dell'icona dell'elemento.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [DOUBLE](#DOUBLE) | Double. |
+| [NORMAL](#NORMAL) | Normale. |
+| [TALL](#TALL) | Alto. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+| [WIDE](#WIDE) | Largo. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DOUBLE {#DOUBLE}
+```
+public static final int DOUBLE
+```
+
+
+Double.
+
+### NORMAL {#NORMAL}
+```
+public static final int NORMAL
+```
+
+
+Normale.
+
+### TALL {#TALL}
+```
+public static final int TALL
+```
+
+
+Alto.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### WIDE {#WIDE}
+```
+public static final int WIDE
+```
+
+
+Largo.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/image/_index.md
+++ b/italian/java/com.aspose.diagram/image/_index.md
@@ -1,0 +1,227 @@
+---
+title: Immagine
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene i valori di gamma, luminosità, contrasto, sfocatura, nitidezza, riduzione del rumore e trasparenza per un bitmap.
+type: docs
+weight: 196
+url: /it/java/com.aspose.diagram/image/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Image
+```
+
+Contiene i valori di gamma, luminosità, contrasto, sfocatura, nitidezza, riduzione del rumore e trasparenza per un bitmap.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBlur()](#getBlur--) | Sfoca o ammorbidisce un'immagine bitmap. |
+| [getBrightness()](#getBrightness--) | Regola la luminosità di un'immagine bitmap. |
+| [getClass()](#getClass--) |  |
+| [getContrast()](#getContrast--) | Specifica il contrasto di un'immagine bitmap. |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getDenoise()](#getDenoise--) | Rimuove il rumore (pixel con livelli di colore distribuiti casualmente) da un'immagine bitmap. |
+| [getGamma()](#getGamma--) | Regola o corregge l'intensità di un'immagine per un particolare dispositivo di output, come un monitor o uno scanner. |
+| [getSharpen()](#getSharpen--) | Specifica la quantità di nitidezza per un'immagine bitmap. |
+| [getTransparency()](#getTransparency--) | Specifica il livello di trasparenza per il colore di un livello, da 0 (opaco) a 1 (completamente trasparente). |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/image\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBlur() {#getBlur--}
+```
+public DoubleValue getBlur()
+```
+
+
+Sfoca o ammorbidisce un'immagine bitmap. L'elemento Blur contiene un valore compreso tra 0 e 1; il valore predefinito è 0.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBrightness() {#getBrightness--}
+```
+public DoubleValue getBrightness()
+```
+
+
+Regola la luminosità di un'immagine bitmap. L'elemento Brightness contiene un valore compreso tra 0 e 1; il valore predefinito è 0,5.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getContrast() {#getContrast--}
+```
+public DoubleValue getContrast()
+```
+
+
+Specifica il contrasto di un'immagine bitmap. L'elemento Contrast contiene un valore compreso tra 0 e 1.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getDenoise() {#getDenoise--}
+```
+public DoubleValue getDenoise()
+```
+
+
+Rimuove il rumore (pixel con livelli di colore distribuiti casualmente) da un'immagine bitmap.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getGamma() {#getGamma--}
+```
+public DoubleValue getGamma()
+```
+
+
+Regola o corregge l'intensità di un'immagine per un particolare dispositivo di output, come un monitor o uno scanner. Il valore predefinito è 1 (nessuna correzione.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getSharpen() {#getSharpen--}
+```
+public DoubleValue getSharpen()
+```
+
+
+Specifica la quantità di nitidezza per un'immagine bitmap. La nitidezza di un'immagine la mette a fuoco aumentando il contrasto dei pixel adiacenti.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTransparency() {#getTransparency--}
+```
+public DoubleValue getTransparency()
+```
+
+
+Specifica il livello di trasparenza per il colore di un livello, da 0 (opaco) a 1 (completamente trasparente).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/image\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/imageactivexcontrol/_index.md
+++ b/italian/java/com.aspose.diagram/imageactivexcontrol/_index.md
@@ -1,0 +1,597 @@
+---
+title: ImageActiveXControl
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta il controllo immagine.
+type: docs
+weight: 197
+url: /it/java/com.aspose.diagram/imageactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class ImageActiveXControl extends ActiveXControl
+```
+
+Rappresenta il controllo immagine.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBackOleColor()](#getBackOleColor--) | il colore OLE dello sfondo. |
+| [getBorderOleColor()](#getBorderOleColor--) | il colore OLE dello sfondo. |
+| [getBorderStyle()](#getBorderStyle--) | il tipo di bordo usato dal controllo. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | i dati binari del controllo. |
+| [getForeOleColor()](#getForeOleColor--) | il colore OLE del primo piano. |
+| [getHeight()](#getHeight--) | l'altezza del controllo in unità di punti. |
+| [getIMEMode()](#getIMEMode--) | la modalità di esecuzione predefinita dell'Input Method Editor per il controllo quando riceve il fuoco. |
+| [getMouseIcon()](#getMouseIcon--) | un'icona personalizzata da visualizzare come puntatore del mouse per il controllo. |
+| [getMousePointer()](#getMousePointer--) | il tipo di icona visualizzata come puntatore del mouse per il controllo. |
+| [getPicture()](#getPicture--) | i dati dell'immagine. |
+| [getPictureAlignment()](#getPictureAlignment--) | l'allineamento dell'immagine all'interno del Form o dell'Image. |
+| [getPictureSizeMode()](#getPictureSizeMode--) | come visualizzare l'immagine. |
+| [getSpecialEffect()](#getSpecialEffect--) | l'effetto speciale del controllo. |
+| [getType()](#getType--) | Ottiene il tipo del controllo ActiveX. |
+| [getWidth()](#getWidth--) | la larghezza del controllo in unità di punti. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | Indica se il controllo ridimensionerà automaticamente per visualizzare tutto il contenuto. |
+| [isEnabled()](#isEnabled--) | Indica se il controllo può ricevere il focus e rispondere agli eventi generati dall'utente. |
+| [isLocked()](#isLocked--) | Indica se i dati nel controllo sono bloccati per la modifica. |
+| [isTiled()](#isTiled--) | Indica se l'immagine è ripetuta sullo sfondo. |
+| [isTransparent()](#isTransparent--) | Indica se il controllo è trasparente. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | Per la descrizione di questa proprietà, vedere [isAutoSize()](../../com.aspose.diagram/imageactivexcontrol\#isAutoSize--) |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | Per la descrizione di questa proprietà, vedere [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setBorderOleColor(int value)](#setBorderOleColor-int-) | Per la descrizione di questa proprietà, vedere [getBorderOleColor()](../../com.aspose.diagram/imageactivexcontrol\#getBorderOleColor--) |
+| [setBorderStyle(int value)](#setBorderStyle-int-) | Per la descrizione di questa proprietà, vedere [getBorderStyle()](../../com.aspose.diagram/imageactivexcontrol\#getBorderStyle--) |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | Per la descrizione di questa proprietà, vedere [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | Per la descrizione di questa proprietà, vedere [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setHeight(double value)](#setHeight-double-) | Per la descrizione di questa proprietà, vedere [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setIMEMode(int value)](#setIMEMode-int-) | Per la descrizione di questa proprietà, vedere [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) |
+| [setLocked(boolean value)](#setLocked-boolean-) | Per la descrizione di questa proprietà, vedere [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | Per la descrizione di questa proprietà, vedere [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | Per la descrizione di questa proprietà, vedere [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setPicture(byte[] value)](#setPicture-byte---) | Per la descrizione di questa proprietà, vedere [getPicture()](../../com.aspose.diagram/imageactivexcontrol\#getPicture--) |
+| [setPictureAlignment(int value)](#setPictureAlignment-int-) | Per la descrizione di questa proprietà, vedere [getPictureAlignment()](../../com.aspose.diagram/imageactivexcontrol\#getPictureAlignment--) |
+| [setPictureSizeMode(int value)](#setPictureSizeMode-int-) | Per la descrizione di questa proprietà, vedere [getPictureSizeMode()](../../com.aspose.diagram/imageactivexcontrol\#getPictureSizeMode--) |
+| [setSpecialEffect(int value)](#setSpecialEffect-int-) | Per la descrizione di questa proprietà, vedere [getSpecialEffect()](../../com.aspose.diagram/imageactivexcontrol\#getSpecialEffect--) |
+| [setTiled(boolean value)](#setTiled-boolean-) | Per la descrizione di questa proprietà, vedere [isTiled()](../../com.aspose.diagram/imageactivexcontrol\#isTiled--) |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | Per la descrizione di questa proprietà, vedere [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) |
+| [setWidth(double value)](#setWidth-double-) | Per la descrizione di questa proprietà, vedere [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+il colore OLE dello sfondo.
+
+**Returns:**
+int
+### getBorderOleColor() {#getBorderOleColor--}
+```
+public int getBorderOleColor()
+```
+
+
+il colore OLE dello sfondo.
+
+**Returns:**
+int
+### getBorderStyle() {#getBorderStyle--}
+```
+public int getBorderStyle()
+```
+
+
+il tipo di bordo usato dal controllo.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+i dati binari del controllo.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+Il colore OLE del primo piano. Non si applica al controllo Image.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+l'altezza del controllo in unità di punti.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+la modalità di esecuzione predefinita dell'Input Method Editor per il controllo quando riceve il fuoco.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+un'icona personalizzata da visualizzare come puntatore del mouse per il controllo.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+il tipo di icona visualizzata come puntatore del mouse per il controllo.
+
+**Returns:**
+int
+### getPicture() {#getPicture--}
+```
+public byte[] getPicture()
+```
+
+
+i dati dell'immagine.
+
+**Returns:**
+byte[]
+### getPictureAlignment() {#getPictureAlignment--}
+```
+public int getPictureAlignment()
+```
+
+
+l'allineamento dell'immagine all'interno del Form o dell'Image.
+
+**Returns:**
+int
+### getPictureSizeMode() {#getPictureSizeMode--}
+```
+public int getPictureSizeMode()
+```
+
+
+come visualizzare l'immagine.
+
+**Returns:**
+int
+### getSpecialEffect() {#getSpecialEffect--}
+```
+public int getSpecialEffect()
+```
+
+
+l'effetto speciale del controllo.
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Ottiene il tipo del controllo ActiveX.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+la larghezza del controllo in unità di punti.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+Indica se il controllo ridimensionerà automaticamente per visualizzare tutto il contenuto.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+Indica se il controllo può ricevere il focus e rispondere agli eventi generati dall'utente.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+Indica se i dati nel controllo sono bloccati per la modifica.
+
+**Returns:**
+boolean
+### isTiled() {#isTiled--}
+```
+public boolean isTiled()
+```
+
+
+Indica se l'immagine è ripetuta sullo sfondo.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+Indica se il controllo è trasparente.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isAutoSize()](../../com.aspose.diagram/imageactivexcontrol\#isAutoSize--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setBorderOleColor(int value) {#setBorderOleColor-int-}
+```
+public void setBorderOleColor(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getBorderOleColor()](../../com.aspose.diagram/imageactivexcontrol\#getBorderOleColor--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setBorderStyle(int value) {#setBorderStyle-int-}
+```
+public void setBorderStyle(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getBorderStyle()](../../com.aspose.diagram/imageactivexcontrol\#getBorderStyle--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setPicture(byte[] value) {#setPicture-byte---}
+```
+public void setPicture(byte[] value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getPicture()](../../com.aspose.diagram/imageactivexcontrol\#getPicture--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | byte[] |  |
+
+### setPictureAlignment(int value) {#setPictureAlignment-int-}
+```
+public void setPictureAlignment(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getPictureAlignment()](../../com.aspose.diagram/imageactivexcontrol\#getPictureAlignment--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setPictureSizeMode(int value) {#setPictureSizeMode-int-}
+```
+public void setPictureSizeMode(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getPictureSizeMode()](../../com.aspose.diagram/imageactivexcontrol\#getPictureSizeMode--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setSpecialEffect(int value) {#setSpecialEffect-int-}
+```
+public void setSpecialEffect(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getSpecialEffect()](../../com.aspose.diagram/imageactivexcontrol\#getSpecialEffect--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setTiled(boolean value) {#setTiled-boolean-}
+```
+public void setTiled(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isTiled()](../../com.aspose.diagram/imageactivexcontrol\#isTiled--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/imagecolormode/_index.md
+++ b/italian/java/com.aspose.diagram/imagecolormode/_index.md
@@ -1,0 +1,156 @@
+---
+title: ImageColorMode
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica la modalità colore per le immagini generate delle pagine del documento.
+type: docs
+weight: 198
+url: /it/java/com.aspose.diagram/imagecolormode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ImageColorMode
+```
+
+Specifica la modalità colore per le immagini generate delle pagine del documento.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [BLACK_AND_WHITE](#BLACK-AND-WHITE) | Le pagine del documento saranno renderizzate come immagini in bianco e nero. |
+| [GRAYSCALE](#GRAYSCALE) | Le pagine del documento saranno renderizzate come immagini in scala di grigi. |
+| [NONE](#NONE) | Le pagine del documento saranno renderizzate come immagini a colori. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BLACK_AND_WHITE {#BLACK-AND-WHITE}
+```
+public static final int BLACK_AND_WHITE
+```
+
+
+Le pagine del documento saranno renderizzate come immagini in bianco e nero.
+
+### GRAYSCALE {#GRAYSCALE}
+```
+public static final int GRAYSCALE
+```
+
+
+Le pagine del documento saranno renderizzate come immagini in scala di grigi.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Le pagine del documento saranno renderizzate come immagini a colori.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/imageformat/_index.md
+++ b/italian/java/com.aspose.diagram/imageformat/_index.md
@@ -1,0 +1,273 @@
+---
+title: ImageFormat
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica il formato file dell'immagine.
+type: docs
+weight: 199
+url: /it/java/com.aspose.diagram/imageformat/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ImageFormat
+```
+
+Specifica il formato file dell'immagine.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [ImageFormat()](#ImageFormat--) |  |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object obj)](#equals-java.lang.Object-) | Restituisce un valore che indica se l'oggetto specificato è un oggetto ImageFormat equivalente a questo oggetto ImageFormat. |
+| [getBmp()](#getBmp--) | Ottiene il formato immagine bitmap (BMP). |
+| [getClass()](#getClass--) |  |
+| [getEmf()](#getEmf--) | Ottiene il formato immagine metafile avanzato (EMF). |
+| [getExif()](#getExif--) | Ottiene il formato Exchangeable Image File (Exif). |
+| [getGif()](#getGif--) | Ottiene il formato immagine Graphics Interchange Format (GIF). |
+| [getIcon()](#getIcon--) | Ottiene il formato immagine icona di Windows. |
+| [getImageFormatFromSuffixName(String name)](#getImageFormatFromSuffixName-java.lang.String-) | Ottieni il formato immagine in base al nome del suffisso |
+| [getJpeg()](#getJpeg--) | Ottiene il formato immagine Joint Photographic Experts Group (JPEG). |
+| [getMemoryBmp()](#getMemoryBmp--) | Ottiene un formato immagine bitmap in memoria. |
+| [getName()](#getName--) | Ottieni il nome stringa di questa istanza ImageFormat |
+| [getPng()](#getPng--) | Ottiene il formato immagine W3C Portable Network Graphics (PNG). |
+| [getTiff()](#getTiff--) | Restituisce il formato immagine Tagged Image File Format (TIFF). |
+| [getWmf()](#getWmf--) | Restituisce il formato immagine Windows metafile (WMF). |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ImageFormat() {#ImageFormat--}
+```
+public ImageFormat()
+```
+
+
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+Restituisce un valore che indica se l'oggetto specificato è un oggetto ImageFormat equivalente a questo oggetto ImageFormat.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| obj | java.lang.Object | L'oggetto da testare. |
+
+**Returns:**
+boolean - true se o è un oggetto ImageFormat equivalente a questo oggetto ImageFormat; altrimenti, false.
+### getBmp() {#getBmp--}
+```
+public static ImageFormat getBmp()
+```
+
+
+Ottiene il formato immagine bitmap (BMP).
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the bitmap image format.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getEmf() {#getEmf--}
+```
+public static ImageFormat getEmf()
+```
+
+
+Ottiene il formato immagine metafile avanzato (EMF).
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the enhanced metafile image format.
+### getExif() {#getExif--}
+```
+public static ImageFormat getExif()
+```
+
+
+Ottiene il formato Exchangeable Image File (Exif).
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the Exif format.
+### getGif() {#getGif--}
+```
+public static ImageFormat getGif()
+```
+
+
+Ottiene il formato immagine Graphics Interchange Format (GIF).
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the GIF image format.
+### getIcon() {#getIcon--}
+```
+public static ImageFormat getIcon()
+```
+
+
+Ottiene il formato immagine icona di Windows.
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the Windows icon image format.
+### getImageFormatFromSuffixName(String name) {#getImageFormatFromSuffixName-java.lang.String-}
+```
+public static ImageFormat getImageFormatFromSuffixName(String name)
+```
+
+
+Ottieni il formato immagine in base al nome del suffisso
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| nome | java.lang.String | nome suffisso |
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - >An ImageFormat object according to the suffix name.
+### getJpeg() {#getJpeg--}
+```
+public static ImageFormat getJpeg()
+```
+
+
+Ottiene il formato immagine Joint Photographic Experts Group (JPEG).
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the JPEG image format.
+### getMemoryBmp() {#getMemoryBmp--}
+```
+public static ImageFormat getMemoryBmp()
+```
+
+
+Ottiene un formato immagine bitmap in memoria.
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the memory bitmap image format.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Ottieni il nome stringa di questa istanza ImageFormat
+
+**Returns:**
+java.lang.String - Il nome stringa di questa istanza ImageFormat
+### getPng() {#getPng--}
+```
+public static ImageFormat getPng()
+```
+
+
+Ottiene il formato immagine W3C Portable Network Graphics (PNG).
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the PNG image format.
+### getTiff() {#getTiff--}
+```
+public static ImageFormat getTiff()
+```
+
+
+Restituisce il formato immagine Tagged Image File Format (TIFF).
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the TIFF image format.
+### getWmf() {#getWmf--}
+```
+public static ImageFormat getWmf()
+```
+
+
+Restituisce il formato immagine Windows metafile (WMF).
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the Windows metafile image format.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/imagesaveoptions/_index.md
+++ b/italian/java/com.aspose.diagram/imagesaveoptions/_index.md
@@ -1,0 +1,809 @@
+---
+title: ImageSaveOptions
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Consente di specificare opzioni aggiuntive durante il rendering delle pagine del diagramma in immagini.
+type: docs
+weight: 200
+url: /it/java/com.aspose.diagram/imagesaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.SaveOptions](../../com.aspose.diagram/saveoptions), [com.aspose.diagram.RenderingSaveOptions](../../com.aspose.diagram/renderingsaveoptions)
+```
+public class ImageSaveOptions extends RenderingSaveOptions
+```
+
+Consente di specificare opzioni aggiuntive durante il rendering delle pagine del diagramma in immagini.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [ImageSaveOptions(int saveFormat)](#ImageSaveOptions-int-) | Inizializza una nuova istanza di questa classe che può essere utilizzata per salvare immagini renderizzate nei formati Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat o Aspose.Diagram.SaveFileFormat. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | Crea un oggetto di opzioni di salvataggio di una classe adatta al formato di salvataggio specificato. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCompositingQuality()](#getCompositingQuality--) | Specifica il livello di qualità da utilizzare durante il compositing. |
+| [getContentZoom()](#getContentZoom--) | Questo parametro è simile alla scala, ma non influisce sulla dimensione dell'immagine generata. |
+| [getDefaultFont()](#getDefaultFont--) | Quando i caratteri nel diagramma sono Unicode e non vengono impostati con il valore di carattere corretto o il carattere non è installato localmente, possono apparire come blocchi in PDF, immagine o XPS. |
+| [getEmfRenderSetting()](#getEmfRenderSetting--) | Impostazione per il rendering del metafile Emf. |
+| [getEnlargePage()](#getEnlargePage--) | Specifica se ingrandire la pagina. |
+| [getExportGuideShapes()](#getExportGuideShapes--) | Definisce se è necessario esportare le forme guida o meno. |
+| [getExportHiddenPage()](#getExportHiddenPage--) | Definisce se è necessario esportare la pagina nascosta o meno. |
+| [getImageBrightness()](#getImageBrightness--) | la luminosità per le immagini generate. |
+| [getImageColorMode()](#getImageColorMode--) | la modalità colore per le immagini generate. |
+| [getImageContrast()](#getImageContrast--) | il contrasto per le immagini generate. |
+| [getInterpolationMode()](#getInterpolationMode--) | Specifica l'algoritmo utilizzato quando le immagini vengono scalate o ruotate. |
+| [getJpegQuality()](#getJpegQuality--) | un valore che determina la qualità delle immagini JPEG generate. |
+| [getPageCount()](#getPageCount--) | il numero di pagine da renderizzare durante il salvataggio in un file TIFF multipagina. |
+| [getPageIndex()](#getPageIndex--) | l'indice basato su zero della prima pagina da renderizzare. |
+| [getPageSize()](#getPageSize--) | la dimensione della pagina per le immagini generate. |
+| [getPixelOffsetMode()](#getPixelOffsetMode--) | un valore che specifica come i pixel sono spostati durante il rendering. |
+| [getResolution()](#getResolution--) | la risoluzione per le immagini generate, in punti per pollice. |
+| [getSameAsPdfConversionArea()](#getSameAsPdfConversionArea--) | Specifica se l'area di salvataggio è la stessa del PDF. |
+| [getSaveForegroundPagesOnly()](#getSaveForegroundPagesOnly--) | Specifica se tutte le pagine saranno salvate come immagine o solo il primo piano. |
+| [getSaveFormat()](#getSaveFormat--) | Specifica il formato in cui le pagine del diagramma renderizzate saranno salvate se viene utilizzato questo oggetto di opzioni di salvataggio. |
+| [getScale()](#getScale--) | il fattore di zoom per le immagini generate. |
+| [getShapes()](#getShapes--) | forme da renderizzare. |
+| [getSmoothingMode()](#getSmoothingMode--) | Specifica se l'anti-aliasing (smussatura) è applicato a linee e curve e ai bordi delle aree riempite. |
+| [getTiffCompression()](#getTiffCompression--) | il tipo di compressione da applicare quando si salvano le immagini generate nel formato TIFF. |
+| [getWarningCallback()](#getWarningCallback--) | callback di avviso. |
+| [hashCode()](#hashCode--) |  |
+| [isExportComments()](#isExportComments--) | Definisce se è necessario esportare i commenti o meno. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCompositingQuality(int value)](#setCompositingQuality-int-) | Per la descrizione di questa proprietà, consultare [getCompositingQuality()](../../com.aspose.diagram/imagesaveoptions\#getCompositingQuality--) |
+| [setContentZoom(float value)](#setContentZoom-float-) | Per la descrizione di questa proprietà, consultare [getContentZoom()](../../com.aspose.diagram/imagesaveoptions\#getContentZoom--) |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--) |
+| [setEmfRenderSetting(int value)](#setEmfRenderSetting-int-) | Per la descrizione di questa proprietà, vedere [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--) |
+| [setEnlargePage(boolean value)](#setEnlargePage-boolean-) | Per la descrizione di questa proprietà, vedere [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\\#getEnlargePage--) |
+| [setExportComments(boolean value)](#setExportComments-boolean-) | Per la descrizione di questa proprietà, vedere [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\\#isExportComments--) |
+| [setExportGuideShapes(boolean value)](#setExportGuideShapes-boolean-) | Per la descrizione di questa proprietà, vedere [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\\#getExportGuideShapes--) |
+| [setExportHiddenPage(boolean value)](#setExportHiddenPage-boolean-) | Per la descrizione di questa proprietà, consultare [getExportHiddenPage()](../../com.aspose.diagram/imagesaveoptions\#getExportHiddenPage--) |
+| [setImageBrightness(float value)](#setImageBrightness-float-) | Per la descrizione di questa proprietà, consultare [getImageBrightness()](../../com.aspose.diagram/imagesaveoptions\#getImageBrightness--) |
+| [setImageColorMode(int value)](#setImageColorMode-int-) | Per la descrizione di questa proprietà, consultare [getImageColorMode()](../../com.aspose.diagram/imagesaveoptions\#getImageColorMode--) |
+| [setImageContrast(float value)](#setImageContrast-float-) | Per la descrizione di questa proprietà, consultare [getImageContrast()](../../com.aspose.diagram/imagesaveoptions\#getImageContrast--) |
+| [setInterpolationMode(int value)](#setInterpolationMode-int-) | Per la descrizione di questa proprietà, consultare [getInterpolationMode()](../../com.aspose.diagram/imagesaveoptions\#getInterpolationMode--) |
+| [setJpegQuality(int value)](#setJpegQuality-int-) | Per la descrizione di questa proprietà, consultare [getJpegQuality()](../../com.aspose.diagram/imagesaveoptions\#getJpegQuality--) |
+| [setPageCount(int value)](#setPageCount-int-) | Per la descrizione di questa proprietà, consultare [getPageCount()](../../com.aspose.diagram/imagesaveoptions\#getPageCount--) |
+| [setPageIndex(int value)](#setPageIndex-int-) | Per la descrizione di questa proprietà, consultare [getPageIndex()](../../com.aspose.diagram/imagesaveoptions\#getPageIndex--) |
+| [setPageSize(PageSize value)](#setPageSize-com.aspose.diagram.PageSize-) | Per la descrizione di questa proprietà, vedere [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\\#getPageSize--) |
+| [setPixelOffsetMode(int value)](#setPixelOffsetMode-int-) | Per la descrizione di questa proprietà, consultare [getPixelOffsetMode()](../../com.aspose.diagram/imagesaveoptions\#getPixelOffsetMode--) |
+| [setResolution(float value)](#setResolution-float-) | Per la descrizione di questa proprietà, consultare [getResolution()](../../com.aspose.diagram/imagesaveoptions\#getResolution--) |
+| [setSameAsPdfConversionArea(boolean value)](#setSameAsPdfConversionArea-boolean-) | Per la descrizione di questa proprietà, consultare [getSameAsPdfConversionArea()](../../com.aspose.diagram/imagesaveoptions\#getSameAsPdfConversionArea--) |
+| [setSaveForegroundPagesOnly(boolean value)](#setSaveForegroundPagesOnly-boolean-) | Per la descrizione di questa proprietà, consultare [getSaveForegroundPagesOnly()](../../com.aspose.diagram/imagesaveoptions\#getSaveForegroundPagesOnly--) |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | Per la descrizione di questa proprietà, consultare [getSaveFormat()](../../com.aspose.diagram/imagesaveoptions\#getSaveFormat--) |
+| [setScale(float value)](#setScale-float-) | Per la descrizione di questa proprietà, consultare [getScale()](../../com.aspose.diagram/imagesaveoptions\#getScale--) |
+| [setShapes(ShapeCollection value)](#setShapes-com.aspose.diagram.ShapeCollection-) | Per la descrizione di questa proprietà, vedere [getShapes()](../../com.aspose.diagram/renderingsaveoptions\\#getShapes--) |
+| [setSmoothingMode(int value)](#setSmoothingMode-int-) | Per la descrizione di questa proprietà, consultare [getSmoothingMode()](../../com.aspose.diagram/imagesaveoptions\#getSmoothingMode--) |
+| [setTiffCompression(int value)](#setTiffCompression-int-) | Per la descrizione di questa proprietà, consultare [getTiffCompression()](../../com.aspose.diagram/imagesaveoptions\#getTiffCompression--) |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ImageSaveOptions(int saveFormat) {#ImageSaveOptions-int-}
+```
+public ImageSaveOptions(int saveFormat)
+```
+
+
+Inizializza una nuova istanza di questa classe che può essere utilizzata per salvare immagini renderizzate nei formati Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat o Aspose.Diagram.SaveFileFormat.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| saveFormat | int | Può essere Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat o Aspose.Diagram.SaveFileFormat. |
+
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+Crea un oggetto di opzioni di salvataggio di una classe adatta al formato di salvataggio specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| saveFormat | int | Il Aspose.Diagram.SaveFileFormat per il quale creare un oggetto di opzioni di salvataggio. |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCompositingQuality() {#getCompositingQuality--}
+```
+public int getCompositingQuality()
+```
+
+
+Specifica il livello di qualità da utilizzare durante il compositing. Questa proprietà ha effetto solo quando si salva in formati di immagine raster. Il valore predefinito è Aspose.Diagram.Saving.CompositingQuality.
+
+**Returns:**
+int
+### getContentZoom() {#getContentZoom--}
+```
+public float getContentZoom()
+```
+
+
+Questo parametro è simile a scala, ma non influisce sulla dimensione dell'immagine generata. Il valore predefinito è 1.0. Il valore deve essere maggiore di 0.
+
+**Returns:**
+float
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+Quando i caratteri nel diagramma sono Unicode e non sono impostati con il valore di font corretto o il font non è installato localmente, possono apparire come blocchi in PDF, immagine o XPS. Impostare il DefaultFont, ad esempio MingLiu o MS Gothic, per visualizzare questi caratteri.
+
+**Returns:**
+java.lang.String
+### getEmfRenderSetting() {#getEmfRenderSetting--}
+```
+public int getEmfRenderSetting()
+```
+
+
+Impostazione per il rendering dei metafile EMF. I metafile EMF identificati come "EMF+ Dual" possono contenere sia record EMF+ sia record EMF. Entrambi i tipi di record possono essere usati per renderizzare l'immagine, solo record EMF+, o solo record EMF. Quando EmfPlusPrefer è impostato, i record EMF+ verranno analizzati, altrimenti verranno analizzati solo i record EMF. Il valore predefinito è EmfOnly"/>.
+
+**Returns:**
+int
+### getEnlargePage() {#getEnlargePage--}
+```
+public boolean getEnlargePage()
+```
+
+
+Specifica se ingrandire la pagina. Se true - ingrandire la pagina. Se false - non ingrandire la pagina. Il valore predefinito è true.
+
+**Returns:**
+boolean
+### getExportGuideShapes() {#getExportGuideShapes--}
+```
+public boolean getExportGuideShapes()
+```
+
+
+Definisce se è necessario esportare le forme guida o meno. Il valore predefinito è true.
+
+**Returns:**
+boolean
+### getExportHiddenPage() {#getExportHiddenPage--}
+```
+public boolean getExportHiddenPage()
+```
+
+
+Definisce se è necessario esportare la pagina nascosta o meno. Il valore predefinito è true.
+
+**Returns:**
+boolean
+### getImageBrightness() {#getImageBrightness--}
+```
+public float getImageBrightness()
+```
+
+
+la luminosità per le immagini generate. Questa proprietà ha effetto solo quando si salva in formati di immagine raster. Il valore predefinito è 0.5. Il valore deve essere compreso nell'intervallo tra 0 e 1.
+
+**Returns:**
+float
+### getImageColorMode() {#getImageColorMode--}
+```
+public int getImageColorMode()
+```
+
+
+la modalità colore per le immagini generate. Questa proprietà ha effetto solo quando si salva in formati di immagine raster. Il valore predefinito è Aspose.Diagram.Saving.ImageColorMode.
+
+**Returns:**
+int
+### getImageContrast() {#getImageContrast--}
+```
+public float getImageContrast()
+```
+
+
+il contrasto per le immagini generate. Questa proprietà ha effetto solo quando si salva in formati di immagine raster. Il valore predefinito è 0.5. Il valore deve essere compreso nell'intervallo tra 0 e 1.
+
+**Returns:**
+float
+### getInterpolationMode() {#getInterpolationMode--}
+```
+public int getInterpolationMode()
+```
+
+
+Specifica l'algoritmo utilizzato quando le immagini vengono scalate o ruotate. Questa proprietà ha effetto solo quando si salva in formati di immagine raster. Il valore predefinito è Aspose.Diagram.Saving.InterpolationMode.
+
+**Returns:**
+int
+### getJpegQuality() {#getJpegQuality--}
+```
+public int getJpegQuality()
+```
+
+
+un valore che determina la qualità delle immagini JPEG generate. Ha effetto solo quando si salva in JPEG. Usa questa proprietà per ottenere o impostare la qualità delle immagini generate quando si salva in formato JPEG. Il valore può variare da 0 a 100 dove 0 indica la qualità più bassa ma la massima compressione e 100 indica la migliore qualità ma la compressione minima. Il valore predefinito è 95.
+
+**Returns:**
+int
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+il numero di pagine da rendere quando si salva in un file TIFF multipagina. Il valore predefinito è MaxValue, che significa che tutte le pagine del diagramma verranno renderizzate.
+
+**Returns:**
+int
+### getPageIndex() {#getPageIndex--}
+```
+public int getPageIndex()
+```
+
+
+L'indice basato su zero della prima pagina da renderizzare. Il valore predefinito è 0.
+
+**Returns:**
+int
+### getPageSize() {#getPageSize--}
+```
+public PageSize getPageSize()
+```
+
+
+la dimensione della pagina per le immagini generate. Può essere [PageSize](../../com.aspose.diagram/pagesize) o null. Il valore predefinito è null. Se PageSize è null, la dimensione della pagina per l'immagine generata viene ottenuta dal diagramma di origine.
+
+**Returns:**
+[PageSize](../../com.aspose.diagram/pagesize)
+### getPixelOffsetMode() {#getPixelOffsetMode--}
+```
+public int getPixelOffsetMode()
+```
+
+
+un valore che specifica come i pixel vengono spostati durante il rendering. Questa proprietà ha effetto solo quando si salva in formati di immagine raster. Il valore predefinito è Aspose.Diagram.Saving.PixelOffsetMode.
+
+**Returns:**
+int
+### getResolution() {#getResolution--}
+```
+public float getResolution()
+```
+
+
+la risoluzione per le immagini generate, in punti per pollice. Questa proprietà ha effetto solo quando si salva in formati di immagine raster. Il valore predefinito è 96.
+
+**Returns:**
+float
+### getSameAsPdfConversionArea() {#getSameAsPdfConversionArea--}
+```
+public boolean getSameAsPdfConversionArea()
+```
+
+
+Specifica se l'area di salvataggio è la stessa del PDF. Se vero - l'area renderizzata è la stessa del PDF. Se falso - l'area renderizzata è quella predefinita. Il valore predefinito è false.
+
+**Returns:**
+boolean
+### getSaveForegroundPagesOnly() {#getSaveForegroundPagesOnly--}
+```
+public boolean getSaveForegroundPagesOnly()
+```
+
+
+Specifica se tutte le pagine saranno salvate in immagine o solo il primo piano. Se true - vengono renderizzate solo le pagine di primo piano (con lo sfondo se presente). Se false - vengono renderizzate le pagine di primo piano (con lo sfondo se presente) seguite da pagine di sfondo vuote. Può restituire true solo quando PageCount > 1. Il valore predefinito è false.
+
+**Returns:**
+boolean
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+Specifica il formato in cui le pagine del diagramma renderizzate saranno salvate se viene utilizzato questo oggetto di opzioni di salvataggio. Può essere Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat o Aspose.Diagram.SaveFileFormat.
+
+**Returns:**
+int
+### getScale() {#getScale--}
+```
+public float getScale()
+```
+
+
+il fattore di zoom per le immagini generate. Il valore predefinito è 1.0. Il valore deve essere maggiore di 0.
+
+**Returns:**
+float
+### getShapes() {#getShapes--}
+```
+public ShapeCollection getShapes()
+```
+
+
+forme da renderizzare. Il conteggio predefinito è 0.
+
+**Returns:**
+[ShapeCollection](../../com.aspose.diagram/shapecollection)
+### getSmoothingMode() {#getSmoothingMode--}
+```
+public int getSmoothingMode()
+```
+
+
+Specifica se l'anti-aliasing (smussatura) è applicato a linee e curve e ai bordi delle aree riempite. Questa proprietà ha effetto solo quando si salva in formati di immagine raster. Il valore predefinito è Aspose.Diagram.Saving.SmoothingMode.
+
+**Returns:**
+int
+### getTiffCompression() {#getTiffCompression--}
+```
+public int getTiffCompression()
+```
+
+
+il tipo di compressione da applicare quando si salvano le immagini generate nel formato TIFF. Ha effetto solo quando si salva in TIFF. Il valore predefinito è Aspose.Diagram.Saving.TiffCompression.
+
+**Returns:**
+int
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+callback di avviso.
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExportComments() {#isExportComments--}
+```
+public boolean isExportComments()
+```
+
+
+Definisce se è necessario esportare i commenti o meno. Il valore predefinito è false.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCompositingQuality(int value) {#setCompositingQuality-int-}
+```
+public void setCompositingQuality(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getCompositingQuality()](../../com.aspose.diagram/imagesaveoptions\#getCompositingQuality--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setContentZoom(float value) {#setContentZoom-float-}
+```
+public void setContentZoom(float value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getContentZoom()](../../com.aspose.diagram/imagesaveoptions\#getContentZoom--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | float |  |
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setEmfRenderSetting(int value) {#setEmfRenderSetting-int-}
+```
+public void setEmfRenderSetting(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setEnlargePage(boolean value) {#setEnlargePage-boolean-}
+```
+public void setEnlargePage(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\\#getEnlargePage--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setExportComments(boolean value) {#setExportComments-boolean-}
+```
+public void setExportComments(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\\#isExportComments--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setExportGuideShapes(boolean value) {#setExportGuideShapes-boolean-}
+```
+public void setExportGuideShapes(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\\#getExportGuideShapes--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setExportHiddenPage(boolean value) {#setExportHiddenPage-boolean-}
+```
+public void setExportHiddenPage(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getExportHiddenPage()](../../com.aspose.diagram/imagesaveoptions\#getExportHiddenPage--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setImageBrightness(float value) {#setImageBrightness-float-}
+```
+public void setImageBrightness(float value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getImageBrightness()](../../com.aspose.diagram/imagesaveoptions\#getImageBrightness--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | float |  |
+
+### setImageColorMode(int value) {#setImageColorMode-int-}
+```
+public void setImageColorMode(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getImageColorMode()](../../com.aspose.diagram/imagesaveoptions\#getImageColorMode--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setImageContrast(float value) {#setImageContrast-float-}
+```
+public void setImageContrast(float value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getImageContrast()](../../com.aspose.diagram/imagesaveoptions\#getImageContrast--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | float |  |
+
+### setInterpolationMode(int value) {#setInterpolationMode-int-}
+```
+public void setInterpolationMode(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getInterpolationMode()](../../com.aspose.diagram/imagesaveoptions\#getInterpolationMode--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setJpegQuality(int value) {#setJpegQuality-int-}
+```
+public void setJpegQuality(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getJpegQuality()](../../com.aspose.diagram/imagesaveoptions\#getJpegQuality--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setPageCount(int value) {#setPageCount-int-}
+```
+public void setPageCount(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getPageCount()](../../com.aspose.diagram/imagesaveoptions\#getPageCount--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setPageIndex(int value) {#setPageIndex-int-}
+```
+public void setPageIndex(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getPageIndex()](../../com.aspose.diagram/imagesaveoptions\#getPageIndex--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setPageSize(PageSize value) {#setPageSize-com.aspose.diagram.PageSize-}
+```
+public void setPageSize(PageSize value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\\#getPageSize--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [PageSize](../../com.aspose.diagram/pagesize) |  |
+
+### setPixelOffsetMode(int value) {#setPixelOffsetMode-int-}
+```
+public void setPixelOffsetMode(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getPixelOffsetMode()](../../com.aspose.diagram/imagesaveoptions\#getPixelOffsetMode--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setResolution(float value) {#setResolution-float-}
+```
+public void setResolution(float value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getResolution()](../../com.aspose.diagram/imagesaveoptions\#getResolution--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | float |  |
+
+### setSameAsPdfConversionArea(boolean value) {#setSameAsPdfConversionArea-boolean-}
+```
+public void setSameAsPdfConversionArea(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getSameAsPdfConversionArea()](../../com.aspose.diagram/imagesaveoptions\#getSameAsPdfConversionArea--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setSaveForegroundPagesOnly(boolean value) {#setSaveForegroundPagesOnly-boolean-}
+```
+public void setSaveForegroundPagesOnly(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getSaveForegroundPagesOnly()](../../com.aspose.diagram/imagesaveoptions\#getSaveForegroundPagesOnly--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getSaveFormat()](../../com.aspose.diagram/imagesaveoptions\#getSaveFormat--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setScale(float value) {#setScale-float-}
+```
+public void setScale(float value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getScale()](../../com.aspose.diagram/imagesaveoptions\#getScale--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | float |  |
+
+### setShapes(ShapeCollection value) {#setShapes-com.aspose.diagram.ShapeCollection-}
+```
+public void setShapes(ShapeCollection value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getShapes()](../../com.aspose.diagram/renderingsaveoptions\\#getShapes--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [ShapeCollection](../../com.aspose.diagram/shapecollection) |  |
+
+### setSmoothingMode(int value) {#setSmoothingMode-int-}
+```
+public void setSmoothingMode(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getSmoothingMode()](../../com.aspose.diagram/imagesaveoptions\#getSmoothingMode--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setTiffCompression(int value) {#setTiffCompression-int-}
+```
+public void setTiffCompression(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getTiffCompression()](../../com.aspose.diagram/imagesaveoptions\#getTiffCompression--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/individualfontconfigs/_index.md
+++ b/italian/java/com.aspose.diagram/individualfontconfigs/_index.md
@@ -1,0 +1,193 @@
+---
+title: IndividualFontConfigs
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Configurazioni dei font per ogni oggetto.
+type: docs
+weight: 201
+url: /it/java/com.aspose.diagram/individualfontconfigs/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class IndividualFontConfigs
+```
+
+Configurazioni dei font per ogni oggetto [Diagram](../../com.aspose.diagram/diagram).
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [IndividualFontConfigs()](#IndividualFontConfigs--) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFontSources()](#getFontSources--) | Ottiene una copia dell'array che contiene l'elenco delle origini |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setFontFolder(String fontFolder, boolean recursive)](#setFontFolder-java.lang.String-boolean-) | Imposta la cartella dei caratteri |
+| [setFontFolders(String[] fontFolders, boolean recursive)](#setFontFolders-java.lang.String---boolean-) | Imposta le cartelle dei caratteri |
+| [setFontSources(FontSourceBase[] sources)](#setFontSources-com.aspose.diagram.FontSourceBase---) | Imposta le origini dei caratteri. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### IndividualFontConfigs() {#IndividualFontConfigs--}
+```
+public IndividualFontConfigs()
+```
+
+
+Costruttore.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFontSources() {#getFontSources--}
+```
+public FontSourceBase[] getFontSources()
+```
+
+
+Ottiene una copia dell'array che contiene l'elenco delle origini
+
+**Returns:**
+com.aspose.diagram.FontSourceBase[] -
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setFontFolder(String fontFolder, boolean recursive) {#setFontFolder-java.lang.String-boolean-}
+```
+public void setFontFolder(String fontFolder, boolean recursive)
+```
+
+
+Imposta la cartella dei caratteri
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontFolder | java.lang.String | La cartella che contiene i caratteri TrueType. |
+| recursive | boolean | Determina se eseguire o meno la scansione delle sottocartelle. |
+
+### setFontFolders(String[] fontFolders, boolean recursive) {#setFontFolders-java.lang.String---boolean-}
+```
+public void setFontFolders(String[] fontFolders, boolean recursive)
+```
+
+
+Imposta le cartelle dei caratteri
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontFolders | java.lang.String[] | Le cartelle che contengono i caratteri TrueType. |
+| recursive | boolean | Determina se eseguire o meno la scansione delle sottocartelle. |
+
+### setFontSources(FontSourceBase[] sources) {#setFontSources-com.aspose.diagram.FontSourceBase---}
+```
+public void setFontSources(FontSourceBase[] sources)
+```
+
+
+Imposta le origini dei caratteri.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| sources | [FontSourceBase\[\]](../../com.aspose.diagram/fontsourcebase) | Un array di sorgenti che contengono i caratteri TrueType. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/infiniteline/_index.md
+++ b/italian/java/com.aspose.diagram/infiniteline/_index.md
@@ -1,0 +1,299 @@
+---
+title: InfiniteLine
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene elementi che specificano le coordinate x e y di due punti su una linea infinita.
+type: docs
+weight: 202
+url: /it/java/com.aspose.diagram/infiniteline/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class InfiniteLine extends Coordinate
+```
+
+Contiene gli elementi che specificano le coordinate x e y di due punti su una linea infinita. Gli elementi X e Y specificano le coordinate x e y del primo punto, e gli elementi A e B specificano le coordinate x e y del secondo punto.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [InfiniteLine()](#InfiniteLine--) | Crea un'istanza della classe [InfiniteLine](../../com.aspose.diagram/infiniteline). |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | Una coordinata x di un punto sulla linea infinita associata alla coordinata y rappresentata dall'elemento B. |
+| [getB()](#getB--) | Una coordinata y di un punto su una linea infinita associata a una coordinata x rappresentata dall'elemento A. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getIX()](#getIX--) | L'indice basato su zero dell'elemento all'interno del suo elemento genitore. |
+| [getX()](#getX--) | Una coordinata x di un punto sulla linea infinita. |
+| [getY()](#getY--) | Una coordinata y di un punto sulla linea infinita. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getA()](../../com.aspose.diagram/infiniteline\#getA--) |
+| [setB(DoubleValue value)](#setB-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getB()](../../com.aspose.diagram/infiniteline\#getB--) |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/infiniteline\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Per la descrizione di questa proprietà, vedere [getIX()](../../com.aspose.diagram/infiniteline\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getX()](../../com.aspose.diagram/infiniteline\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getY()](../../com.aspose.diagram/infiniteline\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### InfiniteLine() {#InfiniteLine--}
+```
+public InfiniteLine()
+```
+
+
+Crea un'istanza della classe [InfiniteLine](../../com.aspose.diagram/infiniteline).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+Una coordinata x di un punto sulla linea infinita associata alla coordinata y rappresentata dall'elemento B.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getB() {#getB--}
+```
+public DoubleValue getB()
+```
+
+
+Una coordinata y di un punto su una linea infinita associata a una coordinata x rappresentata dall'elemento A.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+L'indice basato su zero dell'elemento all'interno del suo elemento genitore.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+Una coordinata x di un punto sulla linea infinita.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+Una coordinata y di un punto sulla linea infinita.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getA()](../../com.aspose.diagram/infiniteline\#getA--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setB(DoubleValue value) {#setB-com.aspose.diagram.DoubleValue-}
+```
+public void setB(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getB()](../../com.aspose.diagram/infiniteline\#getB--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/infiniteline\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getIX()](../../com.aspose.diagram/infiniteline\#getIX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getX()](../../com.aspose.diagram/infiniteline\#getX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getY()](../../com.aspose.diagram/infiniteline\#getY--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/infinitelinecollection/_index.md
+++ b/italian/java/com.aspose.diagram/infinitelinecollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: InfiniteLineCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Raccolta InfiniteLine.
+type: docs
+weight: 203
+url: /it/java/com.aspose.diagram/infinitelinecollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class InfiniteLineCollection extends Collection
+```
+
+Raccolta InfiniteLine.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public InfiniteLine get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[InfiniteLine](../../com.aspose.diagram/infiniteline) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/inputmethodeditormode/_index.md
+++ b/italian/java/com.aspose.diagram/inputmethodeditormode/_index.md
@@ -1,0 +1,246 @@
+---
+title: InputMethodEditorMode
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta la modalità di esecuzione predefinita dell'Input Method Editor.
+type: docs
+weight: 204
+url: /it/java/com.aspose.diagram/inputmethodeditormode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class InputMethodEditorMode
+```
+
+Rappresenta la modalità di esecuzione predefinita dell'Input Method Editor.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [ALPHA](#ALPHA) | IME attivo con modalità alfanumerica a larghezza ridotta. |
+| [ALPHA_FULL](#ALPHA-FULL) | IME attivo con modalità alfanumerica a larghezza intera. |
+| [DISABLE](#DISABLE) | IME disattivo. L'utente non può attivare IME dalla tastiera. |
+| [HANGUL](#HANGUL) | IME attivo con modalità hangul a larghezza ridotta. |
+| [HANGUL_FULL](#HANGUL-FULL) | IME attivo con modalità hangul a larghezza intera. |
+| [HANZI](#HANZI) | IME attivo con modalità hanzi a larghezza ridotta. |
+| [HANZI_FULL](#HANZI-FULL) | IME attivo con modalità hanzi a larghezza intera. |
+| [HIRAGANA](#HIRAGANA) | IME attivo con modalità hiragana a larghezza intera. |
+| [KATAKANA](#KATAKANA) | IME attivo con modalità katakana a larghezza intera. |
+| [KATAKANA_HALF](#KATAKANA-HALF) | IME attivo con modalità katakana a larghezza ridotta. |
+| [NO_CONTROL](#NO-CONTROL) | Non controlla IME. |
+| [OFF](#OFF) | IME disattivo. |
+| [ON](#ON) | IME attivo. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALPHA {#ALPHA}
+```
+public static final int ALPHA
+```
+
+
+IME attivo con modalità alfanumerica a larghezza ridotta.
+
+### ALPHA_FULL {#ALPHA-FULL}
+```
+public static final int ALPHA_FULL
+```
+
+
+IME attivo con modalità alfanumerica a larghezza intera.
+
+### DISABLE {#DISABLE}
+```
+public static final int DISABLE
+```
+
+
+IME disattivo. L'utente non può attivare IME dalla tastiera.
+
+### HANGUL {#HANGUL}
+```
+public static final int HANGUL
+```
+
+
+IME attivo con modalità hangul a larghezza ridotta.
+
+### HANGUL_FULL {#HANGUL-FULL}
+```
+public static final int HANGUL_FULL
+```
+
+
+IME attivo con modalità hangul a larghezza intera.
+
+### HANZI {#HANZI}
+```
+public static final int HANZI
+```
+
+
+IME attivo con modalità hanzi a larghezza ridotta.
+
+### HANZI_FULL {#HANZI-FULL}
+```
+public static final int HANZI_FULL
+```
+
+
+IME attivo con modalità hanzi a larghezza intera.
+
+### HIRAGANA {#HIRAGANA}
+```
+public static final int HIRAGANA
+```
+
+
+IME attivo con modalità hiragana a larghezza intera.
+
+### KATAKANA {#KATAKANA}
+```
+public static final int KATAKANA
+```
+
+
+IME attivo con modalità katakana a larghezza intera.
+
+### KATAKANA_HALF {#KATAKANA-HALF}
+```
+public static final int KATAKANA_HALF
+```
+
+
+IME attivo con modalità katakana a larghezza ridotta.
+
+### NO_CONTROL {#NO-CONTROL}
+```
+public static final int NO_CONTROL
+```
+
+
+Non controlla IME.
+
+### OFF {#OFF}
+```
+public static final int OFF
+```
+
+
+IME disattivo. Modalità inglese.
+
+### ON {#ON}
+```
+public static final int ON
+```
+
+
+IME attivo.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/interpolationmode/_index.md
+++ b/italian/java/com.aspose.diagram/interpolationmode/_index.md
@@ -1,0 +1,210 @@
+---
+title: InterpolationMode
+second_title: Riferimento API di Aspose.Diagram per Java
+description: L'enumerazione InterpolationMode specifica l'algoritmo utilizzato quando le immagini vengono scalate o ruotate.
+type: docs
+weight: 206
+url: /it/java/com.aspose.diagram/interpolationmode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class InterpolationMode
+```
+
+L'enumerazione InterpolationMode specifica l'algoritmo utilizzato quando le immagini vengono scalate o ruotate.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [BICUBIC](#BICUBIC) | Specifica l'interpolazione bicubica. |
+| [BILINEAR](#BILINEAR) | Specifica l'interpolazione bilineare. |
+| [DEFAULT](#DEFAULT) | Specifica la modalità predefinita. |
+| [HIGH](#HIGH) | Specifica l'interpolazione ad alta qualità. |
+| [HIGH_QUALITY_BICUBIC](#HIGH-QUALITY-BICUBIC) | Specifica l'interpolazione bicubica ad alta qualità. |
+| [HIGH_QUALITY_BILINEAR](#HIGH-QUALITY-BILINEAR) | Specifica l'interpolazione bilineare ad alta qualità. |
+| [INVALID](#INVALID) | Equivalente all'elemento Invalid dell'enumerazione QualityMode. |
+| [LOW](#LOW) | Specifica l'interpolazione a bassa qualità. |
+| [NEAREST_NEIGHBOR](#NEAREST-NEIGHBOR) | Specifica l'interpolazione nearest-neighbor. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BICUBIC {#BICUBIC}
+```
+public static final int BICUBIC
+```
+
+
+Specifica l'interpolazione bicubica. Non viene eseguito alcun prefiltraggio. Questa modalità non è adatta per ridurre un'immagine al di sotto del 25 percento della sua dimensione originale.
+
+### BILINEAR {#BILINEAR}
+```
+public static final int BILINEAR
+```
+
+
+Specifica l'interpolazione bilineare. Non viene eseguito alcun prefiltraggio. Questa modalità non è adatta per ridurre un'immagine al di sotto del 50 percento della sua dimensione originale.
+
+### DEFAULT {#DEFAULT}
+```
+public static final int DEFAULT
+```
+
+
+Specifica la modalità predefinita.
+
+### HIGH {#HIGH}
+```
+public static final int HIGH
+```
+
+
+Specifica l'interpolazione ad alta qualità.
+
+### HIGH_QUALITY_BICUBIC {#HIGH-QUALITY-BICUBIC}
+```
+public static final int HIGH_QUALITY_BICUBIC
+```
+
+
+Specifica l'interpolazione bicubica ad alta qualità. Viene eseguito il prefiltraggio per garantire una riduzione ad alta qualità. Questa modalità produce le immagini trasformate della massima qualità.
+
+### HIGH_QUALITY_BILINEAR {#HIGH-QUALITY-BILINEAR}
+```
+public static final int HIGH_QUALITY_BILINEAR
+```
+
+
+Specifica l'interpolazione bilineare ad alta qualità. Viene eseguito il prefiltraggio per garantire una riduzione ad alta qualità.
+
+### INVALID {#INVALID}
+```
+public static final int INVALID
+```
+
+
+Equivalente all'elemento Invalid dell'enumerazione QualityMode.
+
+### LOW {#LOW}
+```
+public static final int LOW
+```
+
+
+Specifica l'interpolazione a bassa qualità.
+
+### NEAREST_NEIGHBOR {#NEAREST-NEIGHBOR}
+```
+public static final int NEAREST_NEIGHBOR
+```
+
+
+Specifica l'interpolazione nearest-neighbor.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/interruptmonitor/_index.md
+++ b/italian/java/com.aspose.diagram/interruptmonitor/_index.md
@@ -1,0 +1,156 @@
+---
+title: InterruptMonitor
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta tutti gli operatori relativi all'interruzione.
+type: docs
+weight: 207
+url: /it/java/com.aspose.diagram/interruptmonitor/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.AbstractInterruptMonitor](../../com.aspose.diagram/abstractinterruptmonitor)
+```
+public class InterruptMonitor extends AbstractInterruptMonitor
+```
+
+Rappresenta tutti gli operatori relativi all'interruzione.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [InterruptMonitor()](#InterruptMonitor--) |  |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [interrupt()](#interrupt--) | Interrompi l'operatore corrente. |
+| [isInterruptionRequested()](#isInterruptionRequested--) | Segna il monitor come richiedente interruzione |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### InterruptMonitor() {#InterruptMonitor--}
+```
+public InterruptMonitor()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### interrupt() {#interrupt--}
+```
+public void interrupt()
+```
+
+
+Interrompi l'operatore corrente.
+
+### isInterruptionRequested() {#isInterruptionRequested--}
+```
+public boolean isInterruptionRequested()
+```
+
+
+Segna il monitor come richiedente interruzione
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/intvalue/_index.md
+++ b/italian/java/com.aspose.diagram/intvalue/_index.md
@@ -1,0 +1,230 @@
+---
+title: IntValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Valore intero
+type: docs
+weight: 205
+url: /it/java/com.aspose.diagram/intvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class IntValue
+```
+
+Valore intero
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [IntValue(int value, int unit)](#IntValue-int-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Attributi di un elemento. |
+| [getValue()](#getValue--) | Valore intero. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [isThemed()](#isThemed--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setThemed(boolean value)](#setThemed-boolean-) | Per la descrizione di questa proprietà, vedere [isThemed()](../../com.aspose.diagram/intvalue\#isThemed--) |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | Per la descrizione di questa proprietà, vedere [getUfe()](../../com.aspose.diagram/intvalue\#getUfe--) |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/intvalue\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### IntValue(int value, int unit) {#IntValue-int-int-}
+```
+public IntValue(int value, int unit)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+| unità | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Valore intero.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### isThemed() {#isThemed--}
+```
+public boolean isThemed()
+```
+
+
+
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setThemed(boolean value) {#setThemed-boolean-}
+```
+public void setThemed(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isThemed()](../../com.aspose.diagram/intvalue\#isThemed--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getUfe()](../../com.aspose.diagram/intvalue\#getUfe--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/intvalue\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/ipagesavingcallback/_index.md
+++ b/italian/java/com.aspose.diagram/ipagesavingcallback/_index.md
@@ -1,0 +1,45 @@
+---
+title: IPageSavingCallback
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Controlla/Indica l'avanzamento del processo di salvataggio della pagina.
+type: docs
+weight: 456
+url: /it/java/com.aspose.diagram/ipagesavingcallback/
+---
+```
+public interface IPageSavingCallback
+```
+
+Controlla/Indica l'avanzamento del processo di salvataggio della pagina.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [pageEndSaving(PageEndSavingArgs args)](#pageEndSaving-com.aspose.diagram.PageEndSavingArgs-) | Controllo/Indicare che una pagina termina per l'output. |
+| [pageStartSaving(PageStartSavingArgs args)](#pageStartSaving-com.aspose.diagram.PageStartSavingArgs-) | Controllo/Indicare che una pagina inizia per l'output. |
+### pageEndSaving(PageEndSavingArgs args) {#pageEndSaving-com.aspose.diagram.PageEndSavingArgs-}
+```
+public abstract void pageEndSaving(PageEndSavingArgs args)
+```
+
+
+Controllo/Indicare che una pagina termina per l'output.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| args | [PageEndSavingArgs](../../com.aspose.diagram/pageendsavingargs) | Informazioni per una pagina terminano il processo di salvataggio. |
+
+### pageStartSaving(PageStartSavingArgs args) {#pageStartSaving-com.aspose.diagram.PageStartSavingArgs-}
+```
+public abstract void pageStartSaving(PageStartSavingArgs args)
+```
+
+
+Controllo/Indicare che una pagina inizia per l'output.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| args | [PageStartSavingArgs](../../com.aspose.diagram/pagestartsavingargs) | Informazioni per una pagina avviano il processo di salvataggio. |
+

--- a/italian/java/com.aspose.diagram/issue/_index.md
+++ b/italian/java/com.aspose.diagram/issue/_index.md
@@ -1,0 +1,210 @@
+---
+title: Issue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta un singolo problema di convalida nel documento.
+type: docs
+weight: 208
+url: /it/java/com.aspose.diagram/issue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Issue
+```
+
+Rappresenta un singolo problema di convalida nel documento.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [Issue()](#Issue--) | Costruttore |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getID()](#getID--) | Specifica l'identificatore univoco del problema di convalida. |
+| [getIgnored()](#getIgnored--) | Specifica se il problema di convalida è attualmente ignorato. |
+| [getIssueTarget()](#getIssueTarget--) | A seconda dell'obiettivo del problema di convalida padre, specifica la pagina o sia la pagina che la forma a cui il problema di convalida padre è associato. |
+| [getRuleInfo()](#getRuleInfo--) | Specifica le informazioni sulla regola di convalida a cui si riferisce il problema di convalida padre. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setID(long value)](#setID-long-) | Per la descrizione di questa proprietà, consultare [getID()](../../com.aspose.diagram/issue\\#getID--) |
+| [setIgnored(int value)](#setIgnored-int-) | Per la descrizione di questa proprietà, consultare [getIgnored()](../../com.aspose.diagram/issue\\#getIgnored--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Issue() {#Issue--}
+```
+public Issue()
+```
+
+
+Costruttore
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getID() {#getID--}
+```
+public long getID()
+```
+
+
+Specifica l'identificatore univoco del problema di convalida.
+
+**Returns:**
+long
+### getIgnored() {#getIgnored--}
+```
+public int getIgnored()
+```
+
+
+Specifica se il problema di convalida è attualmente ignorato. Il valore predefinito è False.
+
+**Returns:**
+int
+### getIssueTarget() {#getIssueTarget--}
+```
+public IssueTarget getIssueTarget()
+```
+
+
+A seconda del target del problema di validazione padre, specifica la pagina o sia la pagina che la forma a cui il problema di validazione padre è associato. Se il target del problema di validazione padre è un documento, IssueTarget non specifica né una pagina né una forma.
+
+**Returns:**
+[IssueTarget](../../com.aspose.diagram/issuetarget)
+### getRuleInfo() {#getRuleInfo--}
+```
+public RuleInfo getRuleInfo()
+```
+
+
+Specifica le informazioni sulla regola di convalida a cui si riferisce il problema di convalida padre.
+
+**Returns:**
+[RuleInfo](../../com.aspose.diagram/ruleinfo)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setID(long value) {#setID-long-}
+```
+public void setID(long value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getID()](../../com.aspose.diagram/issue\\#getID--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | long |  |
+
+### setIgnored(int value) {#setIgnored-int-}
+```
+public void setIgnored(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getIgnored()](../../com.aspose.diagram/issue\\#getIgnored--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/issuecollection/_index.md
+++ b/italian/java/com.aspose.diagram/issuecollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: IssueCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Raccolta Issue.
+type: docs
+weight: 209
+url: /it/java/com.aspose.diagram/issuecollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class IssueCollection extends Collection
+```
+
+Raccolta Issue.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [add(Issue issue)](#add-com.aspose.diagram.Issue-) | Aggiungi il problema nella collezione. |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Issue issue)](#remove-com.aspose.diagram.Issue-) | Rimuovi il problema dalla collezione. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Issue issue) {#add-com.aspose.diagram.Issue-}
+```
+public int add(Issue issue)
+```
+
+
+Aggiungi il problema nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| issue | [Issue](../../com.aspose.diagram/issue) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Issue get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[Issue](../../com.aspose.diagram/issue) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Issue issue) {#remove-com.aspose.diagram.Issue-}
+```
+public void remove(Issue issue)
+```
+
+
+Rimuovi il problema dalla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| issue | [Issue](../../com.aspose.diagram/issue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/issuetarget/_index.md
+++ b/italian/java/com.aspose.diagram/issuetarget/_index.md
@@ -1,0 +1,194 @@
+---
+title: IssueTarget
+second_title: Riferimento API di Aspose.Diagram per Java
+description: A seconda del target del problema di validazione padre, specifica o la pagina o sia la pagina che la forma a cui il problema di validazione padre è associato.
+type: docs
+weight: 210
+url: /it/java/com.aspose.diagram/issuetarget/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class IssueTarget
+```
+
+A seconda del target del problema di validazione padre, specifica la pagina o sia la pagina che la forma a cui il problema di validazione padre è associato. Se il target del problema di validazione padre è un documento, IssueTarget non specifica né una pagina né una forma.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [IssueTarget(long pageID, long shapeID)](#IssueTarget-long-long-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getPageId()](#getPageId--) | Specifica l'identificatore univoco della pagina associata al problema di validazione padre. |
+| [getShapeId()](#getShapeId--) | Specifica l'identificatore univoco della forma associata al problema di validazione padre. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setPageId(long value)](#setPageId-long-) | Per la descrizione di questa proprietà, consultare [getPageId()](../../com.aspose.diagram/issuetarget\#getPageId--) |
+| [setShapeId(long value)](#setShapeId-long-) | Per la descrizione di questa proprietà, consultare [getShapeId()](../../com.aspose.diagram/issuetarget\#getShapeId--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### IssueTarget(long pageID, long shapeID) {#IssueTarget-long-long-}
+```
+public IssueTarget(long pageID, long shapeID)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| pageID | long |  |
+| shapeID | long |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getPageId() {#getPageId--}
+```
+public long getPageId()
+```
+
+
+Specifica l'identificatore univoco della pagina associata al problema di validazione padre. Se il target è il documento, il valore PageID può essere 0xFFFFFFFF.
+
+**Returns:**
+long
+### getShapeId() {#getShapeId--}
+```
+public long getShapeId()
+```
+
+
+Specifica l'identificatore univoco della forma associata al problema di validazione padre. Se il target è il documento o una pagina, il valore ShapeID può essere 0xFFFFFFFF.
+
+**Returns:**
+long
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setPageId(long value) {#setPageId-long-}
+```
+public void setPageId(long value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getPageId()](../../com.aspose.diagram/issuetarget\#getPageId--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | long |  |
+
+### setShapeId(long value) {#setShapeId-long-}
+```
+public void setShapeId(long value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getShapeId()](../../com.aspose.diagram/issuetarget\#getShapeId--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | long |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/istreamprovider/_index.md
+++ b/italian/java/com.aspose.diagram/istreamprovider/_index.md
@@ -1,0 +1,45 @@
+---
+title: IStreamProvider
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta il provider di stream esportato.
+type: docs
+weight: 457
+url: /it/java/com.aspose.diagram/istreamprovider/
+---
+```
+public interface IStreamProvider
+```
+
+Rappresenta il provider di stream esportato.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [closeStream(StreamProviderOptions options)](#closeStream-com.aspose.diagram.StreamProviderOptions-) | Chiude lo stream. |
+| [initStream(StreamProviderOptions options)](#initStream-com.aspose.diagram.StreamProviderOptions-) | Ottiene lo stream. |
+### closeStream(StreamProviderOptions options) {#closeStream-com.aspose.diagram.StreamProviderOptions-}
+```
+public abstract void closeStream(StreamProviderOptions options)
+```
+
+
+Chiude lo stream.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| options | [StreamProviderOptions](../../com.aspose.diagram/streamprovideroptions) |  |
+
+### initStream(StreamProviderOptions options) {#initStream-com.aspose.diagram.StreamProviderOptions-}
+```
+public abstract void initStream(StreamProviderOptions options)
+```
+
+
+Ottiene lo stream.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| options | [StreamProviderOptions](../../com.aspose.diagram/streamprovideroptions) |  |
+

--- a/italian/java/com.aspose.diagram/iwarningcallback/_index.md
+++ b/italian/java/com.aspose.diagram/iwarningcallback/_index.md
@@ -1,0 +1,31 @@
+---
+title: IWarningCallback
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Interfaccia di callback di avviso.
+type: docs
+weight: 458
+url: /it/java/com.aspose.diagram/iwarningcallback/
+---
+```
+public interface IWarningCallback
+```
+
+Interfaccia di callback di avviso.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [warning(WarningInfo warningInfo)](#warning-com.aspose.diagram.WarningInfo-) | Il nostro callback deve solo implementare il metodo "Warning". |
+### warning(WarningInfo warningInfo) {#warning-com.aspose.diagram.WarningInfo-}
+```
+public abstract void warning(WarningInfo warningInfo)
+```
+
+
+Il nostro callback deve solo implementare il metodo "Warning".
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| warningInfo | [WarningInfo](../../com.aspose.diagram/warninginfo) | informazioni di avviso |
+

--- a/italian/java/com.aspose.diagram/labelactivexcontrol/_index.md
+++ b/italian/java/com.aspose.diagram/labelactivexcontrol/_index.md
@@ -1,0 +1,622 @@
+---
+title: LabelActiveXControl
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta il controllo ActiveX label.
+type: docs
+weight: 211
+url: /it/java/com.aspose.diagram/labelactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class LabelActiveXControl extends ActiveXControl
+```
+
+Rappresenta il controllo ActiveX label.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAccelerator()](#getAccelerator--) | il tasto di accelerazione per il controllo. |
+| [getBackOleColor()](#getBackOleColor--) | il colore OLE dello sfondo. |
+| [getBorderOleColor()](#getBorderOleColor--) | il colore OLE dello sfondo. |
+| [getBorderStyle()](#getBorderStyle--) | il tipo di bordo usato dal controllo. |
+| [getCaption()](#getCaption--) | il testo descrittivo che appare su un controllo. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | i dati binari del controllo. |
+| [getForeOleColor()](#getForeOleColor--) | il colore OLE del primo piano. |
+| [getHeight()](#getHeight--) | l'altezza del controllo in unità di punti. |
+| [getIMEMode()](#getIMEMode--) | la modalità di esecuzione predefinita dell'Input Method Editor per il controllo quando riceve il fuoco. |
+| [getMouseIcon()](#getMouseIcon--) | un'icona personalizzata da visualizzare come puntatore del mouse per il controllo. |
+| [getMousePointer()](#getMousePointer--) | il tipo di icona visualizzata come puntatore del mouse per il controllo. |
+| [getPicture()](#getPicture--) | i dati dell'immagine. |
+| [getPicturePosition()](#getPicturePosition--) | la posizione dell'immagine del controllo rispetto alla sua didascalia. |
+| [getSpecialEffect()](#getSpecialEffect--) | l'effetto speciale del controllo. |
+| [getType()](#getType--) | Ottiene il tipo del controllo ActiveX. |
+| [getWidth()](#getWidth--) | la larghezza del controllo in unità di punti. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | Indica se il controllo ridimensionerà automaticamente per visualizzare tutto il contenuto. |
+| [isEnabled()](#isEnabled--) | Indica se il controllo può ricevere il focus e rispondere agli eventi generati dall'utente. |
+| [isLocked()](#isLocked--) | Indica se i dati nel controllo sono bloccati per la modifica. |
+| [isTransparent()](#isTransparent--) | Indica se il controllo è trasparente. |
+| [isWordWrapped()](#isWordWrapped--) | Indica se il contenuto del controllo avvolge automaticamente alla fine di una riga. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAccelerator(char value)](#setAccelerator-char-) | Per la descrizione di questa proprietà, consultare [getAccelerator()](../../com.aspose.diagram/labelactivexcontrol\#getAccelerator--) |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | Per la descrizione di questa proprietà, vedere [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | Per la descrizione di questa proprietà, vedere [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setBorderOleColor(int value)](#setBorderOleColor-int-) | Per la descrizione di questa proprietà, consultare [getBorderOleColor()](../../com.aspose.diagram/labelactivexcontrol\#getBorderOleColor--) |
+| [setBorderStyle(int value)](#setBorderStyle-int-) | Per la descrizione di questa proprietà, consultare [getBorderStyle()](../../com.aspose.diagram/labelactivexcontrol\#getBorderStyle--) |
+| [setCaption(String value)](#setCaption-java.lang.String-) | Per la descrizione di questa proprietà, consultare [getCaption()](../../com.aspose.diagram/labelactivexcontrol\#getCaption--) |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | Per la descrizione di questa proprietà, vedere [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | Per la descrizione di questa proprietà, vedere [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setHeight(double value)](#setHeight-double-) | Per la descrizione di questa proprietà, vedere [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setIMEMode(int value)](#setIMEMode-int-) | Per la descrizione di questa proprietà, vedere [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) |
+| [setLocked(boolean value)](#setLocked-boolean-) | Per la descrizione di questa proprietà, vedere [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | Per la descrizione di questa proprietà, vedere [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | Per la descrizione di questa proprietà, vedere [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setPicture(byte[] value)](#setPicture-byte---) | Per la descrizione di questa proprietà, consultare [getPicture()](../../com.aspose.diagram/labelactivexcontrol\#getPicture--) |
+| [setPicturePosition(int value)](#setPicturePosition-int-) | Per la descrizione di questa proprietà, consultare [getPicturePosition()](../../com.aspose.diagram/labelactivexcontrol\#getPicturePosition--) |
+| [setSpecialEffect(int value)](#setSpecialEffect-int-) | Per la descrizione di questa proprietà, consultare [getSpecialEffect()](../../com.aspose.diagram/labelactivexcontrol\#getSpecialEffect--) |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | Per la descrizione di questa proprietà, vedere [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) |
+| [setWidth(double value)](#setWidth-double-) | Per la descrizione di questa proprietà, vedere [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [setWordWrapped(boolean value)](#setWordWrapped-boolean-) | Per la descrizione di questa proprietà, consultare [isWordWrapped()](../../com.aspose.diagram/labelactivexcontrol\#isWordWrapped--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAccelerator() {#getAccelerator--}
+```
+public char getAccelerator()
+```
+
+
+il tasto di accelerazione per il controllo.
+
+**Returns:**
+char
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+il colore OLE dello sfondo.
+
+**Returns:**
+int
+### getBorderOleColor() {#getBorderOleColor--}
+```
+public int getBorderOleColor()
+```
+
+
+il colore OLE dello sfondo.
+
+**Returns:**
+int
+### getBorderStyle() {#getBorderStyle--}
+```
+public int getBorderStyle()
+```
+
+
+il tipo di bordo usato dal controllo.
+
+**Returns:**
+int
+### getCaption() {#getCaption--}
+```
+public String getCaption()
+```
+
+
+il testo descrittivo che appare su un controllo.
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+i dati binari del controllo.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+Il colore OLE del primo piano. Non si applica al controllo Image.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+l'altezza del controllo in unità di punti.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+la modalità di esecuzione predefinita dell'Input Method Editor per il controllo quando riceve il fuoco.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+un'icona personalizzata da visualizzare come puntatore del mouse per il controllo.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+il tipo di icona visualizzata come puntatore del mouse per il controllo.
+
+**Returns:**
+int
+### getPicture() {#getPicture--}
+```
+public byte[] getPicture()
+```
+
+
+i dati dell'immagine.
+
+**Returns:**
+byte[]
+### getPicturePosition() {#getPicturePosition--}
+```
+public int getPicturePosition()
+```
+
+
+la posizione dell'immagine del controllo rispetto alla sua didascalia.
+
+**Returns:**
+int
+### getSpecialEffect() {#getSpecialEffect--}
+```
+public int getSpecialEffect()
+```
+
+
+l'effetto speciale del controllo.
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Ottiene il tipo del controllo ActiveX.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+la larghezza del controllo in unità di punti.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+Indica se il controllo ridimensionerà automaticamente per visualizzare tutto il contenuto.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+Indica se il controllo può ricevere il focus e rispondere agli eventi generati dall'utente.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+Indica se i dati nel controllo sono bloccati per la modifica.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+Indica se il controllo è trasparente.
+
+**Returns:**
+boolean
+### isWordWrapped() {#isWordWrapped--}
+```
+public boolean isWordWrapped()
+```
+
+
+Indica se il contenuto del controllo avvolge automaticamente alla fine di una riga.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAccelerator(char value) {#setAccelerator-char-}
+```
+public void setAccelerator(char value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getAccelerator()](../../com.aspose.diagram/labelactivexcontrol\#getAccelerator--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | char |  |
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setBorderOleColor(int value) {#setBorderOleColor-int-}
+```
+public void setBorderOleColor(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getBorderOleColor()](../../com.aspose.diagram/labelactivexcontrol\#getBorderOleColor--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setBorderStyle(int value) {#setBorderStyle-int-}
+```
+public void setBorderStyle(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getBorderStyle()](../../com.aspose.diagram/labelactivexcontrol\#getBorderStyle--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setCaption(String value) {#setCaption-java.lang.String-}
+```
+public void setCaption(String value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getCaption()](../../com.aspose.diagram/labelactivexcontrol\#getCaption--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setPicture(byte[] value) {#setPicture-byte---}
+```
+public void setPicture(byte[] value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getPicture()](../../com.aspose.diagram/labelactivexcontrol\#getPicture--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | byte[] |  |
+
+### setPicturePosition(int value) {#setPicturePosition-int-}
+```
+public void setPicturePosition(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getPicturePosition()](../../com.aspose.diagram/labelactivexcontrol\#getPicturePosition--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setSpecialEffect(int value) {#setSpecialEffect-int-}
+```
+public void setSpecialEffect(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getSpecialEffect()](../../com.aspose.diagram/labelactivexcontrol\#getSpecialEffect--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double |  |
+
+### setWordWrapped(boolean value) {#setWordWrapped-boolean-}
+```
+public void setWordWrapped(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [isWordWrapped()](../../com.aspose.diagram/labelactivexcontrol\#isWordWrapped--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/layer/_index.md
+++ b/italian/java/com.aspose.diagram/layer/_index.md
@@ -1,0 +1,334 @@
+---
+title: Layer
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene elementi che definiscono un singolo livello e le sue proprietà per una pagina.
+type: docs
+weight: 212
+url: /it/java/com.aspose.diagram/layer/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Layer
+```
+
+Contiene elementi che definiscono un singolo livello e le sue proprietà per una pagina.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [Layer()](#Layer--) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getActive()](#getActive--) | Specifica se un livello è attivo. |
+| [getClass()](#getClass--) |  |
+| [getColor()](#getColor--) | L'indice del colore nella tavola dei colori usato per visualizzare il livello o un valore RGB che specifica un colore personalizzato non presente nella tavola dei colori (ad esempio, \#ff9900). |
+| [getColorTrans()](#getColorTrans--) | Determina il grado di trasparenza del colore del testo di un livello o di una forma, da 0 (completamente opaco) a 1 (completamente trasparente). |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getGlue()](#getGlue--) | Specifica se le forme appartenenti al livello possono essere incollate. |
+| [getIX()](#getIX--) | L'indice basato su zero dell'elemento all'interno del suo elemento genitore. |
+| [getLock()](#getLock--) | Specifica se le forme appartenenti al livello sono bloccate dalla selezione o dalla modifica. |
+| [getName()](#getName--) | L'elemento Name specifica il nome di un livello. |
+| [getNameUniv()](#getNameUniv--) | Specifica il nome universale di un livello. |
+| [getPrint()](#getPrint--) | Specifica se le forme appartenenti al livello vengono stampate quando il disegno è stampato. |
+| [getSnap()](#getSnap--) | Specifica se altre forme possono agganciarsi alle forme assegnate al livello. |
+| [getStatus()](#getStatus--) | Specifica se il livello è un livello valido per un documento. |
+| [getVisible()](#getVisible--) | Specifica se le forme appartenenti al livello sono visibili nella pagina del disegno. |
+| [hashCode()](#hashCode--) |  |
+| [isColorChecked()](#isColorChecked--) | Un flag che indica se l'elemento è stato controllato localmente. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setColorChecked(int value)](#setColorChecked-int-) | Per la descrizione di questa proprietà, vedere [isColorChecked()](../../com.aspose.diagram/layer\#isColorChecked--) |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/layer\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Per la descrizione di questa proprietà, vedere [getIX()](../../com.aspose.diagram/layer\#getIX--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Layer() {#Layer--}
+```
+public Layer()
+```
+
+
+Costruttore.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getActive() {#getActive--}
+```
+public BoolValue getActive()
+```
+
+
+Specifica se un livello è attivo. Le forme che non sono preassegnate ai livelli vengono assegnate al(i) livello(i) attivo(i) quando vengono rilasciate sulla pagina del disegno.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColor() {#getColor--}
+```
+public ColorValue getColor()
+```
+
+
+L'indice del colore nella tavola dei colori usato per visualizzare il livello o un valore RGB che specifica un colore personalizzato non presente nella tavola dei colori (ad esempio, \#ff9900).
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getColorTrans() {#getColorTrans--}
+```
+public DoubleValue getColorTrans()
+```
+
+
+Determina il grado di trasparenza del colore del testo di un livello o di una forma, da 0 (completamente opaco) a 1 (completamente trasparente).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getGlue() {#getGlue--}
+```
+public BoolValue getGlue()
+```
+
+
+Specifica se le forme appartenenti al livello possono essere incollate.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+L'indice basato su zero dell'elemento all'interno del suo elemento genitore.
+
+**Returns:**
+int
+### getLock() {#getLock--}
+```
+public BoolValue getLock()
+```
+
+
+Specifica se le forme appartenenti al livello sono bloccate dalla selezione o dalla modifica.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getName() {#getName--}
+```
+public Str2Value getName()
+```
+
+
+L'elemento Name specifica il nome di un livello.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getNameUniv() {#getNameUniv--}
+```
+public Str2Value getNameUniv()
+```
+
+
+Specifica il nome universale di un livello.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getPrint() {#getPrint--}
+```
+public BoolValue getPrint()
+```
+
+
+Specifica se le forme appartenenti al livello vengono stampate quando il disegno è stampato.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getSnap() {#getSnap--}
+```
+public BoolValue getSnap()
+```
+
+
+Specifica se altre forme possono agganciarsi alle forme assegnate al livello. Le forme assegnate al livello possono agganciarsi ad altre forme, ma le altre forme non possono agganciarsi a esse.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getStatus() {#getStatus--}
+```
+public BoolValue getStatus()
+```
+
+
+Specifica se il livello è un livello valido per un documento.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getVisible() {#getVisible--}
+```
+public BoolValue getVisible()
+```
+
+
+Specifica se le forme appartenenti al livello sono visibili nella pagina del disegno.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isColorChecked() {#isColorChecked--}
+```
+public int isColorChecked()
+```
+
+
+Un flag che indica se l'elemento è stato controllato localmente. Un valore di 1 indica che l'elemento è stato controllato localmente.
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setColorChecked(int value) {#setColorChecked-int-}
+```
+public void setColorChecked(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isColorChecked()](../../com.aspose.diagram/layer\#isColorChecked--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/layer\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getIX()](../../com.aspose.diagram/layer\#getIX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/layercollection/_index.md
+++ b/italian/java/com.aspose.diagram/layercollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: LayerCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Raccolta Layer.
+type: docs
+weight: 213
+url: /it/java/com.aspose.diagram/layercollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class LayerCollection extends Collection
+```
+
+Raccolta Layer.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [add(Layer item)](#add-com.aspose.diagram.Layer-) | Aggiungi l'oggetto Layer nella collezione. |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Layer item)](#remove-com.aspose.diagram.Layer-) | Rimuovi l'oggetto Layer dalla collezione. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Layer item) {#add-com.aspose.diagram.Layer-}
+```
+public int add(Layer item)
+```
+
+
+Aggiungi l'oggetto Layer nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [Layer](../../com.aspose.diagram/layer) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Layer get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[Layer](../../com.aspose.diagram/layer) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Layer item) {#remove-com.aspose.diagram.Layer-}
+```
+public void remove(Layer item)
+```
+
+
+Rimuovi l'oggetto Layer dalla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [Layer](../../com.aspose.diagram/layer) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/layermem/_index.md
+++ b/italian/java/com.aspose.diagram/layermem/_index.md
@@ -1,0 +1,161 @@
+---
+title: LayerMem
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene l'elemento LayerMember che specifica ciascun livello a cui la forma è assegnata.
+type: docs
+weight: 214
+url: /it/java/com.aspose.diagram/layermem/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LayerMem
+```
+
+Contiene l'elemento LayerMember, che specifica ogni livello a cui la forma è assegnata.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getLayerMember()](#getLayerMember--) | Specifica il livello o i livelli a cui la forma è assegnata. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, consultare [getDel()](../../com.aspose.diagram/layermem\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getLayerMember() {#getLayerMember--}
+```
+public Str2Value getLayerMember()
+```
+
+
+Specifica il livello o i livelli a cui la forma è assegnata. L'assegnazione del livello è specificata in base all'indice a base zero dei livelli per la pagina. Se una forma è assegnata a più di un livello, ogni indice di livello appare separato da un punto e virgola.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getDel()](../../com.aspose.diagram/layermem\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/layout/_index.md
+++ b/italian/java/com.aspose.diagram/layout/_index.md
@@ -1,0 +1,362 @@
+---
+title: Layout
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene elementi che controllano il posizionamento delle forme e le impostazioni di instradamento dei connettori.
+type: docs
+weight: 215
+url: /it/java/com.aspose.diagram/layout/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Layout
+```
+
+Contiene elementi che controllano il posizionamento delle forme e le impostazioni di instradamento dei connettori.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getConFixedCode()](#getConFixedCode--) | Determina quando un connettore viene ricalcolato. |
+| [getConLineJumpCode()](#getConLineJumpCode--) | Determina se un connettore salta quando due connettori si incrociano, |
+| [getConLineJumpDirX()](#getConLineJumpDirX--) | Determina la direzione del salto di linea per i salti di linea che si verificano su un segmento orizzontale di un connettore dinamico. |
+| [getConLineJumpDirY()](#getConLineJumpDirY--) | Determina la direzione del salto di linea per i salti di linea che si verificano su un segmento verticale di un connettore dinamico. |
+| [getConLineJumpStyle()](#getConLineJumpStyle--) | Determina lo stile del salto di linea per i salti di linea su un connettore dinamico. |
+| [getConLineRouteExt()](#getConLineRouteExt--) | Determina l'aspetto di un connettore. |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getDisplayLevel()](#getDisplayLevel--) | Determina la fascia di livello di visualizzazione (l'intervallo relativo del raggruppamento Z-order) per la forma. |
+| [getRelationships()](#getRelationships--) | Memorizza le relazioni tra contenitori, elenchi, callout e forme. |
+| [getShapeFixedCode()](#getShapeFixedCode--) | Specifica il comportamento di posizionamento per una forma posizionabile. |
+| [getShapePermeablePlace()](#getShapePermeablePlace--) | Specifica se le forme posizionabili possono essere collocate sopra una forma quando l'utente seleziona Lay Out Shapes (menu Shapes). |
+| [getShapePermeableX()](#getShapePermeableX--) | Specifica se un connettore può percorrere orizzontalmente una forma. |
+| [getShapePermeableY()](#getShapePermeableY--) | Specifica se un connettore può percorrere verticalmente una forma. |
+| [getShapePlaceFlip()](#getShapePlaceFlip--) | Specifica come una forma posizionabile si capovolge e/o ruota nella pagina quando l'utente seleziona Disposizione forme (menu Forme). |
+| [getShapePlaceStyle()](#getShapePlaceStyle--) | Determina lo stile di posizionamento per i figli. |
+| [getShapePlowCode()](#getShapePlowCode--) | Specifica se una forma posizionabile si allontana quando trascini un'altra forma posizionabile vicino alla forma nella pagina di disegno. |
+| [getShapeRouteStyle()](#getShapeRouteStyle--) | Specifica lo stile di instradamento e la direzione per un connettore nella pagina di disegno. |
+| [getShapeSplit()](#getShapeSplit--) | Determina se questa forma può dividere forme che sono divisibili. |
+| [getShapeSplittable()](#getShapeSplittable--) | Determina se questa forma 1-D può essere divisa. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/layout\#getDel--) |
+| [setShapePlaceStyle(ShapePlaceStyle value)](#setShapePlaceStyle-com.aspose.diagram.ShapePlaceStyle-) | Per la descrizione di questa proprietà, vedere [getShapePlaceStyle()](../../com.aspose.diagram/layout\#getShapePlaceStyle--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConFixedCode() {#getConFixedCode--}
+```
+public ConFixedCode getConFixedCode()
+```
+
+
+Determina quando un connettore viene ricalcolato.
+
+**Returns:**
+[ConFixedCode](../../com.aspose.diagram/confixedcode)
+### getConLineJumpCode() {#getConLineJumpCode--}
+```
+public ConLineJumpCode getConLineJumpCode()
+```
+
+
+Determina se un connettore salta quando due connettori si incrociano,
+
+**Returns:**
+[ConLineJumpCode](../../com.aspose.diagram/conlinejumpcode)
+### getConLineJumpDirX() {#getConLineJumpDirX--}
+```
+public ConLineJumpDirX getConLineJumpDirX()
+```
+
+
+Determina la direzione del salto di linea per i salti di linea che si verificano su un segmento orizzontale di un connettore dinamico.
+
+**Returns:**
+[ConLineJumpDirX](../../com.aspose.diagram/conlinejumpdirx)
+### getConLineJumpDirY() {#getConLineJumpDirY--}
+```
+public ConLineJumpDirY getConLineJumpDirY()
+```
+
+
+Determina la direzione del salto di linea per i salti di linea che si verificano su un segmento verticale di un connettore dinamico.
+
+**Returns:**
+[ConLineJumpDirY](../../com.aspose.diagram/conlinejumpdiry)
+### getConLineJumpStyle() {#getConLineJumpStyle--}
+```
+public ConLineJumpStyle getConLineJumpStyle()
+```
+
+
+Determina lo stile del salto di linea per i salti di linea su un connettore dinamico.
+
+**Returns:**
+[ConLineJumpStyle](../../com.aspose.diagram/conlinejumpstyle)
+### getConLineRouteExt() {#getConLineRouteExt--}
+```
+public ConLineRouteExt getConLineRouteExt()
+```
+
+
+Determina l'aspetto di un connettore.
+
+**Returns:**
+[ConLineRouteExt](../../com.aspose.diagram/conlinerouteext)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getDisplayLevel() {#getDisplayLevel--}
+```
+public IntValue getDisplayLevel()
+```
+
+
+Determina la fascia di livello di visualizzazione (l'intervallo relativo del raggruppamento Z-order) per la forma.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getRelationships() {#getRelationships--}
+```
+public BoolValue getRelationships()
+```
+
+
+Memorizza le relazioni tra contenitori, elenchi, callout e forme.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getShapeFixedCode() {#getShapeFixedCode--}
+```
+public ShapeFixedCode getShapeFixedCode()
+```
+
+
+Specifica il comportamento di posizionamento per una forma posizionabile.
+
+**Returns:**
+[ShapeFixedCode](../../com.aspose.diagram/shapefixedcode)
+### getShapePermeablePlace() {#getShapePermeablePlace--}
+```
+public BoolValue getShapePermeablePlace()
+```
+
+
+Specifica se le forme posizionabili possono essere collocate sopra una forma quando l'utente seleziona Lay Out Shapes (menu Shapes).
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getShapePermeableX() {#getShapePermeableX--}
+```
+public BoolValue getShapePermeableX()
+```
+
+
+Specifica se un connettore può percorrere orizzontalmente una forma.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getShapePermeableY() {#getShapePermeableY--}
+```
+public BoolValue getShapePermeableY()
+```
+
+
+Specifica se un connettore può percorrere verticalmente una forma.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getShapePlaceFlip() {#getShapePlaceFlip--}
+```
+public ShapePlaceFlip getShapePlaceFlip()
+```
+
+
+Specifica come una forma posizionabile si capovolge e/o ruota nella pagina quando l'utente seleziona Disposizione forme (menu Forme).
+
+**Returns:**
+[ShapePlaceFlip](../../com.aspose.diagram/shapeplaceflip)
+### getShapePlaceStyle() {#getShapePlaceStyle--}
+```
+public ShapePlaceStyle getShapePlaceStyle()
+```
+
+
+Determina lo stile di posizionamento per i figli.
+
+**Returns:**
+[ShapePlaceStyle](../../com.aspose.diagram/shapeplacestyle)
+### getShapePlowCode() {#getShapePlowCode--}
+```
+public ShapePlowCode getShapePlowCode()
+```
+
+
+Specifica se una forma posizionabile si allontana quando trascini un'altra forma posizionabile vicino alla forma nella pagina di disegno.
+
+**Returns:**
+[ShapePlowCode](../../com.aspose.diagram/shapeplowcode)
+### getShapeRouteStyle() {#getShapeRouteStyle--}
+```
+public ShapeRouteStyle getShapeRouteStyle()
+```
+
+
+Specifica lo stile di instradamento e la direzione per un connettore nella pagina di disegno.
+
+**Returns:**
+[ShapeRouteStyle](../../com.aspose.diagram/shaperoutestyle)
+### getShapeSplit() {#getShapeSplit--}
+```
+public BoolValue getShapeSplit()
+```
+
+
+Determina se questa forma può dividere forme che sono divisibili.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getShapeSplittable() {#getShapeSplittable--}
+```
+public BoolValue getShapeSplittable()
+```
+
+
+Determina se questa forma 1-D può essere divisa.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/layout\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setShapePlaceStyle(ShapePlaceStyle value) {#setShapePlaceStyle-com.aspose.diagram.ShapePlaceStyle-}
+```
+public void setShapePlaceStyle(ShapePlaceStyle value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getShapePlaceStyle()](../../com.aspose.diagram/layout\#getShapePlaceStyle--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [ShapePlaceStyle](../../com.aspose.diagram/shapeplacestyle) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/layoutdirection/_index.md
+++ b/italian/java/com.aspose.diagram/layoutdirection/_index.md
@@ -1,0 +1,201 @@
+---
+title: LayoutDirection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Utilizzato per impostare la direzione del layout.
+type: docs
+weight: 216
+url: /it/java/com.aspose.diagram/layoutdirection/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LayoutDirection
+```
+
+Utilizzato per impostare la direzione del layout.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [BOTTOM_TO_TOP](#BOTTOM-TO-TOP) | Posiziona la forma dal basso verso l'alto. |
+| [DOWN_THEN_LEFT](#DOWN-THEN-LEFT) | Posiziona le forme prima verso il basso e poi a sinistra. |
+| [DOWN_THEN_RIGHT](#DOWN-THEN-RIGHT) | Posiziona le forme prima verso il basso e poi a destra. |
+| [LEFT_THEN_DOWN](#LEFT-THEN-DOWN) | Posiziona le forme prima a sinistra e poi verso il basso. |
+| [LEFT_TO_RIGHT](#LEFT-TO-RIGHT) | Posiziona la forma da sinistra a destra . |
+| [RIGHT_THEN_DOWN](#RIGHT-THEN-DOWN) | Posiziona le forme prima a destra e poi verso il basso. |
+| [RIGHT_TO_LEFT](#RIGHT-TO-LEFT) | Posiziona la forma da destra a sinistra. |
+| [TOP_TO_BOTTOM](#TOP-TO-BOTTOM) | Posiziona la forma dall'alto verso il basso. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOTTOM_TO_TOP {#BOTTOM-TO-TOP}
+```
+public static final int BOTTOM_TO_TOP
+```
+
+
+Posiziona la forma dal basso verso l'alto. Ha senso solo quando è selezionato lo stile Flowchart.
+
+### DOWN_THEN_LEFT {#DOWN-THEN-LEFT}
+```
+public static final int DOWN_THEN_LEFT
+```
+
+
+Posiziona le forme prima verso il basso e poi a sinistra. Ha senso solo quando è selezionato lo stile CompactTree.
+
+### DOWN_THEN_RIGHT {#DOWN-THEN-RIGHT}
+```
+public static final int DOWN_THEN_RIGHT
+```
+
+
+Posiziona le forme prima verso il basso e poi a destra. Ha senso solo quando è selezionato lo stile CompactTree.
+
+### LEFT_THEN_DOWN {#LEFT-THEN-DOWN}
+```
+public static final int LEFT_THEN_DOWN
+```
+
+
+Posiziona le forme prima a sinistra e poi verso il basso. Ha senso solo quando è selezionato lo stile CompactTree.
+
+### LEFT_TO_RIGHT {#LEFT-TO-RIGHT}
+```
+public static final int LEFT_TO_RIGHT
+```
+
+
+Posiziona la forma da sinistra a destra. Ha senso solo quando lo stile Flowchart è scelto.
+
+### RIGHT_THEN_DOWN {#RIGHT-THEN-DOWN}
+```
+public static final int RIGHT_THEN_DOWN
+```
+
+
+Posiziona le forme prima a destra e poi in basso. Ha senso solo quando lo stile CompactTree è scelto.
+
+### RIGHT_TO_LEFT {#RIGHT-TO-LEFT}
+```
+public static final int RIGHT_TO_LEFT
+```
+
+
+Posiziona la forma da destra a sinistra. Ha senso solo quando lo stile Flowchart è scelto.
+
+### TOP_TO_BOTTOM {#TOP-TO-BOTTOM}
+```
+public static final int TOP_TO_BOTTOM
+```
+
+
+Posiziona la forma dall'alto verso il basso. Ha senso solo quando lo stile Flowchart è scelto.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/layoutoptions/_index.md
+++ b/italian/java/com.aspose.diagram/layoutoptions/_index.md
@@ -1,0 +1,238 @@
+---
+title: LayoutOptions
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Utilizzato per specificare lo stile e le opzioni aggiuntive del layout delle forme per eseguire il Re-Layout delle pagine.
+type: docs
+weight: 217
+url: /it/java/com.aspose.diagram/layoutoptions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LayoutOptions
+```
+
+Utilizzato per specificare lo stile e le opzioni aggiuntive del layout delle forme per eseguire il Re-Layout di pagina(pagine).
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [LayoutOptions()](#LayoutOptions--) | Inizializza una nuova istanza di LayoutOptions. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDirection()](#getDirection--) | Utilizzato per impostare la direzione del layout delle forme. |
+| [getEnlargePage()](#getEnlargePage--) | Definisce se è necessario ingrandire la pagina per adattare il disegno o meno. |
+| [getLayoutStyle()](#getLayoutStyle--) | Utilizzato per specificare lo stile del layout. |
+| [getSpaceShapes()](#getSpaceShapes--) | Definisce la spaziatura tra le forme in pollici. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDirection(int value)](#setDirection-int-) | Per la descrizione di questa proprietà, vedere [getDirection()](../../com.aspose.diagram/layoutoptions\#getDirection--) |
+| [setEnlargePage(boolean value)](#setEnlargePage-boolean-) | Per la descrizione di questa proprietà, vedere [getEnlargePage()](../../com.aspose.diagram/layoutoptions\#getEnlargePage--) |
+| [setLayoutStyle(int value)](#setLayoutStyle-int-) | Per la descrizione di questa proprietà, vedere [getLayoutStyle()](../../com.aspose.diagram/layoutoptions\#getLayoutStyle--) |
+| [setSpaceShapes(float value)](#setSpaceShapes-float-) | Per la descrizione di questa proprietà, vedere [getSpaceShapes()](../../com.aspose.diagram/layoutoptions\#getSpaceShapes--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LayoutOptions() {#LayoutOptions--}
+```
+public LayoutOptions()
+```
+
+
+Inizializza una nuova istanza di LayoutOptions.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDirection() {#getDirection--}
+```
+public int getDirection()
+```
+
+
+Utilizzato per impostare la direzione del layout delle forme. Il valore predefinito è TopToBottom.
+
+**Returns:**
+int
+### getEnlargePage() {#getEnlargePage--}
+```
+public boolean getEnlargePage()
+```
+
+
+Definisce se è necessario ingrandire la pagina per adattare il disegno o meno. Il valore predefinito è false.
+
+**Returns:**
+boolean
+### getLayoutStyle() {#getLayoutStyle--}
+```
+public int getLayoutStyle()
+```
+
+
+Utilizzato per specificare lo stile del layout. Il valore predefinito è FlowChart.
+
+**Returns:**
+int
+### getSpaceShapes() {#getSpaceShapes--}
+```
+public float getSpaceShapes()
+```
+
+
+Definisce la spaziatura tra le forme in pollici. Il valore predefinito è 0,3 pollici ~ 7,5 mm.
+
+**Returns:**
+float
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDirection(int value) {#setDirection-int-}
+```
+public void setDirection(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDirection()](../../com.aspose.diagram/layoutoptions\#getDirection--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setEnlargePage(boolean value) {#setEnlargePage-boolean-}
+```
+public void setEnlargePage(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getEnlargePage()](../../com.aspose.diagram/layoutoptions\#getEnlargePage--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setLayoutStyle(int value) {#setLayoutStyle-int-}
+```
+public void setLayoutStyle(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getLayoutStyle()](../../com.aspose.diagram/layoutoptions\#getLayoutStyle--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setSpaceShapes(float value) {#setSpaceShapes-float-}
+```
+public void setSpaceShapes(float value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getSpaceShapes()](../../com.aspose.diagram/layoutoptions\#getSpaceShapes--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | float |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/layoutstyle/_index.md
+++ b/italian/java/com.aspose.diagram/layoutstyle/_index.md
@@ -1,0 +1,165 @@
+---
+title: LayoutStyle
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Utilizzato per specificare lo stile del layout.
+type: docs
+weight: 218
+url: /it/java/com.aspose.diagram/layoutstyle/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LayoutStyle
+```
+
+Utilizzato per specificare lo stile del layout.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [CIRCULAR](#CIRCULAR) | Stile circolare. |
+| [COMPACT_TREE](#COMPACT-TREE) | Stile ad albero. |
+| [FLOW_CHART](#FLOW-CHART) | Stile diagramma di flusso. |
+| [RADIAL](#RADIAL) | Stile radiale. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CIRCULAR {#CIRCULAR}
+```
+public static final int CIRCULAR
+```
+
+
+Stile circolare.
+
+### COMPACT_TREE {#COMPACT-TREE}
+```
+public static final int COMPACT_TREE
+```
+
+
+Stile ad albero.
+
+### FLOW_CHART {#FLOW-CHART}
+```
+public static final int FLOW_CHART
+```
+
+
+Stile diagramma di flusso.
+
+### RADIAL {#RADIAL}
+```
+public static final int RADIAL
+```
+
+
+Stile radiale.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/license/_index.md
+++ b/italian/java/com.aspose.diagram/license/_index.md
@@ -1,0 +1,188 @@
+---
+title: Licenza
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Fornisce metodi per licenziare il componente.
+type: docs
+weight: 219
+url: /it/java/com.aspose.diagram/license/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class License
+```
+
+Fornisce metodi per licenziare il componente.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [License()](#License--) | Inizializza una nuova istanza di questa classe. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setLicense(InputStream stream)](#setLicense-java.io.InputStream-) | Licenzia il componente. |
+| [setLicense(String licenseName)](#setLicense-java.lang.String-) | Licenzia il componente. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### License() {#License--}
+```
+public License()
+```
+
+
+Inizializza una nuova istanza di questa classe.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setLicense(InputStream stream) {#setLicense-java.io.InputStream-}
+```
+public void setLicense(InputStream stream)
+```
+
+
+Licenzia il componente.
+
+Usa questo metodo per caricare una licenza da uno stream.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| flusso | java.io.InputStream | Uno stream che contiene la licenza. |
+
+### setLicense(String licenseName) {#setLicense-java.lang.String-}
+```
+public void setLicense(String licenseName)
+```
+
+
+Licenzia il componente.
+
+Cerca di trovare la licenza nelle seguenti posizioni:
+
+1. Percorso esplicito.
+
+2. La cartella dell'assembly del componente.
+
+3. La cartella dell'assembly chiamante del client.
+
+4. La cartella dell'assembly di ingresso.
+
+5. Una risorsa incorporata nell'assembly chiamante del client.
+
+**Note:**On the .NET Compact Framework, tries to find the license only in these locations:
+
+1. Percorso esplicito.
+
+2. Una risorsa incorporata nell'assembly chiamante del client.
+
+2. La cartella del file jar del componente.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| licenseName | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/lightrigdirectiontype/_index.md
+++ b/italian/java/com.aspose.diagram/lightrigdirectiontype/_index.md
@@ -1,0 +1,201 @@
+---
+title: LightRigDirectionType
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta il tipo di direzione del rig luminoso.
+type: docs
+weight: 220
+url: /it/java/com.aspose.diagram/lightrigdirectiontype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LightRigDirectionType
+```
+
+Rappresenta il tipo di direzione del rig luminoso.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [BOTTOM](#BOTTOM) | Inferiore |
+| [BOTTOM_LEFT](#BOTTOM-LEFT) | In basso a sinistra. |
+| [BOTTOM_RIGHT](#BOTTOM-RIGHT) | In basso a destra. |
+| [LEFT](#LEFT) | Sinistra. |
+| [RIGHT](#RIGHT) | Destra. |
+| [TOP](#TOP) | Superiore. |
+| [TOP_LEFT](#TOP-LEFT) | In alto a sinistra. |
+| [TOP_RIGHT](#TOP-RIGHT) | In alto a destra. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOTTOM {#BOTTOM}
+```
+public static final int BOTTOM
+```
+
+
+Inferiore
+
+### BOTTOM_LEFT {#BOTTOM-LEFT}
+```
+public static final int BOTTOM_LEFT
+```
+
+
+In basso a sinistra.
+
+### BOTTOM_RIGHT {#BOTTOM-RIGHT}
+```
+public static final int BOTTOM_RIGHT
+```
+
+
+In basso a destra.
+
+### LEFT {#LEFT}
+```
+public static final int LEFT
+```
+
+
+Sinistra.
+
+### RIGHT {#RIGHT}
+```
+public static final int RIGHT
+```
+
+
+Destra.
+
+### TOP {#TOP}
+```
+public static final int TOP
+```
+
+
+Superiore.
+
+### TOP_LEFT {#TOP-LEFT}
+```
+public static final int TOP_LEFT
+```
+
+
+In alto a sinistra.
+
+### TOP_RIGHT {#TOP-RIGHT}
+```
+public static final int TOP_RIGHT
+```
+
+
+In alto a destra.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/line/_index.md
+++ b/italian/java/com.aspose.diagram/line/_index.md
@@ -1,0 +1,447 @@
+---
+title: Line
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene elementi che specificano informazioni generali di posizionamento su una forma.
+type: docs
+weight: 221
+url: /it/java/com.aspose.diagram/line/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Line
+```
+
+Contiene elementi che specificano informazioni generali di posizionamento su una forma.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBeginArrow()](#getBeginArrow--) | Indica se una linea ha una punta di freccia o altro formato di estremità della linea al suo primo vertice. |
+| [getBeginArrowSize()](#getBeginArrowSize--) | Determina la dimensione della punta di freccia all'inizio della linea. |
+| [getClass()](#getClass--) |  |
+| [getCompoundType()](#getCompoundType--) | Specifica il CompoundType della linea della forma. |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getEndArrow()](#getEndArrow--) | Indica se una linea ha una punta di freccia o altro formato di estremità della linea all'ultimo vertice. |
+| [getEndArrowSize()](#getEndArrowSize--) | Specifica la dimensione della punta di freccia alla fine della linea. |
+| [getGradientLine()](#getGradientLine--) | Contiene i valori attuali di formattazione della linea gradiente per la forma |
+| [getLineCap()](#getLineCap--) | Specifica se una linea ha estremità arrotondate o quadrate. |
+| [getLineColor()](#getLineColor--) | Specifica il colore della linea della forma. |
+| [getLineColorTrans()](#getLineColorTrans--) | Specifica il livello di trasparenza del colore della linea di una forma, da 0 (opaco) a 1 (completamente trasparente). |
+| [getLinePattern()](#getLinePattern--) | Specifica il modello di linea della forma |
+| [getLineWeight()](#getLineWeight--) | Specifica lo spessore della linea di una forma. |
+| [getRounding()](#getRounding--) | Specifica il raggio dell'arco di arrotondamento applicato dove due segmenti contigui di un percorso si incontrano. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setBeginArrow(IntValue value)](#setBeginArrow-com.aspose.diagram.IntValue-) | Per la descrizione di questa proprietà, vedere [getBeginArrow()](../../com.aspose.diagram/line\#getBeginArrow--) |
+| [setBeginArrowSize(ArrowSize value)](#setBeginArrowSize-com.aspose.diagram.ArrowSize-) | Per la descrizione di questa proprietà, vedere [getBeginArrowSize()](../../com.aspose.diagram/line\#getBeginArrowSize--) |
+| [setCompoundType(CompoundType value)](#setCompoundType-com.aspose.diagram.CompoundType-) | Per la descrizione di questa proprietà, vedere [getCompoundType()](../../com.aspose.diagram/line\#getCompoundType--) |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/line\#getDel--) |
+| [setEndArrow(IntValue value)](#setEndArrow-com.aspose.diagram.IntValue-) | Per la descrizione di questa proprietà, vedere [getEndArrow()](../../com.aspose.diagram/line\#getEndArrow--) |
+| [setEndArrowSize(ArrowSize value)](#setEndArrowSize-com.aspose.diagram.ArrowSize-) | Per la descrizione di questa proprietà, vedere [getEndArrowSize()](../../com.aspose.diagram/line\#getEndArrowSize--) |
+| [setLineCap(BoolValue value)](#setLineCap-com.aspose.diagram.BoolValue-) | Per la descrizione di questa proprietà, vedere [getLineCap()](../../com.aspose.diagram/line\#getLineCap--) |
+| [setLineColor(ColorValue value)](#setLineColor-com.aspose.diagram.ColorValue-) | Per la descrizione di questa proprietà, vedere [getLineColor()](../../com.aspose.diagram/line\#getLineColor--) |
+| [setLineColorTrans(DoubleValue value)](#setLineColorTrans-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getLineColorTrans()](../../com.aspose.diagram/line\#getLineColorTrans--) |
+| [setLinePattern(IntValue value)](#setLinePattern-com.aspose.diagram.IntValue-) | Per la descrizione di questa proprietà, vedere [getLinePattern()](../../com.aspose.diagram/line\#getLinePattern--) |
+| [setLineWeight(DoubleValue value)](#setLineWeight-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getLineWeight()](../../com.aspose.diagram/line\#getLineWeight--) |
+| [setRounding(DoubleValue value)](#setRounding-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getRounding()](../../com.aspose.diagram/line\#getRounding--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBeginArrow() {#getBeginArrow--}
+```
+public IntValue getBeginArrow()
+```
+
+
+Indica se una linea ha una punta di freccia o altro formato di estremità della linea al suo primo vertice. Inserire un numero da 0 a 45 o la funzione USE con il nome di un'estremità di linea personalizzata.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getBeginArrowSize() {#getBeginArrowSize--}
+```
+public ArrowSize getBeginArrowSize()
+```
+
+
+Determina la dimensione della punta della freccia all'inizio della linea. Inserisci un numero da 0 a 6.
+
+**Returns:**
+[ArrowSize](../../com.aspose.diagram/arrowsize)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCompoundType() {#getCompoundType--}
+```
+public CompoundType getCompoundType()
+```
+
+
+Specifica il CompoundType della linea della forma.
+
+**Returns:**
+[CompoundType](../../com.aspose.diagram/compoundtype)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getEndArrow() {#getEndArrow--}
+```
+public IntValue getEndArrow()
+```
+
+
+Indica se una linea ha una punta di freccia o altro formato di estremità della linea all'ultimo vertice.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getEndArrowSize() {#getEndArrowSize--}
+```
+public ArrowSize getEndArrowSize()
+```
+
+
+Specifica la dimensione della punta di freccia alla fine della linea.
+
+**Returns:**
+[ArrowSize](../../com.aspose.diagram/arrowsize)
+### getGradientLine() {#getGradientLine--}
+```
+public GradientFill getGradientLine()
+```
+
+
+Contiene i valori attuali di formattazione della linea gradiente per la forma
+
+**Returns:**
+[GradientFill](../../com.aspose.diagram/gradientfill)
+### getLineCap() {#getLineCap--}
+```
+public BoolValue getLineCap()
+```
+
+
+Specifica se una linea ha estremità arrotondate o quadrate.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLineColor() {#getLineColor--}
+```
+public ColorValue getLineColor()
+```
+
+
+Specifica il colore della linea della forma.
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getLineColorTrans() {#getLineColorTrans--}
+```
+public DoubleValue getLineColorTrans()
+```
+
+
+Specifica il livello di trasparenza del colore della linea di una forma, da 0 (opaco) a 1 (completamente trasparente). Il valore predefinito è 0.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLinePattern() {#getLinePattern--}
+```
+public IntValue getLinePattern()
+```
+
+
+Specifica il modello di linea della forma
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getLineWeight() {#getLineWeight--}
+```
+public DoubleValue getLineWeight()
+```
+
+
+Specifica lo spessore della linea di una forma. Lo spessore della linea è indipendente dalla scala del disegno. Se il disegno viene scalato, lo spessore della linea rimane invariato.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getRounding() {#getRounding--}
+```
+public DoubleValue getRounding()
+```
+
+
+Specifica il raggio dell'arco di arrotondamento applicato dove due segmenti contigui di un percorso si incontrano. Ad esempio, l'arrotondamento può essere usato per dare a un rettangolo angoli arrotondati.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setBeginArrow(IntValue value) {#setBeginArrow-com.aspose.diagram.IntValue-}
+```
+public void setBeginArrow(IntValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getBeginArrow()](../../com.aspose.diagram/line\#getBeginArrow--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setBeginArrowSize(ArrowSize value) {#setBeginArrowSize-com.aspose.diagram.ArrowSize-}
+```
+public void setBeginArrowSize(ArrowSize value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getBeginArrowSize()](../../com.aspose.diagram/line\#getBeginArrowSize--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [ArrowSize](../../com.aspose.diagram/arrowsize) |  |
+
+### setCompoundType(CompoundType value) {#setCompoundType-com.aspose.diagram.CompoundType-}
+```
+public void setCompoundType(CompoundType value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getCompoundType()](../../com.aspose.diagram/line\#getCompoundType--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [CompoundType](../../com.aspose.diagram/compoundtype) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/line\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setEndArrow(IntValue value) {#setEndArrow-com.aspose.diagram.IntValue-}
+```
+public void setEndArrow(IntValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getEndArrow()](../../com.aspose.diagram/line\#getEndArrow--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setEndArrowSize(ArrowSize value) {#setEndArrowSize-com.aspose.diagram.ArrowSize-}
+```
+public void setEndArrowSize(ArrowSize value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getEndArrowSize()](../../com.aspose.diagram/line\#getEndArrowSize--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [ArrowSize](../../com.aspose.diagram/arrowsize) |  |
+
+### setLineCap(BoolValue value) {#setLineCap-com.aspose.diagram.BoolValue-}
+```
+public void setLineCap(BoolValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getLineCap()](../../com.aspose.diagram/line\#getLineCap--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setLineColor(ColorValue value) {#setLineColor-com.aspose.diagram.ColorValue-}
+```
+public void setLineColor(ColorValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getLineColor()](../../com.aspose.diagram/line\#getLineColor--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setLineColorTrans(DoubleValue value) {#setLineColorTrans-com.aspose.diagram.DoubleValue-}
+```
+public void setLineColorTrans(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getLineColorTrans()](../../com.aspose.diagram/line\#getLineColorTrans--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setLinePattern(IntValue value) {#setLinePattern-com.aspose.diagram.IntValue-}
+```
+public void setLinePattern(IntValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getLinePattern()](../../com.aspose.diagram/line\#getLinePattern--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setLineWeight(DoubleValue value) {#setLineWeight-com.aspose.diagram.DoubleValue-}
+```
+public void setLineWeight(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getLineWeight()](../../com.aspose.diagram/line\#getLineWeight--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setRounding(DoubleValue value) {#setRounding-com.aspose.diagram.DoubleValue-}
+```
+public void setRounding(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getRounding()](../../com.aspose.diagram/line\#getRounding--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/lineadjustfrom/_index.md
+++ b/italian/java/com.aspose.diagram/lineadjustfrom/_index.md
@@ -1,0 +1,179 @@
+---
+title: LineAdjustFrom
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica quali connettori dinamici separare se si sovrappongono.
+type: docs
+weight: 222
+url: /it/java/com.aspose.diagram/lineadjustfrom/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LineAdjustFrom
+```
+
+Specifica quali connettori dinamici separare se si sovrappongono.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [LineAdjustFrom(int value)](#LineAdjustFrom-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Specifica quali connettori dinamici separare se si sovrappongono. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | For the description of this property, please see [getValue()](../../com.aspose.diagram/lineadjustfrom\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LineAdjustFrom(int value) {#LineAdjustFrom-int-}
+```
+public LineAdjustFrom(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specifica quali connettori dinamici separare se si sovrappongono.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+For the description of this property, please see [getValue()](../../com.aspose.diagram/lineadjustfrom\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/lineadjustfromvalue/_index.md
+++ b/italian/java/com.aspose.diagram/lineadjustfromvalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: LineAdjustFromValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica quali connettori dinamici separare se si sovrappongono.
+type: docs
+weight: 223
+url: /it/java/com.aspose.diagram/lineadjustfromvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LineAdjustFromValue
+```
+
+Specifica quali connettori dinamici separare se si sovrappongono.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [ALL_LINES](#ALL-LINES) | Tutte le linee. |
+| [NO_LINES](#NO-LINES) | Nessuna linea. |
+| [ROUTING_STYLE_DEFAULT](#ROUTING-STYLE-DEFAULT) | Stile di instradamento predefinito. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+| [UNRELATED_LINES](#UNRELATED-LINES) | Righe non correlate. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALL_LINES {#ALL-LINES}
+```
+public static final int ALL_LINES
+```
+
+
+Tutte le linee.
+
+### NO_LINES {#NO-LINES}
+```
+public static final int NO_LINES
+```
+
+
+Nessuna linea.
+
+### ROUTING_STYLE_DEFAULT {#ROUTING-STYLE-DEFAULT}
+```
+public static final int ROUTING_STYLE_DEFAULT
+```
+
+
+Stile di instradamento predefinito.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### UNRELATED_LINES {#UNRELATED-LINES}
+```
+public static final int UNRELATED_LINES
+```
+
+
+Righe non correlate.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/lineadjustto/_index.md
+++ b/italian/java/com.aspose.diagram/lineadjustto/_index.md
@@ -1,0 +1,179 @@
+---
+title: LineAdjustTo
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica quali connettori dinamici allineare uno sopra l'altro se si sovrappongono.
+type: docs
+weight: 224
+url: /it/java/com.aspose.diagram/lineadjustto/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LineAdjustTo
+```
+
+Specifica quali connettori dinamici allineare uno sopra l'altro se si sovrappongono.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [LineAdjustTo(int value)](#LineAdjustTo-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Specifica quali connettori dinamici allineare uno sopra l'altro se si sovrappongono. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/lineadjustto\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LineAdjustTo(int value) {#LineAdjustTo-int-}
+```
+public LineAdjustTo(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specifica quali connettori dinamici allineare uno sopra l'altro se si sovrappongono.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/lineadjustto\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/lineadjusttovalue/_index.md
+++ b/italian/java/com.aspose.diagram/lineadjusttovalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: LineAdjustToValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica quali connettori dinamici allineare uno sopra l'altro se si sovrappongono.
+type: docs
+weight: 225
+url: /it/java/com.aspose.diagram/lineadjusttovalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LineAdjustToValue
+```
+
+Specifica quali connettori dinamici allineare uno sopra l'altro se si sovrappongono.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [ALL_LINES_CLOSE](#ALL-LINES-CLOSE) | Tutte le linee che sono vicine tra loro. |
+| [NO_LINES](#NO-LINES) | Nessuna linea. |
+| [RELATEDLINES](#RELATEDLINES) | Linee correlate. |
+| [ROUTING_STYLE_DEFAULT](#ROUTING-STYLE-DEFAULT) | Stile di instradamento predefinito. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALL_LINES_CLOSE {#ALL-LINES-CLOSE}
+```
+public static final int ALL_LINES_CLOSE
+```
+
+
+Tutte le linee che sono vicine tra loro.
+
+### NO_LINES {#NO-LINES}
+```
+public static final int NO_LINES
+```
+
+
+Nessuna linea.
+
+### RELATEDLINES {#RELATEDLINES}
+```
+public static final int RELATEDLINES
+```
+
+
+Linee correlate.
+
+### ROUTING_STYLE_DEFAULT {#ROUTING-STYLE-DEFAULT}
+```
+public static final int ROUTING_STYLE_DEFAULT
+```
+
+
+Stile di instradamento predefinito.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/linejumpcode/_index.md
+++ b/italian/java/com.aspose.diagram/linejumpcode/_index.md
@@ -1,0 +1,179 @@
+---
+title: LineJumpCode
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Determina i connettori dinamici a cui si desidera aggiungere salti.
+type: docs
+weight: 226
+url: /it/java/com.aspose.diagram/linejumpcode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LineJumpCode
+```
+
+Determina i connettori dinamici a cui si desidera aggiungere salti.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [LineJumpCode(int value)](#LineJumpCode-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Determina i connettori dinamici a cui si desidera aggiungere salti. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/linejumpcode\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LineJumpCode(int value) {#LineJumpCode-int-}
+```
+public LineJumpCode(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Determina i connettori dinamici a cui si desidera aggiungere salti.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/linejumpcode\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/linejumpcodevalue/_index.md
+++ b/italian/java/com.aspose.diagram/linejumpcodevalue/_index.md
@@ -1,0 +1,192 @@
+---
+title: LineJumpCodeValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Determina i connettori dinamici a cui si desidera aggiungere salti.
+type: docs
+weight: 227
+url: /it/java/com.aspose.diagram/linejumpcodevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LineJumpCodeValue
+```
+
+Determina i connettori dinamici a cui si desidera aggiungere salti.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [FIRST_DISPLAYED_LINE](#FIRST-DISPLAYED-LINE) | Prima linea visualizzata (forma inferiore nell'ordine di visualizzazione). |
+| [HORIZONTAL_LINES](#HORIZONTAL-LINES) | Linee orizzontali. |
+| [LAST_DISPLAYED_LINE](#LAST-DISPLAYED-LINE) | Ultima linea visualizzata (forma superiore nell'ordine di visualizzazione). |
+| [LAST_ROUTED_LINE](#LAST-ROUTED-LINE) | Ultima linea instradata. |
+| [NONE](#NONE) | None. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+| [VERTICAL_LINES](#VERTICAL-LINES) | Linee verticali. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FIRST_DISPLAYED_LINE {#FIRST-DISPLAYED-LINE}
+```
+public static final int FIRST_DISPLAYED_LINE
+```
+
+
+Prima linea visualizzata (forma inferiore nell'ordine di visualizzazione).
+
+### HORIZONTAL_LINES {#HORIZONTAL-LINES}
+```
+public static final int HORIZONTAL_LINES
+```
+
+
+Linee orizzontali.
+
+### LAST_DISPLAYED_LINE {#LAST-DISPLAYED-LINE}
+```
+public static final int LAST_DISPLAYED_LINE
+```
+
+
+Ultima linea visualizzata (forma superiore nell'ordine di visualizzazione).
+
+### LAST_ROUTED_LINE {#LAST-ROUTED-LINE}
+```
+public static final int LAST_ROUTED_LINE
+```
+
+
+Ultima linea instradata.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+None.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### VERTICAL_LINES {#VERTICAL-LINES}
+```
+public static final int VERTICAL_LINES
+```
+
+
+Linee verticali.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/linejumpstyle/_index.md
+++ b/italian/java/com.aspose.diagram/linejumpstyle/_index.md
@@ -1,0 +1,179 @@
+---
+title: LineJumpStyle
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica lo stile di salto di linea per tutti i connettori nella pagina di disegno che non hanno uno stile di salto di linea locale.
+type: docs
+weight: 228
+url: /it/java/com.aspose.diagram/linejumpstyle/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LineJumpStyle
+```
+
+Specifica lo stile di salto di linea per tutti i connettori sulla pagina di disegno che non hanno uno stile di salto di linea locale.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [LineJumpStyle(int value)](#LineJumpStyle-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Specifica lo stile di salto di linea per tutti i connettori sulla pagina di disegno che non hanno uno stile di salto di linea locale. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/linejumpstyle\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LineJumpStyle(int value) {#LineJumpStyle-int-}
+```
+public LineJumpStyle(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specifica lo stile di salto di linea per tutti i connettori sulla pagina di disegno che non hanno uno stile di salto di linea locale.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/linejumpstyle\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/linejumpstylevalue/_index.md
+++ b/italian/java/com.aspose.diagram/linejumpstylevalue/_index.md
@@ -1,0 +1,228 @@
+---
+title: LineJumpStyleValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica lo stile di salto di linea per tutti i connettori nella pagina di disegno che non hanno uno stile di salto di linea locale.
+type: docs
+weight: 229
+url: /it/java/com.aspose.diagram/linejumpstylevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LineJumpStyleValue
+```
+
+Specifica lo stile di salto di linea per tutti i connettori sulla pagina di disegno che non hanno uno stile di salto di linea locale.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [ARC](#ARC) | Arco. |
+| [DEFAULT](#DEFAULT) | Predefinito. |
+| [GAP](#GAP) | Spazio. |
+| [SIDES_2](#SIDES-2) | 2 Lati. |
+| [SIDES_3](#SIDES-3) | 3 Lati. |
+| [SIDES_4](#SIDES-4) | 4 Lati. |
+| [SIDES_5](#SIDES-5) | 5 Lati. |
+| [SIDES_6](#SIDES-6) | 6 Lati. |
+| [SIDES_7](#SIDES-7) | 7 Lati. |
+| [SQUARE](#SQUARE) | Quadrato. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ARC {#ARC}
+```
+public static final int ARC
+```
+
+
+Arco.
+
+### DEFAULT {#DEFAULT}
+```
+public static final int DEFAULT
+```
+
+
+Predefinito.
+
+### GAP {#GAP}
+```
+public static final int GAP
+```
+
+
+Spazio.
+
+### SIDES_2 {#SIDES-2}
+```
+public static final int SIDES_2
+```
+
+
+2 Lati.
+
+### SIDES_3 {#SIDES-3}
+```
+public static final int SIDES_3
+```
+
+
+3 Lati.
+
+### SIDES_4 {#SIDES-4}
+```
+public static final int SIDES_4
+```
+
+
+4 Lati.
+
+### SIDES_5 {#SIDES-5}
+```
+public static final int SIDES_5
+```
+
+
+5 Lati.
+
+### SIDES_6 {#SIDES-6}
+```
+public static final int SIDES_6
+```
+
+
+6 Lati.
+
+### SIDES_7 {#SIDES-7}
+```
+public static final int SIDES_7
+```
+
+
+7 Lati.
+
+### SQUARE {#SQUARE}
+```
+public static final int SQUARE
+```
+
+
+Quadrato.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/linerouteext/_index.md
+++ b/italian/java/com.aspose.diagram/linerouteext/_index.md
@@ -1,0 +1,179 @@
+---
+title: LineRouteExt
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica l'aspetto predefinito per tutti i connettori su una pagina.
+type: docs
+weight: 230
+url: /it/java/com.aspose.diagram/linerouteext/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LineRouteExt
+```
+
+Specifica l'aspetto predefinito per tutti i connettori su una pagina.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [LineRouteExt(int value)](#LineRouteExt-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Specifica l'aspetto predefinito per tutti i connettori su una pagina. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/linerouteext\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LineRouteExt(int value) {#LineRouteExt-int-}
+```
+public LineRouteExt(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specifica l'aspetto predefinito per tutti i connettori su una pagina.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/linerouteext\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/linerouteextvalue/_index.md
+++ b/italian/java/com.aspose.diagram/linerouteextvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: LineRouteExtValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica l'aspetto predefinito per tutti i connettori su una pagina.
+type: docs
+weight: 231
+url: /it/java/com.aspose.diagram/linerouteextvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LineRouteExtValue
+```
+
+Specifica l'aspetto predefinito per tutti i connettori su una pagina.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [CURVED](#CURVED) | Curvo. |
+| [DEFAULT](#DEFAULT) | Predefinito. |
+| [STRAIGHT](#STRAIGHT) | Retto. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CURVED {#CURVED}
+```
+public static final int CURVED
+```
+
+
+Curvo.
+
+### DEFAULT {#DEFAULT}
+```
+public static final int DEFAULT
+```
+
+
+Predefinito.
+
+### STRAIGHT {#STRAIGHT}
+```
+public static final int STRAIGHT
+```
+
+
+Retto.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/lineto/_index.md
+++ b/italian/java/com.aspose.diagram/lineto/_index.md
@@ -1,0 +1,249 @@
+---
+title: LineTo
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene le coordinate x e y del vertice finale di un segmento di linea retta.
+type: docs
+weight: 232
+url: /it/java/com.aspose.diagram/lineto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class LineTo extends Coordinate
+```
+
+Contiene le coordinate x e y del vertice finale di un segmento di linea retta. Queste coordinate sono contenute rispettivamente negli elementi X e Y.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [LineTo()](#LineTo--) | Crea un'istanza della classe [LineTo](../../com.aspose.diagram/lineto). |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getIX()](#getIX--) | L'indice basato su zero dell'elemento all'interno del suo elemento genitore. |
+| [getX()](#getX--) | La coordinata x del vertice finale di un segmento di linea retta. |
+| [getY()](#getY--) | La coordinata y del vertice finale di un segmento di linea retta. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, consulta [getDel()](../../com.aspose.diagram/lineto\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Per la descrizione di questa proprietà, consulta [getIX()](../../com.aspose.diagram/lineto\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, consulta [getX()](../../com.aspose.diagram/lineto\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, consulta [getY()](../../com.aspose.diagram/lineto\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LineTo() {#LineTo--}
+```
+public LineTo()
+```
+
+
+Crea un'istanza della classe [LineTo](../../com.aspose.diagram/lineto).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+L'indice basato su zero dell'elemento all'interno del suo elemento genitore.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+La coordinata x del vertice finale di un segmento di linea retta.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+La coordinata y del vertice finale di un segmento di linea retta.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, consulta [getDel()](../../com.aspose.diagram/lineto\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Per la descrizione di questa proprietà, consulta [getIX()](../../com.aspose.diagram/lineto\#getIX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, consulta [getX()](../../com.aspose.diagram/lineto\#getX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, consulta [getY()](../../com.aspose.diagram/lineto\#getY--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/linetocollection/_index.md
+++ b/italian/java/com.aspose.diagram/linetocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: LineToCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Raccolta LineTo.
+type: docs
+weight: 233
+url: /it/java/com.aspose.diagram/linetocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class LineToCollection extends Collection
+```
+
+Raccolta LineTo.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public LineTo get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[LineTo](../../com.aspose.diagram/lineto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/listboxactivexcontrol/_index.md
+++ b/italian/java/com.aspose.diagram/listboxactivexcontrol/_index.md
@@ -1,0 +1,772 @@
+---
+title: ListBoxActiveXControl
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta un controllo ActiveX ListBox.
+type: docs
+weight: 234
+url: /it/java/com.aspose.diagram/listboxactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class ListBoxActiveXControl extends ActiveXControl
+```
+
+Rappresenta un controllo ActiveX ListBox.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBackOleColor()](#getBackOleColor--) | il colore OLE dello sfondo. |
+| [getBorderOleColor()](#getBorderOleColor--) | il colore OLE dello sfondo. |
+| [getBorderStyle()](#getBorderStyle--) | il tipo di bordo usato dal controllo. |
+| [getBoundColumn()](#getBoundColumn--) | Rappresenta come la proprietà Value viene determinata per una ComboBox o ListBox quando il valore della proprietà MultiSelect (fmMultiSelectSingle). |
+| [getClass()](#getClass--) |  |
+| [getColumnCount()](#getColumnCount--) | Rappresenta il numero di colonne da visualizzare in una ComboBox o ListBox. |
+| [getColumnWidths()](#getColumnWidths--) | la larghezza della colonna. |
+| [getData()](#getData--) | i dati binari del controllo. |
+| [getForeOleColor()](#getForeOleColor--) | il colore OLE del primo piano. |
+| [getHeight()](#getHeight--) | l'altezza del controllo in unità di punti. |
+| [getIMEMode()](#getIMEMode--) | la modalità di esecuzione predefinita dell'Input Method Editor per il controllo quando riceve il fuoco. |
+| [getIntegralHeight()](#getIntegralHeight--) | Indica se il controllo mostrerà solo linee di testo complete senza mostrare linee parziali. |
+| [getListStyle()](#getListStyle--) | l'aspetto visivo. |
+| [getListWidth()](#getListWidth--) | la larghezza in unità di punti. |
+| [getMatchEntry()](#getMatchEntry--) | Indica come un ListBox o ComboBox ricerca la sua lista mentre l'utente digita. |
+| [getMouseIcon()](#getMouseIcon--) | un'icona personalizzata da visualizzare come puntatore del mouse per il controllo. |
+| [getMousePointer()](#getMousePointer--) | il tipo di icona visualizzata come puntatore del mouse per il controllo. |
+| [getScrollBars()](#getScrollBars--) | Indica se il controllo ha barre di scorrimento verticali, barre di scorrimento orizzontali, entrambe o nessuna. |
+| [getShowColumnHeads()](#getShowColumnHeads--) | Indica se le intestazioni di colonna sono visualizzate. |
+| [getSpecialEffect()](#getSpecialEffect--) | l'effetto speciale del controllo. |
+| [getTextColumn()](#getTextColumn--) | Rappresenta la colonna in un ComboBox o ListBox da visualizzare all'utente. |
+| [getType()](#getType--) | Ottiene il tipo del controllo ActiveX. |
+| [getValue()](#getValue--) | il valore del controllo. |
+| [getWidth()](#getWidth--) | la larghezza del controllo in unità di punti. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | Indica se il controllo ridimensionerà automaticamente per visualizzare tutto il contenuto. |
+| [isEnabled()](#isEnabled--) | Indica se il controllo può ricevere il focus e rispondere agli eventi generati dall'utente. |
+| [isLocked()](#isLocked--) | Indica se i dati nel controllo sono bloccati per la modifica. |
+| [isTransparent()](#isTransparent--) | Indica se il controllo è trasparente. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | Per la descrizione di questa proprietà, vedere [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | Per la descrizione di questa proprietà, vedere [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setBorderOleColor(int value)](#setBorderOleColor-int-) | Per la descrizione di questa proprietà, vedere [getBorderOleColor()](../../com.aspose.diagram/listboxactivexcontrol\#getBorderOleColor--) |
+| [setBorderStyle(int value)](#setBorderStyle-int-) | Per la descrizione di questa proprietà, vedere [getBorderStyle()](../../com.aspose.diagram/listboxactivexcontrol\#getBorderStyle--) |
+| [setBoundColumn(int value)](#setBoundColumn-int-) | Per la descrizione di questa proprietà, vedere [getBoundColumn()](../../com.aspose.diagram/listboxactivexcontrol\#getBoundColumn--) |
+| [setColumnCount(int value)](#setColumnCount-int-) | Per la descrizione di questa proprietà, vedere [getColumnCount()](../../com.aspose.diagram/listboxactivexcontrol\#getColumnCount--) |
+| [setColumnWidths(double value)](#setColumnWidths-double-) | Per la descrizione di questa proprietà, vedere [getColumnWidths()](../../com.aspose.diagram/listboxactivexcontrol\#getColumnWidths--) |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | Per la descrizione di questa proprietà, vedere [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | Per la descrizione di questa proprietà, vedere [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setHeight(double value)](#setHeight-double-) | Per la descrizione di questa proprietà, vedere [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setIMEMode(int value)](#setIMEMode-int-) | Per la descrizione di questa proprietà, vedere [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) |
+| [setIntegralHeight(boolean value)](#setIntegralHeight-boolean-) | Per la descrizione di questa proprietà, vedere [getIntegralHeight()](../../com.aspose.diagram/listboxactivexcontrol\#getIntegralHeight--) |
+| [setListStyle(int value)](#setListStyle-int-) | Per la descrizione di questa proprietà, vedere [getListStyle()](../../com.aspose.diagram/listboxactivexcontrol\#getListStyle--) |
+| [setListWidth(double value)](#setListWidth-double-) | Per la descrizione di questa proprietà, vedere [getListWidth()](../../com.aspose.diagram/listboxactivexcontrol\#getListWidth--) |
+| [setLocked(boolean value)](#setLocked-boolean-) | Per la descrizione di questa proprietà, vedere [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) |
+| [setMatchEntry(int value)](#setMatchEntry-int-) | Per la descrizione di questa proprietà, vedere [getMatchEntry()](../../com.aspose.diagram/listboxactivexcontrol\#getMatchEntry--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | Per la descrizione di questa proprietà, vedere [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | Per la descrizione di questa proprietà, vedere [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setScrollBars(int value)](#setScrollBars-int-) | Per la descrizione di questa proprietà, vedere [getScrollBars()](../../com.aspose.diagram/listboxactivexcontrol\#getScrollBars--) |
+| [setShowColumnHeads(boolean value)](#setShowColumnHeads-boolean-) | Per la descrizione di questa proprietà, vedere [getShowColumnHeads()](../../com.aspose.diagram/listboxactivexcontrol\#getShowColumnHeads--) |
+| [setSpecialEffect(int value)](#setSpecialEffect-int-) | Per la descrizione di questa proprietà, vedere [getSpecialEffect()](../../com.aspose.diagram/listboxactivexcontrol\#getSpecialEffect--) |
+| [setTextColumn(int value)](#setTextColumn-int-) | Per la descrizione di questa proprietà, vedere [getTextColumn()](../../com.aspose.diagram/listboxactivexcontrol\#getTextColumn--) |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | Per la descrizione di questa proprietà, vedere [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) |
+| [setValue(String value)](#setValue-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/listboxactivexcontrol\#getValue--) |
+| [setWidth(double value)](#setWidth-double-) | Per la descrizione di questa proprietà, vedere [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+il colore OLE dello sfondo.
+
+**Returns:**
+int
+### getBorderOleColor() {#getBorderOleColor--}
+```
+public int getBorderOleColor()
+```
+
+
+il colore OLE dello sfondo.
+
+**Returns:**
+int
+### getBorderStyle() {#getBorderStyle--}
+```
+public int getBorderStyle()
+```
+
+
+il tipo di bordo usato dal controllo.
+
+**Returns:**
+int
+### getBoundColumn() {#getBoundColumn--}
+```
+public int getBoundColumn()
+```
+
+
+Rappresenta come la proprietà Value viene determinata per una ComboBox o ListBox quando il valore della proprietà MultiSelect (fmMultiSelectSingle).
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColumnCount() {#getColumnCount--}
+```
+public int getColumnCount()
+```
+
+
+Rappresenta il numero di colonne da visualizzare in una ComboBox o ListBox.
+
+**Returns:**
+int
+### getColumnWidths() {#getColumnWidths--}
+```
+public double getColumnWidths()
+```
+
+
+la larghezza della colonna.
+
+**Returns:**
+double
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+i dati binari del controllo.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+Il colore OLE del primo piano. Non si applica al controllo Image.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+l'altezza del controllo in unità di punti.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+la modalità di esecuzione predefinita dell'Input Method Editor per il controllo quando riceve il fuoco.
+
+**Returns:**
+int
+### getIntegralHeight() {#getIntegralHeight--}
+```
+public boolean getIntegralHeight()
+```
+
+
+Indica se il controllo mostrerà solo linee di testo complete senza mostrare linee parziali.
+
+**Returns:**
+boolean
+### getListStyle() {#getListStyle--}
+```
+public int getListStyle()
+```
+
+
+l'aspetto visivo.
+
+**Returns:**
+int
+### getListWidth() {#getListWidth--}
+```
+public double getListWidth()
+```
+
+
+la larghezza in unità di punti.
+
+**Returns:**
+double
+### getMatchEntry() {#getMatchEntry--}
+```
+public int getMatchEntry()
+```
+
+
+Indica come un ListBox o ComboBox ricerca la sua lista mentre l'utente digita.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+un'icona personalizzata da visualizzare come puntatore del mouse per il controllo.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+il tipo di icona visualizzata come puntatore del mouse per il controllo.
+
+**Returns:**
+int
+### getScrollBars() {#getScrollBars--}
+```
+public int getScrollBars()
+```
+
+
+Indica se il controllo ha barre di scorrimento verticali, barre di scorrimento orizzontali, entrambe o nessuna.
+
+**Returns:**
+int
+### getShowColumnHeads() {#getShowColumnHeads--}
+```
+public boolean getShowColumnHeads()
+```
+
+
+Indica se le intestazioni di colonna sono visualizzate.
+
+**Returns:**
+boolean
+### getSpecialEffect() {#getSpecialEffect--}
+```
+public int getSpecialEffect()
+```
+
+
+l'effetto speciale del controllo.
+
+**Returns:**
+int
+### getTextColumn() {#getTextColumn--}
+```
+public int getTextColumn()
+```
+
+
+Rappresenta la colonna in un ComboBox o ListBox da visualizzare all'utente.
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Ottiene il tipo del controllo ActiveX.
+
+**Returns:**
+int
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+il valore del controllo.
+
+**Returns:**
+java.lang.String
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+la larghezza del controllo in unità di punti.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+Indica se il controllo ridimensionerà automaticamente per visualizzare tutto il contenuto.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+Indica se il controllo può ricevere il focus e rispondere agli eventi generati dall'utente.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+Indica se i dati nel controllo sono bloccati per la modifica.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+Indica se il controllo è trasparente.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setBorderOleColor(int value) {#setBorderOleColor-int-}
+```
+public void setBorderOleColor(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getBorderOleColor()](../../com.aspose.diagram/listboxactivexcontrol\#getBorderOleColor--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setBorderStyle(int value) {#setBorderStyle-int-}
+```
+public void setBorderStyle(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getBorderStyle()](../../com.aspose.diagram/listboxactivexcontrol\#getBorderStyle--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setBoundColumn(int value) {#setBoundColumn-int-}
+```
+public void setBoundColumn(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getBoundColumn()](../../com.aspose.diagram/listboxactivexcontrol\#getBoundColumn--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setColumnCount(int value) {#setColumnCount-int-}
+```
+public void setColumnCount(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getColumnCount()](../../com.aspose.diagram/listboxactivexcontrol\#getColumnCount--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setColumnWidths(double value) {#setColumnWidths-double-}
+```
+public void setColumnWidths(double value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getColumnWidths()](../../com.aspose.diagram/listboxactivexcontrol\#getColumnWidths--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setIntegralHeight(boolean value) {#setIntegralHeight-boolean-}
+```
+public void setIntegralHeight(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getIntegralHeight()](../../com.aspose.diagram/listboxactivexcontrol\#getIntegralHeight--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setListStyle(int value) {#setListStyle-int-}
+```
+public void setListStyle(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getListStyle()](../../com.aspose.diagram/listboxactivexcontrol\#getListStyle--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setListWidth(double value) {#setListWidth-double-}
+```
+public void setListWidth(double value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getListWidth()](../../com.aspose.diagram/listboxactivexcontrol\#getListWidth--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setMatchEntry(int value) {#setMatchEntry-int-}
+```
+public void setMatchEntry(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getMatchEntry()](../../com.aspose.diagram/listboxactivexcontrol\#getMatchEntry--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setScrollBars(int value) {#setScrollBars-int-}
+```
+public void setScrollBars(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getScrollBars()](../../com.aspose.diagram/listboxactivexcontrol\#getScrollBars--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setShowColumnHeads(boolean value) {#setShowColumnHeads-boolean-}
+```
+public void setShowColumnHeads(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getShowColumnHeads()](../../com.aspose.diagram/listboxactivexcontrol\#getShowColumnHeads--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setSpecialEffect(int value) {#setSpecialEffect-int-}
+```
+public void setSpecialEffect(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getSpecialEffect()](../../com.aspose.diagram/listboxactivexcontrol\#getSpecialEffect--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setTextColumn(int value) {#setTextColumn-int-}
+```
+public void setTextColumn(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getTextColumn()](../../com.aspose.diagram/listboxactivexcontrol\#getTextColumn--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setValue(String value) {#setValue-java.lang.String-}
+```
+public void setValue(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/listboxactivexcontrol\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/loadfileformat/_index.md
+++ b/italian/java/com.aspose.diagram/loadfileformat/_index.md
@@ -1,0 +1,246 @@
+---
+title: LoadFileFormat
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Enumerazione per la selezione del formato di caricamento del diagramma.
+type: docs
+weight: 235
+url: /it/java/com.aspose.diagram/loadfileformat/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LoadFileFormat
+```
+
+Enumerazione per la selezione del formato di caricamento del diagramma.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [VDW](#VDW) | Formato di disegno web Vdw di MS Visio. |
+| [VDX](#VDX) | Formato XML VDX di MS Visio. |
+| [VSD](#VSD) | Formato binario Vsd di MS Visio. |
+| [VSDM](#VSDM) | Formato file Vsdm di MS Visio che consente macro. |
+| [VSDX](#VSDX) | Formato file Vsdx di MS Visio 2013. |
+| [VSS](#VSS) | Formato stencil binario Vss di MS Visio. |
+| [VSSM](#VSSM) | Formato file Vssm di MS Visio che consente macro. |
+| [VSSX](#VSSX) | Formato file Vssx di MS Visio 2013. |
+| [VST](#VST) | Formato modello binario Vst di MS Visio. |
+| [VSTM](#VSTM) | Formato file Vstm di MS Visio che consente macro. |
+| [VSTX](#VSTX) | Formato file modello Vstx di MS Visio 2013. |
+| [VSX](#VSX) | Formato stencil xml Vsx di MS Visio. |
+| [VTX](#VTX) | Formato modello XML Vtx di MS Visio. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### VDW {#VDW}
+```
+public static final int VDW
+```
+
+
+Formato di disegno web Vdw di MS Visio.
+
+### VDX {#VDX}
+```
+public static final int VDX
+```
+
+
+Formato XML VDX di MS Visio.
+
+### VSD {#VSD}
+```
+public static final int VSD
+```
+
+
+Formato binario Vsd di MS Visio.
+
+### VSDM {#VSDM}
+```
+public static final int VSDM
+```
+
+
+Formato file Vsdm di MS Visio che consente macro.
+
+### VSDX {#VSDX}
+```
+public static final int VSDX
+```
+
+
+Formato file Vsdx di MS Visio 2013.
+
+### VSS {#VSS}
+```
+public static final int VSS
+```
+
+
+Formato stencil binario Vss di MS Visio.
+
+### VSSM {#VSSM}
+```
+public static final int VSSM
+```
+
+
+Formato file Vssm di MS Visio che consente macro.
+
+### VSSX {#VSSX}
+```
+public static final int VSSX
+```
+
+
+Formato file Vssx di MS Visio 2013.
+
+### VST {#VST}
+```
+public static final int VST
+```
+
+
+Formato modello binario Vst di MS Visio.
+
+### VSTM {#VSTM}
+```
+public static final int VSTM
+```
+
+
+Formato file Vstm di MS Visio che consente macro.
+
+### VSTX {#VSTX}
+```
+public static final int VSTX
+```
+
+
+Formato file modello Vstx di MS Visio 2013.
+
+### VSX {#VSX}
+```
+public static final int VSX
+```
+
+
+Formato stencil xml Vsx di MS Visio.
+
+### VTX {#VTX}
+```
+public static final int VTX
+```
+
+
+Formato modello XML Vtx di MS Visio.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/loadoptions/_index.md
+++ b/italian/java/com.aspose.diagram/loadoptions/_index.md
@@ -1,0 +1,252 @@
+---
+title: LoadOptions
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Consente di specificare opzioni aggiuntive durante il caricamento di un diagramma in un oggetto Diagram.
+type: docs
+weight: 236
+url: /it/java/com.aspose.diagram/loadoptions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LoadOptions
+```
+
+Consente di specificare opzioni aggiuntive durante il caricamento di un diagramma in un oggetto Diagram.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [LoadOptions()](#LoadOptions--) | Inizializza una nuova istanza di questa classe con i valori predefiniti. |
+| [LoadOptions(int format)](#LoadOptions-int-) | Inizializza una nuova istanza di questa classe con il formato specificato. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getInterruptMonitor()](#getInterruptMonitor--) | il monitor di interruzione. |
+| [getLoadFormat()](#getLoadFormat--) | Specifica il formato del diagramma da caricare. |
+| [getLocale()](#getLocale--) | Il locale utilizzato per il diagramma al momento del caricamento del file. |
+| [getPages()](#getPages--) | Specifica l'indice delle pagine da caricare. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setInterruptMonitor(AbstractInterruptMonitor value)](#setInterruptMonitor-com.aspose.diagram.AbstractInterruptMonitor-) | Per la descrizione di questa proprietà, vedere [getInterruptMonitor()](../../com.aspose.diagram/loadoptions\#getInterruptMonitor--) |
+| [setLoadFormat(int value)](#setLoadFormat-int-) | Per la descrizione di questa proprietà, vedere [getLoadFormat()](../../com.aspose.diagram/loadoptions\#getLoadFormat--) |
+| [setLocale(Locale value)](#setLocale-java.util.Locale-) | Per la descrizione di questa proprietà, vedere [getLocale()](../../com.aspose.diagram/loadoptions\#getLocale--) |
+| [setPages(ArrayList value)](#setPages-java.util.ArrayList-) | Per la descrizione di questa proprietà, vedere [getPages()](../../com.aspose.diagram/loadoptions\#getPages--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LoadOptions() {#LoadOptions--}
+```
+public LoadOptions()
+```
+
+
+Inizializza una nuova istanza di questa classe con i valori predefiniti. Il formato file predefinito è impostato su Aspose.Diagram.LoadFileFormat.
+
+### LoadOptions(int format) {#LoadOptions-int-}
+```
+public LoadOptions(int format)
+```
+
+
+Inizializza una nuova istanza di questa classe con il formato specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| formato | int | Aspose.Diagram.LoadFileFormat carica il formato file. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getInterruptMonitor() {#getInterruptMonitor--}
+```
+public AbstractInterruptMonitor getInterruptMonitor()
+```
+
+
+il monitor di interruzione.
+
+**Returns:**
+[AbstractInterruptMonitor](../../com.aspose.diagram/abstractinterruptmonitor)
+### getLoadFormat() {#getLoadFormat--}
+```
+public int getLoadFormat()
+```
+
+
+Specifica il formato del diagramma da caricare. Il valore predefinito è Aspose.Diagram.LoadFileFormat. Lettura/scrittura Aspose.Diagram.LoadFileFormat.
+
+**Returns:**
+int
+### getLocale() {#getLocale--}
+```
+public Locale getLocale()
+```
+
+
+Il locale utilizzato per il diagramma al momento del caricamento del file.
+
+**Returns:**
+java.util.Locale
+### getPages() {#getPages--}
+```
+public ArrayList getPages()
+```
+
+
+Specifica l'indice delle pagine da caricare.
+
+**Returns:**
+java.util.ArrayList
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setInterruptMonitor(AbstractInterruptMonitor value) {#setInterruptMonitor-com.aspose.diagram.AbstractInterruptMonitor-}
+```
+public void setInterruptMonitor(AbstractInterruptMonitor value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getInterruptMonitor()](../../com.aspose.diagram/loadoptions\#getInterruptMonitor--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [AbstractInterruptMonitor](../../com.aspose.diagram/abstractinterruptmonitor) |  |
+
+### setLoadFormat(int value) {#setLoadFormat-int-}
+```
+public void setLoadFormat(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getLoadFormat()](../../com.aspose.diagram/loadoptions\#getLoadFormat--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setLocale(Locale value) {#setLocale-java.util.Locale-}
+```
+public void setLocale(Locale value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getLocale()](../../com.aspose.diagram/loadoptions\#getLocale--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.util.Locale |  |
+
+### setPages(ArrayList value) {#setPages-java.util.ArrayList-}
+```
+public void setPages(ArrayList value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getPages()](../../com.aspose.diagram/loadoptions\#getPages--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.util.ArrayList |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/localizefont/_index.md
+++ b/italian/java/com.aspose.diagram/localizefont/_index.md
@@ -1,0 +1,204 @@
+---
+title: LocalizeFont
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica se il testo della forma deve essere localizzato, tradotto in un'altra lingua.
+type: docs
+weight: 237
+url: /it/java/com.aspose.diagram/localizefont/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LocalizeFont
+```
+
+Specifica se il testo della forma deve essere localizzato (tradotto in un'altra lingua).
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [LocalizeFont(int value)](#LocalizeFont-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Specifica se il testo della forma deve essere localizzato (tradotto in un'altra lingua). |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | Per la descrizione di questa proprietà, vedere [getUfe()](../../com.aspose.diagram/localizefont\#getUfe--) |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/localizefont\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LocalizeFont(int value) {#LocalizeFont-int-}
+```
+public LocalizeFont(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specifica se il testo della forma deve essere localizzato (tradotto in un'altra lingua).
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getUfe()](../../com.aspose.diagram/localizefont\#getUfe--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/localizefont\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/localizefontvalue/_index.md
+++ b/italian/java/com.aspose.diagram/localizefontvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: LocalizeFontValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica se il testo della forma deve essere localizzato, tradotto in un'altra lingua.
+type: docs
+weight: 238
+url: /it/java/com.aspose.diagram/localizefontvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LocalizeFontValue
+```
+
+Specifica se il testo della forma deve essere localizzato (tradotto in un'altra lingua).
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [ALWAYS_LOCALIZE_FONT](#ALWAYS-LOCALIZE-FONT) | Localizza sempre il carattere. |
+| [LOCALIZE_FONT_ONLY_ARIAL_SYMBOL](#LOCALIZE-FONT-ONLY-ARIAL-SYMBOL) | Localizza il carattere solo se è Arial o Symbol (impostazione predefinita). |
+| [NEVER_LOCALIZE_FONT](#NEVER-LOCALIZE-FONT) | Non localizzare mai il carattere. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALWAYS_LOCALIZE_FONT {#ALWAYS-LOCALIZE-FONT}
+```
+public static final int ALWAYS_LOCALIZE_FONT
+```
+
+
+Localizza sempre il carattere.
+
+### LOCALIZE_FONT_ONLY_ARIAL_SYMBOL {#LOCALIZE-FONT-ONLY-ARIAL-SYMBOL}
+```
+public static final int LOCALIZE_FONT_ONLY_ARIAL_SYMBOL
+```
+
+
+Localizza il carattere solo se è Arial o Symbol (impostazione predefinita).
+
+### NEVER_LOCALIZE_FONT {#NEVER-LOCALIZE-FONT}
+```
+public static final int NEVER_LOCALIZE_FONT
+```
+
+
+Non localizzare mai il carattere.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/margin/_index.md
+++ b/italian/java/com.aspose.diagram/margin/_index.md
@@ -1,0 +1,194 @@
+---
+title: Margin
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica il margine.
+type: docs
+weight: 239
+url: /it/java/com.aspose.diagram/margin/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Margin
+```
+
+Specifica il margine.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [Margin(double value, int unit)](#Margin-double-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUnit()](#getUnit--) | Rappresenta un'unità di misura. |
+| [getValue()](#getValue--) | Specifica il margine. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUnit(int value)](#setUnit-int-) | Per la descrizione di questa proprietà, vedere [getUnit()](../../com.aspose.diagram/margin\#getUnit--) |
+| [setValue(double value)](#setValue-double-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/margin\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Margin(double value, int unit) {#Margin-double-int-}
+```
+public Margin(double value, int unit)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double |  |
+| unità | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUnit() {#getUnit--}
+```
+public int getUnit()
+```
+
+
+Rappresenta un'unità di misura. Il valore predefinito è DP.
+
+**Returns:**
+int
+### getValue() {#getValue--}
+```
+public double getValue()
+```
+
+
+Specifica il margine.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUnit(int value) {#setUnit-int-}
+```
+public void setUnit(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getUnit()](../../com.aspose.diagram/margin\#getUnit--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setValue(double value) {#setValue-double-}
+```
+public void setValue(double value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/margin\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/master/_index.md
+++ b/italian/java/com.aspose.diagram/master/_index.md
@@ -1,0 +1,516 @@
+---
+title: Master
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene gli elementi che definiscono un master per il documento.
+type: docs
+weight: 240
+url: /it/java/com.aspose.diagram/master/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Master
+```
+
+Contiene elementi che definiscono un master per il documento. Un master è una forma su uno stencil che utilizzi ripetutamente per creare disegni. Quando trascini una forma dallo stencil sulla pagina del disegno, la forma diventa un'istanza di quel master e una copia locale del master è inclusa nel documento.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [Master()](#Master--) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [dispose()](#dispose--) | Esegue operazioni definite dall'applicazione associate al rilascio, alla liberazione o al reset delle risorse non gestite. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAlignName()](#getAlignName--) | Specifica se il testo del master nella finestra stencil è allineato a sinistra, a destra o al centro. |
+| [getBaseID()](#getBaseID--) | Un GUID (identificatore unico globale) che identifica il master tra i documenti. |
+| [getClass()](#getClass--) |  |
+| [getConnects()](#getConnects--) | Contiene un elemento Connect per ogni connessione tra due forme in un disegno. |
+| [getHidden()](#getHidden--) | Specifica se il master è nascosto nell'interfaccia utente. |
+| [getID()](#getID--) | L'ID univoco dell'elemento all'interno del suo elemento genitore. |
+| [getIcon()](#getIcon--) | Specifica un'icona binaria codificata MIME (Multipurpose Internet Mail Extensions) (in formato .ico) per un elemento Master o MasterShortcut in un documento. |
+| [getIconSize()](#getIconSize--) | La dimensione dell'icona dell'elemento. |
+| [getIconUpdate()](#getIconUpdate--) | Specifica se l'icona è generata automaticamente dal master stesso. |
+| [getMatchByName()](#getMatchByName--) | L'attributo MatchByName determina come Microsoft Visio decide se un master del documento è già presente quando un'istanza di un master viene rilasciata sulla pagina del disegno. |
+| [getName()](#getName--) | Il nome dell'elemento. |
+| [getNameU()](#getNameU--) | Il nome universale dell'elemento. |
+| [getPageSheet()](#getPageSheet--) | Contiene elementi che definiscono il foglio di pagina per un elemento Pagina o Master. |
+| [getPatternFlags()](#getPatternFlags--) | L'attributo PatternFlags determina se un master si comporta come un modello personalizzato. |
+| [getPrompt()](#getPrompt--) | La barra di stato e il suggerimento del tooltip per l'elemento. |
+| [getShapes()](#getShapes--) | Raccolta di oggetti Shape. |
+| [getUniqueID()](#getUniqueID--) | Un GUID che identifica il master all'interno del documento. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAlignName(int value)](#setAlignName-int-) | Per la descrizione di questa proprietà, vedere [getAlignName()](../../com.aspose.diagram/master\#getAlignName--) |
+| [setBaseID(UUID value)](#setBaseID-java.util.UUID-) | Per la descrizione di questa proprietà, vedere [getBaseID()](../../com.aspose.diagram/master\#getBaseID--) |
+| [setHidden(int value)](#setHidden-int-) | Per la descrizione di questa proprietà, vedere [getHidden()](../../com.aspose.diagram/master\#getHidden--) |
+| [setID(int value)](#setID-int-) | Per la descrizione di questa proprietà, vedere [getID()](../../com.aspose.diagram/master\#getID--) |
+| [setIcon(byte[] value)](#setIcon-byte---) | Per la descrizione di questa proprietà, vedere [getIcon()](../../com.aspose.diagram/master\#getIcon--) |
+| [setIconSize(int value)](#setIconSize-int-) | Per la descrizione di questa proprietà, vedere [getIconSize()](../../com.aspose.diagram/master\#getIconSize--) |
+| [setIconUpdate(int value)](#setIconUpdate-int-) | Per la descrizione di questa proprietà, vedere [getIconUpdate()](../../com.aspose.diagram/master\#getIconUpdate--) |
+| [setMatchByName(int value)](#setMatchByName-int-) | Per la descrizione di questa proprietà, vedere [getMatchByName()](../../com.aspose.diagram/master\#getMatchByName--) |
+| [setName(String value)](#setName-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getName()](../../com.aspose.diagram/master\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getNameU()](../../com.aspose.diagram/master\#getNameU--) |
+| [setPatternFlags(int value)](#setPatternFlags-int-) | Per la descrizione di questa proprietà, vedere [getPatternFlags()](../../com.aspose.diagram/master\#getPatternFlags--) |
+| [setPrompt(String value)](#setPrompt-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getPrompt()](../../com.aspose.diagram/master\#getPrompt--) |
+| [setUniqueID(UUID value)](#setUniqueID-java.util.UUID-) | Per la descrizione di questa proprietà, vedere [getUniqueID()](../../com.aspose.diagram/master\#getUniqueID--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Master() {#Master--}
+```
+public Master()
+```
+
+
+Costruttore.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### dispose() {#dispose--}
+```
+public void dispose()
+```
+
+
+Esegue operazioni definite dall'applicazione associate al rilascio, alla liberazione o al reset delle risorse non gestite.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAlignName() {#getAlignName--}
+```
+public int getAlignName()
+```
+
+
+Specifica se il testo del master nella finestra stencil è allineato a sinistra, a destra o al centro.
+
+**Returns:**
+int
+### getBaseID() {#getBaseID--}
+```
+public UUID getBaseID()
+```
+
+
+Un GUID (identificatore unico globale) che identifica il master tra i documenti.
+
+**Returns:**
+java.util.UUID
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConnects() {#getConnects--}
+```
+public ConnectCollection getConnects()
+```
+
+
+Contiene un elemento Connect per ogni connessione tra due forme in un disegno.
+
+**Returns:**
+[ConnectCollection](../../com.aspose.diagram/connectcollection)
+### getHidden() {#getHidden--}
+```
+public int getHidden()
+```
+
+
+Specifica se il master è nascosto nell'interfaccia utente.
+
+**Returns:**
+int
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+L'ID univoco dell'elemento all'interno del suo elemento genitore.
+
+**Returns:**
+int
+### getIcon() {#getIcon--}
+```
+public byte[] getIcon()
+```
+
+
+Specifica un'icona binaria codificata MIME (Multipurpose Internet Mail Extensions) (in formato .ico) per un elemento Master o MasterShortcut in un documento.
+
+**Returns:**
+byte[]
+### getIconSize() {#getIconSize--}
+```
+public int getIconSize()
+```
+
+
+La dimensione dell'icona dell'elemento.
+
+**Returns:**
+int
+### getIconUpdate() {#getIconUpdate--}
+```
+public int getIconUpdate()
+```
+
+
+Specifica se l'icona è generata automaticamente dal master stesso.
+
+**Returns:**
+int
+### getMatchByName() {#getMatchByName--}
+```
+public int getMatchByName()
+```
+
+
+L'attributo MatchByName determina come Microsoft Visio decide se un master di documento è già presente quando un'istanza di un master viene rilasciata sulla pagina di disegno. Consente alle modifiche apportate a un master di documento di essere applicate alle nuove istanze del master, anche se le istanze vengono trascinate da un file stencil autonomo.
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Il nome dell'elemento.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+Il nome universale dell'elemento.
+
+**Returns:**
+java.lang.String
+### getPageSheet() {#getPageSheet--}
+```
+public PageSheet getPageSheet()
+```
+
+
+Contiene elementi che definiscono il foglio di pagina per un elemento Pagina o Master.
+
+**Returns:**
+[PageSheet](../../com.aspose.diagram/pagesheet)
+### getPatternFlags() {#getPatternFlags--}
+```
+public int getPatternFlags()
+```
+
+
+L'attributo PatternFlags determina se un master si comporta come un modello personalizzato.
+
+**Returns:**
+int
+### getPrompt() {#getPrompt--}
+```
+public String getPrompt()
+```
+
+
+La barra di stato e il suggerimento del tooltip per l'elemento.
+
+**Returns:**
+java.lang.String
+### getShapes() {#getShapes--}
+```
+public ShapeCollection getShapes()
+```
+
+
+Raccolta di oggetti Shape.
+
+**Returns:**
+[ShapeCollection](../../com.aspose.diagram/shapecollection)
+### getUniqueID() {#getUniqueID--}
+```
+public UUID getUniqueID()
+```
+
+
+Un GUID che identifica il master all'interno del documento.
+
+**Returns:**
+java.util.UUID
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAlignName(int value) {#setAlignName-int-}
+```
+public void setAlignName(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getAlignName()](../../com.aspose.diagram/master\#getAlignName--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setBaseID(UUID value) {#setBaseID-java.util.UUID-}
+```
+public void setBaseID(UUID value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getBaseID()](../../com.aspose.diagram/master\#getBaseID--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.util.UUID |  |
+
+### setHidden(int value) {#setHidden-int-}
+```
+public void setHidden(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getHidden()](../../com.aspose.diagram/master\#getHidden--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getID()](../../com.aspose.diagram/master\#getID--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setIcon(byte[] value) {#setIcon-byte---}
+```
+public void setIcon(byte[] value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getIcon()](../../com.aspose.diagram/master\#getIcon--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | byte[] |  |
+
+### setIconSize(int value) {#setIconSize-int-}
+```
+public void setIconSize(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getIconSize()](../../com.aspose.diagram/master\#getIconSize--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setIconUpdate(int value) {#setIconUpdate-int-}
+```
+public void setIconUpdate(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getIconUpdate()](../../com.aspose.diagram/master\#getIconUpdate--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setMatchByName(int value) {#setMatchByName-int-}
+```
+public void setMatchByName(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getMatchByName()](../../com.aspose.diagram/master\#getMatchByName--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getName()](../../com.aspose.diagram/master\#getName--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getNameU()](../../com.aspose.diagram/master\#getNameU--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setPatternFlags(int value) {#setPatternFlags-int-}
+```
+public void setPatternFlags(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getPatternFlags()](../../com.aspose.diagram/master\#getPatternFlags--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setPrompt(String value) {#setPrompt-java.lang.String-}
+```
+public void setPrompt(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getPrompt()](../../com.aspose.diagram/master\#getPrompt--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setUniqueID(UUID value) {#setUniqueID-java.util.UUID-}
+```
+public void setUniqueID(UUID value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getUniqueID()](../../com.aspose.diagram/master\#getUniqueID--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.util.UUID |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/mastercollection/_index.md
+++ b/italian/java/com.aspose.diagram/mastercollection/_index.md
@@ -1,0 +1,304 @@
+---
+title: MasterCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Raccolta Master.
+type: docs
+weight: 241
+url: /it/java/com.aspose.diagram/mastercollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class MasterCollection extends Collection
+```
+
+Raccolta Master.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [add(Master master)](#add-com.aspose.diagram.Master-) | Aggiungi l'oggetto Master nella collezione. |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [getMaster(int ID)](#getMaster-int-) | Restituisce l'elemento con l'ID specificato. |
+| [getMasterByName(String name)](#getMasterByName-java.lang.String-) | Ottieni il master per nome. |
+| [getMasterShortcuts()](#getMasterShortcuts--) | Raccolta MasterShortcut. |
+| [getMaxRelID()](#getMaxRelID--) | ottieni l'ID rel massimo nella collezione. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [isExist(String name)](#isExist-java.lang.String-) | Esiste un master nella collezione. |
+| [isExistRelId(String relID)](#isExistRelId-java.lang.String-) | Esiste un ID rel del master nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Master master)](#remove-com.aspose.diagram.Master-) | Rimuovi l'oggetto Master dalla collezione. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Master master) {#add-com.aspose.diagram.Master-}
+```
+public int add(Master master)
+```
+
+
+Aggiungi l'oggetto Master nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| master | [Master](../../com.aspose.diagram/master) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Master get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[Master](../../com.aspose.diagram/master) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### getMaster(int ID) {#getMaster-int-}
+```
+public Master getMaster(int ID)
+```
+
+
+Restituisce l'elemento con l'ID specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| ID | int |  |
+
+**Returns:**
+[Master](../../com.aspose.diagram/master) - 
+### getMasterByName(String name) {#getMasterByName-java.lang.String-}
+```
+public Master getMasterByName(String name)
+```
+
+
+Ottieni il master per nome.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| nome | java.lang.String |  |
+
+**Returns:**
+[Master](../../com.aspose.diagram/master) - 
+### getMasterShortcuts() {#getMasterShortcuts--}
+```
+public MasterShortcutCollection getMasterShortcuts()
+```
+
+
+Raccolta MasterShortcut.
+
+**Returns:**
+[MasterShortcutCollection](../../com.aspose.diagram/mastershortcutcollection)
+### getMaxRelID() {#getMaxRelID--}
+```
+public int getMaxRelID()
+```
+
+
+ottieni l'ID rel massimo nella collezione.
+
+**Returns:**
+int -
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### isExist(String name) {#isExist-java.lang.String-}
+```
+public boolean isExist(String name)
+```
+
+
+Esiste un master nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| nome | java.lang.String |  |
+
+**Returns:**
+boolean -
+### isExistRelId(String relID) {#isExistRelId-java.lang.String-}
+```
+public boolean isExistRelId(String relID)
+```
+
+
+Esiste un ID rel del master nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| relID | java.lang.String |  |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Master master) {#remove-com.aspose.diagram.Master-}
+```
+public void remove(Master master)
+```
+
+
+Rimuovi l'oggetto Master dalla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| master | [Master](../../com.aspose.diagram/master) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/mastershortcut/_index.md
+++ b/italian/java/com.aspose.diagram/mastershortcut/_index.md
@@ -1,0 +1,388 @@
+---
+title: MasterShortcut
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica una scorciatoia master definita nel documento.
+type: docs
+weight: 242
+url: /it/java/com.aspose.diagram/mastershortcut/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class MasterShortcut
+```
+
+Specifica una scorciatoia master definita nel documento.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [MasterShortcut()](#MasterShortcut--) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAlignName()](#getAlignName--) | Specifica se il testo dell'elemento nella finestra stencil è allineato a sinistra, a destra o al centro. |
+| [getClass()](#getClass--) |  |
+| [getID()](#getID--) | L'ID univoco dell'elemento all'interno del suo elemento genitore. |
+| [getIcon()](#getIcon--) | Specifica un'icona binaria codificata MIME (Multipurpose Internet Mail Extensions) (in formato .ico) per un elemento Master o MasterShortcut in un documento. |
+| [getIconSize()](#getIconSize--) | La dimensione dell'icona dell'elemento. |
+| [getName()](#getName--) | Il nome dell'elemento. |
+| [getNameU()](#getNameU--) | Il nome universale dell'elemento. |
+| [getPatternFlags()](#getPatternFlags--) | Determina se un master si comporta come un modello personalizzato. |
+| [getPrompt()](#getPrompt--) | La barra di stato e il suggerimento del tooltip per l'elemento. |
+| [getShortcutHelp()](#getShortcutHelp--) | Una stringa di aiuto per l'elemento. |
+| [getShortcutURL()](#getShortcutURL--) | Un URL a un elemento MasterShortcut. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAlignName(int value)](#setAlignName-int-) | Per la descrizione di questa proprietà, vedere [getAlignName()](../../com.aspose.diagram/mastershortcut\#getAlignName--) |
+| [setID(int value)](#setID-int-) | Per la descrizione di questa proprietà, vedere [getID()](../../com.aspose.diagram/mastershortcut\#getID--) |
+| [setIcon(byte[] value)](#setIcon-byte---) | Per la descrizione di questa proprietà, vedere [getIcon()](../../com.aspose.diagram/mastershortcut\#getIcon--) |
+| [setIconSize(int value)](#setIconSize-int-) | Per la descrizione di questa proprietà, vedere [getIconSize()](../../com.aspose.diagram/mastershortcut\#getIconSize--) |
+| [setName(String value)](#setName-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getName()](../../com.aspose.diagram/mastershortcut\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getNameU()](../../com.aspose.diagram/mastershortcut\#getNameU--) |
+| [setPatternFlags(int value)](#setPatternFlags-int-) | Per la descrizione di questa proprietà, vedere [getPatternFlags()](../../com.aspose.diagram/mastershortcut\#getPatternFlags--) |
+| [setPrompt(String value)](#setPrompt-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getPrompt()](../../com.aspose.diagram/mastershortcut\#getPrompt--) |
+| [setShortcutHelp(String value)](#setShortcutHelp-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getShortcutHelp()](../../com.aspose.diagram/mastershortcut\#getShortcutHelp--) |
+| [setShortcutURL(String value)](#setShortcutURL-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getShortcutURL()](../../com.aspose.diagram/mastershortcut\#getShortcutURL--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### MasterShortcut() {#MasterShortcut--}
+```
+public MasterShortcut()
+```
+
+
+Costruttore.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAlignName() {#getAlignName--}
+```
+public int getAlignName()
+```
+
+
+Specifica se il testo dell'elemento nella finestra stencil è allineato a sinistra, a destra o al centro.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+L'ID univoco dell'elemento all'interno del suo elemento genitore.
+
+**Returns:**
+int
+### getIcon() {#getIcon--}
+```
+public byte[] getIcon()
+```
+
+
+Specifica un'icona binaria codificata MIME (Multipurpose Internet Mail Extensions) (in formato .ico) per un elemento Master o MasterShortcut in un documento.
+
+**Returns:**
+byte[]
+### getIconSize() {#getIconSize--}
+```
+public int getIconSize()
+```
+
+
+La dimensione dell'icona dell'elemento.
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Il nome dell'elemento.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+Il nome universale dell'elemento.
+
+**Returns:**
+java.lang.String
+### getPatternFlags() {#getPatternFlags--}
+```
+public int getPatternFlags()
+```
+
+
+Determina se un master si comporta come un modello personalizzato.
+
+**Returns:**
+int
+### getPrompt() {#getPrompt--}
+```
+public String getPrompt()
+```
+
+
+La barra di stato e il suggerimento del tooltip per l'elemento.
+
+**Returns:**
+java.lang.String
+### getShortcutHelp() {#getShortcutHelp--}
+```
+public String getShortcutHelp()
+```
+
+
+Una stringa di aiuto per l'elemento.
+
+**Returns:**
+java.lang.String
+### getShortcutURL() {#getShortcutURL--}
+```
+public String getShortcutURL()
+```
+
+
+Un URL a un elemento MasterShortcut. Se questo attributo è presente, questo elemento MasterShortcut è una scorciatoia.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAlignName(int value) {#setAlignName-int-}
+```
+public void setAlignName(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getAlignName()](../../com.aspose.diagram/mastershortcut\#getAlignName--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getID()](../../com.aspose.diagram/mastershortcut\#getID--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setIcon(byte[] value) {#setIcon-byte---}
+```
+public void setIcon(byte[] value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getIcon()](../../com.aspose.diagram/mastershortcut\#getIcon--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | byte[] |  |
+
+### setIconSize(int value) {#setIconSize-int-}
+```
+public void setIconSize(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getIconSize()](../../com.aspose.diagram/mastershortcut\#getIconSize--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getName()](../../com.aspose.diagram/mastershortcut\#getName--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getNameU()](../../com.aspose.diagram/mastershortcut\#getNameU--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setPatternFlags(int value) {#setPatternFlags-int-}
+```
+public void setPatternFlags(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getPatternFlags()](../../com.aspose.diagram/mastershortcut\#getPatternFlags--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setPrompt(String value) {#setPrompt-java.lang.String-}
+```
+public void setPrompt(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getPrompt()](../../com.aspose.diagram/mastershortcut\#getPrompt--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setShortcutHelp(String value) {#setShortcutHelp-java.lang.String-}
+```
+public void setShortcutHelp(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getShortcutHelp()](../../com.aspose.diagram/mastershortcut\#getShortcutHelp--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setShortcutURL(String value) {#setShortcutURL-java.lang.String-}
+```
+public void setShortcutURL(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getShortcutURL()](../../com.aspose.diagram/mastershortcut\#getShortcutURL--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/mastershortcutcollection/_index.md
+++ b/italian/java/com.aspose.diagram/mastershortcutcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: MasterShortcutCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Raccolta MasterShortcut.
+type: docs
+weight: 243
+url: /it/java/com.aspose.diagram/mastershortcutcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class MasterShortcutCollection extends Collection
+```
+
+Raccolta MasterShortcut.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [add(MasterShortcut masterShortcut)](#add-com.aspose.diagram.MasterShortcut-) | Aggiungi l'oggetto Master nella collezione. |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(MasterShortcut masterShortcut)](#remove-com.aspose.diagram.MasterShortcut-) | Rimuove l'oggetto MasterShortcut dalla collezione. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(MasterShortcut masterShortcut) {#add-com.aspose.diagram.MasterShortcut-}
+```
+public int add(MasterShortcut masterShortcut)
+```
+
+
+Aggiungi l'oggetto Master nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| masterShortcut | [MasterShortcut](../../com.aspose.diagram/mastershortcut) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public MasterShortcut get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[MasterShortcut](../../com.aspose.diagram/mastershortcut) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(MasterShortcut masterShortcut) {#remove-com.aspose.diagram.MasterShortcut-}
+```
+public void remove(MasterShortcut masterShortcut)
+```
+
+
+Rimuove l'oggetto MasterShortcut dalla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| masterShortcut | [MasterShortcut](../../com.aspose.diagram/mastershortcut) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/measureconst/_index.md
+++ b/italian/java/com.aspose.diagram/measureconst/_index.md
@@ -1,0 +1,561 @@
+---
+title: MeasureConst
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Unità di misura.
+type: docs
+weight: 244
+url: /it/java/com.aspose.diagram/measureconst/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class MeasureConst
+```
+
+Unità di\\ misura.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [AC](#AC) | Acre. |
+| [AD](#AD) | Gradi. |
+| [AM](#AM) | Minuti. |
+| [AS](#AS) | Secondi. |
+| [BOOL](#BOOL) | Booleano. |
+| [C](#C) | Ciceri. |
+| [CM](#CM) | Centimetri. |
+| [COLOR](#COLOR) | Un valore di colore. |
+| [CY](#CY) | Valuta. |
+| [C_D](#C-D) | Ciceri/diditi. |
+| [D](#D) | Didoti. |
+| [DA](#DA) | Unità di angolo predefinite. |
+| [DATE](#DATE) | Data e ora. |
+| [DE](#DE) | Unità di durata predefinite. |
+| [DEG](#DEG) | Grado frazionario. |
+| [DL](#DL) | Unità di lunghezza predefinite. |
+| [DP](#DP) | Unità di pagina predefinite. |
+| [DT](#DT) | Unità di tipo predefinite. |
+| [ED](#ED) | Giorni trascorsi. |
+| [EH](#EH) | Ore trascorse. |
+| [EM](#EM) | Minuti trascorsi. |
+| [ES](#ES) | Secondi trascorsi. |
+| [EW](#EW) | Settimane trascorse. |
+| [FT](#FT) | Piedi. |
+| [F_I](#F-I) | Piedi/pollice. |
+| [GUID](#GUID) | Un identificatore unico globale. |
+| [HA](#HA) | Ettaro. |
+| [IN](#IN) | Pollici. |
+| [IN_F](#IN-F) | Pollici frazionari. |
+| [KM](#KM) | Chilometri. |
+| [M](#M) | Metri. |
+| [MI](#MI) | Miglia. |
+| [MI_F](#MI-F) | Milest frazionario. |
+| [MM](#MM) | Millimetri. |
+| [MULTIDIM](#MULTIDIM) | Valore multidimensionale. |
+| [NM](#NM) | Miglia nautiche. |
+| [NUM](#NUM) | Number. |
+| [NURBS](#NURBS) | Dati della curva NURBS. |
+| [P](#P) | Piche. |
+| [PER](#PER) | Percentuale. |
+| [PNT](#PNT) | Coordinate 2-D. |
+| [POLYLINE](#POLYLINE) | Dati dei punti della polilinea. |
+| [PT](#PT) | Punti. |
+| [P_PT](#P-PT) | Piche/punti. |
+| [RAD](#RAD) | Radianti. |
+| [STR](#STR) | Stringa. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+| [YD](#YD) | Iarde. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AC {#AC}
+```
+public static final int AC
+```
+
+
+Acre.
+
+### AD {#AD}
+```
+public static final int AD
+```
+
+
+Gradi.
+
+### AM {#AM}
+```
+public static final int AM
+```
+
+
+Minuti.
+
+### AS {#AS}
+```
+public static final int AS
+```
+
+
+Secondi.
+
+### BOOL {#BOOL}
+```
+public static final int BOOL
+```
+
+
+Booleano.
+
+### C {#C}
+```
+public static final int C
+```
+
+
+Ciceri.
+
+### CM {#CM}
+```
+public static final int CM
+```
+
+
+Centimetri.
+
+### COLOR {#COLOR}
+```
+public static final int COLOR
+```
+
+
+Un valore di colore.
+
+### CY {#CY}
+```
+public static final int CY
+```
+
+
+Valuta.
+
+### C_D {#C-D}
+```
+public static final int C_D
+```
+
+
+Ciceri/diditi.
+
+### D {#D}
+```
+public static final int D
+```
+
+
+Didoti.
+
+### DA {#DA}
+```
+public static final int DA
+```
+
+
+Unità di angolo predefinite.
+
+### DATE {#DATE}
+```
+public static final int DATE
+```
+
+
+Data e ora.
+
+### DE {#DE}
+```
+public static final int DE
+```
+
+
+Unità di durata predefinite.
+
+### DEG {#DEG}
+```
+public static final int DEG
+```
+
+
+Grado frazionario.
+
+### DL {#DL}
+```
+public static final int DL
+```
+
+
+Unità di lunghezza predefinite.
+
+### DP {#DP}
+```
+public static final int DP
+```
+
+
+Unità di pagina predefinite.
+
+### DT {#DT}
+```
+public static final int DT
+```
+
+
+Unità di tipo predefinite.
+
+### ED {#ED}
+```
+public static final int ED
+```
+
+
+Giorni trascorsi.
+
+### EH {#EH}
+```
+public static final int EH
+```
+
+
+Ore trascorse.
+
+### EM {#EM}
+```
+public static final int EM
+```
+
+
+Minuti trascorsi.
+
+### ES {#ES}
+```
+public static final int ES
+```
+
+
+Secondi trascorsi.
+
+### EW {#EW}
+```
+public static final int EW
+```
+
+
+Settimane trascorse.
+
+### FT {#FT}
+```
+public static final int FT
+```
+
+
+Piedi.
+
+### F_I {#F-I}
+```
+public static final int F_I
+```
+
+
+Piedi/pollice.
+
+### GUID {#GUID}
+```
+public static final int GUID
+```
+
+
+Un identificatore unico globale.
+
+### HA {#HA}
+```
+public static final int HA
+```
+
+
+Ettaro.
+
+### IN {#IN}
+```
+public static final int IN
+```
+
+
+Pollici.
+
+### IN_F {#IN-F}
+```
+public static final int IN_F
+```
+
+
+Pollici frazionari.
+
+### KM {#KM}
+```
+public static final int KM
+```
+
+
+Chilometri.
+
+### M {#M}
+```
+public static final int M
+```
+
+
+Metri.
+
+### MI {#MI}
+```
+public static final int MI
+```
+
+
+Miglia.
+
+### MI_F {#MI-F}
+```
+public static final int MI_F
+```
+
+
+Milest frazionario.
+
+### MM {#MM}
+```
+public static final int MM
+```
+
+
+Millimetri.
+
+### MULTIDIM {#MULTIDIM}
+```
+public static final int MULTIDIM
+```
+
+
+Valore multidimensionale.
+
+### NM {#NM}
+```
+public static final int NM
+```
+
+
+Miglia nautiche.
+
+### NUM {#NUM}
+```
+public static final int NUM
+```
+
+
+Number.
+
+### NURBS {#NURBS}
+```
+public static final int NURBS
+```
+
+
+Dati della curva NURBS.
+
+### P {#P}
+```
+public static final int P
+```
+
+
+Piche.
+
+### PER {#PER}
+```
+public static final int PER
+```
+
+
+Percentuale.
+
+### PNT {#PNT}
+```
+public static final int PNT
+```
+
+
+Coordinate 2-D.
+
+### POLYLINE {#POLYLINE}
+```
+public static final int POLYLINE
+```
+
+
+Dati dei punti della polilinea.
+
+### PT {#PT}
+```
+public static final int PT
+```
+
+
+Punti.
+
+### P_PT {#P-PT}
+```
+public static final int P_PT
+```
+
+
+Piche/punti.
+
+### RAD {#RAD}
+```
+public static final int RAD
+```
+
+
+Radianti.
+
+### STR {#STR}
+```
+public static final int STR
+```
+
+
+Stringa.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### YD {#YD}
+```
+public static final int YD
+```
+
+
+Iarde.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/memoryfontsource/_index.md
+++ b/italian/java/com.aspose.diagram/memoryfontsource/_index.md
@@ -1,0 +1,165 @@
+---
+title: MemoryFontSource
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta il singolo file di font TrueType memorizzato in memoria.
+type: docs
+weight: 245
+url: /it/java/com.aspose.diagram/memoryfontsource/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.FontSourceBase](../../com.aspose.diagram/fontsourcebase)
+```
+public class MemoryFontSource extends FontSourceBase
+```
+
+Rappresenta il singolo file di font TrueType memorizzato in memoria.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [MemoryFontSource(byte[] fontData)](#MemoryFontSource-byte---) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFontData()](#getFontData--) | Dati del font binari. |
+| [getType()](#getType--) | Restituisce il tipo della fonte dei font. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### MemoryFontSource(byte[] fontData) {#MemoryFontSource-byte---}
+```
+public MemoryFontSource(byte[] fontData)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontData | byte[] | Dati del font binari. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFontData() {#getFontData--}
+```
+public byte[] getFontData()
+```
+
+
+Dati del font binari.
+
+**Returns:**
+byte[]
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Restituisce il tipo della fonte dei font.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/milestonehelper/_index.md
+++ b/italian/java/com.aspose.diagram/milestonehelper/_index.md
@@ -1,0 +1,278 @@
+---
+title: MilestoneHelper
+second_title: Riferimento API di Aspose.Diagram per Java
+description: MilestoneHelper per impostare la proprietà della forma milestone.
+type: docs
+weight: 246
+url: /it/java/com.aspose.diagram/milestonehelper/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class MilestoneHelper
+```
+
+MilestoneHelper per impostare la proprietà della forma milestone.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [MilestoneHelper(Shape shape)](#MilestoneHelper-com.aspose.diagram.Shape-) |  |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMilestoneDate()](#getMilestoneDate--) | Data della pietra miliare |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [refreshMilestone(Shape timeline)](#refreshMilestone-com.aspose.diagram.Shape-) | Aggiorna pietra miliare |
+| [setAutoUpdate(boolean value)](#setAutoUpdate-boolean-) | se aggiornare i dati per i marcatori (milestones, intervals) mentre vengono spostati sulla timeline |
+|  | [setDateFormat(int value)](#setDateFormat-int-) | DateFormat della forma /// |
+
+| ----------------------- | ------------------------------- |
+| **Value**\u9286\u20ac | **Format String**\u9286\u20ac |
+| 0                       | dddd, yyyy-M-d                  |
+| 1                       | yyyy-MM-dd                      |
+| 2                       | yy-MMM-d                        |
+| 3                       | yyyy/M/d                        |
+| 4                       | yy-MMM.                         | |
+| [setDateFormatString(String value)](#setDateFormatString-java.lang.String-) | Stringa DateFormat della forma |
+| [setMilestoneDate(DateTime value)](#setMilestoneDate-com.aspose.diagram.DateTime-) |  |
+| [setType(int value)](#setType-int-) | Tipo di forma |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### MilestoneHelper(Shape shape) {#MilestoneHelper-com.aspose.diagram.Shape-}
+```
+public MilestoneHelper(Shape shape)
+```
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| shape | [Shape](../../com.aspose.diagram/shape) |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMilestoneDate() {#getMilestoneDate--}
+```
+public DateTime getMilestoneDate()
+```
+
+
+Data della pietra miliare
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### refreshMilestone(Shape timeline) {#refreshMilestone-com.aspose.diagram.Shape-}
+```
+public void refreshMilestone(Shape timeline)
+```
+
+
+Aggiorna pietra miliare
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| timeline | [Shape](../../com.aspose.diagram/shape) |  |
+
+### setAutoUpdate(boolean value) {#setAutoUpdate-boolean-}
+```
+public void setAutoUpdate(boolean value)
+```
+
+
+se aggiornare i dati per i marcatori (milestones, intervals) mentre vengono spostati sulla timeline
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setDateFormat(int value) {#setDateFormat-int-}
+```
+public void setDateFormat(int value)
+```
+
+
+DateFormat della forma ///
+
+| ----------------------- | ------------------------------- |
+| **Value**\u9286\u20ac | **Format String**\u9286\u20ac |
+| 0                       | dddd, yyyy-M-d                  |
+| 1                       | yyyy-MM-dd                      |
+| 2                       | yy-MMM-d                        |
+| 3                       | yyyy/M/d                        |
+| 4                       | yy-MMM.-d                       |
+| 5                       | d MMMM yyyy                     |
+| 6                       | yy-M                            |
+| 7                       | MMM-yy                          |
+| 8                       | MMMM d, yyyy                    |
+| 9                       | MMM d, yyyy                     |
+| 10                      | M-d-yy                          |
+| 11                      | M-d                             |
+| 12                      | d MMMM, yyyy                    |
+| 13                      | d MMM, yyyy                     |
+| 14                      | d-M-yy                          |
+| 15                      | d-M                             |
+| 16                      | yy-M-d                          |
+| 17                      | yyyy-M-d                        |
+| 18                      | M-yy                            |
+| 19                      | M-yyyy                          |
+| 20                      | MMMM yyyy                       |
+| 21                      | MMMM yy                         |
+| 22                      | MMM yyyy                        |
+| 23                      | MMM yy                          |
+| 24                      | yy                              |
+| 25                      | yyyy                            |
+| 26                      | d                               |
+| 27                      | MMMM                            |
+| 28                      | MMM                             |
+| 29                      | M                               |
+| 30                      | MM/dd/yyyy                      |
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setDateFormatString(String value) {#setDateFormatString-java.lang.String-}
+```
+public void setDateFormatString(String value)
+```
+
+
+Stringa DateFormat della forma
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setMilestoneDate(DateTime value) {#setMilestoneDate-com.aspose.diagram.DateTime-}
+```
+public void setMilestoneDate(DateTime value)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setType(int value) {#setType-int-}
+```
+public void setType(int value)
+```
+
+
+Tipo di forma
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/misc/_index.md
+++ b/italian/java/com.aspose.diagram/misc/_index.md
@@ -1,0 +1,381 @@
+---
+title: Varie
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene vari elementi di forme e gruppi, come quelli che controllano l'evidenziazione della selezione e la visibilità.
+type: docs
+weight: 247
+url: /it/java/com.aspose.diagram/misc/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Misc
+```
+
+Contiene vari elementi di forme e gruppi, come quelli che controllano l'evidenziazione della selezione e la visibilità.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBegTrigger()](#getBegTrigger--) | Contiene una formula trigger generata da Microsoft Visio che determina se spostare il punto iniziale di una forma 1-D per mantenere la sua connessione a un'altra forma. |
+| [getCalendar()](#getCalendar--) | Determina il calendario utilizzato per le proprietà personalizzate, i campi di testo e le formule degli elementi. |
+| [getClass()](#getClass--) |  |
+| [getComment()](#getComment--) | Contiene il testo del commento in formato stringa per una forma. |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getDropOnPageScale()](#getDropOnPageScale--) | Determina la percentuale di scala di una forma quando viene rilasciata sulla pagina di disegno. |
+| [getDynFeedback()](#getDynFeedback--) | Specifica il tipo di feedback visivo fornito agli utenti quando trascinano un connettore. |
+| [getEndTrigger()](#getEndTrigger--) | Contiene una formula trigger generata da Microsoft Visio. |
+| [getGlueType()](#getGlueType--) | Specifica se è consentito l'incollaggio dinamico (forma‑a‑forma) quando si collega a una forma. |
+| [getHideText()](#getHideText--) | Nasconde il testo di una forma. |
+| [getLangID()](#getLangID--) | Indica l'ID locale (LCID) della lingua in cui è stata inserita la formula della cella, il testo, la proprietà personalizzata o il commento. |
+| [getLocalizeMerge()](#getLocalizeMerge--) | Determina se le forme sono localizzate (se il loro elemento LangID viene reimpostato) quando vengono copiate tra documenti. |
+| [getNoAlignBox()](#getNoAlignBox--) | Specifica se il rettangolo di selezione è visualizzato quando la forma è selezionata. |
+| [getNoCtlHandles()](#getNoCtlHandles--) | Specifica se le maniglie di controllo sono visualizzate quando la forma è selezionata. |
+| [getNoLiveDynamics()](#getNoLiveDynamics--) | Specifica se una forma si ridimensiona o ruota dinamicamente mentre l'utente la manipola. |
+| [getNoObjHandles()](#getNoObjHandles--) | Specifica se le maniglie di selezione sono visualizzate quando la forma è selezionata. |
+| [getNonPrinting()](#getNonPrinting--) | Specifica se una forma selezionata può essere stampata. |
+| [getObjType()](#getObjType--) | Specifica se gli oggetti sono posizionabili o instradabili nei diagrammi quando si utilizza Microsoft Visio per disporre le forme sulla pagina di disegno. |
+| [getShapeKeywords()](#getShapeKeywords--) | Contiene parole chiave di ricerca assegnate a forme master personalizzate. |
+| [getUpdateAlignBox()](#getUpdateAlignBox--) | Specifica se ricalcolare il rettangolo di selezione di una forma ogni volta che una maniglia di controllo viene spostata. |
+| [getWalkPreference()](#getWalkPreference--) | Specifica se un'estremità di una forma 1-D si sposta verso un punto di connessione orizzontale o verticale sulla forma a cui è incollata, utilizzando la colla dinamica, quando la forma viene spostata in una posizione ambigua. |
+| [hashCode()](#hashCode--) |  |
+| [isDropSource()](#isDropSource--) | Specifica se la forma può essere aggiunta a un gruppo rilasciandola sul gruppo. |
+| [isReplaceLockShapeData()](#isReplaceLockShapeData--) | Indica se i valori delle celle specificate in una forma master sovrascrivono i valori (inclusi quelli locali) di una forma che viene sostituita durante un'operazione di sostituzione della forma. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/misc\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBegTrigger() {#getBegTrigger--}
+```
+public DoubleValue getBegTrigger()
+```
+
+
+Contiene una formula trigger generata da Microsoft Visio che determina se spostare il punto iniziale di una forma 1-D per mantenere la sua connessione a un'altra forma.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getCalendar() {#getCalendar--}
+```
+public Calendar getCalendar()
+```
+
+
+Determina il calendario utilizzato per le proprietà personalizzate, i campi di testo e le formule degli elementi.
+
+**Returns:**
+[Calendar](../../com.aspose.diagram/calendar)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getComment() {#getComment--}
+```
+public Str2Value getComment()
+```
+
+
+Contiene il testo del commento in formato stringa per una forma.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getDropOnPageScale() {#getDropOnPageScale--}
+```
+public DoubleValue getDropOnPageScale()
+```
+
+
+Determina la percentuale di scala di una forma quando viene rilasciata sulla pagina di disegno.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDynFeedback() {#getDynFeedback--}
+```
+public DynFeedback getDynFeedback()
+```
+
+
+Specifica il tipo di feedback visivo fornito agli utenti quando trascinano un connettore.
+
+**Returns:**
+[DynFeedback](../../com.aspose.diagram/dynfeedback)
+### getEndTrigger() {#getEndTrigger--}
+```
+public DoubleValue getEndTrigger()
+```
+
+
+Contiene una formula trigger generata da Microsoft Visio. Questa formula trigger determina se spostare il punto finale di una forma 1-D per mantenere la sua connessione a un'altra forma.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getGlueType() {#getGlueType--}
+```
+public GlueType getGlueType()
+```
+
+
+Specifica se è consentito l'incollaggio dinamico (forma‑a‑forma) quando si collega a una forma.
+
+**Returns:**
+[GlueType](../../com.aspose.diagram/gluetype)
+### getHideText() {#getHideText--}
+```
+public BoolValue getHideText()
+```
+
+
+Nasconde il testo per una forma. È possibile visualizzare il testo, modificare le proprietà e applicare stili al testo nel blocco di testo, anche se le modifiche non appariranno finché non si specifica l'elemento HideText a 0.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLangID() {#getLangID--}
+```
+public IntValue getLangID()
+```
+
+
+Indica l'ID locale (LCID) della lingua in cui è stata inserita la formula della cella, il testo, la proprietà personalizzata o il commento.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getLocalizeMerge() {#getLocalizeMerge--}
+```
+public BoolValue getLocalizeMerge()
+```
+
+
+Determina se le forme sono localizzate (se il loro elemento LangID viene reimpostato) quando vengono copiate tra documenti.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getNoAlignBox() {#getNoAlignBox--}
+```
+public BoolValue getNoAlignBox()
+```
+
+
+Specifica se il rettangolo di selezione è visualizzato quando la forma è selezionata.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getNoCtlHandles() {#getNoCtlHandles--}
+```
+public BoolValue getNoCtlHandles()
+```
+
+
+Specifica se le maniglie di controllo sono visualizzate quando la forma è selezionata.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getNoLiveDynamics() {#getNoLiveDynamics--}
+```
+public BoolValue getNoLiveDynamics()
+```
+
+
+Specifica se una forma si ridimensiona o ruota dinamicamente mentre l'utente la manipola.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getNoObjHandles() {#getNoObjHandles--}
+```
+public BoolValue getNoObjHandles()
+```
+
+
+Specifica se le maniglie di selezione sono visualizzate quando la forma è selezionata.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getNonPrinting() {#getNonPrinting--}
+```
+public BoolValue getNonPrinting()
+```
+
+
+Specifica se una forma selezionata può essere stampata.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getObjType() {#getObjType--}
+```
+public ObjType getObjType()
+```
+
+
+Specifica se gli oggetti sono posizionabili o instradabili nei diagrammi quando si utilizza Microsoft Visio per disporre le forme sulla pagina di disegno.
+
+**Returns:**
+[ObjType](../../com.aspose.diagram/objtype)
+### getShapeKeywords() {#getShapeKeywords--}
+```
+public Str2Value getShapeKeywords()
+```
+
+
+Contiene parole chiave di ricerca assegnate a forme master personalizzate.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getUpdateAlignBox() {#getUpdateAlignBox--}
+```
+public BoolValue getUpdateAlignBox()
+```
+
+
+Specifica se ricalcolare il rettangolo di selezione di una forma ogni volta che una maniglia di controllo viene spostata.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getWalkPreference() {#getWalkPreference--}
+```
+public WalkPreference getWalkPreference()
+```
+
+
+Specifica se un'estremità di una forma 1-D si sposta verso un punto di connessione orizzontale o verticale sulla forma a cui è incollata, utilizzando la colla dinamica, quando la forma viene spostata in una posizione ambigua.
+
+**Returns:**
+[WalkPreference](../../com.aspose.diagram/walkpreference)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isDropSource() {#isDropSource--}
+```
+public BoolValue isDropSource()
+```
+
+
+Specifica se la forma può essere aggiunta a un gruppo rilasciandola sul gruppo.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### isReplaceLockShapeData() {#isReplaceLockShapeData--}
+```
+public BoolValue isReplaceLockShapeData()
+```
+
+
+Indica se i valori delle celle specificate in una forma master sovrascrivono i valori (inclusi quelli locali) di una forma che viene sostituita durante un'operazione di sostituzione della forma.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/misc\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/moveto/_index.md
+++ b/italian/java/com.aspose.diagram/moveto/_index.md
@@ -1,0 +1,249 @@
+---
+title: MoveTo
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene le coordinate x e y del primo vertice di una forma o contiene le coordinate x e y del primo vertice dopo un'interruzione in un percorso.
+type: docs
+weight: 248
+url: /it/java/com.aspose.diagram/moveto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class MoveTo extends Coordinate
+```
+
+Contiene le coordinate x e y del primo vertice di una forma, oppure le coordinate x e y del primo vertice dopo un'interruzione in un percorso.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [MoveTo()](#MoveTo--) | Crea un'istanza della classe [MoveTo](../../com.aspose.diagram/moveto). |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getIX()](#getIX--) | L'indice basato su zero dell'elemento all'interno del suo elemento genitore. |
+| [getX()](#getX--) | L'elemento X rappresenta la coordinata x del primo vertice di un percorso. |
+| [getY()](#getY--) | L'elemento Y rappresenta la coordinata y del primo vertice di un percorso. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/moveto\\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Per la descrizione di questa proprietà, vedere [getIX()](../../com.aspose.diagram/moveto\\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getX()](../../com.aspose.diagram/moveto\\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getY()](../../com.aspose.diagram/moveto\\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### MoveTo() {#MoveTo--}
+```
+public MoveTo()
+```
+
+
+Crea un'istanza della classe [MoveTo](../../com.aspose.diagram/moveto).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+L'indice basato su zero dell'elemento all'interno del suo elemento genitore.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+L'elemento X rappresenta la coordinata x del primo vertice di un percorso. Se l'elemento MoveTo appare tra due elementi, l'elemento X rappresenta la coordinata x del primo vertice dopo l'interruzione nel percorso
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+L'elemento Y rappresenta la coordinata y del primo vertice di un percorso. Se l'elemento MoveTo appare tra due elementi, l'elemento Y rappresenta la coordinata y del primo vertice dopo l'interruzione nel percorso.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/moveto\\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getIX()](../../com.aspose.diagram/moveto\\#getIX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getX()](../../com.aspose.diagram/moveto\\#getX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getY()](../../com.aspose.diagram/moveto\\#getY--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/movetocollection/_index.md
+++ b/italian/java/com.aspose.diagram/movetocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: MoveToCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Raccolta MoveTo.
+type: docs
+weight: 249
+url: /it/java/com.aspose.diagram/movetocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class MoveToCollection extends Collection
+```
+
+Raccolta MoveTo.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public MoveTo get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[MoveTo](../../com.aspose.diagram/moveto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/nurbsto/_index.md
+++ b/italian/java/com.aspose.diagram/nurbsto/_index.md
@@ -1,0 +1,374 @@
+---
+title: NURBSTo
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene la posizione delle coordinate x e y del penultimo nodo, della posizione dell'ultimo peso, della posizione del primo nodo, della posizione del primo peso e la formula per una B-spline razionale non uniforme (NURBS).
+type: docs
+weight: 250
+url: /it/java/com.aspose.diagram/nurbsto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class NURBSTo extends Coordinate
+```
+
+Contiene le coordinate x e y, la posizione del penultimo nodo, la posizione dell'ultimo peso, la posizione del primo nodo, la posizione del primo peso e la formula per una B-spline razionale non uniforme (NURBS). Queste informazioni sono specificate rispettivamente negli elementi X, Y, A, B, C, D ed E.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [NURBSTo()](#NURBSTo--) | Crea un'istanza della classe [NURBSTo](../../com.aspose.diagram/nurbsto). |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | Il penultimo nodo della B-spline razionale non uniforme (NURBS). |
+| [getB()](#getB--) | L'ultimo peso della B-spline razionale non uniforme (NURBS). |
+| [getC()](#getC--) | Il primo nodo della B-spline razionale non uniforme (NURBS). |
+| [getClass()](#getClass--) |  |
+| [getD()](#getD--) | Il primo peso della B-spline razionale non uniforme (NURBS) |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getE()](#getE--) | Contiene una formula di B-spline razionale non uniforme (NURBS). |
+| [getIX()](#getIX--) | L'indice basato su zero dell'elemento all'interno del suo elemento genitore. |
+| [getX()](#getX--) | La coordinata x dell'ultimo punto di controllo di una B-spline razionale non uniforme (NURBS). |
+| [getY()](#getY--) | La coordinata y dell'ultimo punto di controllo di una B-spline razionale non uniforme (NURBS). |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getA()](../../com.aspose.diagram/nurbsto\#getA--) |
+| [setB(DoubleValue value)](#setB-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getB()](../../com.aspose.diagram/nurbsto\#getB--) |
+| [setC(DoubleValue value)](#setC-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getC()](../../com.aspose.diagram/nurbsto\#getC--) |
+| [setD(DoubleValue value)](#setD-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getD()](../../com.aspose.diagram/nurbsto\#getD--) |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/nurbsto\#getDel--) |
+| [setE(StrValue value)](#setE-com.aspose.diagram.StrValue-) | Per la descrizione di questa proprietà, vedere [getE()](../../com.aspose.diagram/nurbsto\#getE--) |
+| [setIX(int value)](#setIX-int-) | Per la descrizione di questa proprietà, vedere [getIX()](../../com.aspose.diagram/nurbsto\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getX()](../../com.aspose.diagram/nurbsto\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getY()](../../com.aspose.diagram/nurbsto\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### NURBSTo() {#NURBSTo--}
+```
+public NURBSTo()
+```
+
+
+Crea un'istanza della classe [NURBSTo](../../com.aspose.diagram/nurbsto).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+Il penultimo nodo della B-spline razionale non uniforme (NURBS).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getB() {#getB--}
+```
+public DoubleValue getB()
+```
+
+
+L'ultimo peso della B-spline razionale non uniforme (NURBS).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getC() {#getC--}
+```
+public DoubleValue getC()
+```
+
+
+Il primo nodo della B-spline razionale non uniforme (NURBS).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getD() {#getD--}
+```
+public DoubleValue getD()
+```
+
+
+Il primo peso della B-spline razionale non uniforme (NURBS)
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getE() {#getE--}
+```
+public StrValue getE()
+```
+
+
+Contiene una formula di B-spline razionale non uniforme (NURBS).
+
+**Returns:**
+[StrValue](../../com.aspose.diagram/strvalue)
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+L'indice basato su zero dell'elemento all'interno del suo elemento genitore.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+La coordinata x dell'ultimo punto di controllo di una B-spline razionale non uniforme (NURBS).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+La coordinata y dell'ultimo punto di controllo di una B-spline razionale non uniforme (NURBS).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getA()](../../com.aspose.diagram/nurbsto\#getA--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setB(DoubleValue value) {#setB-com.aspose.diagram.DoubleValue-}
+```
+public void setB(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getB()](../../com.aspose.diagram/nurbsto\#getB--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setC(DoubleValue value) {#setC-com.aspose.diagram.DoubleValue-}
+```
+public void setC(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getC()](../../com.aspose.diagram/nurbsto\#getC--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setD(DoubleValue value) {#setD-com.aspose.diagram.DoubleValue-}
+```
+public void setD(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getD()](../../com.aspose.diagram/nurbsto\#getD--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/nurbsto\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setE(StrValue value) {#setE-com.aspose.diagram.StrValue-}
+```
+public void setE(StrValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getE()](../../com.aspose.diagram/nurbsto\#getE--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [StrValue](../../com.aspose.diagram/strvalue) |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getIX()](../../com.aspose.diagram/nurbsto\#getIX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getX()](../../com.aspose.diagram/nurbsto\#getX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getY()](../../com.aspose.diagram/nurbsto\#getY--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/nurbstocollection/_index.md
+++ b/italian/java/com.aspose.diagram/nurbstocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: NURBSToCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Raccolta NURBSTo.
+type: docs
+weight: 251
+url: /it/java/com.aspose.diagram/nurbstocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class NURBSToCollection extends Collection
+```
+
+Raccolta NURBSTo.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public NURBSTo get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[NURBSTo](../../com.aspose.diagram/nurbsto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/objectkind/_index.md
+++ b/italian/java/com.aspose.diagram/objectkind/_index.md
@@ -1,0 +1,190 @@
+---
+title: ObjectKind
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Indica il tipo di campo di testo.
+type: docs
+weight: 254
+url: /it/java/com.aspose.diagram/objectkind/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ObjectKind
+```
+
+Indica il tipo di campo di testo.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [ObjectKind(int value)](#ObjectKind-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Indica il tipo di campo di testo. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, consultare [getValue()](../../com.aspose.diagram/objectkind\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ObjectKind(int value) {#ObjectKind-int-}
+```
+public ObjectKind(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Indica il tipo di campo di testo.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getValue()](../../com.aspose.diagram/objectkind\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/objectkindvalue/_index.md
+++ b/italian/java/com.aspose.diagram/objectkindvalue/_index.md
@@ -1,0 +1,156 @@
+---
+title: ObjectKindValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Indica il tipo di campo di testo.
+type: docs
+weight: 255
+url: /it/java/com.aspose.diagram/objectkindvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ObjectKindValue
+```
+
+Indica il tipo di campo di testo.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [HORIZONTAL_IN_VERTICAL](#HORIZONTAL-IN-VERTICAL) | Orizzontale in verticale. |
+| [STANDARD](#STANDARD) | Standard. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### HORIZONTAL_IN_VERTICAL {#HORIZONTAL-IN-VERTICAL}
+```
+public static final int HORIZONTAL_IN_VERTICAL
+```
+
+
+Orizzontale in verticale.
+
+### STANDARD {#STANDARD}
+```
+public static final int STANDARD
+```
+
+
+Standard.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/objecttype/_index.md
+++ b/italian/java/com.aspose.diagram/objecttype/_index.md
@@ -1,0 +1,183 @@
+---
+title: ObjectType
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Se l'attributo ForeignType è Object, l'elemento ForeignData deve avere anche un attributo ObjectType.
+type: docs
+weight: 256
+url: /it/java/com.aspose.diagram/objecttype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ObjectType
+```
+
+Se l'attributo ForeignType è "Object", l'elemento ForeignData deve inoltre avere un attributo ObjectType.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [CONTROL](#CONTROL) | Controllo. |
+| [EMBEDDED_OBJECT](#EMBEDDED-OBJECT) | Oggetto incorporato. |
+| [LINKED_OBJECT](#LINKED-OBJECT) | Oggetto collegato. |
+| [OLE_2_NAMED](#OLE-2-NAMED) | OLE2 denominato. |
+| [OLE_2_OBJECT](#OLE-2-OBJECT) | Oggetto OLE2. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CONTROL {#CONTROL}
+```
+public static final int CONTROL
+```
+
+
+Controllo.
+
+### EMBEDDED_OBJECT {#EMBEDDED-OBJECT}
+```
+public static final int EMBEDDED_OBJECT
+```
+
+
+Oggetto incorporato.
+
+### LINKED_OBJECT {#LINKED-OBJECT}
+```
+public static final int LINKED_OBJECT
+```
+
+
+Oggetto collegato.
+
+### OLE_2_NAMED {#OLE-2-NAMED}
+```
+public static final int OLE_2_NAMED
+```
+
+
+OLE2 denominato.
+
+### OLE_2_OBJECT {#OLE-2-OBJECT}
+```
+public static final int OLE_2_OBJECT
+```
+
+
+Oggetto OLE2.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/objtype/_index.md
+++ b/italian/java/com.aspose.diagram/objtype/_index.md
@@ -1,0 +1,179 @@
+---
+title: ObjType
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica se gli oggetti sono posizionabili o instradabili nei diagrammi quando si utilizza Microsoft Visio per disporre le forme sulla pagina di disegno.
+type: docs
+weight: 252
+url: /it/java/com.aspose.diagram/objtype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ObjType
+```
+
+Specifica se gli oggetti sono posizionabili o instradabili nei diagrammi quando si utilizza Microsoft Visio per disporre le forme sulla pagina di disegno.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [ObjType(int value)](#ObjType-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Specifica se gli oggetti sono posizionabili o instradabili nei diagrammi quando si utilizza Microsoft Visio per disporre le forme sulla pagina di disegno. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | For the description of this property, please see [getValue()](../../com.aspose.diagram/objtype\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ObjType(int value) {#ObjType-int-}
+```
+public ObjType(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specifica se gli oggetti sono posizionabili o instradabili nei diagrammi quando si utilizza Microsoft Visio per disporre le forme sulla pagina di disegno.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+For the description of this property, please see [getValue()](../../com.aspose.diagram/objtype\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/objtypevalue/_index.md
+++ b/italian/java/com.aspose.diagram/objtypevalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: ObjTypeValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica se gli oggetti sono posizionabili o instradabili nei diagrammi quando si utilizza Microsoft Visio per disporre le forme sulla pagina di disegno.
+type: docs
+weight: 253
+url: /it/java/com.aspose.diagram/objtypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ObjTypeValue
+```
+
+Specifica se gli oggetti sono posizionabili o instradabili nei diagrammi quando si utilizza Microsoft Visio per disporre le forme sulla pagina di disegno.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [DRAWING_CONTEXT](#DRAWING-CONTEXT) | Visio decide in base al contesto del disegno. |
+| [SHAPE_NOT_PLACEABLE_NOT_ROUTABLE](#SHAPE-NOT-PLACEABLE-NOT-ROUTABLE) | La forma non è posizionabile, non è instradabile. |
+| [SHAPE_PLACEABLE](#SHAPE-PLACEABLE) | La forma è posizionabile. |
+| [SHAPE_PLACEABLE_ROUTABLE](#SHAPE-PLACEABLE-ROUTABLE) | Il gruppo contiene forme posizionabili/instradabili. |
+| [SHAPE_ROUTABLE](#SHAPE-ROUTABLE) | Shape è instradabile. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DRAWING_CONTEXT {#DRAWING-CONTEXT}
+```
+public static final int DRAWING_CONTEXT
+```
+
+
+Visio decide in base al contesto del disegno.
+
+### SHAPE_NOT_PLACEABLE_NOT_ROUTABLE {#SHAPE-NOT-PLACEABLE-NOT-ROUTABLE}
+```
+public static final int SHAPE_NOT_PLACEABLE_NOT_ROUTABLE
+```
+
+
+La forma non è posizionabile, non è instradabile.
+
+### SHAPE_PLACEABLE {#SHAPE-PLACEABLE}
+```
+public static final int SHAPE_PLACEABLE
+```
+
+
+La forma è posizionabile.
+
+### SHAPE_PLACEABLE_ROUTABLE {#SHAPE-PLACEABLE-ROUTABLE}
+```
+public static final int SHAPE_PLACEABLE_ROUTABLE
+```
+
+
+Il gruppo contiene forme posizionabili/instradabili.
+
+### SHAPE_ROUTABLE {#SHAPE-ROUTABLE}
+```
+public static final int SHAPE_ROUTABLE
+```
+
+
+Shape è instradabile.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/optionsvalue/_index.md
+++ b/italian/java/com.aspose.diagram/optionsvalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: OptionsValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Intero senza segno opzionale.
+type: docs
+weight: 257
+url: /it/java/com.aspose.diagram/optionsvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class OptionsValue
+```
+
+Intero senza segno opzionale. Opzioni da applicare al recordset di dati. I valori possibili possono essere qualsiasi combinazione di uno o più di quelli mostrati nella tabella seguente.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [DELAY_QUERY](#DELAY-QUERY) | Non esegue la query della stringa di comando fino al prossimo aggiornamento del recordset di dati. |
+| [NO_ADV_CONFIG](#NO-ADV-CONFIG) | Limita il controllo degli utenti su come il recordset di dati viene aggiornato nella finestra di dialogo Configura Aggiornamento per il recordset di dati. |
+| [NO_EXTERNAL_DATA_UI](#NO-EXTERNAL-DATA-UI) | Impedisce che i dati nel recordset di dati vengano visualizzati nella finestra Dati Esterni. |
+| [NO_LINK_ON_PASTE](#NO-LINK-ON-PASTE) | Non copia i collegamenti dati-forma negli Appunti quando le forme vengono copiate o tagliate. |
+| [NO_REFRESH_UI](#NO-REFRESH-UI) | Impedisce che il recordset di dati venga visualizzato nella finestra di dialogo Aggiorna Dati. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DELAY_QUERY {#DELAY-QUERY}
+```
+public static final int DELAY_QUERY
+```
+
+
+Non esegue la query della stringa di comando fino al prossimo aggiornamento del recordset di dati.
+
+### NO_ADV_CONFIG {#NO-ADV-CONFIG}
+```
+public static final int NO_ADV_CONFIG
+```
+
+
+Limita il controllo degli utenti su come il recordset di dati viene aggiornato nella finestra di dialogo Configura Aggiornamento per il recordset di dati. In particolare, gli utenti non possono modificare la chiave primaria o specificare quando i dati della forma devono essere sovrascritti; tuttavia, gli utenti possono impostare l'intervallo di aggiornamento e possono modificare la fonte dei dati.
+
+### NO_EXTERNAL_DATA_UI {#NO-EXTERNAL-DATA-UI}
+```
+public static final int NO_EXTERNAL_DATA_UI
+```
+
+
+Impedisce che i dati nel recordset di dati vengano visualizzati nella finestra Dati Esterni.
+
+### NO_LINK_ON_PASTE {#NO-LINK-ON-PASTE}
+```
+public static final int NO_LINK_ON_PASTE
+```
+
+
+Non copia i collegamenti dati-forma negli Appunti quando le forme vengono copiate o tagliate.
+
+### NO_REFRESH_UI {#NO-REFRESH-UI}
+```
+public static final int NO_REFRESH_UI
+```
+
+
+Impedisce che il recordset di dati venga visualizzato nella finestra di dialogo Aggiorna Dati.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/outputformat/_index.md
+++ b/italian/java/com.aspose.diagram/outputformat/_index.md
@@ -1,0 +1,179 @@
+---
+title: OutputFormat
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica il formato di output per un disegno.
+type: docs
+weight: 258
+url: /it/java/com.aspose.diagram/outputformat/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class OutputFormat
+```
+
+Specifica il formato di output per un disegno.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [OutputFormat(int value)](#OutputFormat-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Specifica il formato di output per un disegno. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, consultare [getValue()](../../com.aspose.diagram/outputformat\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### OutputFormat(int value) {#OutputFormat-int-}
+```
+public OutputFormat(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specifica il formato di output per un disegno.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getValue()](../../com.aspose.diagram/outputformat\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/outputformatvalue/_index.md
+++ b/italian/java/com.aspose.diagram/outputformatvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: OutputFormatValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica il formato di output per un disegno.
+type: docs
+weight: 259
+url: /it/java/com.aspose.diagram/outputformatvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class OutputFormatValue
+```
+
+Specifica il formato di output per un disegno.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [DEFAULT_PRINT](#DEFAULT-PRINT) | Predefinito. |
+| [HTML_OR_GIF_OUTPUT](#HTML-OR-GIF-OUTPUT) | Output HTML o GIF. |
+| [POWER_POINT_SLIDE_SHOW](#POWER-POINT-SLIDE-SHOW) | Presentazione diapositive PowerPoint. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DEFAULT_PRINT {#DEFAULT-PRINT}
+```
+public static final int DEFAULT_PRINT
+```
+
+
+Predefinito. Stampa.
+
+### HTML_OR_GIF_OUTPUT {#HTML-OR-GIF-OUTPUT}
+```
+public static final int HTML_OR_GIF_OUTPUT
+```
+
+
+Output HTML o GIF.
+
+### POWER_POINT_SLIDE_SHOW {#POWER-POINT-SLIDE-SHOW}
+```
+public static final int POWER_POINT_SLIDE_SHOW
+```
+
+
+Presentazione diapositive PowerPoint.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/page/_index.md
+++ b/italian/java/com.aspose.diagram/page/_index.md
@@ -1,0 +1,1156 @@
+---
+title: Page
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene gli elementi che definiscono una pagina nel documento.
+type: docs
+weight: 260
+url: /it/java/com.aspose.diagram/page/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Page
+```
+
+Contiene gli elementi che definiscono una pagina nel documento.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [Page()](#Page--) | Costruttore. |
+| [Page(int ID)](#Page-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [addActiveXControl(int type, double pinX, double pinY, double width, double height)](#addActiveXControl-int-double-double-double-double-) | Crea un controllo Activex. |
+| [addComment(Shape shape, String comment)](#addComment-com.aspose.diagram.Shape-java.lang.String-) | Aggiunge un commento a una forma. |
+| [addComment(double pinX, double pinY, String comment)](#addComment-double-double-java.lang.String-) | Aggiunge un commento con PinX e PinY definiti. |
+| [addComment(long shapeID, String comment)](#addComment-long-java.lang.String-) | Aggiunge un commento a una forma con l'ID della forma. |
+| [addShape(Shape newShape, String masterName)](#addShape-com.aspose.diagram.Shape-java.lang.String-) | Aggiunge una forma creata dal master a una pagina specifica. |
+| [addShape(double pinX, double pinY, double width, double height, InputStream stream)](#addShape-double-double-double-double-java.io.InputStream-) |  |
+| [addShape(double pinX, double pinY, double width, double height, InputStream imageStream, InputStream objectDataStream)](#addShape-double-double-double-double-java.io.InputStream-java.io.InputStream-) |  |
+| [addShape(double pinX, double pinY, double width, double height, String masterName)](#addShape-double-double-double-double-java.lang.String-) | Aggiunge una forma creata dal master sulla pagina con PinX, PinY, larghezza e altezza definiti. |
+| [addShape(double pinX, double pinY, String masterName)](#addShape-double-double-java.lang.String-) | Aggiunge una forma creata dal master sulla pagina con PinX e PinY definiti. |
+| [addText(double pinX, double pinY, double width, double height, String text)](#addText-double-double-double-double-java.lang.String-) | Aggiunge testo con PinX e PinY definiti. |
+| [addText(double pinX, double pinY, double width, double height, String text, String fontName, String fontColor, double size)](#addText-double-double-double-double-java.lang.String-java.lang.String-java.lang.String-double-) | Aggiunge testo con PinX e PinY definiti. |
+| [applyStyle(int textStyle, int lineStyle, int fillStyle)](#applyStyle-int-int-int-) | Applica lo stile per l'intera pagina. |
+| [autoSpaceShapes(ShapeCollection shapes, AutoSpaceOptions options)](#autoSpaceShapes-com.aspose.diagram.ShapeCollection-com.aspose.diagram.AutoSpaceOptions-) | Spaziatura automatica delle forme |
+| [bringForward(long shapeId)](#bringForward-long-) | Porta una forma, definita per ID, avanti di una posizione nell'ordine Z. |
+| [bringToFront(long shapeId)](#bringToFront-long-) | Porta una forma, definita per ID, in primo piano nell'ordine Z. |
+| [centerDrawing()](#centerDrawing--) | Centra le forme della pagina rispetto all'estensione della pagina. |
+| [connectShapesViaConnector(Shape shapeFrom, int placeFrom, Shape shapeTo, int placeTo, Shape connector)](#connectShapesViaConnector-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-) | Collega le forme tramite connettore. |
+| [connectShapesViaConnector(long shapeFromId, int placeFrom, long shapeToId, int placeTo, long connectorId)](#connectShapesViaConnector-long-int-long-int-long-) | Collega le forme tramite connettore. |
+| [connectShapesViaConnector(long shapeFromId, String fromConnectionName, long shapeToId, String toConnectionName, long connectorId)](#connectShapesViaConnector-long-java.lang.String-long-java.lang.String-long-) | Collega le forme tramite connettore. |
+| [connectShapesViaConnectorIndex(Shape shapeFrom, int fromIndex, Shape shapeTo, int toIndex, Shape connector)](#connectShapesViaConnectorIndex-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-) | Collega le forme tramite indice del connettore. |
+| [connectShapesViaConnectorIndex(long shapeFromId, int fromIndex, long shapeToId, int toIndex, long connectorId)](#connectShapesViaConnectorIndex-long-int-long-int-long-) | Collega le forme tramite indice del connettore. |
+| [copy(Page source)](#copy-com.aspose.diagram.Page-) |  |
+| [dispose()](#dispose--) | Esegue operazioni definite dall'applicazione associate al rilascio, alla liberazione o al reset delle risorse non gestite. |
+| [drawEllipse(double pinX, double pinY, double width, double height)](#drawEllipse-double-double-double-double-) | Il processo di disegno dell'ellisse. |
+| [drawLine(double beginX, double beginY, double endX, double endY)](#drawLine-double-double-double-double-) | Il processo di disegno di una linea singola. |
+| [drawLine(double pinX, double pinY, double width, double height, double[] xyArray)](#drawLine-double-double-double-double-double---) | Il processo di disegno della linea. |
+| [drawPolyline(double pinX, double pinY, double width, double height, double[] xyArray)](#drawPolyline-double-double-double-double-double---) | Il processo di disegno della polilinea. |
+| [drawRectangle(double pinX, double pinY, double width, double height)](#drawRectangle-double-double-double-double-) | Il processo di disegno del rettangolo. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAssociatedPage()](#getAssociatedPage--) | L'ID della pagina di disegno originale che è stata annotata su overlay di markup separati dai revisori del disegno. |
+| [getBackPage()](#getBackPage--) | La pagina di sfondo della pagina. |
+| [getBackground()](#getBackground--) | Un flag che indica se la pagina è una pagina di sfondo. |
+| [getClass()](#getClass--) |  |
+| [getConnects()](#getConnects--) | Contiene un elemento Connect per ogni connessione tra due forme in un disegno. |
+| [getID()](#getID--) | L'ID univoco dell'elemento all'interno del suo elemento genitore. |
+| [getName()](#getName--) | Il nome dell'elemento. |
+| [getNameU()](#getNameU--) | Il nome universale dell'elemento. |
+| [getPageSheet()](#getPageSheet--) | Contiene elementi che definiscono il foglio di pagina per un elemento Pagina o Master. |
+| [getPages()](#getPages--) | Raccolta di pagine. |
+| [getReviewerID()](#getReviewerID--) | L'ID del revisore associato all'overlay di markup. |
+| [getShapes()](#getShapes--) | Raccolta di forme. |
+| [getViewCenterX()](#getViewCenterX--) | ViewCenterX e ViewCenterY specificano un punto centrale su una pagina che una nuova vista (finestra) assume quando viene aperta inizialmente. |
+| [getViewCenterY()](#getViewCenterY--) | ViewCenterX e ViewCenterY specificano un punto centrale su una pagina che una nuova vista (finestra) assume quando viene aperta inizialmente. |
+| [getViewScale()](#getViewScale--) | Il fattore di ingrandimento predefinito da utilizzare quando viene aperta una nuova vista (finestra) della pagina. |
+| [glueShapeToConnectorBeginX(long shapeFromId, String connectionName, long connectorId)](#glueShapeToConnectorBeginX-long-java.lang.String-long-) | Incolla la forma al BeginX del Connettore |
+| [glueShapeToConnectorEndX(long shapeToId, String connectionName, long connectorId)](#glueShapeToConnectorEndX-long-java.lang.String-long-) | Incolla la forma al EndX del Connettore |
+| [glueShapes(Shape shapeFrom, int placeTo, Shape shapeTo)](#glueShapes-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-) | Incolla forme. |
+| [glueShapes(long shapeFromId, int placeTo, long shapeToId)](#glueShapes-long-int-long-) | Incolla forme |
+| [glueShapesInContainer(long shapeFromId, int shapeToBeginConnectionIndex, int shapeToEndConnectionIndex, long shapeToId)](#glueShapesInContainer-long-int-int-long-) | Incolla forme nel contenitore |
+| [glueShapesInContainer(long shapeFromId, String shapeToBeginConnectionName, String shapeToEndConnectionName, long shapeToId)](#glueShapesInContainer-long-java.lang.String-java.lang.String-long-) | Incolla forme nel contenitore usando il nome della connessione |
+| [glueShapesInContainerByID(long shapeFromId, int shapeToBeginConnectionID, int shapeToEndConnectionID, long shapeToId)](#glueShapesInContainerByID-long-int-int-long-) | Incolla forme per ID di connessione nel contenitore |
+| [hashCode()](#hashCode--) |  |
+| [layout(LayoutOptions options)](#layout-com.aspose.diagram.LayoutOptions-) | Dispone le forme e/o riorienta i connettori per la pagina. |
+| [moveTo(int index)](#moveTo-int-) | Sposta la pagina in un'altra posizione tra le pagine. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [sendBackward(long shapeId)](#sendBackward-long-) | Sposta una forma, definita per ID, indietro di una posizione nell'ordine Z. |
+| [sendToBack(long shapeId)](#sendToBack-long-) | Sposta una forma, definita per ID, in fondo all'ordine Z. |
+| [setAssociatedPage(Page value)](#setAssociatedPage-com.aspose.diagram.Page-) | Per la descrizione di questa proprietà, vedere [getAssociatedPage()](../../com.aspose.diagram/page\#getAssociatedPage--) |
+| [setBackPage(Page value)](#setBackPage-com.aspose.diagram.Page-) | Per la descrizione di questa proprietà, vedere [getBackPage()](../../com.aspose.diagram/page\#getBackPage--) |
+| [setBackground(int value)](#setBackground-int-) | Per la descrizione di questa proprietà, vedere [getBackground()](../../com.aspose.diagram/page\#getBackground--) |
+| [setID(int value)](#setID-int-) | Per la descrizione di questa proprietà, vedere [getID()](../../com.aspose.diagram/page\#getID--) |
+| [setName(String value)](#setName-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getName()](../../com.aspose.diagram/page\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getNameU()](../../com.aspose.diagram/page\#getNameU--) |
+| [setPages(PageCollection value)](#setPages-com.aspose.diagram.PageCollection-) | Per la descrizione di questa proprietà, vedere [getPages()](../../com.aspose.diagram/page\#getPages--) |
+| [setPresetTheme(int value)](#setPresetTheme-int-) | Applica un tema predefinito a questa pagina |
+| [setPresetThemeQuickStyle(int value)](#setPresetThemeQuickStyle-int-) | Applica una variante di tema predefinito quickstyle a questa pagina |
+| [setPresetThemeVariant(int value)](#setPresetThemeVariant-int-) | Applica una variante di tema predefinito a questa pagina |
+| [setReviewerID(int value)](#setReviewerID-int-) | Per la descrizione di questa proprietà, vedere [getReviewerID()](../../com.aspose.diagram/page\#getReviewerID--) |
+| [setViewCenterX(double value)](#setViewCenterX-double-) | Per la descrizione di questa proprietà, vedere [getViewCenterX()](../../com.aspose.diagram/page\#getViewCenterX--) |
+| [setViewCenterY(double value)](#setViewCenterY-double-) | Per la descrizione di questa proprietà, vedere [getViewCenterY()](../../com.aspose.diagram/page\#getViewCenterY--) |
+| [setViewScale(double value)](#setViewScale-double-) | Per la descrizione di questa proprietà, vedere [getViewScale()](../../com.aspose.diagram/page\#getViewScale--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Page() {#Page--}
+```
+public Page()
+```
+
+
+Costruttore.
+
+### Page(int ID) {#Page-int-}
+```
+public Page(int ID)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| ID | int |  |
+
+### addActiveXControl(int type, double pinX, double pinY, double width, double height) {#addActiveXControl-int-double-double-double-double-}
+```
+public long addActiveXControl(int type, double pinX, double pinY, double width, double height)
+```
+
+
+Crea un controllo Activex.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| tipo | int | Il tipo del controllo. |
+| pinX | double | Specifica la coordinata x del perno della forma (centro di rotazione) in relazione alla pagina. |
+| pinY | double | Specifica la coordinata y del perno della forma (centro di rotazione) in relazione alla pagina. |
+| width | double | Specifica la larghezza della forma in pollici. |
+| height | double | Specifica l'altezza della forma in pollici. |
+
+**Returns:**
+long -
+### addComment(Shape shape, String comment) {#addComment-com.aspose.diagram.Shape-java.lang.String-}
+```
+public void addComment(Shape shape, String comment)
+```
+
+
+Aggiunge un commento a una forma.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| shape | [Shape](../../com.aspose.diagram/shape) | Specifica la forma che aggiunge il commento. |
+| comment | java.lang.String | Stringa del commento. |
+
+### addComment(double pinX, double pinY, String comment) {#addComment-double-double-java.lang.String-}
+```
+public void addComment(double pinX, double pinY, String comment)
+```
+
+
+Aggiunge un commento con PinX e PinY definiti.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| pinX | double | Specifica la coordinata x del perno del commento (centro di rotazione) in relazione alla pagina. |
+| pinY | double | Specifica la coordinata y del perno del commento (centro di rotazione) in relazione alla pagina. |
+| comment | java.lang.String | Stringa del commento. |
+
+### addComment(long shapeID, String comment) {#addComment-long-java.lang.String-}
+```
+public void addComment(long shapeID, String comment)
+```
+
+
+Aggiunge un commento a una forma con l'ID della forma.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| shapeID | long |  |
+| comment | java.lang.String | Stringa del commento. |
+
+### addShape(Shape newShape, String masterName) {#addShape-com.aspose.diagram.Shape-java.lang.String-}
+```
+public long addShape(Shape newShape, String masterName)
+```
+
+
+Aggiunge una forma creata dal master a una pagina specifica.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| newShape | [Shape](../../com.aspose.diagram/shape) | Nuovo oggetto shape[Shape](../../com.aspose.diagram/shape). |
+| masterName | java.lang.String | Nome del master. |
+
+**Returns:**
+long - L'ID univoco della forma all'interno della collezione di forme nella pagina specificata.
+### addShape(double pinX, double pinY, double width, double height, InputStream stream) {#addShape-double-double-double-double-java.io.InputStream-}
+```
+public long addShape(double pinX, double pinY, double width, double height, InputStream stream)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| pinX | double |  |
+| pinY | double |  |
+| width | double |  |
+| height | double |  |
+| flusso | java.io.InputStream |  |
+
+**Returns:**
+long
+### addShape(double pinX, double pinY, double width, double height, InputStream imageStream, InputStream objectDataStream) {#addShape-double-double-double-double-java.io.InputStream-java.io.InputStream-}
+```
+public long addShape(double pinX, double pinY, double width, double height, InputStream imageStream, InputStream objectDataStream)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| pinX | double |  |
+| pinY | double |  |
+| width | double |  |
+| height | double |  |
+| imageStream | java.io.InputStream |  |
+| objectDataStream | java.io.InputStream |  |
+
+**Returns:**
+long
+### addShape(double pinX, double pinY, double width, double height, String masterName) {#addShape-double-double-double-double-java.lang.String-}
+```
+public long addShape(double pinX, double pinY, double width, double height, String masterName)
+```
+
+
+Aggiunge una forma creata dal master sulla pagina con PinX, PinY, larghezza e altezza definiti.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| pinX | double | Specifica la coordinata x del perno della forma (centro di rotazione) in relazione alla pagina. |
+| pinY | double | Specifica la coordinata y del perno della forma (centro di rotazione) in relazione alla pagina. |
+| width | double | Specifica la larghezza della forma in pollici. |
+| height | double | Specifica l'altezza della forma in pollici. |
+| masterName | java.lang.String | Nome del master. |
+
+**Returns:**
+long - L'ID univoco della forma all'interno della collezione di forme nella pagina specificata.
+### addShape(double pinX, double pinY, String masterName) {#addShape-double-double-java.lang.String-}
+```
+public long addShape(double pinX, double pinY, String masterName)
+```
+
+
+Aggiunge una forma creata dal master sulla pagina con PinX e PinY definiti.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| pinX | double | Specifica la coordinata x del perno della forma (centro di rotazione) in relazione alla pagina. |
+| pinY | double | Specifica la coordinata y del perno della forma (centro di rotazione) in relazione alla pagina. |
+| masterName | java.lang.String | Nome del master. |
+
+**Returns:**
+long - L'ID univoco della forma all'interno della collezione di forme nella pagina specificata.
+### addText(double pinX, double pinY, double width, double height, String text) {#addText-double-double-double-double-java.lang.String-}
+```
+public Shape addText(double pinX, double pinY, double width, double height, String text)
+```
+
+
+Aggiunge testo con PinX e PinY definiti.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| pinX | double | Specifica la coordinata x del perno del testo (centro di rotazione) in relazione alla pagina. |
+| pinY | double | Specifica la coordinata y del perno del testo (centro di rotazione) in relazione alla pagina. |
+| width | double |  |
+| height | double |  |
+| text | java.lang.String | stringa di testo. |
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape) - Returns a shape object that represents the new text object.
+### addText(double pinX, double pinY, double width, double height, String text, String fontName, String fontColor, double size) {#addText-double-double-double-double-java.lang.String-java.lang.String-java.lang.String-double-}
+```
+public Shape addText(double pinX, double pinY, double width, double height, String text, String fontName, String fontColor, double size)
+```
+
+
+Aggiunge testo con PinX e PinY definiti.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| pinX | double | Specifica la coordinata x del perno del testo (centro di rotazione) in relazione alla pagina. |
+| pinY | double | Specifica la coordinata y del perno del testo (centro di rotazione) in relazione alla pagina. |
+| width | double | Specifica la larghezza del testo. |
+| height | double | Specifica l'altezza del testo. |
+| text | java.lang.String | stringa di testo. |
+| fontName | java.lang.String | nome del carattere del testo. |
+| fontColor | java.lang.String | colore del carattere del testo. |
+| size | double | dimensione del carattere del testo. |
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape) - Returns a shape object that represents the new text object.
+### applyStyle(int textStyle, int lineStyle, int fillStyle) {#applyStyle-int-int-int-}
+```
+public void applyStyle(int textStyle, int lineStyle, int fillStyle)
+```
+
+
+Applica lo stile per l'intera pagina. Il valore predefinito è -1.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| textStyle | int | ID dello stile del testo. |
+| lineStyle | int | ID dello stile della linea. |
+| fillStyle | int | ID dello stile di riempimento. |
+
+### autoSpaceShapes(ShapeCollection shapes, AutoSpaceOptions options) {#autoSpaceShapes-com.aspose.diagram.ShapeCollection-com.aspose.diagram.AutoSpaceOptions-}
+```
+public void autoSpaceShapes(ShapeCollection shapes, AutoSpaceOptions options)
+```
+
+
+Spaziatura automatica delle forme
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| shapes | [ShapeCollection](../../com.aspose.diagram/shapecollection) | Specifica che le forme siano spaziati automaticamente. |
+| options | [AutoSpaceOptions](../../com.aspose.diagram/autospaceoptions) |  |
+
+### bringForward(long shapeId) {#bringForward-long-}
+```
+public void bringForward(long shapeId)
+```
+
+
+Porta una forma, definita per ID, avanti di una posizione nell'ordine Z.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| shapeId | long | ID di shape.long |
+
+### bringToFront(long shapeId) {#bringToFront-long-}
+```
+public void bringToFront(long shapeId)
+```
+
+
+Porta una forma, definita per ID, in primo piano nell'ordine Z.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| shapeId | long | ID di shape.long |
+
+### centerDrawing() {#centerDrawing--}
+```
+public void centerDrawing()
+```
+
+
+Centra le forme di una pagina rispetto all'estensione della pagina. Il centramento delle forme non cambia la loro posizione relativa tra loro.
+
+### connectShapesViaConnector(Shape shapeFrom, int placeFrom, Shape shapeTo, int placeTo, Shape connector) {#connectShapesViaConnector-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-}
+```
+public void connectShapesViaConnector(Shape shapeFrom, int placeFrom, Shape shapeTo, int placeTo, Shape connector)
+```
+
+
+Collega le forme tramite connettore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| shapeFrom | [Shape](../../com.aspose.diagram/shape) | La forma dove inizia il connettore [Shape](../../com.aspose.diagram/shape). |
+| placeFrom | int | La posizione sulla prima forma dove il connettore sarà collegato Aspose.Diagram.Manipulation.ConnectionPointPlace. |
+| shapeTo | [Shape](../../com.aspose.diagram/shape) | La forma dove il connettore termina [Shape](../../com.aspose.diagram/shape). |
+| placeTo | int | La posizione sulla seconda forma dove il connettore sarà collegato Aspose.Diagram.Manipulation.ConnectionPointPlace. |
+| connector | [Shape](../../com.aspose.diagram/shape) | La forma con tipo Dynamic connector [Shape](../../com.aspose.diagram/shape). |
+
+### connectShapesViaConnector(long shapeFromId, int placeFrom, long shapeToId, int placeTo, long connectorId) {#connectShapesViaConnector-long-int-long-int-long-}
+```
+public void connectShapesViaConnector(long shapeFromId, int placeFrom, long shapeToId, int placeTo, long connectorId)
+```
+
+
+Collega le forme tramite connettore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| shapeFromId | long | L'ID della forma dove il connettore inizia [Shape](../../com.aspose.diagram/shape). |
+| placeFrom | int | La posizione sulla prima forma dove il connettore sarà collegato Aspose.Diagram.Manipulation.ConnectionPointPlace. |
+| shapeToId | long | L'ID della forma dove il connettore termina [Shape](../../com.aspose.diagram/shape). |
+| placeTo | int | La posizione sulla seconda forma dove il connettore sarà collegato Aspose.Diagram.Manipulation.ConnectionPointPlace. |
+| connectorId | long | L'ID della forma con tipo Dynamic connector [Shape](../../com.aspose.diagram/shape). |
+
+### connectShapesViaConnector(long shapeFromId, String fromConnectionName, long shapeToId, String toConnectionName, long connectorId) {#connectShapesViaConnector-long-java.lang.String-long-java.lang.String-long-}
+```
+public void connectShapesViaConnector(long shapeFromId, String fromConnectionName, long shapeToId, String toConnectionName, long connectorId)
+```
+
+
+Collega le forme tramite connettore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| shapeFromId | long | L'ID della forma dove il connettore inizia [Shape](../../com.aspose.diagram/shape). |
+| fromConnectionName | java.lang.String | Il nome della connessione sulla prima forma dove il connettore sarà collegato. |
+| shapeToId | long | L'ID della forma dove il connettore termina [Shape](../../com.aspose.diagram/shape). |
+| toConnectionName | java.lang.String | Il nome della connessione sulla seconda forma dove il connettore sarà collegato. |
+| connectorId | long | L'ID della forma con tipo Dynamic connector [Shape](../../com.aspose.diagram/shape). |
+
+### connectShapesViaConnectorIndex(Shape shapeFrom, int fromIndex, Shape shapeTo, int toIndex, Shape connector) {#connectShapesViaConnectorIndex-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-}
+```
+public void connectShapesViaConnectorIndex(Shape shapeFrom, int fromIndex, Shape shapeTo, int toIndex, Shape connector)
+```
+
+
+Collega le forme tramite indice del connettore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| shapeFrom | [Shape](../../com.aspose.diagram/shape) | La forma dove inizia il connettore [Shape](../../com.aspose.diagram/shape). |
+| fromIndex | int | L'indice della connessione sulla prima forma |
+| shapeTo | [Shape](../../com.aspose.diagram/shape) | La forma dove il connettore termina [Shape](../../com.aspose.diagram/shape). |
+| toIndex | int | L'indice della connessione sulla seconda forma |
+| connector | [Shape](../../com.aspose.diagram/shape) | La forma con tipo Dynamic connector [Shape](../../com.aspose.diagram/shape). |
+
+### connectShapesViaConnectorIndex(long shapeFromId, int fromIndex, long shapeToId, int toIndex, long connectorId) {#connectShapesViaConnectorIndex-long-int-long-int-long-}
+```
+public void connectShapesViaConnectorIndex(long shapeFromId, int fromIndex, long shapeToId, int toIndex, long connectorId)
+```
+
+
+Collega le forme tramite indice del connettore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| shapeFromId | long | L'ID della forma dove il connettore inizia [Shape](../../com.aspose.diagram/shape). |
+| fromIndex | int | L'indice della connessione sulla prima forma |
+| shapeToId | long | L'ID della forma dove il connettore termina [Shape](../../com.aspose.diagram/shape). |
+| toIndex | int | L'indice della connessione sulla seconda forma |
+| connectorId | long | L'ID della forma con tipo Dynamic connector [Shape](../../com.aspose.diagram/shape). |
+
+### copy(Page source) {#copy-com.aspose.diagram.Page-}
+```
+public void copy(Page source)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| source | [Page](../../com.aspose.diagram/page) |  |
+
+### dispose() {#dispose--}
+```
+public void dispose()
+```
+
+
+Esegue operazioni definite dall'applicazione associate al rilascio, alla liberazione o al reset delle risorse non gestite.
+
+### drawEllipse(double pinX, double pinY, double width, double height) {#drawEllipse-double-double-double-double-}
+```
+public long drawEllipse(double pinX, double pinY, double width, double height)
+```
+
+
+Il processo di disegno dell'ellisse.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| pinX | double | Specifica la coordinata x del perno della forma (centro di rotazione) in relazione alla pagina. |
+| pinY | double | Specifica la coordinata y del perno della forma (centro di rotazione) in relazione alla pagina. |
+| width | double | Specifica la larghezza della forma |
+| height | double | Specifica l'altezza della forma |
+
+**Returns:**
+long -
+### drawLine(double beginX, double beginY, double endX, double endY) {#drawLine-double-double-double-double-}
+```
+public long drawLine(double beginX, double beginY, double endX, double endY)
+```
+
+
+Il processo di disegno di una linea singola.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| beginX | double | Specifica la coordinata x iniziale della posizione della forma in relazione alla pagina. |
+| beginY | double | Specifica la coordinata y iniziale della posizione della forma in relazione alla pagina. |
+| endX | double | Specifica la coordinata x finale della posizione della forma in relazione alla pagina. |
+| endY | double | Specifica la coordinata y finale della posizione della forma rispetto alla pagina. |
+
+**Returns:**
+long - L'ID univoco della forma all'interno della collezione di forme nella pagina specificata.
+### drawLine(double pinX, double pinY, double width, double height, double[] xyArray) {#drawLine-double-double-double-double-double---}
+```
+public long drawLine(double pinX, double pinY, double width, double height, double[] xyArray)
+```
+
+
+Il processo di disegno della linea.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| pinX | double | Specifica la coordinata x del perno della forma (centro di rotazione) in relazione alla pagina. |
+| pinY | double | Specifica la coordinata y del perno della forma (centro di rotazione) in relazione alla pagina. |
+| width | double | Specifica la larghezza della forma |
+| height | double | Specifica l'altezza della forma |
+| xyArray | double[] | Un array di valori x e y alternati che definisce i punti nella nuova forma |
+
+**Returns:**
+long - L'ID univoco della forma all'interno della collezione di forme nella pagina specificata.
+### drawPolyline(double pinX, double pinY, double width, double height, double[] xyArray) {#drawPolyline-double-double-double-double-double---}
+```
+public long drawPolyline(double pinX, double pinY, double width, double height, double[] xyArray)
+```
+
+
+Il processo di disegno della polilinea.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| pinX | double | Specifica la coordinata x del perno della forma (centro di rotazione) in relazione alla pagina. |
+| pinY | double | Specifica la coordinata y del perno della forma (centro di rotazione) in relazione alla pagina. |
+| width | double | Specifica la larghezza della forma |
+| height | double | Specifica l'altezza della forma |
+| xyArray | double[] | Un array di valori x e y alternati che definisce i punti nella nuova forma |
+
+**Returns:**
+long - L'ID univoco della forma all'interno della collezione di forme nella pagina specificata.
+### drawRectangle(double pinX, double pinY, double width, double height) {#drawRectangle-double-double-double-double-}
+```
+public long drawRectangle(double pinX, double pinY, double width, double height)
+```
+
+
+Il processo di disegno del rettangolo.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| pinX | double | Specifica la coordinata x del perno della forma (centro di rotazione) in relazione alla pagina. |
+| pinY | double | Specifica la coordinata y del perno della forma (centro di rotazione) in relazione alla pagina. |
+| width | double | Specifica la larghezza della forma |
+| height | double | Specifica l'altezza della forma |
+
+**Returns:**
+long - L'ID univoco della forma all'interno della collezione di forme nella pagina specificata.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAssociatedPage() {#getAssociatedPage--}
+```
+public Page getAssociatedPage()
+```
+
+
+L'ID della pagina di disegno originale che è stata annotata su overlay di markup separati dai revisori del disegno.
+
+**Returns:**
+[Page](../../com.aspose.diagram/page)
+### getBackPage() {#getBackPage--}
+```
+public Page getBackPage()
+```
+
+
+La pagina di sfondo della pagina.
+
+**Returns:**
+[Page](../../com.aspose.diagram/page)
+### getBackground() {#getBackground--}
+```
+public int getBackground()
+```
+
+
+Un flag che indica se la pagina è una pagina di sfondo.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConnects() {#getConnects--}
+```
+public ConnectCollection getConnects()
+```
+
+
+Contiene un elemento Connect per ogni connessione tra due forme in un disegno.
+
+**Returns:**
+[ConnectCollection](../../com.aspose.diagram/connectcollection)
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+L'ID univoco dell'elemento all'interno del suo elemento genitore.
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Il nome dell'elemento.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+Il nome universale dell'elemento.
+
+**Returns:**
+java.lang.String
+### getPageSheet() {#getPageSheet--}
+```
+public PageSheet getPageSheet()
+```
+
+
+Contiene elementi che definiscono il foglio di pagina per un elemento Pagina o Master.
+
+**Returns:**
+[PageSheet](../../com.aspose.diagram/pagesheet)
+### getPages() {#getPages--}
+```
+public PageCollection getPages()
+```
+
+
+Raccolta di pagine.
+
+**Returns:**
+[PageCollection](../../com.aspose.diagram/pagecollection)
+### getReviewerID() {#getReviewerID--}
+```
+public int getReviewerID()
+```
+
+
+L'ID del revisore associato all'overlay di markup.
+
+**Returns:**
+int
+### getShapes() {#getShapes--}
+```
+public ShapeCollection getShapes()
+```
+
+
+Raccolta di forme.
+
+**Returns:**
+[ShapeCollection](../../com.aspose.diagram/shapecollection)
+### getViewCenterX() {#getViewCenterX--}
+```
+public double getViewCenterX()
+```
+
+
+ViewCenterX e ViewCenterY specificano un punto centrale su una pagina che una nuova vista (finestra) assume quando viene aperta inizialmente.
+
+**Returns:**
+double
+### getViewCenterY() {#getViewCenterY--}
+```
+public double getViewCenterY()
+```
+
+
+ViewCenterX e ViewCenterY specificano un punto centrale su una pagina che una nuova vista (finestra) assume quando viene aperta inizialmente.
+
+**Returns:**
+double
+### getViewScale() {#getViewScale--}
+```
+public double getViewScale()
+```
+
+
+Il fattore di ingrandimento predefinito da utilizzare quando viene aperta una nuova visualizzazione (finestra) della pagina. Per esempio, 1 = 100%; 1.5 = 150%, e così via.
+
+**Returns:**
+double
+### glueShapeToConnectorBeginX(long shapeFromId, String connectionName, long connectorId) {#glueShapeToConnectorBeginX-long-java.lang.String-long-}
+```
+public void glueShapeToConnectorBeginX(long shapeFromId, String connectionName, long connectorId)
+```
+
+
+Incolla la forma al BeginX del Connettore
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| shapeFromId | long | L'ID della forma dove il connettore inizia [Shape](../../com.aspose.diagram/shape). |
+| connectionName | java.lang.String | Il nome della connessione sulla forma dove verrà collegato il connettore. |
+| connectorId | long | L'ID della forma con tipo Dynamic connector [Shape](../../com.aspose.diagram/shape). |
+
+### glueShapeToConnectorEndX(long shapeToId, String connectionName, long connectorId) {#glueShapeToConnectorEndX-long-java.lang.String-long-}
+```
+public void glueShapeToConnectorEndX(long shapeToId, String connectionName, long connectorId)
+```
+
+
+Incolla la forma al EndX del Connettore
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| shapeToId | long | L'ID della forma dove il connettore termina [Shape](../../com.aspose.diagram/shape). |
+| connectionName | java.lang.String | Il nome della connessione sulla seconda forma dove il connettore sarà collegato. |
+| connectorId | long | L'ID della forma con tipo Dynamic connector [Shape](../../com.aspose.diagram/shape). |
+
+### glueShapes(Shape shapeFrom, int placeTo, Shape shapeTo) {#glueShapes-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-}
+```
+public void glueShapes(Shape shapeFrom, int placeTo, Shape shapeTo)
+```
+
+
+Incolla forme.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| shapeFrom | [Shape](../../com.aspose.diagram/shape) | La forma da cui è incollata [Shape](../../com.aspose.diagram/shape). |
+| placeTo | int | La posizione sulla prima forma dove incollare Aspose.Diagram.Manipulation.ConnectionPointPlace. |
+| shapeTo | [Shape](../../com.aspose.diagram/shape) | La forma a cui incollare [Shape](../../com.aspose.diagram/shape). |
+
+### glueShapes(long shapeFromId, int placeTo, long shapeToId) {#glueShapes-long-int-long-}
+```
+public void glueShapes(long shapeFromId, int placeTo, long shapeToId)
+```
+
+
+Incolla forme
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| shapeFromId | long | L'ID della forma da cui è incollata [Shape](../../com.aspose.diagram/shape). |
+| placeTo | int | La posizione sulla prima forma dove incollare Aspose.Diagram.Manipulation.ConnectionPointPlace. |
+| shapeToId | long | L'ID della forma a cui incollare [Shape](../../com.aspose.diagram/shape). |
+
+### glueShapesInContainer(long shapeFromId, int shapeToBeginConnectionIndex, int shapeToEndConnectionIndex, long shapeToId) {#glueShapesInContainer-long-int-int-long-}
+```
+public void glueShapesInContainer(long shapeFromId, int shapeToBeginConnectionIndex, int shapeToEndConnectionIndex, long shapeToId)
+```
+
+
+Incolla forme nel contenitore
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| shapeFromId | long | L'ID della forma da cui è incollata [Shape](../../com.aspose.diagram/shape). |
+| shapeToBeginConnectionIndex | int | La posizione sul primo indice di connessione dove incollare. |
+| shapeToEndConnectionIndex | int | La posizione sull'indice di connessione finale dove incollare. |
+| shapeToId | long | L'ID della forma a cui incollare [Shape](../../com.aspose.diagram/shape). |
+
+### glueShapesInContainer(long shapeFromId, String shapeToBeginConnectionName, String shapeToEndConnectionName, long shapeToId) {#glueShapesInContainer-long-java.lang.String-java.lang.String-long-}
+```
+public void glueShapesInContainer(long shapeFromId, String shapeToBeginConnectionName, String shapeToEndConnectionName, long shapeToId)
+```
+
+
+Incolla forme nel contenitore usando il nome della connessione
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| shapeFromId | long | L'ID della forma da cui è incollata [Shape](../../com.aspose.diagram/shape). |
+| shapeToBeginConnectionName | java.lang.String | La posizione sul primo nome di connessione dove incollare. |
+| shapeToEndConnectionName | java.lang.String | La posizione sul nome di connessione finale dove incollare. |
+| shapeToId | long | L'ID della forma a cui incollare [Shape](../../com.aspose.diagram/shape). |
+
+### glueShapesInContainerByID(long shapeFromId, int shapeToBeginConnectionID, int shapeToEndConnectionID, long shapeToId) {#glueShapesInContainerByID-long-int-int-long-}
+```
+public void glueShapesInContainerByID(long shapeFromId, int shapeToBeginConnectionID, int shapeToEndConnectionID, long shapeToId)
+```
+
+
+Incolla forme per ID di connessione nel contenitore
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| shapeFromId | long | L'ID della forma da cui è incollata [Shape](../../com.aspose.diagram/shape). |
+| shapeToBeginConnectionID | int | La posizione sul primo ID di connessione dove incollare. |
+| shapeToEndConnectionID | int | La posizione sull'ID di connessione finale dove incollare. |
+| shapeToId | long | L'ID della forma a cui incollare [Shape](../../com.aspose.diagram/shape). |
+
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### layout(LayoutOptions options) {#layout-com.aspose.diagram.LayoutOptions-}
+```
+public void layout(LayoutOptions options)
+```
+
+
+Dispone le forme e/o riorienta i connettori per la pagina.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| options | [LayoutOptions](../../com.aspose.diagram/layoutoptions) | Utilizzando [LayoutOptions](../../com.aspose.diagram/layoutoptions) per configurare le opzioni del layout. |
+
+### moveTo(int index) {#moveTo-int-}
+```
+public void moveTo(int index)
+```
+
+
+Sposta la pagina in un'altra posizione tra le pagine.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | Indice della pagina di destinazione. |
+
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### sendBackward(long shapeId) {#sendBackward-long-}
+```
+public void sendBackward(long shapeId)
+```
+
+
+Sposta una forma, definita per ID, indietro di una posizione nell'ordine Z.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| shapeId | long | ID di shape.long |
+
+### sendToBack(long shapeId) {#sendToBack-long-}
+```
+public void sendToBack(long shapeId)
+```
+
+
+Sposta una forma, definita per ID, in fondo all'ordine Z.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| shapeId | long | ID di shape.long |
+
+### setAssociatedPage(Page value) {#setAssociatedPage-com.aspose.diagram.Page-}
+```
+public void setAssociatedPage(Page value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getAssociatedPage()](../../com.aspose.diagram/page\#getAssociatedPage--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [Page](../../com.aspose.diagram/page) |  |
+
+### setBackPage(Page value) {#setBackPage-com.aspose.diagram.Page-}
+```
+public void setBackPage(Page value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getBackPage()](../../com.aspose.diagram/page\#getBackPage--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [Page](../../com.aspose.diagram/page) |  |
+
+### setBackground(int value) {#setBackground-int-}
+```
+public void setBackground(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getBackground()](../../com.aspose.diagram/page\#getBackground--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getID()](../../com.aspose.diagram/page\#getID--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getName()](../../com.aspose.diagram/page\#getName--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getNameU()](../../com.aspose.diagram/page\#getNameU--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setPages(PageCollection value) {#setPages-com.aspose.diagram.PageCollection-}
+```
+public void setPages(PageCollection value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getPages()](../../com.aspose.diagram/page\#getPages--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [PageCollection](../../com.aspose.diagram/pagecollection) |  |
+
+### setPresetTheme(int value) {#setPresetTheme-int-}
+```
+public void setPresetTheme(int value)
+```
+
+
+Applica un tema predefinito a questa pagina
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setPresetThemeQuickStyle(int value) {#setPresetThemeQuickStyle-int-}
+```
+public void setPresetThemeQuickStyle(int value)
+```
+
+
+Applica una variante di tema predefinito quickstyle a questa pagina
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setPresetThemeVariant(int value) {#setPresetThemeVariant-int-}
+```
+public void setPresetThemeVariant(int value)
+```
+
+
+Applica una variante di tema predefinito a questa pagina
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setReviewerID(int value) {#setReviewerID-int-}
+```
+public void setReviewerID(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getReviewerID()](../../com.aspose.diagram/page\#getReviewerID--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setViewCenterX(double value) {#setViewCenterX-double-}
+```
+public void setViewCenterX(double value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getViewCenterX()](../../com.aspose.diagram/page\#getViewCenterX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double |  |
+
+### setViewCenterY(double value) {#setViewCenterY-double-}
+```
+public void setViewCenterY(double value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getViewCenterY()](../../com.aspose.diagram/page\#getViewCenterY--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double |  |
+
+### setViewScale(double value) {#setViewScale-double-}
+```
+public void setViewScale(double value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getViewScale()](../../com.aspose.diagram/page\#getViewScale--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/pagecollection/_index.md
+++ b/italian/java/com.aspose.diagram/pagecollection/_index.md
@@ -1,0 +1,259 @@
+---
+title: PageCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Raccolta di pagine.
+type: docs
+weight: 261
+url: /it/java/com.aspose.diagram/pagecollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class PageCollection extends Collection
+```
+
+Raccolta di pagine.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [add(Page page)](#add-com.aspose.diagram.Page-) | Aggiungi la pagina nella collezione. |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [dispose()](#dispose--) | Esegue operazioni definite dall'applicazione associate al rilascio, alla liberazione o al reset delle risorse non gestite. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [getPage(int ID)](#getPage-int-) | Restituisce l'elemento con l'ID specificato. |
+| [getPage(String name)](#getPage-java.lang.String-) | Restituisce l'elemento con il nome specificato. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Page page)](#remove-com.aspose.diagram.Page-) | Rimuovi la pagina dalla collezione. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Page page) {#add-com.aspose.diagram.Page-}
+```
+public int add(Page page)
+```
+
+
+Aggiungi la pagina nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| page | [Page](../../com.aspose.diagram/page) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### dispose() {#dispose--}
+```
+public void dispose()
+```
+
+
+Esegue operazioni definite dall'applicazione associate al rilascio, alla liberazione o al reset delle risorse non gestite.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Page get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[Page](../../com.aspose.diagram/page) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### getPage(int ID) {#getPage-int-}
+```
+public Page getPage(int ID)
+```
+
+
+Restituisce l'elemento con l'ID specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| ID | int |  |
+
+**Returns:**
+[Page](../../com.aspose.diagram/page) - 
+### getPage(String name) {#getPage-java.lang.String-}
+```
+public Page getPage(String name)
+```
+
+
+Restituisce l'elemento con il nome specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| nome | java.lang.String |  |
+
+**Returns:**
+[Page](../../com.aspose.diagram/page) - 
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Page page) {#remove-com.aspose.diagram.Page-}
+```
+public void remove(Page page)
+```
+
+
+Rimuovi la pagina dalla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| page | [Page](../../com.aspose.diagram/page) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/pageendsavingargs/_index.md
+++ b/italian/java/com.aspose.diagram/pageendsavingargs/_index.md
@@ -1,0 +1,172 @@
+---
+title: PageEndSavingArgs
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Informazioni per una pagina terminano il processo di salvataggio.
+type: docs
+weight: 262
+url: /it/java/com.aspose.diagram/pageendsavingargs/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.PageSavingArgs](../../com.aspose.diagram/pagesavingargs)
+```
+public class PageEndSavingArgs extends PageSavingArgs
+```
+
+Informazioni per una pagina terminano il processo di salvataggio.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getPageCount()](#getPageCount--) | Conteggio totale delle pagine. |
+| [getPageIndex()](#getPageIndex--) | Indice della pagina corrente, basato su zero. |
+| [hasMorePages()](#hasMorePages--) | un valore che indica se ci sono altre pagine da emettere. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setHasMorePages(boolean value)](#setHasMorePages-boolean-) | Per la descrizione di questa proprietà, vedere [hasMorePages()](../../com.aspose.diagram/pageendsavingargs\#hasMorePages--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+Conteggio totale delle pagine.
+
+**Returns:**
+int
+### getPageIndex() {#getPageIndex--}
+```
+public int getPageIndex()
+```
+
+
+Indice della pagina corrente, basato su zero.
+
+**Returns:**
+int
+### hasMorePages() {#hasMorePages--}
+```
+public boolean hasMorePages()
+```
+
+
+un valore che indica se ci sono altre pagine da emettere. Il valore predefinito è true.
+
+**Returns:**
+boolean
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setHasMorePages(boolean value) {#setHasMorePages-boolean-}
+```
+public void setHasMorePages(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [hasMorePages()](../../com.aspose.diagram/pageendsavingargs\#hasMorePages--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/pagelayout/_index.md
+++ b/italian/java/com.aspose.diagram/pagelayout/_index.md
@@ -1,0 +1,458 @@
+---
+title: PageLayout
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene celle che controllano le impostazioni di layout della pagina per forme e connettori, come la spaziatura tra tutte le forme nella pagina, la spaziatura tra tutti i connettori nella pagina e lo stile di instradamento per tutti i connettori nella pagina.
+type: docs
+weight: 263
+url: /it/java/com.aspose.diagram/pagelayout/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PageLayout
+```
+
+Contiene celle che controllano le impostazioni di layout della pagina per forme e connettori, come la spaziatura tra tutte le forme sulla pagina, la spaziatura tra tutti i connettori sulla pagina e lo stile di instradamento per tutti i connettori sulla pagina.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAvenueSizeX()](#getAvenueSizeX--) | Determina la quantità di spazio verticale tra le forme nella pagina di disegno quando si utilizza Microsoft Visio per disporre le forme nella pagina di disegno. |
+| [getAvenueSizeY()](#getAvenueSizeY--) | Determina la quantità di spazio verticale tra le forme nella pagina di disegno quando si utilizza Microsoft Visio per disporre le forme nella pagina di disegno. |
+| [getAvoidPageBreaks()](#getAvoidPageBreaks--) | Specifica come le forme vengono posizionate sulla pagina quando le forme sono disposte dopo che l'utente seleziona Lay Out Shapes (menu Forma). |
+| [getBlockSizeX()](#getBlockSizeX--) | Determina la dimensione del blocco verticale, l'area in cui ciascuna delle tue forme deve adattarsi nella pagina di disegno quando si utilizza Microsoft Visio per disporre le forme nella pagina di disegno. |
+| [getBlockSizeY()](#getBlockSizeY--) | Determina la quantità di spazio orizzontale tra le forme nella pagina di disegno quando si utilizza Microsoft Visio per disporre le forme nella pagina di disegno. |
+| [getClass()](#getClass--) |  |
+| [getCtrlAsInput()](#getCtrlAsInput--) | Determina quale forma è il genitore quando si utilizzano forme tramite maniglie di controllo. |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getDynamicsOff()](#getDynamicsOff--) | Specifica se le forme posizionabili si spostano e i connettori vengono riorientati attorno ad altre forme e connettori nella pagina di disegno. |
+| [getEnableGrid()](#getEnableGrid--) | Specifica se Microsoft Visio dispone le forme basandosi su una griglia interna della pagina quando l'utente seleziona Disposizione forme (menu Forma). |
+| [getLineAdjustFrom()](#getLineAdjustFrom--) | Specifica quali connettori dinamici separare se si sovrappongono. |
+| [getLineAdjustTo()](#getLineAdjustTo--) | Specifica quali connettori dinamici allineare uno sopra l'altro se si sovrappongono. |
+| [getLineJumpCode()](#getLineJumpCode--) | Specifica lo stile di salto di linea per tutti i connettori sulla pagina di disegno che non hanno uno stile di salto di linea locale. |
+| [getLineJumpFactorX()](#getLineJumpFactorX--) | Specifica la dimensione dei salti di linea sui segmenti orizzontali dei connettori dinamici nella pagina, come percentuale del valore dell'elemento LineToLineX (che specifica lo spazio orizzontale tra tutti i connettori nella pagina di disegno). |
+| [getLineJumpFactorY()](#getLineJumpFactorY--) | Specifica la dimensione dei salti di linea sui segmenti verticali dei connettori dinamici nella pagina, come percentuale del valore dell'elemento LineToLineY (che specifica lo spazio verticale tra tutti i connettori nella pagina di disegno). |
+| [getLineJumpStyle()](#getLineJumpStyle--) | Specifica la direzione dei salti di linea sui segmenti orizzontali dei connettori dinamici nella pagina di disegno per i quali non è stata applicata una direzione locale del salto. |
+| [getLineRouteExt()](#getLineRouteExt--) | Specifica l'aspetto predefinito per tutti i connettori su una pagina. |
+| [getLineToLineX()](#getLineToLineX--) | Specifica lo spazio orizzontale minimo tra i connettori dinamici nella pagina di disegno. |
+| [getLineToLineY()](#getLineToLineY--) | Specifica lo spazio verticale minimo tra i connettori dinamici nella pagina di disegno. |
+| [getLineToNodeX()](#getLineToNodeX--) | Specifica lo spazio verticale minimo tra i connettori dinamici e le forme nella pagina di disegno. |
+| [getLineToNodeY()](#getLineToNodeY--) | Determina la dimensione del blocco orizzontale, l'area in cui ciascuna delle tue forme deve adattarsi nella pagina di disegno quando si utilizza Microsoft Visio per disporre le forme nella pagina di disegno. |
+| [getPageLineJumpDirX()](#getPageLineJumpDirX--) | Specifica la direzione dei salti di linea sui connettori dinamici verticali nella pagina di disegno per i quali non è stata applicata una direzione locale del salto. |
+| [getPageLineJumpDirY()](#getPageLineJumpDirY--) | Specifica lo spazio orizzontale minimo tra i connettori dinamici e le forme nella pagina di disegno. |
+| [getPageShapeSplit()](#getPageShapeSplit--) | Indica se le forme nella pagina possono essere divise automaticamente. |
+| [getPlaceDepth()](#getPlaceDepth--) | Specifica se le forme posizionabili si allontanano quando l'utente trascina una forma posizionabile vicino a un'altra forma posizionabile nella pagina di disegno. |
+| [getPlaceFlip()](#getPlaceFlip--) | Specifica come le forme posizionabili vengono capovolte e/o ruotate su una pagina quando le forme sono disposte usando il comando Lay Out Shapes in Microsoft Visio. |
+| [getPlaceStyle()](#getPlaceStyle--) | Specifica lo stile di instradamento e la direzione per tutti i connettori dinamici nella pagina di disegno che non hanno uno stile di instradamento locale. |
+| [getPlowCode()](#getPlowCode--) | Determina i connettori dinamici a cui si desidera aggiungere salti. |
+| [getResizePage()](#getResizePage--) | Specifica se ingrandire la pagina per includere il disegno dopo che l'utente seleziona Disposizione forme (menu Forme). |
+| [getRouteStyle()](#getRouteStyle--) | Per un disegno disposto automaticamente, specifica il metodo con cui il disegno viene analizzato prima di creare il layout e determina il tipo di layout. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/pagelayout\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAvenueSizeX() {#getAvenueSizeX--}
+```
+public DoubleValue getAvenueSizeX()
+```
+
+
+Determina la quantità di spazio verticale tra le forme nella pagina di disegno quando si utilizza Microsoft Visio per disporre le forme nella pagina di disegno.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getAvenueSizeY() {#getAvenueSizeY--}
+```
+public DoubleValue getAvenueSizeY()
+```
+
+
+Determina la quantità di spazio verticale tra le forme nella pagina di disegno quando si utilizza Microsoft Visio per disporre le forme nella pagina di disegno.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getAvoidPageBreaks() {#getAvoidPageBreaks--}
+```
+public BoolValue getAvoidPageBreaks()
+```
+
+
+Specifica come le forme vengono posizionate sulla pagina quando le forme sono disposte dopo che l'utente seleziona Lay Out Shapes (menu Forma).
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getBlockSizeX() {#getBlockSizeX--}
+```
+public DoubleValue getBlockSizeX()
+```
+
+
+Determina la dimensione del blocco verticale, l'area in cui ciascuna delle tue forme deve adattarsi nella pagina di disegno quando si utilizza Microsoft Visio per disporre le forme nella pagina di disegno.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBlockSizeY() {#getBlockSizeY--}
+```
+public DoubleValue getBlockSizeY()
+```
+
+
+Determina la quantità di spazio orizzontale tra le forme nella pagina di disegno quando si utilizza Microsoft Visio per disporre le forme nella pagina di disegno.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCtrlAsInput() {#getCtrlAsInput--}
+```
+public BoolValue getCtrlAsInput()
+```
+
+
+Determina quale forma è il genitore quando si utilizzano forme tramite maniglie di controllo. Questo elemento imposta il comportamento per tutte le forme nella pagina di disegno.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getDynamicsOff() {#getDynamicsOff--}
+```
+public BoolValue getDynamicsOff()
+```
+
+
+Specifica se le forme posizionabili si spostano e i connettori vengono riorientati attorno ad altre forme e connettori nella pagina di disegno.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getEnableGrid() {#getEnableGrid--}
+```
+public BoolValue getEnableGrid()
+```
+
+
+Specifica se Microsoft Visio dispone le forme basandosi su una griglia interna della pagina quando l'utente seleziona Disposizione forme (menu Forma).
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLineAdjustFrom() {#getLineAdjustFrom--}
+```
+public LineAdjustFrom getLineAdjustFrom()
+```
+
+
+Specifica quali connettori dinamici separare se si sovrappongono.
+
+**Returns:**
+[LineAdjustFrom](../../com.aspose.diagram/lineadjustfrom)
+### getLineAdjustTo() {#getLineAdjustTo--}
+```
+public LineAdjustTo getLineAdjustTo()
+```
+
+
+Specifica quali connettori dinamici allineare uno sopra l'altro se si sovrappongono.
+
+**Returns:**
+[LineAdjustTo](../../com.aspose.diagram/lineadjustto)
+### getLineJumpCode() {#getLineJumpCode--}
+```
+public LineJumpCode getLineJumpCode()
+```
+
+
+Specifica lo stile di salto di linea per tutti i connettori sulla pagina di disegno che non hanno uno stile di salto di linea locale.
+
+**Returns:**
+[LineJumpCode](../../com.aspose.diagram/linejumpcode)
+### getLineJumpFactorX() {#getLineJumpFactorX--}
+```
+public DoubleValue getLineJumpFactorX()
+```
+
+
+Specifica la dimensione dei salti di linea sui segmenti orizzontali dei connettori dinamici nella pagina, come percentuale del valore dell'elemento LineToLineX (che specifica lo spazio orizzontale tra tutti i connettori nella pagina di disegno). Il valore di questo elemento varia da 0 a 10.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLineJumpFactorY() {#getLineJumpFactorY--}
+```
+public DoubleValue getLineJumpFactorY()
+```
+
+
+Specifica la dimensione dei salti di linea sui segmenti verticali dei connettori dinamici nella pagina, come percentuale del valore dell'elemento LineToLineY (che specifica lo spazio verticale tra tutti i connettori nella pagina di disegno). Questo elemento può contenere un valore da 0 a 10.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLineJumpStyle() {#getLineJumpStyle--}
+```
+public LineJumpStyle getLineJumpStyle()
+```
+
+
+Specifica la direzione dei salti di linea sui segmenti orizzontali dei connettori dinamici nella pagina di disegno per i quali non è stata applicata una direzione locale del salto.
+
+**Returns:**
+[LineJumpStyle](../../com.aspose.diagram/linejumpstyle)
+### getLineRouteExt() {#getLineRouteExt--}
+```
+public LineRouteExt getLineRouteExt()
+```
+
+
+Specifica l'aspetto predefinito per tutti i connettori su una pagina.
+
+**Returns:**
+[LineRouteExt](../../com.aspose.diagram/linerouteext)
+### getLineToLineX() {#getLineToLineX--}
+```
+public DoubleValue getLineToLineX()
+```
+
+
+Specifica lo spazio orizzontale minimo tra i connettori dinamici nella pagina di disegno.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLineToLineY() {#getLineToLineY--}
+```
+public DoubleValue getLineToLineY()
+```
+
+
+Specifica lo spazio verticale minimo tra i connettori dinamici nella pagina di disegno.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLineToNodeX() {#getLineToNodeX--}
+```
+public DoubleValue getLineToNodeX()
+```
+
+
+Specifica lo spazio verticale minimo tra i connettori dinamici e le forme nella pagina di disegno.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLineToNodeY() {#getLineToNodeY--}
+```
+public DoubleValue getLineToNodeY()
+```
+
+
+Determina la dimensione del blocco orizzontale, l'area in cui ciascuna delle tue forme deve adattarsi nella pagina di disegno quando si utilizza Microsoft Visio per disporre le forme nella pagina di disegno.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getPageLineJumpDirX() {#getPageLineJumpDirX--}
+```
+public PageLineJumpDirX getPageLineJumpDirX()
+```
+
+
+Specifica la direzione dei salti di linea sui connettori dinamici verticali nella pagina di disegno per i quali non è stata applicata una direzione locale del salto.
+
+**Returns:**
+[PageLineJumpDirX](../../com.aspose.diagram/pagelinejumpdirx)
+### getPageLineJumpDirY() {#getPageLineJumpDirY--}
+```
+public PageLineJumpDirY getPageLineJumpDirY()
+```
+
+
+Specifica lo spazio orizzontale minimo tra i connettori dinamici e le forme nella pagina di disegno.
+
+**Returns:**
+[PageLineJumpDirY](../../com.aspose.diagram/pagelinejumpdiry)
+### getPageShapeSplit() {#getPageShapeSplit--}
+```
+public BoolValue getPageShapeSplit()
+```
+
+
+Indica se le forme nella pagina possono essere divise automaticamente.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getPlaceDepth() {#getPlaceDepth--}
+```
+public PlaceDepth getPlaceDepth()
+```
+
+
+Specifica se le forme posizionabili si allontanano quando l'utente trascina una forma posizionabile vicino a un'altra forma posizionabile nella pagina di disegno.
+
+**Returns:**
+[PlaceDepth](../../com.aspose.diagram/placedepth)
+### getPlaceFlip() {#getPlaceFlip--}
+```
+public PlaceFlip getPlaceFlip()
+```
+
+
+Specifies how placeable shapes flip and/or rotate on a page when shapes are laid out using the Lay Out Shapes command in Microsoft Visio. The following hexadecimal values are allowed.
+
+**Returns:**
+[PlaceFlip](../../com.aspose.diagram/placeflip)
+### getPlaceStyle() {#getPlaceStyle--}
+```
+public PlaceStyle getPlaceStyle()
+```
+
+
+Specifica lo stile di instradamento e la direzione per tutti i connettori dinamici nella pagina di disegno che non hanno uno stile di instradamento locale.
+
+**Returns:**
+[PlaceStyle](../../com.aspose.diagram/placestyle)
+### getPlowCode() {#getPlowCode--}
+```
+public BoolValue getPlowCode()
+```
+
+
+Determina i connettori dinamici a cui si desidera aggiungere salti.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getResizePage() {#getResizePage--}
+```
+public BoolValue getResizePage()
+```
+
+
+Specifica se ingrandire la pagina per includere il disegno dopo che l'utente seleziona Disposizione forme (menu Forme).
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getRouteStyle() {#getRouteStyle--}
+```
+public RouteStyle getRouteStyle()
+```
+
+
+Per un disegno disposto automaticamente, specifica il metodo con cui il disegno viene analizzato prima di creare il layout e determina il tipo di layout.
+
+**Returns:**
+[RouteStyle](../../com.aspose.diagram/routestyle)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/pagelayout\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/pagelinejumpdirx/_index.md
+++ b/italian/java/com.aspose.diagram/pagelinejumpdirx/_index.md
@@ -1,0 +1,179 @@
+---
+title: PageLineJumpDirX
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica la direzione dei salti di linea sui segmenti orizzontali dei connettori dinamici nella pagina di disegno per i quali non è stata applicata una direzione di salto locale.
+type: docs
+weight: 264
+url: /it/java/com.aspose.diagram/pagelinejumpdirx/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PageLineJumpDirX
+```
+
+Specifica la direzione dei salti di linea sui segmenti orizzontali dei connettori dinamici nella pagina di disegno per i quali non è stata applicata una direzione locale del salto.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [PageLineJumpDirX(int value)](#PageLineJumpDirX-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Specifica la direzione dei salti di linea sui segmenti orizzontali dei connettori dinamici nella pagina di disegno per i quali non è stata applicata una direzione locale del salto. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, consultare [getValue()](../../com.aspose.diagram/pagelinejumpdirx\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageLineJumpDirX(int value) {#PageLineJumpDirX-int-}
+```
+public PageLineJumpDirX(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specifica la direzione dei salti di linea sui segmenti orizzontali dei connettori dinamici nella pagina di disegno per i quali non è stata applicata una direzione locale del salto.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getValue()](../../com.aspose.diagram/pagelinejumpdirx\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/pagelinejumpdirxvalue/_index.md
+++ b/italian/java/com.aspose.diagram/pagelinejumpdirxvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: PageLineJumpDirXValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica la direzione dei salti di linea sui segmenti orizzontali dei connettori dinamici nella pagina di disegno per i quali non è stata applicata una direzione di salto locale.
+type: docs
+weight: 265
+url: /it/java/com.aspose.diagram/pagelinejumpdirxvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PageLineJumpDirXValue
+```
+
+Specifica la direzione dei salti di linea sui segmenti orizzontali dei connettori dinamici nella pagina di disegno per i quali non è stata applicata una direzione locale del salto.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [DEFAULT_UP](#DEFAULT-UP) | Predefinito Su. |
+| [DOWN](#DOWN) | Giù |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+| [UP](#UP) | Su. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DEFAULT_UP {#DEFAULT-UP}
+```
+public static final int DEFAULT_UP
+```
+
+
+Predefinito Su.
+
+### DOWN {#DOWN}
+```
+public static final int DOWN
+```
+
+
+Giù
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### UP {#UP}
+```
+public static final int UP
+```
+
+
+Su.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/pagelinejumpdiry/_index.md
+++ b/italian/java/com.aspose.diagram/pagelinejumpdiry/_index.md
@@ -1,0 +1,179 @@
+---
+title: PageLineJumpDirY
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica la direzione dei salti di linea sui connettori dinamici verticali nella pagina di disegno per i quali non è stata applicata una direzione di salto locale.
+type: docs
+weight: 266
+url: /it/java/com.aspose.diagram/pagelinejumpdiry/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PageLineJumpDirY
+```
+
+Specifica la direzione dei salti di linea sui connettori dinamici verticali nella pagina di disegno per i quali non è stata applicata una direzione locale del salto.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [PageLineJumpDirY(int value)](#PageLineJumpDirY-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Specifica la direzione dei salti di linea sui connettori dinamici verticali nella pagina di disegno per i quali non è stata applicata una direzione locale del salto. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/pagelinejumpdiry\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageLineJumpDirY(int value) {#PageLineJumpDirY-int-}
+```
+public PageLineJumpDirY(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specifica la direzione dei salti di linea sui connettori dinamici verticali nella pagina di disegno per i quali non è stata applicata una direzione locale del salto.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/pagelinejumpdiry\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/pagelinejumpdiryvalue/_index.md
+++ b/italian/java/com.aspose.diagram/pagelinejumpdiryvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: PageLineJumpDirYValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica la direzione dei salti di linea sui connettori dinamici verticali nella pagina di disegno per i quali non è stata applicata una direzione di salto locale.
+type: docs
+weight: 267
+url: /it/java/com.aspose.diagram/pagelinejumpdiryvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PageLineJumpDirYValue
+```
+
+Specifica la direzione dei salti di linea sui connettori dinamici verticali nella pagina di disegno per i quali non è stata applicata una direzione locale del salto.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [DEFAULTLEFT](#DEFAULTLEFT) | Predefinito a sinistra. |
+| [LEFT](#LEFT) | Sinistra. |
+| [RIGHT](#RIGHT) | Destra. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DEFAULTLEFT {#DEFAULTLEFT}
+```
+public static final int DEFAULTLEFT
+```
+
+
+Predefinito a sinistra.
+
+### LEFT {#LEFT}
+```
+public static final int LEFT
+```
+
+
+Sinistra.
+
+### RIGHT {#RIGHT}
+```
+public static final int RIGHT
+```
+
+
+Destra.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/pageprops/_index.md
+++ b/italian/java/com.aspose.diagram/pageprops/_index.md
@@ -1,0 +1,315 @@
+---
+title: PageProps
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene celle che controllano gli attributi della pagina come larghezza, altezza e scala della pagina.
+type: docs
+weight: 268
+url: /it/java/com.aspose.diagram/pageprops/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PageProps
+```
+
+Contiene celle che controllano gli attributi della pagina, come larghezza, altezza e scala della pagina.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getDrawingResizeType()](#getDrawingResizeType--) | Determina se la pagina di disegno si ridimensiona automaticamente per adattarsi al diagramma. |
+| [getDrawingScale()](#getDrawingScale--) | Rappresenta il valore dell'unità di disegno nella scala di disegno corrente. |
+| [getDrawingScaleType()](#getDrawingScaleType--) | Specifica il tipo di scala di disegno da utilizzare per una pagina. |
+| [getDrawingSizeType()](#getDrawingSizeType--) | Specifica le dimensioni di disegno di una pagina. |
+| [getInhibitSnap()](#getInhibitSnap--) | Specifica se le forme su una pagina in primo piano si agganciano ad altri oggetti sulla pagina e alle forme sulla pagina di sfondo. |
+| [getPageHeight()](#getPageHeight--) | Specifica l'altezza della pagina in unità di disegno. |
+| [getPageScale()](#getPageScale--) | Specifica il valore dell'unità di pagina predefinita nella scala di disegno corrente. |
+| [getPageWidth()](#getPageWidth--) | Specifica la larghezza della pagina in unità di disegno. |
+| [getShdwObliqueAngle()](#getShdwObliqueAngle--) | Contiene un numero che specifica l'angolo della direzione obliqua quando viene applicato il tipo di ombra predefinito della pagina. |
+| [getShdwOffsetX()](#getShdwOffsetX--) | Specifica la distanza in unità di pagina di cui l'ombra proiettata di una forma è spostata orizzontalmente dalla forma. |
+| [getShdwOffsetY()](#getShdwOffsetY--) | Specifica la distanza in unità di pagina di cui l'ombra proiettata di una forma è spostata verticalmente dalla forma. |
+| [getShdwScaleFactor()](#getShdwScaleFactor--) | Specifica la percentuale per ingrandire o ridurre l'ombra di una forma. |
+| [getShdwType()](#getShdwType--) | Indica il tipo di ombra predefinito per una pagina. |
+| [getUIVisibility()](#getUIVisibility--) | Determina se il nome della pagina è esposto nell'interfaccia utente (UI). |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/pageprops\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getDrawingResizeType() {#getDrawingResizeType--}
+```
+public DrawingResizeType getDrawingResizeType()
+```
+
+
+Determina se la pagina di disegno si ridimensiona automaticamente per adattarsi al diagramma.
+
+**Returns:**
+[DrawingResizeType](../../com.aspose.diagram/drawingresizetype)
+### getDrawingScale() {#getDrawingScale--}
+```
+public DoubleValue getDrawingScale()
+```
+
+
+Rappresenta il valore dell'unità di disegno nella scala di disegno corrente. La scala di disegno per la pagina è il rapporto dell'unità di pagina contenuta nell'elemento PageScale all'unità di disegno. Le unità di questo elemento determinano le unità di lunghezza predefinite (DL) per la pagina.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDrawingScaleType() {#getDrawingScaleType--}
+```
+public DrawingScaleType getDrawingScaleType()
+```
+
+
+Specifica il tipo di scala di disegno da utilizzare per una pagina.
+
+**Returns:**
+[DrawingScaleType](../../com.aspose.diagram/drawingscaletype)
+### getDrawingSizeType() {#getDrawingSizeType--}
+```
+public DrawingSizeType getDrawingSizeType()
+```
+
+
+Specifica le dimensioni di disegno di una pagina.
+
+**Returns:**
+[DrawingSizeType](../../com.aspose.diagram/drawingsizetype)
+### getInhibitSnap() {#getInhibitSnap--}
+```
+public BoolValue getInhibitSnap()
+```
+
+
+Specifica se le forme su una pagina in primo piano si agganciano ad altri oggetti sulla pagina e alle forme sulla pagina di sfondo.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getPageHeight() {#getPageHeight--}
+```
+public DoubleValue getPageHeight()
+```
+
+
+Specifica l'altezza della pagina in unità di disegno.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getPageScale() {#getPageScale--}
+```
+public DoubleValue getPageScale()
+```
+
+
+Specifica il valore dell'unità di pagina predefinita nella scala di disegno corrente. La scala di disegno per la pagina è il rapporto dell'unità di pagina nell'elemento PageScale all'unità di disegno mostrata nell'elemento DrawingScale.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getPageWidth() {#getPageWidth--}
+```
+public DoubleValue getPageWidth()
+```
+
+
+Specifica la larghezza della pagina in unità di disegno.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShdwObliqueAngle() {#getShdwObliqueAngle--}
+```
+public DoubleValue getShdwObliqueAngle()
+```
+
+
+Contiene un numero che specifica l'angolo della direzione obliqua quando viene applicato il tipo di ombra predefinito della pagina.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShdwOffsetX() {#getShdwOffsetX--}
+```
+public DoubleValue getShdwOffsetX()
+```
+
+
+Specifica la distanza in unità di pagina di cui l'ombra proiettata di una forma è spostata orizzontalmente dalla forma.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShdwOffsetY() {#getShdwOffsetY--}
+```
+public DoubleValue getShdwOffsetY()
+```
+
+
+Specifica la distanza in unità di pagina di cui l'ombra proiettata di una forma è spostata verticalmente dalla forma.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShdwScaleFactor() {#getShdwScaleFactor--}
+```
+public DoubleValue getShdwScaleFactor()
+```
+
+
+Specifica la percentuale per ingrandire o ridurre l'ombra di una forma.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShdwType() {#getShdwType--}
+```
+public ShdwType getShdwType()
+```
+
+
+Indica il tipo di ombra predefinito per una pagina.
+
+**Returns:**
+[ShdwType](../../com.aspose.diagram/shdwtype)
+### getUIVisibility() {#getUIVisibility--}
+```
+public UIVisibility getUIVisibility()
+```
+
+
+Determina se il nome della pagina è esposto nell'interfaccia utente (UI). Un valore di uno indica che la pagina non è visibile; un valore di zero indica che la pagina è visibile.
+
+**Returns:**
+[UIVisibility](../../com.aspose.diagram/uivisibility)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/pageprops\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/pagesavingargs/_index.md
+++ b/italian/java/com.aspose.diagram/pagesavingargs/_index.md
@@ -1,0 +1,147 @@
+---
+title: PageSavingArgs
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Informazioni per il processo di salvataggio di una pagina.
+type: docs
+weight: 269
+url: /it/java/com.aspose.diagram/pagesavingargs/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PageSavingArgs
+```
+
+Informazioni per il processo di salvataggio di una pagina.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getPageCount()](#getPageCount--) | Conteggio totale delle pagine. |
+| [getPageIndex()](#getPageIndex--) | Indice della pagina corrente, basato su zero. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+Conteggio totale delle pagine.
+
+**Returns:**
+int
+### getPageIndex() {#getPageIndex--}
+```
+public int getPageIndex()
+```
+
+
+Indice della pagina corrente, basato su zero.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/pagesheet/_index.md
+++ b/italian/java/com.aspose.diagram/pagesheet/_index.md
@@ -1,0 +1,426 @@
+---
+title: PageSheet
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene elementi che definiscono il foglio di pagina per un elemento Pagina o Master.
+type: docs
+weight: 270
+url: /it/java/com.aspose.diagram/pagesheet/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PageSheet
+```
+
+Contiene elementi che definiscono il foglio di pagina per un elemento Pagina o Master.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [copy(PageSheet source)](#copy-com.aspose.diagram.PageSheet-) | Copia il pagesheet da un oggetto sorgente. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getActs()](#getActs--) | Contiene una raccolta di elementi Act. |
+| [getAnnotations()](#getAnnotations--) | Contiene elementi che includono informazioni sui commenti inseriti in una pagina del documento. |
+| [getClass()](#getClass--) |  |
+| [getConnectionABCDs()](#getConnectionABCDs--) | Contiene una raccolta di elementi ConnectionABCD. |
+| [getConnections()](#getConnections--) | Contiene una raccolta di elementi Connection. |
+| [getFillStyle()](#getFillStyle--) | Elemento StyleSheet da cui il PageSheet eredita la formattazione di riempimento. |
+| [getForeign()](#getForeign--) | Contiene elementi che specificano la larghezza e l'altezza di un oggetto proveniente da un altro programma utilizzato in un documento Microsoft Visio. |
+| [getForeignData()](#getForeignData--) | Contiene un BLOB codificato MIME (Multipurpose Internet Mail Extensions) di dati immagine, come metafile Windows, bitmap o dati OLE. |
+| [getHyperlinks()](#getHyperlinks--) | Contiene una raccolta di elementi Hyperlink. |
+| [getLayers()](#getLayers--) | Contiene una raccolta di elementi Layer. |
+| [getLineStyle()](#getLineStyle--) | Elemento StyleSheet da cui il PageSheet eredita la formattazione delle linee. |
+| [getPageLayout()](#getPageLayout--) | Contiene Diagram che controlla le impostazioni di layout della pagina per forme e connettori, come la spaziatura tra tutte le forme sulla pagina, la spaziatura tra tutti i connettori sulla pagina e lo stile di instradamento per tutti i connettori sulla pagina. |
+| [getPageProps()](#getPageProps--) | Contiene Diagram che controlla gli attributi della pagina, come larghezza, altezza e scala della pagina. |
+| [getPrintProps()](#getPrintProps--) | Contiene elementi che controllano come la pagina di disegno è formattata (appare) sulla pagina della stampante. |
+| [getProps()](#getProps--) | Contiene una raccolta di elementi Prop. |
+| [getRulerGrid()](#getRulerGrid--) | Contiene elementi che specificano le impostazioni dei righelli e della griglia della pagina. |
+| [getScratchs()](#getScratchs--) | Contiene una raccolta di elementi Scratch. |
+| [getSmartTagDefs()](#getSmartTagDefs--) | Contiene una raccolta di elementi SmartTagDef. |
+| [getTextStyle()](#getTextStyle--) | Elemento StyleSheet da cui il PageSheet eredita la formattazione del testo. |
+| [getUniqueID()](#getUniqueID--) | Un GUID (identificatore univoco globale) per l'elemento. |
+| [getUsers()](#getUsers--) | Contiene una raccolta di elementi Utente. |
+| [getXForm()](#getXForm--) | Contiene elementi che specificano informazioni generali di posizionamento su una forma. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setFillStyle(StyleSheet value)](#setFillStyle-com.aspose.diagram.StyleSheet-) | Per la descrizione di questa proprietà, vedere [getFillStyle()](../../com.aspose.diagram/pagesheet\#getFillStyle--) |
+| [setLineStyle(StyleSheet value)](#setLineStyle-com.aspose.diagram.StyleSheet-) | Per la descrizione di questa proprietà, vedere [getLineStyle()](../../com.aspose.diagram/pagesheet\#getLineStyle--) |
+| [setTextStyle(StyleSheet value)](#setTextStyle-com.aspose.diagram.StyleSheet-) | For the description of this property, please see [getTextStyle()](../../com.aspose.diagram/pagesheet\#getTextStyle--) |
+| [setUniqueID(UUID value)](#setUniqueID-java.util.UUID-) | For the description of this property, please see [getUniqueID()](../../com.aspose.diagram/pagesheet\#getUniqueID--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### copy(PageSheet source) {#copy-com.aspose.diagram.PageSheet-}
+```
+public void copy(PageSheet source)
+```
+
+
+Copia il pagesheet da un oggetto sorgente.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| source | [PageSheet](../../com.aspose.diagram/pagesheet) | source pagesheet. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getActs() {#getActs--}
+```
+public ActCollection getActs()
+```
+
+
+Contiene una raccolta di elementi Act.
+
+**Returns:**
+[ActCollection](../../com.aspose.diagram/actcollection)
+### getAnnotations() {#getAnnotations--}
+```
+public AnnotationCollection getAnnotations()
+```
+
+
+Contiene elementi che includono informazioni sui commenti inseriti in una pagina del documento.
+
+**Returns:**
+[AnnotationCollection](../../com.aspose.diagram/annotationcollection)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConnectionABCDs() {#getConnectionABCDs--}
+```
+public ConnectionABCDCollection getConnectionABCDs()
+```
+
+
+Contiene una raccolta di elementi ConnectionABCD.
+
+**Returns:**
+[ConnectionABCDCollection](../../com.aspose.diagram/connectionabcdcollection)
+### getConnections() {#getConnections--}
+```
+public ConnectionCollection getConnections()
+```
+
+
+Contiene una raccolta di elementi Connection.
+
+**Returns:**
+[ConnectionCollection](../../com.aspose.diagram/connectioncollection)
+### getFillStyle() {#getFillStyle--}
+```
+public StyleSheet getFillStyle()
+```
+
+
+Elemento StyleSheet da cui il PageSheet eredita la formattazione di riempimento.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getForeign() {#getForeign--}
+```
+public Foreign getForeign()
+```
+
+
+Contiene elementi che specificano la larghezza e l'altezza di un oggetto proveniente da un altro programma utilizzato in un documento Microsoft Visio. Include anche elementi che specificano la distanza di offset dell'immagine dell'oggetto all'interno dei suoi bordi.
+
+**Returns:**
+[Foreign](../../com.aspose.diagram/foreign)
+### getForeignData() {#getForeignData--}
+```
+public ForeignData getForeignData()
+```
+
+
+Contiene un BLOB codificato MIME (Multipurpose Internet Mail Extensions) di dati immagine, come metafile Windows, bitmap o dati OLE.
+
+**Returns:**
+[ForeignData](../../com.aspose.diagram/foreigndata)
+### getHyperlinks() {#getHyperlinks--}
+```
+public HyperlinkCollection getHyperlinks()
+```
+
+
+Contiene una raccolta di elementi Hyperlink.
+
+**Returns:**
+[HyperlinkCollection](../../com.aspose.diagram/hyperlinkcollection)
+### getLayers() {#getLayers--}
+```
+public LayerCollection getLayers()
+```
+
+
+Contiene una raccolta di elementi Layer.
+
+**Returns:**
+[LayerCollection](../../com.aspose.diagram/layercollection)
+### getLineStyle() {#getLineStyle--}
+```
+public StyleSheet getLineStyle()
+```
+
+
+Elemento StyleSheet da cui il PageSheet eredita la formattazione delle linee.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getPageLayout() {#getPageLayout--}
+```
+public PageLayout getPageLayout()
+```
+
+
+Contiene Diagram che controlla le impostazioni di layout della pagina per forme e connettori, come la spaziatura tra tutte le forme sulla pagina, la spaziatura tra tutti i connettori sulla pagina e lo stile di instradamento per tutti i connettori sulla pagina.
+
+**Returns:**
+[PageLayout](../../com.aspose.diagram/pagelayout)
+### getPageProps() {#getPageProps--}
+```
+public PageProps getPageProps()
+```
+
+
+Contiene Diagram che controlla gli attributi della pagina, come larghezza, altezza e scala della pagina.
+
+**Returns:**
+[PageProps](../../com.aspose.diagram/pageprops)
+### getPrintProps() {#getPrintProps--}
+```
+public PrintProps getPrintProps()
+```
+
+
+Contiene elementi che controllano come la pagina di disegno è formattata (appare) sulla pagina della stampante.
+
+**Returns:**
+[PrintProps](../../com.aspose.diagram/printprops)
+### getProps() {#getProps--}
+```
+public PropCollection getProps()
+```
+
+
+Contiene una raccolta di elementi Prop.
+
+**Returns:**
+[PropCollection](../../com.aspose.diagram/propcollection)
+### getRulerGrid() {#getRulerGrid--}
+```
+public RulerGrid getRulerGrid()
+```
+
+
+Contiene elementi che specificano le impostazioni dei righelli e della griglia della pagina.
+
+**Returns:**
+[RulerGrid](../../com.aspose.diagram/rulergrid)
+### getScratchs() {#getScratchs--}
+```
+public ScratchCollection getScratchs()
+```
+
+
+Contiene una raccolta di elementi Scratch.
+
+**Returns:**
+[ScratchCollection](../../com.aspose.diagram/scratchcollection)
+### getSmartTagDefs() {#getSmartTagDefs--}
+```
+public SmartTagDefCollection getSmartTagDefs()
+```
+
+
+Contiene una raccolta di elementi SmartTagDef.
+
+**Returns:**
+[SmartTagDefCollection](../../com.aspose.diagram/smarttagdefcollection)
+### getTextStyle() {#getTextStyle--}
+```
+public StyleSheet getTextStyle()
+```
+
+
+Elemento StyleSheet da cui il PageSheet eredita la formattazione del testo.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getUniqueID() {#getUniqueID--}
+```
+public UUID getUniqueID()
+```
+
+
+Un GUID (identificatore univoco globale) per l'elemento.
+
+**Returns:**
+java.util.UUID
+### getUsers() {#getUsers--}
+```
+public UserCollection getUsers()
+```
+
+
+Contiene una raccolta di elementi Utente.
+
+**Returns:**
+[UserCollection](../../com.aspose.diagram/usercollection)
+### getXForm() {#getXForm--}
+```
+public XForm getXForm()
+```
+
+
+Contiene elementi che specificano informazioni generali di posizionamento su una forma.
+
+**Returns:**
+[XForm](../../com.aspose.diagram/xform)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setFillStyle(StyleSheet value) {#setFillStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setFillStyle(StyleSheet value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getFillStyle()](../../com.aspose.diagram/pagesheet\#getFillStyle--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setLineStyle(StyleSheet value) {#setLineStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setLineStyle(StyleSheet value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getLineStyle()](../../com.aspose.diagram/pagesheet\#getLineStyle--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setTextStyle(StyleSheet value) {#setTextStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setTextStyle(StyleSheet value)
+```
+
+
+For the description of this property, please see [getTextStyle()](../../com.aspose.diagram/pagesheet\#getTextStyle--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setUniqueID(UUID value) {#setUniqueID-java.util.UUID-}
+```
+public void setUniqueID(UUID value)
+```
+
+
+For the description of this property, please see [getUniqueID()](../../com.aspose.diagram/pagesheet\#getUniqueID--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.util.UUID |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/pagesize/_index.md
+++ b/italian/java/com.aspose.diagram/pagesize/_index.md
@@ -1,0 +1,233 @@
+---
+title: PageSize
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene informazioni sulla dimensione della pagina per le immagini generate.
+type: docs
+weight: 271
+url: /it/java/com.aspose.diagram/pagesize/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PageSize
+```
+
+Contiene informazioni sulla dimensione della pagina per le immagini generate.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [PageSize(int paperSizeFormat)](#PageSize-int-) | Inizializza una nuova istanza di questa classe che può essere usata per impostare la dimensione della pagina per le immagini generate. |
+| [PageSize(float width, float height)](#PageSize-float-float-) | Inizializza una nuova istanza di questa classe che può essere usata per impostare la dimensione della pagina per le immagini generate. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getHeight()](#getHeight--) | L'altezza della pagina in punti per le immagini generate. |
+| [getPaperSizeFormat()](#getPaperSizeFormat--) | Il formato della dimensione della carta per le immagini generate. |
+| [getWidth()](#getWidth--) | La larghezza della pagina in punti per le immagini generate. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setHeight(float value)](#setHeight-float-) | Per la descrizione di questa proprietà, vedere [getHeight()](../../com.aspose.diagram/pagesize\#getHeight--) |
+| [setPaperSizeFormat(int value)](#setPaperSizeFormat-int-) | Per la descrizione di questa proprietà, vedere [getPaperSizeFormat()](../../com.aspose.diagram/pagesize\#getPaperSizeFormat--) |
+| [setWidth(float value)](#setWidth-float-) | Per la descrizione di questa proprietà, vedere [getWidth()](../../com.aspose.diagram/pagesize\#getWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageSize(int paperSizeFormat) {#PageSize-int-}
+```
+public PageSize(int paperSizeFormat)
+```
+
+
+Inizializza una nuova istanza di questa classe che può essere usata per impostare la dimensione della pagina per le immagini generate.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| paperSizeFormat | int | Può essere Aspose.Diagram.Saving.PaperSizeFormat. |
+
+### PageSize(float width, float height) {#PageSize-float-float-}
+```
+public PageSize(float width, float height)
+```
+
+
+Inizializza una nuova istanza di questa classe che può essere usata per impostare la dimensione della pagina per le immagini generate.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| width | float | Larghezza della pagina in punti per le immagini generate. |
+| height | float | Altezza della pagina in punti per le immagini generate. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getHeight() {#getHeight--}
+```
+public float getHeight()
+```
+
+
+l'altezza della pagina in punti per le immagini generate. Il valore deve essere > 0. Se Height è impostato, Width deve essere impostato anch'esso.
+
+**Returns:**
+float
+### getPaperSizeFormat() {#getPaperSizeFormat--}
+```
+public int getPaperSizeFormat()
+```
+
+
+il formato della dimensione della carta per le immagini generate. Può essere Aspose.Diagram.Saving.PaperSizeFormat.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public float getWidth()
+```
+
+
+la larghezza della pagina in punti per le immagini generate. Il valore deve essere > 0. Se Width è impostato, Height deve essere impostato anch'esso.
+
+**Returns:**
+float
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setHeight(float value) {#setHeight-float-}
+```
+public void setHeight(float value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getHeight()](../../com.aspose.diagram/pagesize\#getHeight--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | float |  |
+
+### setPaperSizeFormat(int value) {#setPaperSizeFormat-int-}
+```
+public void setPaperSizeFormat(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getPaperSizeFormat()](../../com.aspose.diagram/pagesize\#getPaperSizeFormat--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setWidth(float value) {#setWidth-float-}
+```
+public void setWidth(float value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getWidth()](../../com.aspose.diagram/pagesize\#getWidth--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | float |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/pagestartsavingargs/_index.md
+++ b/italian/java/com.aspose.diagram/pagestartsavingargs/_index.md
@@ -1,0 +1,172 @@
+---
+title: PageStartSavingArgs
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Informazioni per una pagina avviano il processo di salvataggio.
+type: docs
+weight: 272
+url: /it/java/com.aspose.diagram/pagestartsavingargs/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.PageSavingArgs](../../com.aspose.diagram/pagesavingargs)
+```
+public class PageStartSavingArgs extends PageSavingArgs
+```
+
+Informazioni per una pagina avviano il processo di salvataggio.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getPageCount()](#getPageCount--) | Conteggio totale delle pagine. |
+| [getPageIndex()](#getPageIndex--) | Indice della pagina corrente, basato su zero. |
+| [hashCode()](#hashCode--) |  |
+| [isToOutput()](#isToOutput--) | un valore che indica se la pagina deve essere emessa. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setToOutput(boolean value)](#setToOutput-boolean-) | Per la descrizione di questa proprietà, vedere [isToOutput()](../../com.aspose.diagram/pagestartsavingargs\#isToOutput--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+Conteggio totale delle pagine.
+
+**Returns:**
+int
+### getPageIndex() {#getPageIndex--}
+```
+public int getPageIndex()
+```
+
+
+Indice della pagina corrente, basato su zero.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isToOutput() {#isToOutput--}
+```
+public boolean isToOutput()
+```
+
+
+un valore che indica se la pagina deve essere emessa. Il valore predefinito è true.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setToOutput(boolean value) {#setToOutput-boolean-}
+```
+public void setToOutput(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isToOutput()](../../com.aspose.diagram/pagestartsavingargs\#isToOutput--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/papersizeformat/_index.md
+++ b/italian/java/com.aspose.diagram/papersizeformat/_index.md
@@ -1,0 +1,435 @@
+---
+title: PaperSizeFormat
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Enumerazione per la selezione del formato di dimensione carta da salvare.
+type: docs
+weight: 273
+url: /it/java/com.aspose.diagram/papersizeformat/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PaperSizeFormat
+```
+
+Enumerazione per la selezione del formato di dimensione carta da salvare.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [A_0](#A-0) | Formato di dimensione carta A0(841mm x 1189mm). |
+| [A_1](#A-1) | Formato di dimensione carta A1(594mm x 841mm). |
+| [A_2](#A-2) | Formato di dimensione carta A2(420mm x 594mm). |
+| [A_3](#A-3) | Formato di dimensione carta A3(297mm x 420mm). |
+| [A_4](#A-4) | Formato di dimensione carta A4(210mm x 297mm). |
+| [A_5](#A-5) | Formato di dimensione carta A5(148mm x 210mm). |
+| [A_6](#A-6) | Formato di dimensione carta A6(105mm x 148mm). |
+| [A_7](#A-7) | Formato di dimensione carta A7(74mm x 105mm). |
+| [B_0](#B-0) | Formato di dimensione carta B0(1000mm x 1414mm). |
+| [B_1](#B-1) | Formato di dimensione carta B1(707mm x 1000mm). |
+| [B_2](#B-2) | Formato di dimensione carta B2(500mm x 707mm). |
+| [B_3](#B-3) | Formato carta B3 (353mm x 500mm). |
+| [B_4](#B-4) | Formato carta B4 (250mm x 353mm). |
+| [B_5](#B-5) | Formato carta B5 (176mm x 250mm). |
+| [B_6](#B-6) | Formato carta B6 (125mm x 176mm). |
+| [B_7](#B-7) | Formato carta B7 (88mm x 125mm). |
+| [COM_10](#COM-10) | Formato carta COM10 (104.78mm x 241.3mm). |
+| [COM_9](#COM-9) | Formato carta COM9 (98.4mm x 225.4mInterpolationMode:Invalidm). |
+| [CUSTOM](#CUSTOM) | Formato carta personalizzato. |
+| [C_0](#C-0) | Formato carta C0 (917mm x 1297mm). |
+| [C_1](#C-1) | Formato carta C1 (648mm x 917mm). |
+| [C_2](#C-2) | Formato carta C2 (458mm x 648mm). |
+| [C_3](#C-3) | Formato carta C3 (324mm x 458mm). |
+| [C_4](#C-4) | Formato carta C4 (229mm x 324mm). |
+| [C_5](#C-5) | Formato carta C5 (162mm x 229mm). |
+| [C_6](#C-6) | Formato carta C6 (114mm x 162mm). |
+| [C_7](#C-7) | Formato carta C7 (81mm x 114mm). |
+| [DL](#DL) | Formato carta DL (110mm x 220mm). |
+| [EXECUTIVE](#EXECUTIVE) | Formato carta Executive (184.15mm x 266.7mm). |
+| [LEGAL](#LEGAL) | Formato carta Legal (215.9mm x 355.6mm). |
+| [LEGAL_13](#LEGAL-13) | Formato carta Legal13 (215.9mm x 330.2mm). |
+| [LETTER](#LETTER) | Formato carta Letter (215.9mm x 279.7mm). |
+| [MONARCH](#MONARCH) | Formato carta Monarch (98.4mm x 190.5mm). |
+| [TABLOID](#TABLOID) | Formato carta Tabloid (279.4mm x 431.8mm). |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### A_0 {#A-0}
+```
+public static final int A_0
+```
+
+
+Formato di dimensione carta A0(841mm x 1189mm).
+
+### A_1 {#A-1}
+```
+public static final int A_1
+```
+
+
+Formato di dimensione carta A1(594mm x 841mm).
+
+### A_2 {#A-2}
+```
+public static final int A_2
+```
+
+
+Formato di dimensione carta A2(420mm x 594mm).
+
+### A_3 {#A-3}
+```
+public static final int A_3
+```
+
+
+Formato di dimensione carta A3(297mm x 420mm).
+
+### A_4 {#A-4}
+```
+public static final int A_4
+```
+
+
+Formato di dimensione carta A4(210mm x 297mm).
+
+### A_5 {#A-5}
+```
+public static final int A_5
+```
+
+
+Formato di dimensione carta A5(148mm x 210mm).
+
+### A_6 {#A-6}
+```
+public static final int A_6
+```
+
+
+Formato di dimensione carta A6(105mm x 148mm).
+
+### A_7 {#A-7}
+```
+public static final int A_7
+```
+
+
+Formato di dimensione carta A7(74mm x 105mm).
+
+### B_0 {#B-0}
+```
+public static final int B_0
+```
+
+
+Formato di dimensione carta B0(1000mm x 1414mm).
+
+### B_1 {#B-1}
+```
+public static final int B_1
+```
+
+
+Formato di dimensione carta B1(707mm x 1000mm).
+
+### B_2 {#B-2}
+```
+public static final int B_2
+```
+
+
+Formato di dimensione carta B2(500mm x 707mm).
+
+### B_3 {#B-3}
+```
+public static final int B_3
+```
+
+
+Formato carta B3 (353mm x 500mm).
+
+### B_4 {#B-4}
+```
+public static final int B_4
+```
+
+
+Formato carta B4 (250mm x 353mm).
+
+### B_5 {#B-5}
+```
+public static final int B_5
+```
+
+
+Formato carta B5 (176mm x 250mm).
+
+### B_6 {#B-6}
+```
+public static final int B_6
+```
+
+
+Formato carta B6 (125mm x 176mm).
+
+### B_7 {#B-7}
+```
+public static final int B_7
+```
+
+
+Formato carta B7 (88mm x 125mm).
+
+### COM_10 {#COM-10}
+```
+public static final int COM_10
+```
+
+
+Formato carta COM10 (104.78mm x 241.3mm).
+
+### COM_9 {#COM-9}
+```
+public static final int COM_9
+```
+
+
+Formato carta COM9 (98.4mm x 225.4mInterpolationMode:Invalidm).
+
+### CUSTOM {#CUSTOM}
+```
+public static final int CUSTOM
+```
+
+
+Formato carta personalizzato.
+
+### C_0 {#C-0}
+```
+public static final int C_0
+```
+
+
+Formato carta C0 (917mm x 1297mm).
+
+### C_1 {#C-1}
+```
+public static final int C_1
+```
+
+
+Formato carta C1 (648mm x 917mm).
+
+### C_2 {#C-2}
+```
+public static final int C_2
+```
+
+
+Formato carta C2 (458mm x 648mm).
+
+### C_3 {#C-3}
+```
+public static final int C_3
+```
+
+
+Formato carta C3 (324mm x 458mm).
+
+### C_4 {#C-4}
+```
+public static final int C_4
+```
+
+
+Formato carta C4 (229mm x 324mm).
+
+### C_5 {#C-5}
+```
+public static final int C_5
+```
+
+
+Formato carta C5 (162mm x 229mm).
+
+### C_6 {#C-6}
+```
+public static final int C_6
+```
+
+
+Formato carta C6 (114mm x 162mm).
+
+### C_7 {#C-7}
+```
+public static final int C_7
+```
+
+
+Formato carta C7 (81mm x 114mm).
+
+### DL {#DL}
+```
+public static final int DL
+```
+
+
+Formato carta DL (110mm x 220mm).
+
+### EXECUTIVE {#EXECUTIVE}
+```
+public static final int EXECUTIVE
+```
+
+
+Formato carta Executive (184.15mm x 266.7mm).
+
+### LEGAL {#LEGAL}
+```
+public static final int LEGAL
+```
+
+
+Formato carta Legal (215.9mm x 355.6mm).
+
+### LEGAL_13 {#LEGAL-13}
+```
+public static final int LEGAL_13
+```
+
+
+Formato carta Legal13 (215.9mm x 330.2mm).
+
+### LETTER {#LETTER}
+```
+public static final int LETTER
+```
+
+
+Formato carta Letter (215.9mm x 279.7mm).
+
+### MONARCH {#MONARCH}
+```
+public static final int MONARCH
+```
+
+
+Formato carta Monarch (98.4mm x 190.5mm).
+
+### TABLOID {#TABLOID}
+```
+public static final int TABLOID
+```
+
+
+Formato carta Tabloid (279.4mm x 431.8mm).
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/para/_index.md
+++ b/italian/java/com.aspose.diagram/para/_index.md
@@ -1,0 +1,549 @@
+---
+title: Para
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contains the paragraph formatting elements for the shapes text such as indents line spacing bullets and horizontal alignment of paragraphs.
+type: docs
+weight: 274
+url: /it/java/com.aspose.diagram/para/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Para
+```
+
+Contiene gli elementi di formattazione del paragrafo per il testo della forma, come rientri, interlinea, elenchi puntati e allineamento orizzontale dei paragrafi.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [Para()](#Para--) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBullet()](#getBullet--) | Determina lo stile del punto elenco. |
+| [getBulletFont()](#getBulletFont--) | Represents the number of the font used to format the text when a custom bullet string is specified and the value in the Bullet element is non-zero. |
+| [getBulletFontSize()](#getBulletFontSize--) | Specifies the size of a bullet. |
+| [getBulletStr()](#getBulletStr--) | "Used to create a custom bullet style. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getFlags()](#getFlags--) | Indicates whether the text direction is left to right or right to left. |
+| [getHorzAlign()](#getHorzAlign--) | Specifica l'allineamento orizzontale del testo nel blocco di testo della forma. |
+| [getIX()](#getIX--) | L'indice basato su zero dell'elemento all'interno del suo elemento genitore. |
+| [getIndFirst()](#getIndFirst--) | Specifies the distance the first line of each paragraph in the shape's text block is indented from the left indent of the paragraph. |
+| [getIndLeft()](#getIndLeft--) | Specifies the distance all lines of text in a paragraph are indented from the left margin of the text block. |
+| [getIndRight()](#getIndRight--) | Specifica la distanza di rientro di tutte le linee di testo in un paragrafo dal margine destro del blocco di testo. |
+| [getLocalizeBulletFont()](#getLocalizeBulletFont--) | Specifica se il carattere del punto elenco deve essere localizzato (tradotto in un'altra lingua). |
+| [getSpAfter()](#getSpAfter--) | Specifica la quantità di spazio inserita dopo ogni paragrafo nel blocco di testo della forma. |
+| [getSpBefore()](#getSpBefore--) | Specifica la quantità di spazio inserita prima di ogni paragrafo nel blocco di testo della forma. |
+| [getSpLine()](#getSpLine--) | Specifica la distanza tra una linea di testo e l'altra, dove il 100% corrisponde all'altezza di una linea di testo. |
+| [getTextPosAfterBullet()](#getTextPosAfterBullet--) | Rappresenta la distanza tra la prima riga del paragrafo e il punto elenco. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setBullet(Bullet value)](#setBullet-com.aspose.diagram.Bullet-) | Per la descrizione di questa proprietà, consultare [getBullet()](../../com.aspose.diagram/para\#getBullet--) |
+| [setBulletFont(IntValue value)](#setBulletFont-com.aspose.diagram.IntValue-) | Per la descrizione di questa proprietà, consultare [getBulletFont()](../../com.aspose.diagram/para\#getBulletFont--) |
+| [setBulletFontSize(DoubleValue value)](#setBulletFontSize-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, consultare [getBulletFontSize()](../../com.aspose.diagram/para\#getBulletFontSize--) |
+| [setBulletStr(Str2Value value)](#setBulletStr-com.aspose.diagram.Str2Value-) | Per la descrizione di questa proprietà, consultare [getBulletStr()](../../com.aspose.diagram/para\#getBulletStr--) |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, consultare [getDel()](../../com.aspose.diagram/para\#getDel--) |
+| [setFlags(BoolValue value)](#setFlags-com.aspose.diagram.BoolValue-) | Per la descrizione di questa proprietà, consultare [getFlags()](../../com.aspose.diagram/para\#getFlags--) |
+| [setHorzAlign(HorzAlign value)](#setHorzAlign-com.aspose.diagram.HorzAlign-) | Per la descrizione di questa proprietà, consultare [getHorzAlign()](../../com.aspose.diagram/para\#getHorzAlign--) |
+| [setIX(int value)](#setIX-int-) | Per la descrizione di questa proprietà, consultare [getIX()](../../com.aspose.diagram/para\#getIX--) |
+| [setIndFirst(DoubleValue value)](#setIndFirst-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, consultare [getIndFirst()](../../com.aspose.diagram/para\#getIndFirst--) |
+| [setIndLeft(DoubleValue value)](#setIndLeft-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, consultare [getIndLeft()](../../com.aspose.diagram/para\#getIndLeft--) |
+| [setIndRight(DoubleValue value)](#setIndRight-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, consultare [getIndRight()](../../com.aspose.diagram/para\#getIndRight--) |
+| [setLocalizeBulletFont(LocalizeFont value)](#setLocalizeBulletFont-com.aspose.diagram.LocalizeFont-) | Per la descrizione di questa proprietà, consultare [getLocalizeBulletFont()](../../com.aspose.diagram/para\#getLocalizeBulletFont--) |
+| [setSpAfter(DoubleValue value)](#setSpAfter-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, consultare [getSpAfter()](../../com.aspose.diagram/para\#getSpAfter--) |
+| [setSpBefore(DoubleValue value)](#setSpBefore-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, consultare [getSpBefore()](../../com.aspose.diagram/para\#getSpBefore--) |
+| [setSpLine(DoubleValue value)](#setSpLine-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, consultare [getSpLine()](../../com.aspose.diagram/para\#getSpLine--) |
+| [setTextPosAfterBullet(DoubleValue value)](#setTextPosAfterBullet-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, consultare [getTextPosAfterBullet()](../../com.aspose.diagram/para\#getTextPosAfterBullet--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Para() {#Para--}
+```
+public Para()
+```
+
+
+Costruttore.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBullet() {#getBullet--}
+```
+public Bullet getBullet()
+```
+
+
+Determina lo stile del punto elenco.
+
+**Returns:**
+[Bullet](../../com.aspose.diagram/bullet)
+### getBulletFont() {#getBulletFont--}
+```
+public IntValue getBulletFont()
+```
+
+
+Represents the number of the font used to format the text when a custom bullet string is specified and the value in the Bullet element is non-zero.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getBulletFontSize() {#getBulletFontSize--}
+```
+public DoubleValue getBulletFontSize()
+```
+
+
+Specifies the size of a bullet.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBulletStr() {#getBulletStr--}
+```
+public Str2Value getBulletStr()
+```
+
+
+"Utilizzato per creare uno stile di punto elenco personalizzato. Inserire lo stile come stringa (tra virgolette). Ad esempio, è possibile inserire la stringa, \"\"ooo.\"\""
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getFlags() {#getFlags--}
+```
+public BoolValue getFlags()
+```
+
+
+Indicates whether the text direction is left to right or right to left.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getHorzAlign() {#getHorzAlign--}
+```
+public HorzAlign getHorzAlign()
+```
+
+
+Specifica l'allineamento orizzontale del testo nel blocco di testo della forma.
+
+**Returns:**
+[HorzAlign](../../com.aspose.diagram/horzalign)
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+L'indice basato su zero dell'elemento all'interno del suo elemento genitore.
+
+**Returns:**
+int
+### getIndFirst() {#getIndFirst--}
+```
+public DoubleValue getIndFirst()
+```
+
+
+Specifica la distanza di rientro della prima riga di ogni paragrafo nel blocco di testo della forma dall'indentazione sinistra del paragrafo. Questo valore è indipendente dalla scala del disegno. Se il disegno è scalato, l'indentazione della prima riga rimane invariata.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getIndLeft() {#getIndLeft--}
+```
+public DoubleValue getIndLeft()
+```
+
+
+Specifica la distanza di rientro di tutte le linee di testo in un paragrafo dal margine sinistro del blocco di testo. Questo valore è indipendente dalla scala del disegno. Se il disegno è scalato, l'indentazione sinistra rimane invariata.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getIndRight() {#getIndRight--}
+```
+public DoubleValue getIndRight()
+```
+
+
+Specifica la distanza di rientro di tutte le righe di testo in un paragrafo dal margine destro del blocco di testo. Questo valore è indipendente dalla scala del disegno. Se il disegno è scalato, il rientro destro rimane lo stesso.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLocalizeBulletFont() {#getLocalizeBulletFont--}
+```
+public LocalizeFont getLocalizeBulletFont()
+```
+
+
+Specifica se il carattere del punto elenco deve essere localizzato (tradotto in un'altra lingua).
+
+**Returns:**
+[LocalizeFont](../../com.aspose.diagram/localizefont)
+### getSpAfter() {#getSpAfter--}
+```
+public DoubleValue getSpAfter()
+```
+
+
+Specifica la quantità di spazio inserita dopo ogni paragrafo nel blocco di testo della forma.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getSpBefore() {#getSpBefore--}
+```
+public DoubleValue getSpBefore()
+```
+
+
+Specifica la quantità di spazio inserita prima di ogni paragrafo nel blocco di testo della forma.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getSpLine() {#getSpLine--}
+```
+public DoubleValue getSpLine()
+```
+
+
+Specifica la distanza tra una linea di testo e l'altra, dove il 100% corrisponde all'altezza di una linea di testo.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTextPosAfterBullet() {#getTextPosAfterBullet--}
+```
+public DoubleValue getTextPosAfterBullet()
+```
+
+
+Rappresenta la distanza tra la prima riga del paragrafo e il punto elenco.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setBullet(Bullet value) {#setBullet-com.aspose.diagram.Bullet-}
+```
+public void setBullet(Bullet value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getBullet()](../../com.aspose.diagram/para\#getBullet--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [Bullet](../../com.aspose.diagram/bullet) |  |
+
+### setBulletFont(IntValue value) {#setBulletFont-com.aspose.diagram.IntValue-}
+```
+public void setBulletFont(IntValue value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getBulletFont()](../../com.aspose.diagram/para\#getBulletFont--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setBulletFontSize(DoubleValue value) {#setBulletFontSize-com.aspose.diagram.DoubleValue-}
+```
+public void setBulletFontSize(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getBulletFontSize()](../../com.aspose.diagram/para\#getBulletFontSize--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setBulletStr(Str2Value value) {#setBulletStr-com.aspose.diagram.Str2Value-}
+```
+public void setBulletStr(Str2Value value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getBulletStr()](../../com.aspose.diagram/para\#getBulletStr--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [Str2Value](../../com.aspose.diagram/str2value) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getDel()](../../com.aspose.diagram/para\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setFlags(BoolValue value) {#setFlags-com.aspose.diagram.BoolValue-}
+```
+public void setFlags(BoolValue value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getFlags()](../../com.aspose.diagram/para\#getFlags--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setHorzAlign(HorzAlign value) {#setHorzAlign-com.aspose.diagram.HorzAlign-}
+```
+public void setHorzAlign(HorzAlign value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getHorzAlign()](../../com.aspose.diagram/para\#getHorzAlign--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [HorzAlign](../../com.aspose.diagram/horzalign) |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getIX()](../../com.aspose.diagram/para\#getIX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setIndFirst(DoubleValue value) {#setIndFirst-com.aspose.diagram.DoubleValue-}
+```
+public void setIndFirst(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getIndFirst()](../../com.aspose.diagram/para\#getIndFirst--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setIndLeft(DoubleValue value) {#setIndLeft-com.aspose.diagram.DoubleValue-}
+```
+public void setIndLeft(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getIndLeft()](../../com.aspose.diagram/para\#getIndLeft--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setIndRight(DoubleValue value) {#setIndRight-com.aspose.diagram.DoubleValue-}
+```
+public void setIndRight(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getIndRight()](../../com.aspose.diagram/para\#getIndRight--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setLocalizeBulletFont(LocalizeFont value) {#setLocalizeBulletFont-com.aspose.diagram.LocalizeFont-}
+```
+public void setLocalizeBulletFont(LocalizeFont value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getLocalizeBulletFont()](../../com.aspose.diagram/para\#getLocalizeBulletFont--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [LocalizeFont](../../com.aspose.diagram/localizefont) |  |
+
+### setSpAfter(DoubleValue value) {#setSpAfter-com.aspose.diagram.DoubleValue-}
+```
+public void setSpAfter(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getSpAfter()](../../com.aspose.diagram/para\#getSpAfter--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setSpBefore(DoubleValue value) {#setSpBefore-com.aspose.diagram.DoubleValue-}
+```
+public void setSpBefore(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getSpBefore()](../../com.aspose.diagram/para\#getSpBefore--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setSpLine(DoubleValue value) {#setSpLine-com.aspose.diagram.DoubleValue-}
+```
+public void setSpLine(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getSpLine()](../../com.aspose.diagram/para\#getSpLine--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTextPosAfterBullet(DoubleValue value) {#setTextPosAfterBullet-com.aspose.diagram.DoubleValue-}
+```
+public void setTextPosAfterBullet(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getTextPosAfterBullet()](../../com.aspose.diagram/para\#getTextPosAfterBullet--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/paracollection/_index.md
+++ b/italian/java/com.aspose.diagram/paracollection/_index.md
@@ -1,0 +1,234 @@
+---
+title: ParaCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Raccolta di paragrafi.
+type: docs
+weight: 275
+url: /it/java/com.aspose.diagram/paracollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ParaCollection extends Collection
+```
+
+Raccolta di paragrafi.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [add(Para item)](#add-com.aspose.diagram.Para-) | Aggiungi l'oggetto Para nella collezione. |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [getPara(int IX)](#getPara-int-) | Ottiene l'elemento all'indice specificato IX. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Para item)](#remove-com.aspose.diagram.Para-) | Rimuovi l'oggetto Para dalla collezione. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Para item) {#add-com.aspose.diagram.Para-}
+```
+public int add(Para item)
+```
+
+
+Aggiungi l'oggetto Para nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [Para](../../com.aspose.diagram/para) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Para get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[Para](../../com.aspose.diagram/para) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### getPara(int IX) {#getPara-int-}
+```
+public Para getPara(int IX)
+```
+
+
+Ottiene l'elemento all'indice specificato IX. Restituisce Null se l'elemento non esiste.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| IX | int |  |
+
+**Returns:**
+[Para](../../com.aspose.diagram/para) - 
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Para item) {#remove-com.aspose.diagram.Para-}
+```
+public void remove(Para item)
+```
+
+
+Rimuovi l'oggetto Para dalla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [Para](../../com.aspose.diagram/para) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/pdfcompliance/_index.md
+++ b/italian/java/com.aspose.diagram/pdfcompliance/_index.md
@@ -1,0 +1,156 @@
+---
+title: PdfCompliance
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica il livello di conformità PDF per il file di output.
+type: docs
+weight: 276
+url: /it/java/com.aspose.diagram/pdfcompliance/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PdfCompliance
+```
+
+Specifica il livello di conformità PDF per il file di output.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [PDF_15](#PDF-15) | Il file di output sarà conforme a PDF 1.5. |
+| [PDF_A_1_A](#PDF-A-1-A) | Il file di output sarà conforme a PDF/A-1a. |
+| [PDF_A_1_B](#PDF-A-1-B) | Il file di output sarà conforme a PDF/A-1b. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PDF_15 {#PDF-15}
+```
+public static final int PDF_15
+```
+
+
+Il file di output sarà conforme a PDF 1.5.
+
+### PDF_A_1_A {#PDF-A-1-A}
+```
+public static final int PDF_A_1_A
+```
+
+
+Il file di output sarà conforme a PDF/A-1a.
+
+### PDF_A_1_B {#PDF-A-1-B}
+```
+public static final int PDF_A_1_B
+```
+
+
+Il file di output sarà conforme a PDF/A-1b.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/pdfdigitalsignaturehashalgorithm/_index.md
+++ b/italian/java/com.aspose.diagram/pdfdigitalsignaturehashalgorithm/_index.md
@@ -1,0 +1,174 @@
+---
+title: PdfDigitalSignatureHashAlgorithm
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica l'algoritmo di hash digitale utilizzato dalla firma digitale.
+type: docs
+weight: 277
+url: /it/java/com.aspose.diagram/pdfdigitalsignaturehashalgorithm/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PdfDigitalSignatureHashAlgorithm
+```
+
+Specifica l'algoritmo di hash digitale utilizzato dalla firma digitale.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [MD_5](#MD-5) | Algoritmo di hash SHA-1. |
+| [SHA_1](#SHA-1) | Algoritmo di hash SHA-1. |
+| [SHA_256](#SHA-256) | Algoritmo di hash SHA-256. |
+| [SHA_384](#SHA-384) | Algoritmo di hash SHA-384. |
+| [SHA_512](#SHA-512) | Algoritmo di hash SHA-512. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### MD_5 {#MD-5}
+```
+public static final int MD_5
+```
+
+
+Algoritmo di hash SHA-1.
+
+### SHA_1 {#SHA-1}
+```
+public static final int SHA_1
+```
+
+
+Algoritmo di hash SHA-1.
+
+### SHA_256 {#SHA-256}
+```
+public static final int SHA_256
+```
+
+
+Algoritmo di hash SHA-256.
+
+### SHA_384 {#SHA-384}
+```
+public static final int SHA_384
+```
+
+
+Algoritmo di hash SHA-384.
+
+### SHA_512 {#SHA-512}
+```
+public static final int SHA_512
+```
+
+
+Algoritmo di hash SHA-512.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/pdfencryptionalgorithm/_index.md
+++ b/italian/java/com.aspose.diagram/pdfencryptionalgorithm/_index.md
@@ -1,0 +1,147 @@
+---
+title: PdfEncryptionAlgorithm
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica l'algoritmo di crittografia da utilizzare per cifrare un documento PDF.
+type: docs
+weight: 278
+url: /it/java/com.aspose.diagram/pdfencryptionalgorithm/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PdfEncryptionAlgorithm
+```
+
+Specifica l'algoritmo di crittografia da utilizzare per cifrare un documento PDF.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [RC_4_128](#RC-4-128) | Cifratura RC4, lunghezza chiave di 128 bit. |
+| [RC_4_40](#RC-4-40) | Cifratura RC4, lunghezza chiave di 40 bit. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RC_4_128 {#RC-4-128}
+```
+public static final int RC_4_128
+```
+
+
+Cifratura RC4, lunghezza chiave di 128 bit.
+
+### RC_4_40 {#RC-4-40}
+```
+public static final int RC_4_40
+```
+
+
+Cifratura RC4, lunghezza chiave di 40 bit.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/pdfencryptiondetails/_index.md
+++ b/italian/java/com.aspose.diagram/pdfencryptiondetails/_index.md
@@ -1,0 +1,245 @@
+---
+title: PdfEncryptionDetails
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene i dettagli per una crittografia PDF.
+type: docs
+weight: 279
+url: /it/java/com.aspose.diagram/pdfencryptiondetails/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PdfEncryptionDetails
+```
+
+Contiene i dettagli per una crittografia PDF.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [PdfEncryptionDetails(String userPassword, String ownerPassword, int encryptionAlgorithm)](#PdfEncryptionDetails-java.lang.String-java.lang.String-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getEncryptionAlgorithm()](#getEncryptionAlgorithm--) | la modalità di crittografia. |
+| [getOwnerPassword()](#getOwnerPassword--) | la password Owner. |
+| [getPermissions()](#getPermissions--) | le autorizzazioni. |
+| [getUserPassword()](#getUserPassword--) | la password User. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setEncryptionAlgorithm(int value)](#setEncryptionAlgorithm-int-) | Per la descrizione di questa proprietà, vedere [getEncryptionAlgorithm()](../../com.aspose.diagram/pdfencryptiondetails\#getEncryptionAlgorithm--) |
+| [setOwnerPassword(String value)](#setOwnerPassword-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getOwnerPassword()](../../com.aspose.diagram/pdfencryptiondetails\#getOwnerPassword--) |
+| [setPermissions(int value)](#setPermissions-int-) | Per la descrizione di questa proprietà, vedere [getPermissions()](../../com.aspose.diagram/pdfencryptiondetails\#getPermissions--) |
+| [setUserPassword(String value)](#setUserPassword-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getUserPassword()](../../com.aspose.diagram/pdfencryptiondetails\#getUserPassword--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PdfEncryptionDetails(String userPassword, String ownerPassword, int encryptionAlgorithm) {#PdfEncryptionDetails-java.lang.String-java.lang.String-int-}
+```
+public PdfEncryptionDetails(String userPassword, String ownerPassword, int encryptionAlgorithm)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| userPassword | java.lang.String |  |
+| ownerPassword | java.lang.String |  |
+| encryptionAlgorithm | int |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getEncryptionAlgorithm() {#getEncryptionAlgorithm--}
+```
+public int getEncryptionAlgorithm()
+```
+
+
+la modalità di crittografia.
+
+**Returns:**
+int
+### getOwnerPassword() {#getOwnerPassword--}
+```
+public String getOwnerPassword()
+```
+
+
+la password Owner. L'apertura del documento con la password Owner corretta (supponendo che non sia la stessa della password utente) consente l'accesso completo (owner) al documento. Questo accesso illimitato include la possibilità di modificare le password del documento\u9225\u6a9a e le autorizzazioni di accesso.
+
+**Returns:**
+java.lang.String
+### getPermissions() {#getPermissions--}
+```
+public int getPermissions()
+```
+
+
+le autorizzazioni.
+
+**Returns:**
+int
+### getUserPassword() {#getUserPassword--}
+```
+public String getUserPassword()
+```
+
+
+la password User. L'apertura del documento con la password utente corretta (o l'apertura di un documento che non ha una password utente) consente di eseguire operazioni aggiuntive secondo le autorizzazioni di accesso utente specificate nel dizionario di crittografia del documento\u9225\u6a9a.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setEncryptionAlgorithm(int value) {#setEncryptionAlgorithm-int-}
+```
+public void setEncryptionAlgorithm(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getEncryptionAlgorithm()](../../com.aspose.diagram/pdfencryptiondetails\#getEncryptionAlgorithm--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setOwnerPassword(String value) {#setOwnerPassword-java.lang.String-}
+```
+public void setOwnerPassword(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getOwnerPassword()](../../com.aspose.diagram/pdfencryptiondetails\#getOwnerPassword--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setPermissions(int value) {#setPermissions-int-}
+```
+public void setPermissions(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getPermissions()](../../com.aspose.diagram/pdfencryptiondetails\#getPermissions--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setUserPassword(String value) {#setUserPassword-java.lang.String-}
+```
+public void setUserPassword(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getUserPassword()](../../com.aspose.diagram/pdfencryptiondetails\#getUserPassword--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/pdfpermissions/_index.md
+++ b/italian/java/com.aspose.diagram/pdfpermissions/_index.md
@@ -1,0 +1,219 @@
+---
+title: PdfPermissions
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica i permessi dell'utente per il documento PDF.
+type: docs
+weight: 280
+url: /it/java/com.aspose.diagram/pdfpermissions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PdfPermissions
+```
+
+Specifica i permessi dell'utente per il documento PDF.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [ALLOW_ALL](#ALLOW-ALL) | Consente tutte le operazioni sul documento PDF. |
+| [CONTENT_COPY](#CONTENT-COPY) | Consente la copia o l'estrazione di testo e grafica dal documento, inclusa l'estrazione per scopi di accessibilità. |
+| [CONTENT_COPY_FOR_ACCESSIBILITY](#CONTENT-COPY-FOR-ACCESSIBILITY) | Consente l'estrazione di testo e grafica a supporto dell'accessibilità per utenti disabili o per altri scopi. |
+| [DISALLOW_ALL](#DISALLOW-ALL) | Non consente alcuna operazione sul documento PDF. |
+| [DOCUMENT_ASSEMBLY](#DOCUMENT-ASSEMBLY) | Consente l'assemblaggio del documento: inserimento, rotazione o eliminazione di pagine e creazione di elementi di navigazione come segnalibri o miniature. |
+| [FILL_IN](#FILL-IN) | Consente la compilazione di moduli e la firma del documento. |
+| [HIGH_RESOLUTION_PRINTING](#HIGH-RESOLUTION-PRINTING) | Consente la stampa del documento alla massima risoluzione possibile. Quando si utilizza la crittografia RC4 a 40 bit, questa opzione è ignorata e la stampa ad alta risoluzione è consentita quando Printing è impostato. |
+| [MODIFY_ANNOTATIONS](#MODIFY-ANNOTATIONS) | Consente di aggiungere o modificare annotazioni di testo. |
+| [MODIFY_CONTENTS](#MODIFY-CONTENTS) | Consente di modificare i contenuti del documento\u9225\u6a9a. |
+| [PRINTING](#PRINTING) | Consente di stampare il documento. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALLOW_ALL {#ALLOW-ALL}
+```
+public static final int ALLOW_ALL
+```
+
+
+Consente tutte le operazioni sul documento PDF.
+
+### CONTENT_COPY {#CONTENT-COPY}
+```
+public static final int CONTENT_COPY
+```
+
+
+Consente la copia o l'estrazione di testo e grafica dal documento, inclusa l'estrazione per scopi di accessibilità.
+
+### CONTENT_COPY_FOR_ACCESSIBILITY {#CONTENT-COPY-FOR-ACCESSIBILITY}
+```
+public static final int CONTENT_COPY_FOR_ACCESSIBILITY
+```
+
+
+Consente di estrarre testo e grafica a supporto dell'accessibilità per utenti disabili o per altri scopi. Quando si utilizza la crittografia RC4 a 40 bit, questa opzione è ignorata e l'accessibilità è consentita ogni volta che è impostato ContentCopy.
+
+### DISALLOW_ALL {#DISALLOW-ALL}
+```
+public static final int DISALLOW_ALL
+```
+
+
+Non consente alcuna operazione sul documento PDF. Questo è il valore predefinito.
+
+### DOCUMENT_ASSEMBLY {#DOCUMENT-ASSEMBLY}
+```
+public static final int DOCUMENT_ASSEMBLY
+```
+
+
+Consente di assemblare il documento: inserire, ruotare o eliminare pagine e creare elementi di navigazione come segnalibri o miniature. Quando si utilizza la crittografia RC4 a 40 bit, questa opzione è ignorata e l'assemblaggio del documento è consentito quando è impostato ModifyContents.
+
+### FILL_IN {#FILL-IN}
+```
+public static final int FILL_IN
+```
+
+
+Consente di compilare i moduli e firmare il documento. Quando si utilizza la crittografia RC4 a 40 bit, questa opzione è ignorata e la compilazione del modulo è consentita ogni volta che è impostato ModifyAnnotations.
+
+### HIGH_RESOLUTION_PRINTING {#HIGH-RESOLUTION-PRINTING}
+```
+public static final int HIGH_RESOLUTION_PRINTING
+```
+
+
+Consente la stampa del documento alla massima risoluzione possibile. Quando si utilizza la crittografia RC4 a 40 bit, questa opzione è ignorata e la stampa ad alta risoluzione è consentita quando Printing è impostato.
+
+### MODIFY_ANNOTATIONS {#MODIFY-ANNOTATIONS}
+```
+public static final int MODIFY_ANNOTATIONS
+```
+
+
+Consente di aggiungere o modificare annotazioni di testo. Quando si utilizza la crittografia RC4 a 40 bit, questa opzione consente anche di compilare i campi del modulo.
+
+### MODIFY_CONTENTS {#MODIFY-CONTENTS}
+```
+public static final int MODIFY_CONTENTS
+```
+
+
+Consente di modificare i contenuti del documento\u9225\u6a9a.
+
+### PRINTING {#PRINTING}
+```
+public static final int PRINTING
+```
+
+
+Consente di stampare il documento.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/pdfsaveoptions/_index.md
+++ b/italian/java/com.aspose.diagram/pdfsaveoptions/_index.md
@@ -1,0 +1,679 @@
+---
+title: PdfSaveOptions
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Consente di specificare opzioni aggiuntive durante il rendering delle pagine del diagramma in PDF.
+type: docs
+weight: 281
+url: /it/java/com.aspose.diagram/pdfsaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.SaveOptions](../../com.aspose.diagram/saveoptions), [com.aspose.diagram.RenderingSaveOptions](../../com.aspose.diagram/renderingsaveoptions)
+```
+public class PdfSaveOptions extends RenderingSaveOptions
+```
+
+Consente di specificare opzioni aggiuntive durante il rendering delle pagine del diagramma in PDF.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [PdfSaveOptions()](#PdfSaveOptions--) | Inizializza una nuova istanza di questa classe che può essere utilizzata per salvare un documento nel formato Aspose.Diagram.SaveFileFormat. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | Crea un oggetto di opzioni di salvataggio di una classe adatta al formato di salvataggio specificato. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCompliance()](#getCompliance--) | Livello di conformità desiderato per il documento PDF generato. |
+| [getDefaultFont()](#getDefaultFont--) | Quando i caratteri nel diagramma sono Unicode e non vengono impostati con il valore di carattere corretto o il carattere non è installato localmente, possono apparire come blocchi in PDF, immagine o XPS. |
+| [getEmfRenderSetting()](#getEmfRenderSetting--) | Impostazione per il rendering del metafile Emf. |
+| [getEncryptionDetails()](#getEncryptionDetails--) | dettagli di crittografia. |
+| [getEnlargePage()](#getEnlargePage--) | Specifica se ingrandire la pagina. |
+| [getExportGuideShapes()](#getExportGuideShapes--) | Definisce se è necessario esportare le forme guida o meno. |
+| [getExportHiddenPage()](#getExportHiddenPage--) | Definisce se è necessario esportare la pagina nascosta o meno. |
+| [getHorizontalResolution()](#getHorizontalResolution--) | la risoluzione orizzontale per le immagini generate, in punti per pollice. |
+| [getJpegQuality()](#getJpegQuality--) | Specifica la qualità della compressione JPEG per le immagini (se viene utilizzata la compressione JPEG). |
+| [getPageCount()](#getPageCount--) | il numero di pagine da renderizzare in PDF. |
+| [getPageIndex()](#getPageIndex--) | l'indice basato su zero della prima pagina da renderizzare. |
+| [getPageSavingCallback()](#getPageSavingCallback--) | Controlla/Indica l'avanzamento del processo di salvataggio della pagina. |
+| [getPageSize()](#getPageSize--) | la dimensione della pagina per le immagini generate. |
+| [getSaveForegroundPagesOnly()](#getSaveForegroundPagesOnly--) | Specifica se tutte le pagine saranno salvate come immagine o solo il primo piano. |
+| [getSaveFormat()](#getSaveFormat--) | Specifica il formato in cui le pagine del diagramma renderizzate saranno salvate se viene utilizzato questo oggetto di opzioni di salvataggio. |
+| [getShapes()](#getShapes--) | forme da renderizzare. |
+| [getSplitMultiPages()](#getSplitMultiPages--) | Definisce se dividere il diagramma in più pagine in base alle impostazioni della pagina. |
+| [getTextCompression()](#getTextCompression--) | Specifica il tipo di compressione da utilizzare per tutti i flussi di contenuto, eccetto le immagini. |
+| [getVerticalResolution()](#getVerticalResolution--) | la risoluzione verticale per le immagini generate, in punti per pollice. |
+| [getWarningCallback()](#getWarningCallback--) | callback di avviso. |
+| [hashCode()](#hashCode--) |  |
+| [isExportComments()](#isExportComments--) | Definisce se è necessario esportare i commenti o meno. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCompliance(int value)](#setCompliance-int-) | Per la descrizione di questa proprietà, vedere [getCompliance()](../../com.aspose.diagram/pdfsaveoptions\#getCompliance--) |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--) |
+| [setEmfRenderSetting(int value)](#setEmfRenderSetting-int-) | Per la descrizione di questa proprietà, vedere [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--) |
+| [setEncryptionDetails(PdfEncryptionDetails value)](#setEncryptionDetails-com.aspose.diagram.PdfEncryptionDetails-) | Per la descrizione di questa proprietà, vedere [getEncryptionDetails()](../../com.aspose.diagram/pdfsaveoptions\#getEncryptionDetails--) |
+| [setEnlargePage(boolean value)](#setEnlargePage-boolean-) | Per la descrizione di questa proprietà, vedere [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\\#getEnlargePage--) |
+| [setExportComments(boolean value)](#setExportComments-boolean-) | Per la descrizione di questa proprietà, vedere [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\\#isExportComments--) |
+| [setExportGuideShapes(boolean value)](#setExportGuideShapes-boolean-) | Per la descrizione di questa proprietà, vedere [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\\#getExportGuideShapes--) |
+| [setExportHiddenPage(boolean value)](#setExportHiddenPage-boolean-) | Per la descrizione di questa proprietà, vedere [getExportHiddenPage()](../../com.aspose.diagram/pdfsaveoptions\#getExportHiddenPage--) |
+| [setHorizontalResolution(int value)](#setHorizontalResolution-int-) | Per la descrizione di questa proprietà, vedere [getHorizontalResolution()](../../com.aspose.diagram/pdfsaveoptions\#getHorizontalResolution--) |
+| [setJpegQuality(int value)](#setJpegQuality-int-) | Per la descrizione di questa proprietà, vedere [getJpegQuality()](../../com.aspose.diagram/pdfsaveoptions\#getJpegQuality--) |
+| [setPageCount(int value)](#setPageCount-int-) | Per la descrizione di questa proprietà, vedere [getPageCount()](../../com.aspose.diagram/pdfsaveoptions\#getPageCount--) |
+| [setPageIndex(int value)](#setPageIndex-int-) | Per la descrizione di questa proprietà, vedere [getPageIndex()](../../com.aspose.diagram/pdfsaveoptions\#getPageIndex--) |
+| [setPageSavingCallback(IPageSavingCallback value)](#setPageSavingCallback-com.aspose.diagram.IPageSavingCallback-) | Per la descrizione di questa proprietà, vedere [getPageSavingCallback()](../../com.aspose.diagram/pdfsaveoptions\#getPageSavingCallback--) |
+| [setPageSize(PageSize value)](#setPageSize-com.aspose.diagram.PageSize-) | Per la descrizione di questa proprietà, vedere [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\\#getPageSize--) |
+| [setSaveForegroundPagesOnly(boolean value)](#setSaveForegroundPagesOnly-boolean-) | Per la descrizione di questa proprietà, vedere [getSaveForegroundPagesOnly()](../../com.aspose.diagram/pdfsaveoptions\#getSaveForegroundPagesOnly--) |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | Per la descrizione di questa proprietà, vedere [getSaveFormat()](../../com.aspose.diagram/pdfsaveoptions\#getSaveFormat--) |
+| [setShapes(ShapeCollection value)](#setShapes-com.aspose.diagram.ShapeCollection-) | Per la descrizione di questa proprietà, vedere [getShapes()](../../com.aspose.diagram/renderingsaveoptions\\#getShapes--) |
+| [setSplitMultiPages(boolean value)](#setSplitMultiPages-boolean-) | Per la descrizione di questa proprietà, vedere [getSplitMultiPages()](../../com.aspose.diagram/pdfsaveoptions\#getSplitMultiPages--) |
+| [setTextCompression(int value)](#setTextCompression-int-) | Per la descrizione di questa proprietà, vedere [getTextCompression()](../../com.aspose.diagram/pdfsaveoptions\#getTextCompression--) |
+| [setVerticalResolution(int value)](#setVerticalResolution-int-) | Per la descrizione di questa proprietà, vedere [getVerticalResolution()](../../com.aspose.diagram/pdfsaveoptions\#getVerticalResolution--) |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PdfSaveOptions() {#PdfSaveOptions--}
+```
+public PdfSaveOptions()
+```
+
+
+Inizializza una nuova istanza di questa classe che può essere utilizzata per salvare un documento nel formato Aspose.Diagram.SaveFileFormat.
+
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+Crea un oggetto di opzioni di salvataggio di una classe adatta al formato di salvataggio specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| saveFormat | int | Il Aspose.Diagram.SaveFileFormat per il quale creare un oggetto di opzioni di salvataggio. |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCompliance() {#getCompliance--}
+```
+public int getCompliance()
+```
+
+
+Livello di conformità desiderato per il documento PDF generato. Il valore predefinito è PdfCompliance.PDF\_15.
+
+**Returns:**
+int
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+Quando i caratteri nel diagramma sono Unicode e non sono impostati con il valore di font corretto o il font non è installato localmente, possono apparire come blocchi in PDF, immagine o XPS. Impostare il DefaultFont, ad esempio MingLiu o MS Gothic, per visualizzare questi caratteri.
+
+**Returns:**
+java.lang.String
+### getEmfRenderSetting() {#getEmfRenderSetting--}
+```
+public int getEmfRenderSetting()
+```
+
+
+Impostazione per il rendering dei metafile EMF. I metafile EMF identificati come "EMF+ Dual" possono contenere sia record EMF+ sia record EMF. Entrambi i tipi di record possono essere usati per renderizzare l'immagine, solo record EMF+, o solo record EMF. Quando EmfPlusPrefer è impostato, i record EMF+ verranno analizzati, altrimenti verranno analizzati solo i record EMF. Il valore predefinito è EmfOnly"/>.
+
+**Returns:**
+int
+### getEncryptionDetails() {#getEncryptionDetails--}
+```
+public PdfEncryptionDetails getEncryptionDetails()
+```
+
+
+dettagli di crittografia. Se non impostato, non verrà eseguita alcuna crittografia.
+
+**Returns:**
+[PdfEncryptionDetails](../../com.aspose.diagram/pdfencryptiondetails)
+### getEnlargePage() {#getEnlargePage--}
+```
+public boolean getEnlargePage()
+```
+
+
+Specifica se ingrandire la pagina. Se true - ingrandire la pagina. Se false - non ingrandire la pagina. Il valore predefinito è true.
+
+**Returns:**
+boolean
+### getExportGuideShapes() {#getExportGuideShapes--}
+```
+public boolean getExportGuideShapes()
+```
+
+
+Definisce se è necessario esportare le forme guida o meno. Il valore predefinito è true.
+
+**Returns:**
+boolean
+### getExportHiddenPage() {#getExportHiddenPage--}
+```
+public boolean getExportHiddenPage()
+```
+
+
+Definisce se è necessario esportare la pagina nascosta o meno. Il valore predefinito è true.
+
+**Returns:**
+boolean
+### getHorizontalResolution() {#getHorizontalResolution--}
+```
+public int getHorizontalResolution()
+```
+
+
+la risoluzione orizzontale per le immagini generate, in punti per pollice. Si applica al metodo di generazione delle immagini, eccetto le immagini in formato EMF. Il valore predefinito è 96.
+
+**Returns:**
+int
+### getJpegQuality() {#getJpegQuality--}
+```
+public int getJpegQuality()
+```
+
+
+Specifica la qualità della compressione JPEG per le immagini (se viene utilizzata la compressione JPEG). Il valore predefinito è 95.
+
+**Returns:**
+int
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+il numero di pagine da renderizzare in PDF. Il valore predefinito è MaxValue, il che significa che verranno renderizzate tutte le pagine del diagramma.
+
+**Returns:**
+int
+### getPageIndex() {#getPageIndex--}
+```
+public int getPageIndex()
+```
+
+
+L'indice basato su zero della prima pagina da renderizzare. Il valore predefinito è 0.
+
+**Returns:**
+int
+### getPageSavingCallback() {#getPageSavingCallback--}
+```
+public IPageSavingCallback getPageSavingCallback()
+```
+
+
+Controlla/Indica l'avanzamento del processo di salvataggio della pagina.
+
+**Returns:**
+[IPageSavingCallback](../../com.aspose.diagram/ipagesavingcallback)
+### getPageSize() {#getPageSize--}
+```
+public PageSize getPageSize()
+```
+
+
+la dimensione della pagina per le immagini generate. Può essere [PageSize](../../com.aspose.diagram/pagesize) o null. Il valore predefinito è null. Se PageSize è null, la dimensione della pagina per l'immagine generata viene ottenuta dal diagramma di origine.
+
+**Returns:**
+[PageSize](../../com.aspose.diagram/pagesize)
+### getSaveForegroundPagesOnly() {#getSaveForegroundPagesOnly--}
+```
+public boolean getSaveForegroundPagesOnly()
+```
+
+
+Specifica se tutte le pagine saranno salvate in immagine o solo il primo piano. Se true - vengono renderizzate solo le pagine di primo piano (con lo sfondo se presente). Se false - vengono renderizzate le pagine di primo piano (con lo sfondo se presente) seguite da pagine di sfondo vuote. Può restituire true solo quando PageCount > 1. Il valore predefinito è false.
+
+**Returns:**
+boolean
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+Specifica il formato in cui le pagine del diagramma renderizzate saranno salvate se viene utilizzato questo oggetto di opzioni di salvataggio. Può essere solo Aspose.Diagram.SaveFileFormat.
+
+**Returns:**
+int
+### getShapes() {#getShapes--}
+```
+public ShapeCollection getShapes()
+```
+
+
+forme da renderizzare. Il conteggio predefinito è 0.
+
+**Returns:**
+[ShapeCollection](../../com.aspose.diagram/shapecollection)
+### getSplitMultiPages() {#getSplitMultiPages--}
+```
+public boolean getSplitMultiPages()
+```
+
+
+Definisce se dividere il diagramma in più pagine in base alle impostazioni della pagina. Il valore predefinito è false.
+
+**Returns:**
+boolean
+### getTextCompression() {#getTextCompression--}
+```
+public int getTextCompression()
+```
+
+
+Specifica il tipo di compressione da utilizzare per tutti i flussi di contenuto, eccetto le immagini. Il valore predefinito è PdfTextCompression.FLATE.
+
+**Returns:**
+int
+### getVerticalResolution() {#getVerticalResolution--}
+```
+public int getVerticalResolution()
+```
+
+
+La risoluzione verticale per le immagini generate, in punti per pollice. Si applica al metodo di generazione dell'immagine, eccetto le immagini in formato Emf. Il valore predefinito è 96.
+
+**Returns:**
+int
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+callback di avviso.
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExportComments() {#isExportComments--}
+```
+public boolean isExportComments()
+```
+
+
+Definisce se è necessario esportare i commenti o meno. Il valore predefinito è false.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCompliance(int value) {#setCompliance-int-}
+```
+public void setCompliance(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getCompliance()](../../com.aspose.diagram/pdfsaveoptions\#getCompliance--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setEmfRenderSetting(int value) {#setEmfRenderSetting-int-}
+```
+public void setEmfRenderSetting(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setEncryptionDetails(PdfEncryptionDetails value) {#setEncryptionDetails-com.aspose.diagram.PdfEncryptionDetails-}
+```
+public void setEncryptionDetails(PdfEncryptionDetails value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getEncryptionDetails()](../../com.aspose.diagram/pdfsaveoptions\#getEncryptionDetails--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [PdfEncryptionDetails](../../com.aspose.diagram/pdfencryptiondetails) |  |
+
+### setEnlargePage(boolean value) {#setEnlargePage-boolean-}
+```
+public void setEnlargePage(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\\#getEnlargePage--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setExportComments(boolean value) {#setExportComments-boolean-}
+```
+public void setExportComments(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\\#isExportComments--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setExportGuideShapes(boolean value) {#setExportGuideShapes-boolean-}
+```
+public void setExportGuideShapes(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\\#getExportGuideShapes--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setExportHiddenPage(boolean value) {#setExportHiddenPage-boolean-}
+```
+public void setExportHiddenPage(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getExportHiddenPage()](../../com.aspose.diagram/pdfsaveoptions\#getExportHiddenPage--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setHorizontalResolution(int value) {#setHorizontalResolution-int-}
+```
+public void setHorizontalResolution(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getHorizontalResolution()](../../com.aspose.diagram/pdfsaveoptions\#getHorizontalResolution--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setJpegQuality(int value) {#setJpegQuality-int-}
+```
+public void setJpegQuality(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getJpegQuality()](../../com.aspose.diagram/pdfsaveoptions\#getJpegQuality--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setPageCount(int value) {#setPageCount-int-}
+```
+public void setPageCount(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getPageCount()](../../com.aspose.diagram/pdfsaveoptions\#getPageCount--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setPageIndex(int value) {#setPageIndex-int-}
+```
+public void setPageIndex(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getPageIndex()](../../com.aspose.diagram/pdfsaveoptions\#getPageIndex--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setPageSavingCallback(IPageSavingCallback value) {#setPageSavingCallback-com.aspose.diagram.IPageSavingCallback-}
+```
+public void setPageSavingCallback(IPageSavingCallback value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getPageSavingCallback()](../../com.aspose.diagram/pdfsaveoptions\#getPageSavingCallback--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [IPageSavingCallback](../../com.aspose.diagram/ipagesavingcallback) |  |
+
+### setPageSize(PageSize value) {#setPageSize-com.aspose.diagram.PageSize-}
+```
+public void setPageSize(PageSize value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\\#getPageSize--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [PageSize](../../com.aspose.diagram/pagesize) |  |
+
+### setSaveForegroundPagesOnly(boolean value) {#setSaveForegroundPagesOnly-boolean-}
+```
+public void setSaveForegroundPagesOnly(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getSaveForegroundPagesOnly()](../../com.aspose.diagram/pdfsaveoptions\#getSaveForegroundPagesOnly--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getSaveFormat()](../../com.aspose.diagram/pdfsaveoptions\#getSaveFormat--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setShapes(ShapeCollection value) {#setShapes-com.aspose.diagram.ShapeCollection-}
+```
+public void setShapes(ShapeCollection value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getShapes()](../../com.aspose.diagram/renderingsaveoptions\\#getShapes--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [ShapeCollection](../../com.aspose.diagram/shapecollection) |  |
+
+### setSplitMultiPages(boolean value) {#setSplitMultiPages-boolean-}
+```
+public void setSplitMultiPages(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getSplitMultiPages()](../../com.aspose.diagram/pdfsaveoptions\#getSplitMultiPages--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setTextCompression(int value) {#setTextCompression-int-}
+```
+public void setTextCompression(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getTextCompression()](../../com.aspose.diagram/pdfsaveoptions\#getTextCompression--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setVerticalResolution(int value) {#setVerticalResolution-int-}
+```
+public void setVerticalResolution(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getVerticalResolution()](../../com.aspose.diagram/pdfsaveoptions\#getVerticalResolution--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/pdftextcompression/_index.md
+++ b/italian/java/com.aspose.diagram/pdftextcompression/_index.md
@@ -1,0 +1,147 @@
+---
+title: PdfTextCompression
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica un tipo di compressione applicato a tutti i contenuti nel file PDF, eccetto le immagini.
+type: docs
+weight: 282
+url: /it/java/com.aspose.diagram/pdftextcompression/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PdfTextCompression
+```
+
+Specifica un tipo di compressione applicato a tutti i contenuti nel file PDF, eccetto le immagini.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [FLATE](#FLATE) | Compressione Flate (ZIP). |
+| [NONE](#NONE) | Nessuna compressione. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FLATE {#FLATE}
+```
+public static final int FLATE
+```
+
+
+Compressione Flate (ZIP).
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Nessuna compressione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/pinposvalue/_index.md
+++ b/italian/java/com.aspose.diagram/pinposvalue/_index.md
@@ -1,0 +1,219 @@
+---
+title: PinPosValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica la posizione del perno per la forma.
+type: docs
+weight: 283
+url: /it/java/com.aspose.diagram/pinposvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PinPosValue
+```
+
+Specifica la posizione del perno per la forma.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [BOTTOM_CENTER](#BOTTOM-CENTER) | in basso al centro |
+| [BOTTOM_LEFT](#BOTTOM-LEFT) | in basso a sinistra. |
+| [BOTTOM_RIGHT](#BOTTOM-RIGHT) | in basso a destra |
+| [CENTER_CENTER](#CENTER-CENTER) | centro-centro |
+| [CENTER_LEFT](#CENTER-LEFT) | centro-sinistra. |
+| [CENTER_RIGHT](#CENTER-RIGHT) | centro-destra |
+| [TOP_CENTER](#TOP-CENTER) | alto-centro |
+| [TOP_LEFT](#TOP-LEFT) | alto-sinistra |
+| [TOP_RIGHT](#TOP-RIGHT) | alto-destra |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOTTOM_CENTER {#BOTTOM-CENTER}
+```
+public static final int BOTTOM_CENTER
+```
+
+
+in basso al centro
+
+### BOTTOM_LEFT {#BOTTOM-LEFT}
+```
+public static final int BOTTOM_LEFT
+```
+
+
+in basso a sinistra.
+
+### BOTTOM_RIGHT {#BOTTOM-RIGHT}
+```
+public static final int BOTTOM_RIGHT
+```
+
+
+in basso a destra
+
+### CENTER_CENTER {#CENTER-CENTER}
+```
+public static final int CENTER_CENTER
+```
+
+
+centro-centro
+
+### CENTER_LEFT {#CENTER-LEFT}
+```
+public static final int CENTER_LEFT
+```
+
+
+centro-sinistra.
+
+### CENTER_RIGHT {#CENTER-RIGHT}
+```
+public static final int CENTER_RIGHT
+```
+
+
+centro-destra
+
+### TOP_CENTER {#TOP-CENTER}
+```
+public static final int TOP_CENTER
+```
+
+
+alto-centro
+
+### TOP_LEFT {#TOP-LEFT}
+```
+public static final int TOP_LEFT
+```
+
+
+alto-sinistra
+
+### TOP_RIGHT {#TOP-RIGHT}
+```
+public static final int TOP_RIGHT
+```
+
+
+alto-destra
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/pixeloffsetmode/_index.md
+++ b/italian/java/com.aspose.diagram/pixeloffsetmode/_index.md
@@ -1,0 +1,183 @@
+---
+title: PixelOffsetMode
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica come i pixel sono spostati durante il rendering.
+type: docs
+weight: 284
+url: /it/java/com.aspose.diagram/pixeloffsetmode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PixelOffsetMode
+```
+
+Specifica come i pixel sono spostati durante il rendering.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [DEFAULT](#DEFAULT) | Specifica la modalità predefinita. |
+| [HALF](#HALF) | Specifica che i pixel sono spostati di -.5 unità, sia orizzontalmente che verticalmente, per un antialiasing ad alta velocità. |
+| [HIGH_QUALITY](#HIGH-QUALITY) | Specifica il rendering ad alta qualità e bassa velocità. |
+| [HIGH_SPEED](#HIGH-SPEED) | Specifica il rendering ad alta velocità e bassa qualità. |
+| [INVALID](#INVALID) | Specifica una modalità non valida. |
+| [NONE](#NONE) | Specifica nessuno spostamento dei pixel. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DEFAULT {#DEFAULT}
+```
+public static final int DEFAULT
+```
+
+
+Specifica la modalità predefinita.
+
+### HALF {#HALF}
+```
+public static final int HALF
+```
+
+
+Specifica che i pixel sono spostati di -.5 unità, sia orizzontalmente che verticalmente, per un antialiasing ad alta velocità.
+
+### HIGH_QUALITY {#HIGH-QUALITY}
+```
+public static final int HIGH_QUALITY
+```
+
+
+Specifica il rendering ad alta qualità e bassa velocità.
+
+### HIGH_SPEED {#HIGH-SPEED}
+```
+public static final int HIGH_SPEED
+```
+
+
+Specifica il rendering ad alta velocità e bassa qualità.
+
+### INVALID {#INVALID}
+```
+public static final int INVALID
+```
+
+
+Specifica una modalità non valida.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Specifica nessuno spostamento dei pixel.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/placedepth/_index.md
+++ b/italian/java/com.aspose.diagram/placedepth/_index.md
@@ -1,0 +1,179 @@
+---
+title: PlaceDepth
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Per un disegno che viene disposto automaticamente, specifica il metodo con cui il disegno è analizzato prima di creare il layout e determina il tipo di layout.
+type: docs
+weight: 285
+url: /it/java/com.aspose.diagram/placedepth/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PlaceDepth
+```
+
+Per un disegno disposto automaticamente, specifica il metodo con cui il disegno viene analizzato prima di creare il layout e determina il tipo di layout.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [PlaceDepth(int value)](#PlaceDepth-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Per un disegno disposto automaticamente, specifica il metodo con cui il disegno viene analizzato prima di creare il layout e determina il tipo di layout. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, consulta [getValue()](../../com.aspose.diagram/placedepth\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PlaceDepth(int value) {#PlaceDepth-int-}
+```
+public PlaceDepth(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Per un disegno disposto automaticamente, specifica il metodo con cui il disegno viene analizzato prima di creare il layout e determina il tipo di layout.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, consulta [getValue()](../../com.aspose.diagram/placedepth\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/placedepthvalue/_index.md
+++ b/italian/java/com.aspose.diagram/placedepthvalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: PlaceDepthValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Per un disegno che viene disposto automaticamente, specifica il metodo con cui il disegno è analizzato prima di creare il layout e determina il tipo di layout.
+type: docs
+weight: 286
+url: /it/java/com.aspose.diagram/placedepthvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PlaceDepthValue
+```
+
+Per un disegno disposto automaticamente, specifica il metodo con cui il disegno viene analizzato prima di creare il layout e determina il tipo di layout.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [DEEP](#DEEP) | Profondo. |
+| [MEDIUM](#MEDIUM) | Medio. |
+| [PAGE_DEFAULT](#PAGE-DEFAULT) | Pagina predefinita. |
+| [SHALLOW](#SHALLOW) | Superficiale. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DEEP {#DEEP}
+```
+public static final int DEEP
+```
+
+
+Profondo.
+
+### MEDIUM {#MEDIUM}
+```
+public static final int MEDIUM
+```
+
+
+Medio.
+
+### PAGE_DEFAULT {#PAGE-DEFAULT}
+```
+public static final int PAGE_DEFAULT
+```
+
+
+Pagina predefinita.
+
+### SHALLOW {#SHALLOW}
+```
+public static final int SHALLOW
+```
+
+
+Superficiale.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/placeflip/_index.md
+++ b/italian/java/com.aspose.diagram/placeflip/_index.md
@@ -1,0 +1,179 @@
+---
+title: PlaceFlip
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica come le forme posizionabili vengono capovolte e/o ruotate su una pagina quando le forme sono disposte usando il comando Lay Out Shapes in Microsoft Visio.
+type: docs
+weight: 287
+url: /it/java/com.aspose.diagram/placeflip/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PlaceFlip
+```
+
+Specifies how placeable shapes flip and/or rotate on a page when shapes are laid out using the Lay Out Shapes command in Microsoft Visio. The following hexadecimal values are allowed.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [PlaceFlip(int value)](#PlaceFlip-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Specifica come le forme posizionabili vengono capovolte e/o ruotate su una pagina quando le forme sono disposte usando il comando Lay Out Shapes in Microsoft Visio. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/placeflip\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PlaceFlip(int value) {#PlaceFlip-int-}
+```
+public PlaceFlip(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specifies how placeable shapes flip and/or rotate on a page when shapes are laid out using the Lay Out Shapes command in Microsoft Visio. The following hexadecimal values are allowed.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/placeflip\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/placeflipvalue/_index.md
+++ b/italian/java/com.aspose.diagram/placeflipvalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: PlaceFlipValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica come le forme posizionabili vengono capovolte e/o ruotate su una pagina quando le forme sono disposte usando il comando Lay Out Shapes in Microsoft Visio.
+type: docs
+weight: 288
+url: /it/java/com.aspose.diagram/placeflipvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PlaceFlipValue
+```
+
+Specifies how placeable shapes flip and/or rotate on a page when shapes are laid out using the Lay Out Shapes command in Microsoft Visio. The following hexadecimal values are allowed.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [DEFAULT_NO_FLIP](#DEFAULT-NO-FLIP) | Predefinito. |
+| [FLIP_90_INCREMENTS](#FLIP-90-INCREMENTS) | Flip in 90-degree increments. |
+| [FLIP_HORIZONTAL](#FLIP-HORIZONTAL) | Flip horizontal. |
+| [FLIP_VERTICAL](#FLIP-VERTICAL) | Flip vertical. |
+| [NO_FLIP](#NO-FLIP) | No flip. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DEFAULT_NO_FLIP {#DEFAULT-NO-FLIP}
+```
+public static final int DEFAULT_NO_FLIP
+```
+
+
+Default. Do not flip.
+
+### FLIP_90_INCREMENTS {#FLIP-90-INCREMENTS}
+```
+public static final int FLIP_90_INCREMENTS
+```
+
+
+Flip in 90-degree increments.
+
+### FLIP_HORIZONTAL {#FLIP-HORIZONTAL}
+```
+public static final int FLIP_HORIZONTAL
+```
+
+
+Flip horizontal.
+
+### FLIP_VERTICAL {#FLIP-VERTICAL}
+```
+public static final int FLIP_VERTICAL
+```
+
+
+Flip vertical.
+
+### NO_FLIP {#NO-FLIP}
+```
+public static final int NO_FLIP
+```
+
+
+No flip.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/placestyle/_index.md
+++ b/italian/java/com.aspose.diagram/placestyle/_index.md
@@ -1,0 +1,179 @@
+---
+title: PlaceStyle
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica come le forme vengono posizionate sulla pagina quando le forme sono disposte e l'utente seleziona il menu Lay Out Shapes Shape.
+type: docs
+weight: 289
+url: /it/java/com.aspose.diagram/placestyle/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PlaceStyle
+```
+
+Specifica come le forme vengono posizionate sulla pagina quando le forme sono disposte dopo che l'utente seleziona Lay Out Shapes (menu Forma).
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [PlaceStyle(int value)](#PlaceStyle-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Specifica come le forme vengono posizionate sulla pagina quando le forme sono disposte dopo che l'utente seleziona Lay Out Shapes (menu Forma). |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/placestyle\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PlaceStyle(int value) {#PlaceStyle-int-}
+```
+public PlaceStyle(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specifica come le forme vengono posizionate sulla pagina quando le forme sono disposte dopo che l'utente seleziona Lay Out Shapes (menu Forma).
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/placestyle\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/placestylevalue/_index.md
+++ b/italian/java/com.aspose.diagram/placestylevalue/_index.md
@@ -1,0 +1,201 @@
+---
+title: PlaceStyleValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica come le forme vengono posizionate sulla pagina quando le forme sono disposte e l'utente seleziona il menu Lay Out Shapes Shape.
+type: docs
+weight: 290
+url: /it/java/com.aspose.diagram/placestylevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PlaceStyleValue
+```
+
+Specifica come le forme vengono posizionate sulla pagina quando le forme sono disposte dopo che l'utente seleziona Lay Out Shapes (menu Forma).
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [BOTTOM_TO_TOP](#BOTTOM-TO-TOP) | Dal basso verso l'alto. |
+| [CIRCULAR](#CIRCULAR) | Circolare. |
+| [DEFAULT_RADIAL](#DEFAULT-RADIAL) | Predefinito. |
+| [LEFT_TO_RIGHT](#LEFT-TO-RIGHT) | Da sinistra a destra. |
+| [RADIAL](#RADIAL) | Radiale. |
+| [RIGHT_TO_LEFT](#RIGHT-TO-LEFT) | Da destra a sinistra. |
+| [TOP_TO_BOTTOM](#TOP-TO-BOTTOM) | Dall'alto verso il basso. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOTTOM_TO_TOP {#BOTTOM-TO-TOP}
+```
+public static final int BOTTOM_TO_TOP
+```
+
+
+Dal basso verso l'alto.
+
+### CIRCULAR {#CIRCULAR}
+```
+public static final int CIRCULAR
+```
+
+
+Circolare.
+
+### DEFAULT_RADIAL {#DEFAULT-RADIAL}
+```
+public static final int DEFAULT_RADIAL
+```
+
+
+Predefinito. Radiale.
+
+### LEFT_TO_RIGHT {#LEFT-TO-RIGHT}
+```
+public static final int LEFT_TO_RIGHT
+```
+
+
+Da sinistra a destra.
+
+### RADIAL {#RADIAL}
+```
+public static final int RADIAL
+```
+
+
+Radiale.
+
+### RIGHT_TO_LEFT {#RIGHT-TO-LEFT}
+```
+public static final int RIGHT_TO_LEFT
+```
+
+
+Da destra a sinistra.
+
+### TOP_TO_BOTTOM {#TOP-TO-BOTTOM}
+```
+public static final int TOP_TO_BOTTOM
+```
+
+
+Dall'alto verso il basso.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/polylineto/_index.md
+++ b/italian/java/com.aspose.diagram/polylineto/_index.md
@@ -1,0 +1,274 @@
+---
+title: PolylineTo
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene le coordinate x e y dell'ultimo punto di una polilinea e la formula della polilinea.
+type: docs
+weight: 291
+url: /it/java/com.aspose.diagram/polylineto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class PolylineTo extends Coordinate
+```
+
+Contiene le coordinate x e y dell'ultimo punto di una polilinea e una formula di polilinea. Le coordinate sono specificate negli elementi X e Y, e la formula è specificata nell'elemento A.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [PolylineTo()](#PolylineTo--) | Crea un'istanza della classe [PolylineTo](../../com.aspose.diagram/polylineto). |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | La formula della polilinea. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getIX()](#getIX--) | L'indice basato su zero dell'elemento all'interno del suo elemento genitore. |
+| [getX()](#getX--) | La coordinata x del vertice finale di una polilinea. |
+| [getY()](#getY--) | La coordinata y del vertice finale di una polilinea. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(StrValue value)](#setA-com.aspose.diagram.StrValue-) | Per la descrizione di questa proprietà, vedere [getA()](../../com.aspose.diagram/polylineto\#getA--) |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/polylineto\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Per la descrizione di questa proprietà, vedere [getIX()](../../com.aspose.diagram/polylineto\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getX()](../../com.aspose.diagram/polylineto\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getY()](../../com.aspose.diagram/polylineto\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PolylineTo() {#PolylineTo--}
+```
+public PolylineTo()
+```
+
+
+Crea un'istanza della classe [PolylineTo](../../com.aspose.diagram/polylineto).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public StrValue getA()
+```
+
+
+La formula della polilinea.
+
+**Returns:**
+[StrValue](../../com.aspose.diagram/strvalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+L'indice basato su zero dell'elemento all'interno del suo elemento genitore.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+La coordinata x del vertice finale di una polilinea.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+La coordinata y del vertice finale di una polilinea.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(StrValue value) {#setA-com.aspose.diagram.StrValue-}
+```
+public void setA(StrValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getA()](../../com.aspose.diagram/polylineto\#getA--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [StrValue](../../com.aspose.diagram/strvalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/polylineto\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getIX()](../../com.aspose.diagram/polylineto\#getIX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getX()](../../com.aspose.diagram/polylineto\#getX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getY()](../../com.aspose.diagram/polylineto\#getY--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/polylinetocollection/_index.md
+++ b/italian/java/com.aspose.diagram/polylinetocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: PolylineToCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Raccolta PolylineTo.
+type: docs
+weight: 292
+url: /it/java/com.aspose.diagram/polylinetocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class PolylineToCollection extends Collection
+```
+
+Raccolta PolylineTo.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public PolylineTo get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[PolylineTo](../../com.aspose.diagram/polylineto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/pos/_index.md
+++ b/italian/java/com.aspose.diagram/pos/_index.md
@@ -1,0 +1,204 @@
+---
+title: Pos
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica la posizione del testo della forma rispetto alla linea di base.
+type: docs
+weight: 293
+url: /it/java/com.aspose.diagram/pos/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Pos
+```
+
+Specifica la posizione del testo della forma rispetto alla linea di base.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [Pos(int value)](#Pos-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Specifica la posizione del testo della forma rispetto alla linea di base. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | Per la descrizione di questa proprietà, vedere [getUfe()](../../com.aspose.diagram/pos\#getUfe--) |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/pos\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Pos(int value) {#Pos-int-}
+```
+public Pos(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specifica la posizione del testo della forma rispetto alla linea di base.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getUfe()](../../com.aspose.diagram/pos\#getUfe--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/pos\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/posvalue/_index.md
+++ b/italian/java/com.aspose.diagram/posvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: PosValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica la posizione del testo della forma rispetto alla linea di base.
+type: docs
+weight: 294
+url: /it/java/com.aspose.diagram/posvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PosValue
+```
+
+Specifica la posizione del testo della forma rispetto alla linea di base.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [NORMAL_POSITION](#NORMAL-POSITION) | Posizione normale. |
+| [SUBSCRIPT](#SUBSCRIPT) | Pedice. |
+| [SUPERSCRIPT](#SUPERSCRIPT) | Apice. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### NORMAL_POSITION {#NORMAL-POSITION}
+```
+public static final int NORMAL_POSITION
+```
+
+
+Posizione normale.
+
+### SUBSCRIPT {#SUBSCRIPT}
+```
+public static final int SUBSCRIPT
+```
+
+
+Pedice.
+
+### SUPERSCRIPT {#SUPERSCRIPT}
+```
+public static final int SUPERSCRIPT
+```
+
+
+Apice.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/pp/_index.md
+++ b/italian/java/com.aspose.diagram/pp/_index.md
@@ -1,0 +1,154 @@
+---
+title: Pp
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica l'inizio di un blocco di proprietà del paragrafo.
+type: docs
+weight: 295
+url: /it/java/com.aspose.diagram/pp/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.FormatTxt](../../com.aspose.diagram/formattxt)
+```
+public class Pp extends FormatTxt
+```
+
+Specifica l'inizio di una sequenza di proprietà del paragrafo. La sequenza è definita fino alla fine del testo o fino al successivo
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [Pp(int IX)](#Pp-int-) | Costruttore |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getValue()](#getValue--) | Valore |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Pp(int IX) {#Pp-int-}
+```
+public Pp(int IX)
+```
+
+
+Costruttore
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| IX | int | L'indice dell'elemento Para che specifica la formattazione applicata a questa sequenza. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+Valore
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/presetcameratype/_index.md
+++ b/italian/java/com.aspose.diagram/presetcameratype/_index.md
@@ -1,0 +1,687 @@
+---
+title: PresetCameraType
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta diversi metodi algoritmici per impostare tutte le proprietà della fotocamera, inclusa la posizione.
+type: docs
+weight: 296
+url: /it/java/com.aspose.diagram/presetcameratype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PresetCameraType
+```
+
+Rappresenta diversi metodi algoritmici per impostare tutte le proprietà della fotocamera, inclusa la posizione.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [ISOMETRIC_BOTTOM_DOWN](#ISOMETRIC-BOTTOM-DOWN) |  |
+| [ISOMETRIC_BOTTOM_UP](#ISOMETRIC-BOTTOM-UP) |  |
+| [ISOMETRIC_LEFT_DOWN](#ISOMETRIC-LEFT-DOWN) |  |
+| [ISOMETRIC_LEFT_UP](#ISOMETRIC-LEFT-UP) |  |
+| [ISOMETRIC_OFF_AXIS_1_LEFT](#ISOMETRIC-OFF-AXIS-1-LEFT) |  |
+| [ISOMETRIC_OFF_AXIS_1_RIGHT](#ISOMETRIC-OFF-AXIS-1-RIGHT) |  |
+| [ISOMETRIC_OFF_AXIS_1_TOP](#ISOMETRIC-OFF-AXIS-1-TOP) |  |
+| [ISOMETRIC_OFF_AXIS_2_LEFT](#ISOMETRIC-OFF-AXIS-2-LEFT) |  |
+| [ISOMETRIC_OFF_AXIS_2_RIGHT](#ISOMETRIC-OFF-AXIS-2-RIGHT) |  |
+| [ISOMETRIC_OFF_AXIS_2_TOP](#ISOMETRIC-OFF-AXIS-2-TOP) |  |
+| [ISOMETRIC_OFF_AXIS_3_BOTTOM](#ISOMETRIC-OFF-AXIS-3-BOTTOM) |  |
+| [ISOMETRIC_OFF_AXIS_3_LEFT](#ISOMETRIC-OFF-AXIS-3-LEFT) |  |
+| [ISOMETRIC_OFF_AXIS_3_RIGHT](#ISOMETRIC-OFF-AXIS-3-RIGHT) |  |
+| [ISOMETRIC_OFF_AXIS_4_BOTTOM](#ISOMETRIC-OFF-AXIS-4-BOTTOM) |  |
+| [ISOMETRIC_OFF_AXIS_4_LEFT](#ISOMETRIC-OFF-AXIS-4-LEFT) |  |
+| [ISOMETRIC_OFF_AXIS_4_RIGHT](#ISOMETRIC-OFF-AXIS-4-RIGHT) |  |
+| [ISOMETRIC_RIGHT_DOWN](#ISOMETRIC-RIGHT-DOWN) |  |
+| [ISOMETRIC_RIGHT_UP](#ISOMETRIC-RIGHT-UP) |  |
+| [ISOMETRIC_TOP_DOWN](#ISOMETRIC-TOP-DOWN) |  |
+| [ISOMETRIC_TOP_UP](#ISOMETRIC-TOP-UP) |  |
+| [LEGACY_OBLIQUE_BOTTOM](#LEGACY-OBLIQUE-BOTTOM) |  |
+| [LEGACY_OBLIQUE_BOTTOM_LEFT](#LEGACY-OBLIQUE-BOTTOM-LEFT) |  |
+| [LEGACY_OBLIQUE_BOTTOM_RIGHT](#LEGACY-OBLIQUE-BOTTOM-RIGHT) |  |
+| [LEGACY_OBLIQUE_FRONT](#LEGACY-OBLIQUE-FRONT) |  |
+| [LEGACY_OBLIQUE_LEFT](#LEGACY-OBLIQUE-LEFT) |  |
+| [LEGACY_OBLIQUE_RIGHT](#LEGACY-OBLIQUE-RIGHT) |  |
+| [LEGACY_OBLIQUE_TOP](#LEGACY-OBLIQUE-TOP) |  |
+| [LEGACY_OBLIQUE_TOP_LEFT](#LEGACY-OBLIQUE-TOP-LEFT) |  |
+| [LEGACY_OBLIQUE_TOP_RIGHT](#LEGACY-OBLIQUE-TOP-RIGHT) |  |
+| [LEGACY_PERSPECTIVE_BOTTOM](#LEGACY-PERSPECTIVE-BOTTOM) |  |
+| [LEGACY_PERSPECTIVE_BOTTOM_LEFT](#LEGACY-PERSPECTIVE-BOTTOM-LEFT) |  |
+| [LEGACY_PERSPECTIVE_BOTTOM_RIGHT](#LEGACY-PERSPECTIVE-BOTTOM-RIGHT) |  |
+| [LEGACY_PERSPECTIVE_FRONT](#LEGACY-PERSPECTIVE-FRONT) |  |
+| [LEGACY_PERSPECTIVE_LEFT](#LEGACY-PERSPECTIVE-LEFT) |  |
+| [LEGACY_PERSPECTIVE_RIGHT](#LEGACY-PERSPECTIVE-RIGHT) |  |
+| [LEGACY_PERSPECTIVE_TOP](#LEGACY-PERSPECTIVE-TOP) |  |
+| [LEGACY_PERSPECTIVE_TOP_LEFT](#LEGACY-PERSPECTIVE-TOP-LEFT) |  |
+| [LEGACY_PERSPECTIVE_TOP_RIGHT](#LEGACY-PERSPECTIVE-TOP-RIGHT) |  |
+| [OBLIQUE_BOTTOM](#OBLIQUE-BOTTOM) |  |
+| [OBLIQUE_BOTTOM_LEFT](#OBLIQUE-BOTTOM-LEFT) |  |
+| [OBLIQUE_BOTTOM_RIGHT](#OBLIQUE-BOTTOM-RIGHT) |  |
+| [OBLIQUE_LEFT](#OBLIQUE-LEFT) |  |
+| [OBLIQUE_RIGHT](#OBLIQUE-RIGHT) |  |
+| [OBLIQUE_TOP](#OBLIQUE-TOP) |  |
+| [OBLIQUE_TOP_LEFT](#OBLIQUE-TOP-LEFT) |  |
+| [OBLIQUE_TOP_RIGHT](#OBLIQUE-TOP-RIGHT) |  |
+| [ORTHOGRAPHIC_FRONT](#ORTHOGRAPHIC-FRONT) |  |
+| [PERSPECTIVE_ABOVE](#PERSPECTIVE-ABOVE) |  |
+| [PERSPECTIVE_ABOVE_LEFT_FACING](#PERSPECTIVE-ABOVE-LEFT-FACING) |  |
+| [PERSPECTIVE_ABOVE_RIGHT_FACING](#PERSPECTIVE-ABOVE-RIGHT-FACING) |  |
+| [PERSPECTIVE_BELOW](#PERSPECTIVE-BELOW) |  |
+| [PERSPECTIVE_CONTRASTING_LEFT_FACING](#PERSPECTIVE-CONTRASTING-LEFT-FACING) |  |
+| [PERSPECTIVE_CONTRASTING_RIGHT_FACING](#PERSPECTIVE-CONTRASTING-RIGHT-FACING) |  |
+| [PERSPECTIVE_FRONT](#PERSPECTIVE-FRONT) |  |
+| [PERSPECTIVE_HEROIC_EXTREME_LEFT_FACING](#PERSPECTIVE-HEROIC-EXTREME-LEFT-FACING) |  |
+| [PERSPECTIVE_HEROIC_EXTREME_RIGHT_FACING](#PERSPECTIVE-HEROIC-EXTREME-RIGHT-FACING) |  |
+| [PERSPECTIVE_HEROIC_LEFT_FACING](#PERSPECTIVE-HEROIC-LEFT-FACING) |  |
+| [PERSPECTIVE_HEROIC_RIGHT_FACING](#PERSPECTIVE-HEROIC-RIGHT-FACING) |  |
+| [PERSPECTIVE_LEFT](#PERSPECTIVE-LEFT) |  |
+| [PERSPECTIVE_RELAXED](#PERSPECTIVE-RELAXED) |  |
+| [PERSPECTIVE_RELAXED_MODERATELY](#PERSPECTIVE-RELAXED-MODERATELY) |  |
+| [PERSPECTIVE_RIGHT](#PERSPECTIVE-RIGHT) |  |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ISOMETRIC_BOTTOM_DOWN {#ISOMETRIC-BOTTOM-DOWN}
+```
+public static final int ISOMETRIC_BOTTOM_DOWN
+```
+
+
+
+
+### ISOMETRIC_BOTTOM_UP {#ISOMETRIC-BOTTOM-UP}
+```
+public static final int ISOMETRIC_BOTTOM_UP
+```
+
+
+
+
+### ISOMETRIC_LEFT_DOWN {#ISOMETRIC-LEFT-DOWN}
+```
+public static final int ISOMETRIC_LEFT_DOWN
+```
+
+
+
+
+### ISOMETRIC_LEFT_UP {#ISOMETRIC-LEFT-UP}
+```
+public static final int ISOMETRIC_LEFT_UP
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_1_LEFT {#ISOMETRIC-OFF-AXIS-1-LEFT}
+```
+public static final int ISOMETRIC_OFF_AXIS_1_LEFT
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_1_RIGHT {#ISOMETRIC-OFF-AXIS-1-RIGHT}
+```
+public static final int ISOMETRIC_OFF_AXIS_1_RIGHT
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_1_TOP {#ISOMETRIC-OFF-AXIS-1-TOP}
+```
+public static final int ISOMETRIC_OFF_AXIS_1_TOP
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_2_LEFT {#ISOMETRIC-OFF-AXIS-2-LEFT}
+```
+public static final int ISOMETRIC_OFF_AXIS_2_LEFT
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_2_RIGHT {#ISOMETRIC-OFF-AXIS-2-RIGHT}
+```
+public static final int ISOMETRIC_OFF_AXIS_2_RIGHT
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_2_TOP {#ISOMETRIC-OFF-AXIS-2-TOP}
+```
+public static final int ISOMETRIC_OFF_AXIS_2_TOP
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_3_BOTTOM {#ISOMETRIC-OFF-AXIS-3-BOTTOM}
+```
+public static final int ISOMETRIC_OFF_AXIS_3_BOTTOM
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_3_LEFT {#ISOMETRIC-OFF-AXIS-3-LEFT}
+```
+public static final int ISOMETRIC_OFF_AXIS_3_LEFT
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_3_RIGHT {#ISOMETRIC-OFF-AXIS-3-RIGHT}
+```
+public static final int ISOMETRIC_OFF_AXIS_3_RIGHT
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_4_BOTTOM {#ISOMETRIC-OFF-AXIS-4-BOTTOM}
+```
+public static final int ISOMETRIC_OFF_AXIS_4_BOTTOM
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_4_LEFT {#ISOMETRIC-OFF-AXIS-4-LEFT}
+```
+public static final int ISOMETRIC_OFF_AXIS_4_LEFT
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_4_RIGHT {#ISOMETRIC-OFF-AXIS-4-RIGHT}
+```
+public static final int ISOMETRIC_OFF_AXIS_4_RIGHT
+```
+
+
+
+
+### ISOMETRIC_RIGHT_DOWN {#ISOMETRIC-RIGHT-DOWN}
+```
+public static final int ISOMETRIC_RIGHT_DOWN
+```
+
+
+
+
+### ISOMETRIC_RIGHT_UP {#ISOMETRIC-RIGHT-UP}
+```
+public static final int ISOMETRIC_RIGHT_UP
+```
+
+
+
+
+### ISOMETRIC_TOP_DOWN {#ISOMETRIC-TOP-DOWN}
+```
+public static final int ISOMETRIC_TOP_DOWN
+```
+
+
+
+
+### ISOMETRIC_TOP_UP {#ISOMETRIC-TOP-UP}
+```
+public static final int ISOMETRIC_TOP_UP
+```
+
+
+
+
+### LEGACY_OBLIQUE_BOTTOM {#LEGACY-OBLIQUE-BOTTOM}
+```
+public static final int LEGACY_OBLIQUE_BOTTOM
+```
+
+
+
+
+### LEGACY_OBLIQUE_BOTTOM_LEFT {#LEGACY-OBLIQUE-BOTTOM-LEFT}
+```
+public static final int LEGACY_OBLIQUE_BOTTOM_LEFT
+```
+
+
+
+
+### LEGACY_OBLIQUE_BOTTOM_RIGHT {#LEGACY-OBLIQUE-BOTTOM-RIGHT}
+```
+public static final int LEGACY_OBLIQUE_BOTTOM_RIGHT
+```
+
+
+
+
+### LEGACY_OBLIQUE_FRONT {#LEGACY-OBLIQUE-FRONT}
+```
+public static final int LEGACY_OBLIQUE_FRONT
+```
+
+
+
+
+### LEGACY_OBLIQUE_LEFT {#LEGACY-OBLIQUE-LEFT}
+```
+public static final int LEGACY_OBLIQUE_LEFT
+```
+
+
+
+
+### LEGACY_OBLIQUE_RIGHT {#LEGACY-OBLIQUE-RIGHT}
+```
+public static final int LEGACY_OBLIQUE_RIGHT
+```
+
+
+
+
+### LEGACY_OBLIQUE_TOP {#LEGACY-OBLIQUE-TOP}
+```
+public static final int LEGACY_OBLIQUE_TOP
+```
+
+
+
+
+### LEGACY_OBLIQUE_TOP_LEFT {#LEGACY-OBLIQUE-TOP-LEFT}
+```
+public static final int LEGACY_OBLIQUE_TOP_LEFT
+```
+
+
+
+
+### LEGACY_OBLIQUE_TOP_RIGHT {#LEGACY-OBLIQUE-TOP-RIGHT}
+```
+public static final int LEGACY_OBLIQUE_TOP_RIGHT
+```
+
+
+
+
+### LEGACY_PERSPECTIVE_BOTTOM {#LEGACY-PERSPECTIVE-BOTTOM}
+```
+public static final int LEGACY_PERSPECTIVE_BOTTOM
+```
+
+
+
+
+### LEGACY_PERSPECTIVE_BOTTOM_LEFT {#LEGACY-PERSPECTIVE-BOTTOM-LEFT}
+```
+public static final int LEGACY_PERSPECTIVE_BOTTOM_LEFT
+```
+
+
+
+
+### LEGACY_PERSPECTIVE_BOTTOM_RIGHT {#LEGACY-PERSPECTIVE-BOTTOM-RIGHT}
+```
+public static final int LEGACY_PERSPECTIVE_BOTTOM_RIGHT
+```
+
+
+
+
+### LEGACY_PERSPECTIVE_FRONT {#LEGACY-PERSPECTIVE-FRONT}
+```
+public static final int LEGACY_PERSPECTIVE_FRONT
+```
+
+
+
+
+### LEGACY_PERSPECTIVE_LEFT {#LEGACY-PERSPECTIVE-LEFT}
+```
+public static final int LEGACY_PERSPECTIVE_LEFT
+```
+
+
+
+
+### LEGACY_PERSPECTIVE_RIGHT {#LEGACY-PERSPECTIVE-RIGHT}
+```
+public static final int LEGACY_PERSPECTIVE_RIGHT
+```
+
+
+
+
+### LEGACY_PERSPECTIVE_TOP {#LEGACY-PERSPECTIVE-TOP}
+```
+public static final int LEGACY_PERSPECTIVE_TOP
+```
+
+
+
+
+### LEGACY_PERSPECTIVE_TOP_LEFT {#LEGACY-PERSPECTIVE-TOP-LEFT}
+```
+public static final int LEGACY_PERSPECTIVE_TOP_LEFT
+```
+
+
+
+
+### LEGACY_PERSPECTIVE_TOP_RIGHT {#LEGACY-PERSPECTIVE-TOP-RIGHT}
+```
+public static final int LEGACY_PERSPECTIVE_TOP_RIGHT
+```
+
+
+
+
+### OBLIQUE_BOTTOM {#OBLIQUE-BOTTOM}
+```
+public static final int OBLIQUE_BOTTOM
+```
+
+
+
+
+### OBLIQUE_BOTTOM_LEFT {#OBLIQUE-BOTTOM-LEFT}
+```
+public static final int OBLIQUE_BOTTOM_LEFT
+```
+
+
+
+
+### OBLIQUE_BOTTOM_RIGHT {#OBLIQUE-BOTTOM-RIGHT}
+```
+public static final int OBLIQUE_BOTTOM_RIGHT
+```
+
+
+
+
+### OBLIQUE_LEFT {#OBLIQUE-LEFT}
+```
+public static final int OBLIQUE_LEFT
+```
+
+
+
+
+### OBLIQUE_RIGHT {#OBLIQUE-RIGHT}
+```
+public static final int OBLIQUE_RIGHT
+```
+
+
+
+
+### OBLIQUE_TOP {#OBLIQUE-TOP}
+```
+public static final int OBLIQUE_TOP
+```
+
+
+
+
+### OBLIQUE_TOP_LEFT {#OBLIQUE-TOP-LEFT}
+```
+public static final int OBLIQUE_TOP_LEFT
+```
+
+
+
+
+### OBLIQUE_TOP_RIGHT {#OBLIQUE-TOP-RIGHT}
+```
+public static final int OBLIQUE_TOP_RIGHT
+```
+
+
+
+
+### ORTHOGRAPHIC_FRONT {#ORTHOGRAPHIC-FRONT}
+```
+public static final int ORTHOGRAPHIC_FRONT
+```
+
+
+
+
+### PERSPECTIVE_ABOVE {#PERSPECTIVE-ABOVE}
+```
+public static final int PERSPECTIVE_ABOVE
+```
+
+
+
+
+### PERSPECTIVE_ABOVE_LEFT_FACING {#PERSPECTIVE-ABOVE-LEFT-FACING}
+```
+public static final int PERSPECTIVE_ABOVE_LEFT_FACING
+```
+
+
+
+
+### PERSPECTIVE_ABOVE_RIGHT_FACING {#PERSPECTIVE-ABOVE-RIGHT-FACING}
+```
+public static final int PERSPECTIVE_ABOVE_RIGHT_FACING
+```
+
+
+
+
+### PERSPECTIVE_BELOW {#PERSPECTIVE-BELOW}
+```
+public static final int PERSPECTIVE_BELOW
+```
+
+
+
+
+### PERSPECTIVE_CONTRASTING_LEFT_FACING {#PERSPECTIVE-CONTRASTING-LEFT-FACING}
+```
+public static final int PERSPECTIVE_CONTRASTING_LEFT_FACING
+```
+
+
+
+
+### PERSPECTIVE_CONTRASTING_RIGHT_FACING {#PERSPECTIVE-CONTRASTING-RIGHT-FACING}
+```
+public static final int PERSPECTIVE_CONTRASTING_RIGHT_FACING
+```
+
+
+
+
+### PERSPECTIVE_FRONT {#PERSPECTIVE-FRONT}
+```
+public static final int PERSPECTIVE_FRONT
+```
+
+
+
+
+### PERSPECTIVE_HEROIC_EXTREME_LEFT_FACING {#PERSPECTIVE-HEROIC-EXTREME-LEFT-FACING}
+```
+public static final int PERSPECTIVE_HEROIC_EXTREME_LEFT_FACING
+```
+
+
+
+
+### PERSPECTIVE_HEROIC_EXTREME_RIGHT_FACING {#PERSPECTIVE-HEROIC-EXTREME-RIGHT-FACING}
+```
+public static final int PERSPECTIVE_HEROIC_EXTREME_RIGHT_FACING
+```
+
+
+
+
+### PERSPECTIVE_HEROIC_LEFT_FACING {#PERSPECTIVE-HEROIC-LEFT-FACING}
+```
+public static final int PERSPECTIVE_HEROIC_LEFT_FACING
+```
+
+
+
+
+### PERSPECTIVE_HEROIC_RIGHT_FACING {#PERSPECTIVE-HEROIC-RIGHT-FACING}
+```
+public static final int PERSPECTIVE_HEROIC_RIGHT_FACING
+```
+
+
+
+
+### PERSPECTIVE_LEFT {#PERSPECTIVE-LEFT}
+```
+public static final int PERSPECTIVE_LEFT
+```
+
+
+
+
+### PERSPECTIVE_RELAXED {#PERSPECTIVE-RELAXED}
+```
+public static final int PERSPECTIVE_RELAXED
+```
+
+
+
+
+### PERSPECTIVE_RELAXED_MODERATELY {#PERSPECTIVE-RELAXED-MODERATELY}
+```
+public static final int PERSPECTIVE_RELAXED_MODERATELY
+```
+
+
+
+
+### PERSPECTIVE_RIGHT {#PERSPECTIVE-RIGHT}
+```
+public static final int PERSPECTIVE_RIGHT
+```
+
+
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/presetcolormatricsvalue/_index.md
+++ b/italian/java/com.aspose.diagram/presetcolormatricsvalue/_index.md
@@ -1,0 +1,192 @@
+---
+title: PresetColorMatricsValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Utilizzato per impostare la proprietà colore degli stili del tema Shape
+type: docs
+weight: 297
+url: /it/java/com.aspose.diagram/presetcolormatricsvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PresetColorMatricsValue
+```
+
+Utilizzato per impostare la proprietà colore dello stile del tema della Forma
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [COLOR_1](#COLOR-1) | Colore1. |
+| [COLOR_2](#COLOR-2) | Colore2. |
+| [COLOR_3](#COLOR-3) | Colore3. |
+| [COLOR_4](#COLOR-4) | Colore4. |
+| [COLOR_5](#COLOR-5) | Colore5. |
+| [COLOR_6](#COLOR-6) | Colore6. |
+| [COLOR_7](#COLOR-7) | Colore7. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### COLOR_1 {#COLOR-1}
+```
+public static final int COLOR_1
+```
+
+
+Colore1.
+
+### COLOR_2 {#COLOR-2}
+```
+public static final int COLOR_2
+```
+
+
+Colore2.
+
+### COLOR_3 {#COLOR-3}
+```
+public static final int COLOR_3
+```
+
+
+Colore3.
+
+### COLOR_4 {#COLOR-4}
+```
+public static final int COLOR_4
+```
+
+
+Colore4.
+
+### COLOR_5 {#COLOR-5}
+```
+public static final int COLOR_5
+```
+
+
+Colore5.
+
+### COLOR_6 {#COLOR-6}
+```
+public static final int COLOR_6
+```
+
+
+Colore6.
+
+### COLOR_7 {#COLOR-7}
+```
+public static final int COLOR_7
+```
+
+
+Colore7.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/presetquickstylevalue/_index.md
+++ b/italian/java/com.aspose.diagram/presetquickstylevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: PresetQuickStyleValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica il valore dello stile rapido del tema
+type: docs
+weight: 298
+url: /it/java/com.aspose.diagram/presetquickstylevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PresetQuickStyleValue
+```
+
+Specifica il valore dello stile rapido del tema
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [VARIANT_STYLE_1](#VARIANT-STYLE-1) | VariantStyle1. |
+| [VARIANT_STYLE_2](#VARIANT-STYLE-2) | VariantStyle2. |
+| [VARIANT_STYLE_3](#VARIANT-STYLE-3) | VariantStyle3. |
+| [VARIANT_STYLE_4](#VARIANT-STYLE-4) | VariantStyle4. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### VARIANT_STYLE_1 {#VARIANT-STYLE-1}
+```
+public static final int VARIANT_STYLE_1
+```
+
+
+VariantStyle1.
+
+### VARIANT_STYLE_2 {#VARIANT-STYLE-2}
+```
+public static final int VARIANT_STYLE_2
+```
+
+
+VariantStyle2.
+
+### VARIANT_STYLE_3 {#VARIANT-STYLE-3}
+```
+public static final int VARIANT_STYLE_3
+```
+
+
+VariantStyle3.
+
+### VARIANT_STYLE_4 {#VARIANT-STYLE-4}
+```
+public static final int VARIANT_STYLE_4
+```
+
+
+VariantStyle4.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/presetshadowtype/_index.md
+++ b/italian/java/com.aspose.diagram/presetshadowtype/_index.md
@@ -1,0 +1,354 @@
+---
+title: PresetShadowType
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta il tipo di ombra predefinito.
+type: docs
+weight: 299
+url: /it/java/com.aspose.diagram/presetshadowtype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PresetShadowType
+```
+
+Rappresenta il tipo di ombra predefinito.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [BELOW](#BELOW) | Ombra esterna sotto. |
+| [CUSTOM](#CUSTOM) | Ombra personalizzata. |
+| [INSIDE_BOTTOM](#INSIDE-BOTTOM) | Ombra interna nella parte inferiore. |
+| [INSIDE_CENTER](#INSIDE-CENTER) | Ombra interna al centro. |
+| [INSIDE_DIAGONAL_BOTTOM_LEFT](#INSIDE-DIAGONAL-BOTTOM-LEFT) | Ombra interna in diagonale in basso a sinistra. |
+| [INSIDE_DIAGONAL_BOTTOM_RIGHT](#INSIDE-DIAGONAL-BOTTOM-RIGHT) | Ombra interna in diagonale in basso a destra. |
+| [INSIDE_DIAGONAL_TOP_LEFT](#INSIDE-DIAGONAL-TOP-LEFT) | Ombra interna in diagonale in alto a sinistra. |
+| [INSIDE_DIAGONAL_TOP_RIGHT](#INSIDE-DIAGONAL-TOP-RIGHT) | Ombra interna in diagonale in alto a destra. |
+| [INSIDE_LEFT](#INSIDE-LEFT) | Ombra interna a sinistra. |
+| [INSIDE_RIGHT](#INSIDE-RIGHT) | Ombra interna a destra. |
+| [INSIDE_TOP](#INSIDE-TOP) | Ombra interna in alto. |
+| [NO_SHADOW](#NO-SHADOW) | Nessuna ombra. |
+| [OFFSET_BOTTOM](#OFFSET-BOTTOM) | Ombra esterna spostata in basso. |
+| [OFFSET_CENTER](#OFFSET-CENTER) | Ombra esterna spostata al centro. |
+| [OFFSET_DIAGONAL_BOTTOM_LEFT](#OFFSET-DIAGONAL-BOTTOM-LEFT) | Ombra esterna spostata in diagonale in basso a sinistra. |
+| [OFFSET_DIAGONAL_BOTTOM_RIGHT](#OFFSET-DIAGONAL-BOTTOM-RIGHT) | Ombra esterna spostata in diagonale in basso a destra. |
+| [OFFSET_DIAGONAL_TOP_LEFT](#OFFSET-DIAGONAL-TOP-LEFT) | Ombra esterna spostata in diagonale in alto a sinistra. |
+| [OFFSET_DIAGONAL_TOP_RIGHT](#OFFSET-DIAGONAL-TOP-RIGHT) | Ombra esterna spostata in diagonale in alto a destra. |
+| [OFFSET_LEFT](#OFFSET-LEFT) | Ombra esterna spostata a sinistra. |
+| [OFFSET_RIGHT](#OFFSET-RIGHT) | Ombra esterna spostata a destra. |
+| [OFFSET_TOP](#OFFSET-TOP) | Ombra esterna spostata in alto. |
+| [PERSPECTIVE_DIAGONAL_LOWER_LEFT](#PERSPECTIVE-DIAGONAL-LOWER-LEFT) | Ombra esterna prospettiva diagonale in basso a sinistra. |
+| [PERSPECTIVE_DIAGONAL_LOWER_RIGHT](#PERSPECTIVE-DIAGONAL-LOWER-RIGHT) | Ombra esterna prospettiva diagonale in basso a destra. |
+| [PERSPECTIVE_DIAGONAL_UPPER_LEFT](#PERSPECTIVE-DIAGONAL-UPPER-LEFT) | Ombra esterna prospettiva diagonale in alto a sinistra. |
+| [PERSPECTIVE_DIAGONAL_UPPER_RIGHT](#PERSPECTIVE-DIAGONAL-UPPER-RIGHT) | Ombra esterna prospettiva diagonale in alto a destra. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BELOW {#BELOW}
+```
+public static final int BELOW
+```
+
+
+Ombra esterna sotto.
+
+### CUSTOM {#CUSTOM}
+```
+public static final int CUSTOM
+```
+
+
+Ombra personalizzata.
+
+### INSIDE_BOTTOM {#INSIDE-BOTTOM}
+```
+public static final int INSIDE_BOTTOM
+```
+
+
+Ombra interna nella parte inferiore.
+
+### INSIDE_CENTER {#INSIDE-CENTER}
+```
+public static final int INSIDE_CENTER
+```
+
+
+Ombra interna al centro.
+
+### INSIDE_DIAGONAL_BOTTOM_LEFT {#INSIDE-DIAGONAL-BOTTOM-LEFT}
+```
+public static final int INSIDE_DIAGONAL_BOTTOM_LEFT
+```
+
+
+Ombra interna in diagonale in basso a sinistra.
+
+### INSIDE_DIAGONAL_BOTTOM_RIGHT {#INSIDE-DIAGONAL-BOTTOM-RIGHT}
+```
+public static final int INSIDE_DIAGONAL_BOTTOM_RIGHT
+```
+
+
+Ombra interna in diagonale in basso a destra.
+
+### INSIDE_DIAGONAL_TOP_LEFT {#INSIDE-DIAGONAL-TOP-LEFT}
+```
+public static final int INSIDE_DIAGONAL_TOP_LEFT
+```
+
+
+Ombra interna in diagonale in alto a sinistra.
+
+### INSIDE_DIAGONAL_TOP_RIGHT {#INSIDE-DIAGONAL-TOP-RIGHT}
+```
+public static final int INSIDE_DIAGONAL_TOP_RIGHT
+```
+
+
+Ombra interna in diagonale in alto a destra.
+
+### INSIDE_LEFT {#INSIDE-LEFT}
+```
+public static final int INSIDE_LEFT
+```
+
+
+Ombra interna a sinistra.
+
+### INSIDE_RIGHT {#INSIDE-RIGHT}
+```
+public static final int INSIDE_RIGHT
+```
+
+
+Ombra interna a destra.
+
+### INSIDE_TOP {#INSIDE-TOP}
+```
+public static final int INSIDE_TOP
+```
+
+
+Ombra interna in alto.
+
+### NO_SHADOW {#NO-SHADOW}
+```
+public static final int NO_SHADOW
+```
+
+
+Nessuna ombra.
+
+### OFFSET_BOTTOM {#OFFSET-BOTTOM}
+```
+public static final int OFFSET_BOTTOM
+```
+
+
+Ombra esterna spostata in basso.
+
+### OFFSET_CENTER {#OFFSET-CENTER}
+```
+public static final int OFFSET_CENTER
+```
+
+
+Ombra esterna spostata al centro.
+
+### OFFSET_DIAGONAL_BOTTOM_LEFT {#OFFSET-DIAGONAL-BOTTOM-LEFT}
+```
+public static final int OFFSET_DIAGONAL_BOTTOM_LEFT
+```
+
+
+Ombra esterna spostata in diagonale in basso a sinistra.
+
+### OFFSET_DIAGONAL_BOTTOM_RIGHT {#OFFSET-DIAGONAL-BOTTOM-RIGHT}
+```
+public static final int OFFSET_DIAGONAL_BOTTOM_RIGHT
+```
+
+
+Ombra esterna spostata in diagonale in basso a destra.
+
+### OFFSET_DIAGONAL_TOP_LEFT {#OFFSET-DIAGONAL-TOP-LEFT}
+```
+public static final int OFFSET_DIAGONAL_TOP_LEFT
+```
+
+
+Ombra esterna spostata in diagonale in alto a sinistra.
+
+### OFFSET_DIAGONAL_TOP_RIGHT {#OFFSET-DIAGONAL-TOP-RIGHT}
+```
+public static final int OFFSET_DIAGONAL_TOP_RIGHT
+```
+
+
+Ombra esterna spostata in diagonale in alto a destra.
+
+### OFFSET_LEFT {#OFFSET-LEFT}
+```
+public static final int OFFSET_LEFT
+```
+
+
+Ombra esterna spostata a sinistra.
+
+### OFFSET_RIGHT {#OFFSET-RIGHT}
+```
+public static final int OFFSET_RIGHT
+```
+
+
+Ombra esterna spostata a destra.
+
+### OFFSET_TOP {#OFFSET-TOP}
+```
+public static final int OFFSET_TOP
+```
+
+
+Ombra esterna spostata in alto.
+
+### PERSPECTIVE_DIAGONAL_LOWER_LEFT {#PERSPECTIVE-DIAGONAL-LOWER-LEFT}
+```
+public static final int PERSPECTIVE_DIAGONAL_LOWER_LEFT
+```
+
+
+Ombra esterna prospettiva diagonale in basso a sinistra.
+
+### PERSPECTIVE_DIAGONAL_LOWER_RIGHT {#PERSPECTIVE-DIAGONAL-LOWER-RIGHT}
+```
+public static final int PERSPECTIVE_DIAGONAL_LOWER_RIGHT
+```
+
+
+Ombra esterna prospettiva diagonale in basso a destra.
+
+### PERSPECTIVE_DIAGONAL_UPPER_LEFT {#PERSPECTIVE-DIAGONAL-UPPER-LEFT}
+```
+public static final int PERSPECTIVE_DIAGONAL_UPPER_LEFT
+```
+
+
+Ombra esterna prospettiva diagonale in alto a sinistra.
+
+### PERSPECTIVE_DIAGONAL_UPPER_RIGHT {#PERSPECTIVE-DIAGONAL-UPPER-RIGHT}
+```
+public static final int PERSPECTIVE_DIAGONAL_UPPER_RIGHT
+```
+
+
+Ombra esterna prospettiva diagonale in alto a destra.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/presetstylematricsvalue/_index.md
+++ b/italian/java/com.aspose.diagram/presetstylematricsvalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: PresetStyleMatricsValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Utilizzato per impostare la proprietà dello stile del tema della Forma
+type: docs
+weight: 300
+url: /it/java/com.aspose.diagram/presetstylematricsvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PresetStyleMatricsValue
+```
+
+Utilizzato per impostare la proprietà dello stile del tema della Forma
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [STYLE_1](#STYLE-1) | Style1 |
+| [STYLE_2](#STYLE-2) | Style2 |
+| [STYLE_3](#STYLE-3) | Style3 |
+| [STYLE_4](#STYLE-4) | Style4 |
+| [STYLE_5](#STYLE-5) | Style5 |
+| [STYLE_6](#STYLE-6) | Style6 |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### STYLE_1 {#STYLE-1}
+```
+public static final int STYLE_1
+```
+
+
+Style1
+
+### STYLE_2 {#STYLE-2}
+```
+public static final int STYLE_2
+```
+
+
+Style2
+
+### STYLE_3 {#STYLE-3}
+```
+public static final int STYLE_3
+```
+
+
+Style3
+
+### STYLE_4 {#STYLE-4}
+```
+public static final int STYLE_4
+```
+
+
+Style4
+
+### STYLE_5 {#STYLE-5}
+```
+public static final int STYLE_5
+```
+
+
+Style5
+
+### STYLE_6 {#STYLE-6}
+```
+public static final int STYLE_6
+```
+
+
+Style6
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/presetthemevalue/_index.md
+++ b/italian/java/com.aspose.diagram/presetthemevalue/_index.md
@@ -1,0 +1,372 @@
+---
+title: PresetThemeValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica il valore del tema
+type: docs
+weight: 301
+url: /it/java/com.aspose.diagram/presetthemevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PresetThemeValue
+```
+
+Specifica il valore del tema
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [BUBBLE](#BUBBLE) | Bolla |
+| [CLOUDS](#CLOUDS) | Nuvole |
+| [DAYBREAK](#DAYBREAK) | Alba |
+| [FACET](#FACET) | Facetta |
+| [GEMSTONE](#GEMSTONE) | Gemma |
+| [INTEGRAL](#INTEGRAL) | Integrale |
+| [ION](#ION) | Ione |
+| [LINEAR](#LINEAR) | Lineare |
+| [LINES](#LINES) | Linee |
+| [MARKER](#MARKER) | Marcatore |
+| [NO_THEME](#NO-THEME) | NessunTema |
+| [OFFICE](#OFFICE) | Ufficio |
+| [ORGANIC](#ORGANIC) | Organico |
+| [PARALLEL](#PARALLEL) | Parallelo |
+| [PEN](#PEN) | Penna |
+| [PENCIL](#PENCIL) | Matita |
+| [PROMINENCE](#PROMINENCE) | Rilevanza |
+| [RADIANCE](#RADIANCE) | Luminosità |
+| [RETROSPECT](#RETROSPECT) | Retrospettiva |
+| [SEQUENCE](#SEQUENCE) | Sequenza |
+| [SHADE](#SHADE) | Ombra |
+| [SIMPLE](#SIMPLE) | Semplice |
+| [SLICE](#SLICE) | Fetta |
+| [SMOKE](#SMOKE) | Fumo |
+| [WHISP](#WHISP) | Soffio |
+| [WHITE_BOARD](#WHITE-BOARD) | LavagnaBianca |
+| [ZEPHYR](#ZEPHYR) | Zefiro |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BUBBLE {#BUBBLE}
+```
+public static final int BUBBLE
+```
+
+
+Bolla
+
+### CLOUDS {#CLOUDS}
+```
+public static final int CLOUDS
+```
+
+
+Nuvole
+
+### DAYBREAK {#DAYBREAK}
+```
+public static final int DAYBREAK
+```
+
+
+Alba
+
+### FACET {#FACET}
+```
+public static final int FACET
+```
+
+
+Facetta
+
+### GEMSTONE {#GEMSTONE}
+```
+public static final int GEMSTONE
+```
+
+
+Gemma
+
+### INTEGRAL {#INTEGRAL}
+```
+public static final int INTEGRAL
+```
+
+
+Integrale
+
+### ION {#ION}
+```
+public static final int ION
+```
+
+
+Ione
+
+### LINEAR {#LINEAR}
+```
+public static final int LINEAR
+```
+
+
+Lineare
+
+### LINES {#LINES}
+```
+public static final int LINES
+```
+
+
+Linee
+
+### MARKER {#MARKER}
+```
+public static final int MARKER
+```
+
+
+Marcatore
+
+### NO_THEME {#NO-THEME}
+```
+public static final int NO_THEME
+```
+
+
+NessunTema
+
+### OFFICE {#OFFICE}
+```
+public static final int OFFICE
+```
+
+
+Ufficio
+
+### ORGANIC {#ORGANIC}
+```
+public static final int ORGANIC
+```
+
+
+Organico
+
+### PARALLEL {#PARALLEL}
+```
+public static final int PARALLEL
+```
+
+
+Parallelo
+
+### PEN {#PEN}
+```
+public static final int PEN
+```
+
+
+Penna
+
+### PENCIL {#PENCIL}
+```
+public static final int PENCIL
+```
+
+
+Matita
+
+### PROMINENCE {#PROMINENCE}
+```
+public static final int PROMINENCE
+```
+
+
+Rilevanza
+
+### RADIANCE {#RADIANCE}
+```
+public static final int RADIANCE
+```
+
+
+Luminosità
+
+### RETROSPECT {#RETROSPECT}
+```
+public static final int RETROSPECT
+```
+
+
+Retrospettiva
+
+### SEQUENCE {#SEQUENCE}
+```
+public static final int SEQUENCE
+```
+
+
+Sequenza
+
+### SHADE {#SHADE}
+```
+public static final int SHADE
+```
+
+
+Ombra
+
+### SIMPLE {#SIMPLE}
+```
+public static final int SIMPLE
+```
+
+
+Semplice
+
+### SLICE {#SLICE}
+```
+public static final int SLICE
+```
+
+
+Fetta
+
+### SMOKE {#SMOKE}
+```
+public static final int SMOKE
+```
+
+
+Fumo
+
+### WHISP {#WHISP}
+```
+public static final int WHISP
+```
+
+
+Soffio
+
+### WHITE_BOARD {#WHITE-BOARD}
+```
+public static final int WHITE_BOARD
+```
+
+
+LavagnaBianca
+
+### ZEPHYR {#ZEPHYR}
+```
+public static final int ZEPHYR
+```
+
+
+Zefiro
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/presetthemevariantvalue/_index.md
+++ b/italian/java/com.aspose.diagram/presetthemevariantvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: PresetThemeVariantValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica il valore della variante del tema
+type: docs
+weight: 302
+url: /it/java/com.aspose.diagram/presetthemevariantvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PresetThemeVariantValue
+```
+
+Specifica il valore della variante del tema
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [VARIANT_1](#VARIANT-1) | Variant1. |
+| [VARIANT_2](#VARIANT-2) | Variant2. |
+| [VARIANT_3](#VARIANT-3) | Variant3. |
+| [VARIANT_4](#VARIANT-4) | Variant4. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### VARIANT_1 {#VARIANT-1}
+```
+public static final int VARIANT_1
+```
+
+
+Variant1.
+
+### VARIANT_2 {#VARIANT-2}
+```
+public static final int VARIANT_2
+```
+
+
+Variant2.
+
+### VARIANT_3 {#VARIANT-3}
+```
+public static final int VARIANT_3
+```
+
+
+Variant3.
+
+### VARIANT_4 {#VARIANT-4}
+```
+public static final int VARIANT_4
+```
+
+
+Variant4.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/previewscope/_index.md
+++ b/italian/java/com.aspose.diagram/previewscope/_index.md
@@ -1,0 +1,179 @@
+---
+title: PreviewScope
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica se il documento include un'anteprima e, in tal caso, se l'anteprima mostra solo la prima pagina o tutte le pagine del documento.
+type: docs
+weight: 303
+url: /it/java/com.aspose.diagram/previewscope/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PreviewScope
+```
+
+Specifica se il documento include un'anteprima e, in tal caso, se l'anteprima mostra solo la prima pagina o tutte le pagine del documento.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [PreviewScope(int value)](#PreviewScope-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Specifica se il documento include un'anteprima e, in tal caso, se l'anteprima mostra solo la prima pagina o tutte le pagine del documento. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/previewscope\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PreviewScope(int value) {#PreviewScope-int-}
+```
+public PreviewScope(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specifica se il documento include un'anteprima e, in tal caso, se l'anteprima mostra solo la prima pagina o tutte le pagine del documento.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/previewscope\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/previewscopevalue/_index.md
+++ b/italian/java/com.aspose.diagram/previewscopevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: PreviewScopeValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica se il documento include un'anteprima e, in tal caso, se l'anteprima mostra solo la prima pagina o tutte le pagine del documento.
+type: docs
+weight: 304
+url: /it/java/com.aspose.diagram/previewscopevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PreviewScopeValue
+```
+
+Specifica se il documento include un'anteprima e, in tal caso, se l'anteprima mostra solo la prima pagina o tutte le pagine del documento.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [ALL_PAGES](#ALL-PAGES) | Tutte le pagine. |
+| [FIRST_PAGE](#FIRST-PAGE) | Prima pagina. |
+| [NO_PREVIEW](#NO-PREVIEW) | Nessuna anteprima. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALL_PAGES {#ALL-PAGES}
+```
+public static final int ALL_PAGES
+```
+
+
+Tutte le pagine.
+
+### FIRST_PAGE {#FIRST-PAGE}
+```
+public static final int FIRST_PAGE
+```
+
+
+Prima pagina.
+
+### NO_PREVIEW {#NO-PREVIEW}
+```
+public static final int NO_PREVIEW
+```
+
+
+Nessuna anteprima.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/printpageorientation/_index.md
+++ b/italian/java/com.aspose.diagram/printpageorientation/_index.md
@@ -1,0 +1,180 @@
+---
+title: PrintPageOrientation
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Determina se la pagina viene stampata in orientamento verticale o orizzontale.
+type: docs
+weight: 305
+url: /it/java/com.aspose.diagram/printpageorientation/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PrintPageOrientation
+```
+
+Determina se la pagina viene stampata in orientamento verticale o orizzontale.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [PrintPageOrientation(PrintProps pp, int value)](#PrintPageOrientation-com.aspose.diagram.PrintProps-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Determina se la pagina viene stampata in orientamento verticale o orizzontale. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/printpageorientation\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PrintPageOrientation(PrintProps pp, int value) {#PrintPageOrientation-com.aspose.diagram.PrintProps-int-}
+```
+public PrintPageOrientation(PrintProps pp, int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| pp | [PrintProps](../../com.aspose.diagram/printprops) |  |
+| valore | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Determina se la pagina viene stampata in orientamento verticale o orizzontale.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/printpageorientation\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/printpageorientationvalue/_index.md
+++ b/italian/java/com.aspose.diagram/printpageorientationvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: PrintPageOrientationValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Determina se la pagina viene stampata in orientamento verticale o orizzontale.
+type: docs
+weight: 306
+url: /it/java/com.aspose.diagram/printpageorientationvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PrintPageOrientationValue
+```
+
+Determina se la pagina viene stampata in orientamento verticale o orizzontale.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [LANDSCAPE](#LANDSCAPE) | Orizzontale. |
+| [PORTRAIT](#PORTRAIT) | Verticale. |
+| [SAME_AS_PRINTER](#SAME-AS-PRINTER) | Stesso della stampante. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LANDSCAPE {#LANDSCAPE}
+```
+public static final int LANDSCAPE
+```
+
+
+Orizzontale.
+
+### PORTRAIT {#PORTRAIT}
+```
+public static final int PORTRAIT
+```
+
+
+Verticale.
+
+### SAME_AS_PRINTER {#SAME-AS-PRINTER}
+```
+public static final int SAME_AS_PRINTER
+```
+
+
+Stesso della stampante.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/printprops/_index.md
+++ b/italian/java/com.aspose.diagram/printprops/_index.md
@@ -1,0 +1,315 @@
+---
+title: PrintProps
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene elementi che controllano come la pagina di disegno formattata appare sulla pagina della stampante.
+type: docs
+weight: 307
+url: /it/java/com.aspose.diagram/printprops/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PrintProps
+```
+
+Contiene elementi che controllano come la pagina di disegno è formattata (appare) sulla pagina della stampante.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCenterX()](#getCenterX--) | Determina se la pagina di disegno è centrata orizzontalmente sulla pagina stampata. |
+| [getCenterY()](#getCenterY--) | Determina se la pagina di disegno è centrata verticalmente sulla pagina stampata. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getOnPage()](#getOnPage--) | Indica se il disegno è stampato su un numero specifico di pagine della stampante. |
+| [getPageBottomMargin()](#getPageBottomMargin--) | Specifica il margine nella parte inferiore della pagina stampata. |
+| [getPageLeftMargin()](#getPageLeftMargin--) | Specifica il margine a sinistra della pagina stampata. |
+| [getPageRightMargin()](#getPageRightMargin--) | Specifica il margine a destra della pagina stampata. |
+| [getPageTopMargin()](#getPageTopMargin--) | Specifica il margine nella parte superiore della pagina della stampante. |
+| [getPagesX()](#getPagesX--) | Determina il numero di pagine della stampante su cui adattare orizzontalmente la pagina di disegno. |
+| [getPagesY()](#getPagesY--) | Determina il numero di pagine della stampante su cui adattare verticalmente la pagina di disegno. |
+| [getPaperKind()](#getPaperKind--) | Specifica il tipo di carta su cui stampare la pagina. |
+| [getPaperSource()](#getPaperSource--) | Determina la sorgente della carta per la pagina. |
+| [getPrintGrid()](#getPrintGrid--) | Specifica se stampare la griglia durante la stampa di una pagina del documento. |
+| [getPrintPageOrientation()](#getPrintPageOrientation--) | Determina se la pagina viene stampata in orientamento verticale o orizzontale. |
+| [getScaleX()](#getScaleX--) | Specifica la percentuale di ingrandimento della pagina di disegno sulla pagina della stampante, nella direzione x (orizzontale). |
+| [getScaleY()](#getScaleY--) | Specifica la percentuale di ingrandimento della pagina di disegno sulla pagina della stampante, nella direzione y (verticale). |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/printprops\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCenterX() {#getCenterX--}
+```
+public BoolValue getCenterX()
+```
+
+
+Determina se la pagina di disegno è centrata orizzontalmente sulla pagina stampata.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getCenterY() {#getCenterY--}
+```
+public BoolValue getCenterY()
+```
+
+
+Determina se la pagina di disegno è centrata verticalmente sulla pagina stampata.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getOnPage() {#getOnPage--}
+```
+public BoolValue getOnPage()
+```
+
+
+Indica se il disegno è stampato su un numero specifico di pagine della stampante.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getPageBottomMargin() {#getPageBottomMargin--}
+```
+public DoubleValue getPageBottomMargin()
+```
+
+
+Specifica il margine nella parte inferiore della pagina stampata.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getPageLeftMargin() {#getPageLeftMargin--}
+```
+public DoubleValue getPageLeftMargin()
+```
+
+
+Specifica il margine a sinistra della pagina stampata.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getPageRightMargin() {#getPageRightMargin--}
+```
+public DoubleValue getPageRightMargin()
+```
+
+
+Specifica il margine a destra della pagina stampata.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getPageTopMargin() {#getPageTopMargin--}
+```
+public DoubleValue getPageTopMargin()
+```
+
+
+Specifica il margine nella parte superiore della pagina della stampante.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getPagesX() {#getPagesX--}
+```
+public IntValue getPagesX()
+```
+
+
+Determina il numero di pagine della stampante su cui adattare orizzontalmente la pagina di disegno.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getPagesY() {#getPagesY--}
+```
+public IntValue getPagesY()
+```
+
+
+Determina il numero di pagine della stampante su cui adattare verticalmente la pagina di disegno.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getPaperKind() {#getPaperKind--}
+```
+public IntValue getPaperKind()
+```
+
+
+Specifica il tipo di carta su cui stampare la pagina.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getPaperSource() {#getPaperSource--}
+```
+public IntValue getPaperSource()
+```
+
+
+Determina la sorgente della carta per la pagina.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getPrintGrid() {#getPrintGrid--}
+```
+public BoolValue getPrintGrid()
+```
+
+
+Specifica se stampare la griglia durante la stampa di una pagina del documento.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getPrintPageOrientation() {#getPrintPageOrientation--}
+```
+public PrintPageOrientation getPrintPageOrientation()
+```
+
+
+Determina se la pagina viene stampata in orientamento verticale o orizzontale.
+
+**Returns:**
+[PrintPageOrientation](../../com.aspose.diagram/printpageorientation)
+### getScaleX() {#getScaleX--}
+```
+public DoubleValue getScaleX()
+```
+
+
+Specifica la percentuale di ingrandimento della pagina di disegno sulla pagina della stampante, nella direzione x (orizzontale).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getScaleY() {#getScaleY--}
+```
+public DoubleValue getScaleY()
+```
+
+
+Specifica la percentuale di ingrandimento della pagina di disegno sulla pagina della stampante, nella direzione y (verticale).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/printprops\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/printsaveoptions/_index.md
+++ b/italian/java/com.aspose.diagram/printsaveoptions/_index.md
@@ -1,0 +1,429 @@
+---
+title: PrintSaveOptions
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Consente di specificare opzioni aggiuntive durante la stampa del diagramma.
+type: docs
+weight: 308
+url: /it/java/com.aspose.diagram/printsaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.SaveOptions](../../com.aspose.diagram/saveoptions), [com.aspose.diagram.RenderingSaveOptions](../../com.aspose.diagram/renderingsaveoptions)
+```
+public class PrintSaveOptions extends RenderingSaveOptions
+```
+
+Consente di specificare opzioni aggiuntive durante la stampa del diagramma.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [PrintSaveOptions()](#PrintSaveOptions--) | Inizializza una nuova istanza di questa classe |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | Crea un oggetto di opzioni di salvataggio di una classe adatta al formato di salvataggio specificato. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDefaultFont()](#getDefaultFont--) | Quando i caratteri nel diagramma sono Unicode e non vengono impostati con il valore di carattere corretto o il carattere non è installato localmente, possono apparire come blocchi in PDF, immagine o XPS. |
+| [getEmfRenderSetting()](#getEmfRenderSetting--) | Impostazione per il rendering del metafile Emf. |
+| [getEnlargePage()](#getEnlargePage--) | Specifica se ingrandire la pagina. |
+| [getExportGuideShapes()](#getExportGuideShapes--) | Definisce se è necessario esportare le forme guida o meno. |
+| [getPageCount()](#getPageCount--) | il numero di pagine da renderizzare durante il salvataggio in un file multipagina. |
+| [getPageSize()](#getPageSize--) | la dimensione della pagina per le immagini generate. |
+| [getSaveForegroundPagesOnly()](#getSaveForegroundPagesOnly--) | Specifica se tutte le pagine verranno stampate o solo il primo piano. |
+| [getSaveFormat()](#getSaveFormat--) | Specifica il formato in cui il documento verrà salvato se viene utilizzato questo oggetto di opzioni di salvataggio. |
+| [getShapes()](#getShapes--) | forme da renderizzare. |
+| [getWarningCallback()](#getWarningCallback--) | callback di avviso. |
+| [hashCode()](#hashCode--) |  |
+| [isExportComments()](#isExportComments--) | Definisce se è necessario esportare i commenti o meno. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--) |
+| [setEmfRenderSetting(int value)](#setEmfRenderSetting-int-) | Per la descrizione di questa proprietà, vedere [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--) |
+| [setEnlargePage(boolean value)](#setEnlargePage-boolean-) | Per la descrizione di questa proprietà, vedere [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\\#getEnlargePage--) |
+| [setExportComments(boolean value)](#setExportComments-boolean-) | Per la descrizione di questa proprietà, vedere [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\\#isExportComments--) |
+| [setExportGuideShapes(boolean value)](#setExportGuideShapes-boolean-) | Per la descrizione di questa proprietà, vedere [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\\#getExportGuideShapes--) |
+| [setPageCount(int value)](#setPageCount-int-) | Per la descrizione di questa proprietà, vedere [getPageCount()](../../com.aspose.diagram/printsaveoptions\#getPageCount--) |
+| [setPageSize(PageSize value)](#setPageSize-com.aspose.diagram.PageSize-) | Per la descrizione di questa proprietà, vedere [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\\#getPageSize--) |
+| [setSaveForegroundPagesOnly(boolean value)](#setSaveForegroundPagesOnly-boolean-) | Per la descrizione di questa proprietà, vedere [getSaveForegroundPagesOnly()](../../com.aspose.diagram/printsaveoptions\#getSaveForegroundPagesOnly--) |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | Per la descrizione di questa proprietà, vedere [getSaveFormat()](../../com.aspose.diagram/saveoptions\#getSaveFormat--) |
+| [setShapes(ShapeCollection value)](#setShapes-com.aspose.diagram.ShapeCollection-) | Per la descrizione di questa proprietà, vedere [getShapes()](../../com.aspose.diagram/renderingsaveoptions\\#getShapes--) |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PrintSaveOptions() {#PrintSaveOptions--}
+```
+public PrintSaveOptions()
+```
+
+
+Inizializza una nuova istanza di questa classe
+
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+Crea un oggetto di opzioni di salvataggio di una classe adatta al formato di salvataggio specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| saveFormat | int | Il Aspose.Diagram.SaveFileFormat per il quale creare un oggetto di opzioni di salvataggio. |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+Quando i caratteri nel diagramma sono Unicode e non sono impostati con il valore di font corretto o il font non è installato localmente, possono apparire come blocchi in PDF, immagine o XPS. Impostare il DefaultFont, ad esempio MingLiu o MS Gothic, per visualizzare questi caratteri.
+
+**Returns:**
+java.lang.String
+### getEmfRenderSetting() {#getEmfRenderSetting--}
+```
+public int getEmfRenderSetting()
+```
+
+
+Impostazione per il rendering dei metafile EMF. I metafile EMF identificati come "EMF+ Dual" possono contenere sia record EMF+ sia record EMF. Entrambi i tipi di record possono essere usati per renderizzare l'immagine, solo record EMF+, o solo record EMF. Quando EmfPlusPrefer è impostato, i record EMF+ verranno analizzati, altrimenti verranno analizzati solo i record EMF. Il valore predefinito è EmfOnly"/>.
+
+**Returns:**
+int
+### getEnlargePage() {#getEnlargePage--}
+```
+public boolean getEnlargePage()
+```
+
+
+Specifica se ingrandire la pagina. Se true - ingrandire la pagina. Se false - non ingrandire la pagina. Il valore predefinito è true.
+
+**Returns:**
+boolean
+### getExportGuideShapes() {#getExportGuideShapes--}
+```
+public boolean getExportGuideShapes()
+```
+
+
+Definisce se è necessario esportare le forme guida o meno. Il valore predefinito è true.
+
+**Returns:**
+boolean
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+il numero di pagine da renderizzare durante il salvataggio in un file multipagina. Il valore predefinito è MaxValue, che significa che tutte le pagine del diagramma verranno stampate.
+
+**Returns:**
+int
+### getPageSize() {#getPageSize--}
+```
+public PageSize getPageSize()
+```
+
+
+la dimensione della pagina per le immagini generate. Può essere [PageSize](../../com.aspose.diagram/pagesize) o null. Il valore predefinito è null. Se PageSize è null, la dimensione della pagina per l'immagine generata viene ottenuta dal diagramma di origine.
+
+**Returns:**
+[PageSize](../../com.aspose.diagram/pagesize)
+### getSaveForegroundPagesOnly() {#getSaveForegroundPagesOnly--}
+```
+public boolean getSaveForegroundPagesOnly()
+```
+
+
+Specifica se tutte le pagine verranno stampate o solo il primo piano. Se true - vengono stampate solo le pagine del primo piano (con lo sfondo se presente). Se false - vengono stampate le pagine del primo piano (con lo sfondo se presente) seguite da pagine di sfondo vuote. Può restituire true solo quando PageCount > 1. Il valore predefinito è false.
+
+**Returns:**
+boolean
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+Specifica il formato in cui il documento verrà salvato se viene utilizzato questo oggetto di opzioni di salvataggio.
+
+**Returns:**
+int
+### getShapes() {#getShapes--}
+```
+public ShapeCollection getShapes()
+```
+
+
+forme da renderizzare. Il conteggio predefinito è 0.
+
+**Returns:**
+[ShapeCollection](../../com.aspose.diagram/shapecollection)
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+callback di avviso.
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExportComments() {#isExportComments--}
+```
+public boolean isExportComments()
+```
+
+
+Definisce se è necessario esportare i commenti o meno. Il valore predefinito è false.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setEmfRenderSetting(int value) {#setEmfRenderSetting-int-}
+```
+public void setEmfRenderSetting(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setEnlargePage(boolean value) {#setEnlargePage-boolean-}
+```
+public void setEnlargePage(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\\#getEnlargePage--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setExportComments(boolean value) {#setExportComments-boolean-}
+```
+public void setExportComments(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\\#isExportComments--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setExportGuideShapes(boolean value) {#setExportGuideShapes-boolean-}
+```
+public void setExportGuideShapes(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\\#getExportGuideShapes--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setPageCount(int value) {#setPageCount-int-}
+```
+public void setPageCount(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getPageCount()](../../com.aspose.diagram/printsaveoptions\#getPageCount--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setPageSize(PageSize value) {#setPageSize-com.aspose.diagram.PageSize-}
+```
+public void setPageSize(PageSize value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\\#getPageSize--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [PageSize](../../com.aspose.diagram/pagesize) |  |
+
+### setSaveForegroundPagesOnly(boolean value) {#setSaveForegroundPagesOnly-boolean-}
+```
+public void setSaveForegroundPagesOnly(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getSaveForegroundPagesOnly()](../../com.aspose.diagram/printsaveoptions\#getSaveForegroundPagesOnly--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getSaveFormat()](../../com.aspose.diagram/saveoptions\#getSaveFormat--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setShapes(ShapeCollection value) {#setShapes-com.aspose.diagram.ShapeCollection-}
+```
+public void setShapes(ShapeCollection value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getShapes()](../../com.aspose.diagram/renderingsaveoptions\\#getShapes--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [ShapeCollection](../../com.aspose.diagram/shapecollection) |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/prop/_index.md
+++ b/italian/java/com.aspose.diagram/prop/_index.md
@@ -1,0 +1,384 @@
+---
+title: Prop
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene elementi per definire proprietà personalizzate ed elementi per associare dati a una forma.
+type: docs
+weight: 309
+url: /it/java/com.aspose.diagram/prop/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Prop
+```
+
+Contiene elementi per definire proprietà personalizzate ed elementi per associare dati a una forma.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [Prop()](#Prop--) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCalendar()](#getCalendar--) | Determina il calendario utilizzato per le proprietà personalizzate, i campi di testo e le formule degli elementi. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getFormat()](#getFormat--) | L'elemento Format specifica la formattazione di una proprietà personalizzata che è una stringa, un elenco fisso, un numero, un elenco variabile, una data o ora, una durata o una valuta. |
+| [getID()](#getID--) | L'ID univoco dell'elemento all'interno del suo elemento genitore. |
+| [getIX()](#getIX--) | L'indice basato su zero dell'elemento all'interno del suo elemento genitore. |
+| [getInvisible()](#getInvisible--) | L'elemento Invisible specifica se la proprietà personalizzata è visibile nella finestra di dialogo Proprietà personalizzate in Microsoft Visio. |
+| [getLabel()](#getLabel--) | Specifica l'etichetta che appare agli utenti nella finestra di dialogo Proprietà personalizzate. |
+| [getLangID()](#getLangID--) | Indica l'ID locale (LCID) della lingua in cui è stata inserita la formula della cella, il testo, la proprietà personalizzata o il commento. |
+| [getName()](#getName--) | Il nome dell'elemento. |
+| [getNameU()](#getNameU--) | Il nome universale dell'elemento. |
+| [getPrompt()](#getPrompt--) | L'elemento Prompt specifica il testo descrittivo o istruttivo che appare agli utenti nella finestra di dialogo Proprietà personalizzate quando la proprietà è selezionata. |
+| [getSortKey()](#getSortKey--) | Specifica una chiave che determina l'ordine in cui le proprietà personalizzate sono elencate nell'interfaccia utente dell'applicazione. |
+| [getType()](#getType--) | Tipo specifica un tipo di dati per il valore della proprietà personalizzata. |
+| [getValue()](#getValue--) | Contiene dati XML ben formati specifici della soluzione, con prefisso in uno spazio dei nomi esplicito e memorizzati con un documento. |
+| [getVerify()](#getVerify--) | Specifica se all'utente viene chiesto di inserire informazioni sulla proprietà personalizzata per una forma quando viene creata un'istanza o la forma è duplicata o copiata. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/prop\#getDel--) |
+| [setID(int value)](#setID-int-) | Per la descrizione di questa proprietà, vedere [getID()](../../com.aspose.diagram/prop\#getID--) |
+| [setIX(int value)](#setIX-int-) | Per la descrizione di questa proprietà, vedere [getIX()](../../com.aspose.diagram/prop\#getIX--) |
+| [setName(String value)](#setName-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getName()](../../com.aspose.diagram/prop\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getNameU()](../../com.aspose.diagram/prop\#getNameU--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Prop() {#Prop--}
+```
+public Prop()
+```
+
+
+Costruttore.
+
+### deepClone() {#deepClone--}
+```
+public Prop deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+[Prop](../../com.aspose.diagram/prop) - 
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCalendar() {#getCalendar--}
+```
+public Calendar getCalendar()
+```
+
+
+Determina il calendario utilizzato per le proprietà personalizzate, i campi di testo e le formule degli elementi.
+
+**Returns:**
+[Calendar](../../com.aspose.diagram/calendar)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getFormat() {#getFormat--}
+```
+public StrValue getFormat()
+```
+
+
+L'elemento Format specifica la formattazione di una proprietà personalizzata che è una stringa, un elenco fisso, un numero, un elenco variabile, una data o ora, una durata o una valuta. Il tipo di proprietà personalizzata è specificato nell'elemento Type corrispondente.
+
+**Returns:**
+[StrValue](../../com.aspose.diagram/strvalue)
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+L'ID univoco dell'elemento all'interno del suo elemento genitore.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+L'indice basato su zero dell'elemento all'interno del suo elemento genitore.
+
+**Returns:**
+int
+### getInvisible() {#getInvisible--}
+```
+public BoolValue getInvisible()
+```
+
+
+L'elemento Invisible specifica se la proprietà personalizzata è visibile nella finestra di dialogo Proprietà personalizzate in Microsoft Visio.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLabel() {#getLabel--}
+```
+public Str2Value getLabel()
+```
+
+
+Specifica l'etichetta che appare agli utenti nella finestra di dialogo Proprietà personalizzate.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getLangID() {#getLangID--}
+```
+public IntValue getLangID()
+```
+
+
+Indica l'ID locale (LCID) della lingua in cui è stata inserita la formula della cella, il testo, la proprietà personalizzata o il commento.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Il nome dell'elemento.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+Il nome universale dell'elemento.
+
+**Returns:**
+java.lang.String
+### getPrompt() {#getPrompt--}
+```
+public Str2Value getPrompt()
+```
+
+
+L'elemento Prompt specifica il testo descrittivo o istruttivo che appare agli utenti nella finestra di dialogo Proprietà personalizzate quando la proprietà è selezionata. Questo testo appare anche come suggerimento quando il puntatore del mouse è posizionato sopra la proprietà nella finestra Proprietà personalizzate.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getSortKey() {#getSortKey--}
+```
+public Str2Value getSortKey()
+```
+
+
+Specifica una chiave che determina l'ordine in cui le proprietà personalizzate sono elencate nell'interfaccia utente dell'applicazione.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getType() {#getType--}
+```
+public TypeProp getType()
+```
+
+
+Tipo specifica un tipo di dati per il valore della proprietà personalizzata.
+
+**Returns:**
+[TypeProp](../../com.aspose.diagram/typeprop)
+### getValue() {#getValue--}
+```
+public Value getValue()
+```
+
+
+Contiene dati XML ben formati specifici della soluzione, con prefisso in uno spazio dei nomi esplicito e memorizzati con un documento.
+
+**Returns:**
+[Value](../../com.aspose.diagram/value)
+### getVerify() {#getVerify--}
+```
+public BoolValue getVerify()
+```
+
+
+Specifica se all'utente viene chiesto di inserire informazioni sulla proprietà personalizzata per una forma quando viene creata un'istanza o la forma è duplicata o copiata.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/prop\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getID()](../../com.aspose.diagram/prop\#getID--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getIX()](../../com.aspose.diagram/prop\#getIX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getName()](../../com.aspose.diagram/prop\#getName--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getNameU()](../../com.aspose.diagram/prop\#getNameU--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/propcollection/_index.md
+++ b/italian/java/com.aspose.diagram/propcollection/_index.md
@@ -1,0 +1,250 @@
+---
+title: PropCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Raccolta Prop.
+type: docs
+weight: 310
+url: /it/java/com.aspose.diagram/propcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class PropCollection extends Collection
+```
+
+Raccolta Prop.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [add(Prop item)](#add-com.aspose.diagram.Prop-) | Aggiungi l'oggetto Prop nella collezione. |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [getProp(int ID)](#getProp-int-) | Restituisce l'elemento con l'ID specificato. |
+| [getProp(String name)](#getProp-java.lang.String-) | Restituisce l'elemento con il nome specificato. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Prop item)](#remove-com.aspose.diagram.Prop-) | Rimuovi l'oggetto Prop dalla collezione. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Prop item) {#add-com.aspose.diagram.Prop-}
+```
+public int add(Prop item)
+```
+
+
+Aggiungi l'oggetto Prop nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [Prop](../../com.aspose.diagram/prop) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Prop get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[Prop](../../com.aspose.diagram/prop) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### getProp(int ID) {#getProp-int-}
+```
+public Prop getProp(int ID)
+```
+
+
+Restituisce l'elemento con l'ID specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| ID | int |  |
+
+**Returns:**
+[Prop](../../com.aspose.diagram/prop) - 
+### getProp(String name) {#getProp-java.lang.String-}
+```
+public Prop getProp(String name)
+```
+
+
+Restituisce l'elemento con il nome specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| nome | java.lang.String |  |
+
+**Returns:**
+[Prop](../../com.aspose.diagram/prop) - 
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Prop item) {#remove-com.aspose.diagram.Prop-}
+```
+public void remove(Prop item)
+```
+
+
+Rimuovi l'oggetto Prop dalla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [Prop](../../com.aspose.diagram/prop) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/proptype/_index.md
+++ b/italian/java/com.aspose.diagram/proptype/_index.md
@@ -1,0 +1,165 @@
+---
+title: PropType
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Tipo di proprietà.
+type: docs
+weight: 311
+url: /it/java/com.aspose.diagram/proptype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PropType
+```
+
+Tipo di proprietà.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [BOOL](#BOOL) | Booleano. |
+| [DATE](#DATE) | Data. |
+| [NUMBER](#NUMBER) | Number. |
+| [STRING](#STRING) | Stringa. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOOL {#BOOL}
+```
+public static final int BOOL
+```
+
+
+Booleano.
+
+### DATE {#DATE}
+```
+public static final int DATE
+```
+
+
+Data.
+
+### NUMBER {#NUMBER}
+```
+public static final int NUMBER
+```
+
+
+Number.
+
+### STRING {#STRING}
+```
+public static final int STRING
+```
+
+
+Stringa.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/protection/_index.md
+++ b/italian/java/com.aspose.diagram/protection/_index.md
@@ -1,0 +1,370 @@
+---
+title: Protezione
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Il blocco aiuta a prevenire modifiche involontarie alla forma ma non impedisce a Microsoft Visio di ripristinare i valori in altre circostanze.
+type: docs
+weight: 312
+url: /it/java/com.aspose.diagram/protection/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Protection
+```
+
+Il blocco aiuta a prevenire modifiche involontarie alla forma ma non impedisce a Microsoft Visio di ripristinare i valori in altre circostanze. Inoltre non protegge dalle modifiche apportate nella finestra ShapeSheet.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getLockAspect()](#getLockAspect--) | Specifica se il rapporto d'aspetto della forma è bloccato. |
+| [getLockBegin()](#getLockBegin--) | Specifica se il punto iniziale di una forma 1-D è bloccato in una posizione specifica. |
+| [getLockCalcWH()](#getLockCalcWH--) | Specifica se il rettangolo di selezione di una forma è bloccato in modo che non possa essere ricalcolato quando un vertice viene modificato o il tipo di elemento viene cambiato nell'elemento Geom. |
+| [getLockCrop()](#getLockCrop--) | Specifica se un oggetto esterno è bloccato contro il ritaglio con lo strumento Crop in Microsoft Visio. |
+| [getLockCustProp()](#getLockCustProp--) | Determina se l'utente può aggiungere, eliminare o modificare proprietà personalizzate nell'interfaccia utente (UI) utilizzando la finestra di dialogo Definisci proprietà personalizzate. |
+| [getLockDelete()](#getLockDelete--) | Specifica se una forma è bloccata contro l'eliminazione. |
+| [getLockEnd()](#getLockEnd--) | Specifica se il punto finale di una forma 1-D è bloccato in una posizione specifica. |
+| [getLockFormat()](#getLockFormat--) | Specifica se la formattazione di una forma è bloccata in modo che non possa essere modificata. |
+| [getLockFromGroupFormat()](#getLockFromGroupFormat--) | Consente a una sottoforma di bloccare le modifiche di formattazione che vengono applicate a una forma di gruppo padre nell'interfaccia utente di Visio e che altrimenti si propagherebbero alle singole forme di gruppo. |
+| [getLockGroup()](#getLockGroup--) | Specifica se un gruppo è bloccato in modo che non possa essere separato. |
+| [getLockHeight()](#getLockHeight--) | Specifica se l'altezza della forma è bloccata. |
+| [getLockMoveX()](#getLockMoveX--) | Specifica se la posizione orizzontale della forma è bloccata in modo che non possa essere spostata orizzontalmente. |
+| [getLockMoveY()](#getLockMoveY--) | Specifica se la posizione verticale della forma è bloccata in modo che non possa essere spostata verticalmente. |
+| [getLockRotate()](#getLockRotate--) | Specifica se la forma è bloccata contro la rotazione con lo strumento Rotazione o i comandi Ruota a sinistra o Ruota a destra in Microsoft Visio. |
+| [getLockSelect()](#getLockSelect--) | Specifica se il rettangolo di selezione di una forma è bloccato in modo che non possa essere ricalcolato quando un vertice viene modificato o il tipo di elemento viene cambiato nell'elemento Geom. |
+| [getLockTextEdit()](#getLockTextEdit--) | Specifica se il testo di una forma è bloccato in modo che non possa essere modificato. |
+| [getLockThemeColors()](#getLockThemeColors--) | Impedisce agli utenti di applicare i colori del tema alla forma. |
+| [getLockThemeEffects()](#getLockThemeEffects--) | Impedisce agli utenti di applicare effetti tema alla forma. |
+| [getLockVtxEdit()](#getLockVtxEdit--) | Specifica se i vertici di una forma sono bloccati in modo che non possano essere modificati con alcuno strumento sulla barra degli strumenti. |
+| [getLockWidth()](#getLockWidth--) | Specifica se la larghezza della forma è bloccata in modo che rimanga invariata quando la forma viene ridimensionata. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, consultare [getDel()](../../com.aspose.diagram/protection\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getLockAspect() {#getLockAspect--}
+```
+public BoolValue getLockAspect()
+```
+
+
+Specifica se le proporzioni della forma sono bloccate. Se bloccate, la forma può essere ridimensionata solo proporzionalmente; non può essere ridimensionata in una singola dimensione.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockBegin() {#getLockBegin--}
+```
+public BoolValue getLockBegin()
+```
+
+
+Specifica se il punto iniziale di una forma 1-D è bloccato in una posizione specifica.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockCalcWH() {#getLockCalcWH--}
+```
+public BoolValue getLockCalcWH()
+```
+
+
+Specifica se il rettangolo di selezione di una forma è bloccato in modo che non possa essere ricalcolato quando un vertice viene modificato o il tipo di elemento viene cambiato nell'elemento Geom.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockCrop() {#getLockCrop--}
+```
+public BoolValue getLockCrop()
+```
+
+
+Specifica se un oggetto esterno è bloccato contro il ritaglio con lo strumento Crop in Microsoft Visio.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockCustProp() {#getLockCustProp--}
+```
+public BoolValue getLockCustProp()
+```
+
+
+Determina se l'utente può aggiungere, eliminare o modificare proprietà personalizzate nell'interfaccia utente (UI) utilizzando la finestra di dialogo Definisci proprietà personalizzate.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockDelete() {#getLockDelete--}
+```
+public BoolValue getLockDelete()
+```
+
+
+Specifica se una forma è bloccata contro l'eliminazione.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockEnd() {#getLockEnd--}
+```
+public BoolValue getLockEnd()
+```
+
+
+Specifica se il punto finale di una forma 1-D è bloccato in una posizione specifica.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockFormat() {#getLockFormat--}
+```
+public BoolValue getLockFormat()
+```
+
+
+Specifica se la formattazione di una forma è bloccata in modo che non possa essere modificata. In particolare, questo elemento protegge dalla modifica del testo, della linea e della formattazione di riempimento, o dalla modifica dell'elemento Style da cui la forma eredita.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockFromGroupFormat() {#getLockFromGroupFormat--}
+```
+public BoolValue getLockFromGroupFormat()
+```
+
+
+Consente a una sottoforma di bloccare le modifiche di formattazione che vengono applicate a una forma di gruppo padre nell'interfaccia utente di Visio e che altrimenti si propagherebbero alle singole forme di gruppo.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockGroup() {#getLockGroup--}
+```
+public BoolValue getLockGroup()
+```
+
+
+Specifica se un gruppo è bloccato in modo che non possa essere separato.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockHeight() {#getLockHeight--}
+```
+public BoolValue getLockHeight()
+```
+
+
+Specifica se l'altezza della forma è bloccata. Se bloccata, la sua altezza rimane invariata quando la forma viene ridimensionata.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockMoveX() {#getLockMoveX--}
+```
+public BoolValue getLockMoveX()
+```
+
+
+Specifica se la posizione orizzontale della forma è bloccata in modo che non possa essere spostata orizzontalmente.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockMoveY() {#getLockMoveY--}
+```
+public BoolValue getLockMoveY()
+```
+
+
+Specifica se la posizione verticale della forma è bloccata in modo che non possa essere spostata verticalmente.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockRotate() {#getLockRotate--}
+```
+public BoolValue getLockRotate()
+```
+
+
+Specifica se la forma è bloccata contro la rotazione con lo strumento Rotazione o i comandi Ruota a sinistra o Ruota a destra in Microsoft Visio.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockSelect() {#getLockSelect--}
+```
+public BoolValue getLockSelect()
+```
+
+
+Specifica se il rettangolo di selezione di una forma è bloccato in modo che non possa essere ricalcolato quando un vertice viene modificato o il tipo di elemento viene cambiato nell'elemento Geom.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockTextEdit() {#getLockTextEdit--}
+```
+public BoolValue getLockTextEdit()
+```
+
+
+Specifica se il testo di una forma è bloccato in modo che non possa essere modificato. Tuttavia, il testo può ancora essere formattato applicando uno stile, usando le opzioni Style nella scheda Font della finestra di dialogo Testo.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockThemeColors() {#getLockThemeColors--}
+```
+public BoolValue getLockThemeColors()
+```
+
+
+Impedisce agli utenti di applicare i colori del tema alla forma.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockThemeEffects() {#getLockThemeEffects--}
+```
+public BoolValue getLockThemeEffects()
+```
+
+
+Impedisce agli utenti di applicare effetti tema alla forma.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockVtxEdit() {#getLockVtxEdit--}
+```
+public BoolValue getLockVtxEdit()
+```
+
+
+Specifica se i vertici di una forma sono bloccati in modo che non possano essere modificati con alcuno strumento sulla barra degli strumenti.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockWidth() {#getLockWidth--}
+```
+public BoolValue getLockWidth()
+```
+
+
+Specifica se la larghezza della forma è bloccata in modo che rimanga invariata quando la forma viene ridimensionata.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getDel()](../../com.aspose.diagram/protection\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/radiobuttonactivexcontrol/_index.md
+++ b/italian/java/com.aspose.diagram/radiobuttonactivexcontrol/_index.md
@@ -1,0 +1,679 @@
+---
+title: RadioButtonActiveXControl
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta un controllo ActiveX RadioButton.
+type: docs
+weight: 313
+url: /it/java/com.aspose.diagram/radiobuttonactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol), [com.aspose.diagram.ToggleButtonActiveXControl](../../com.aspose.diagram/togglebuttonactivexcontrol)
+```
+public class RadioButtonActiveXControl extends ToggleButtonActiveXControl
+```
+
+Rappresenta un controllo ActiveX RadioButton.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAccelerator()](#getAccelerator--) | il tasto di accelerazione per il controllo. |
+| [getAlignment()](#getAlignment--) | la posizione della Caption relativa al controllo. |
+| [getBackOleColor()](#getBackOleColor--) | il colore OLE dello sfondo. |
+| [getCaption()](#getCaption--) | il testo descrittivo che appare su un controllo. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | i dati binari del controllo. |
+| [getForeOleColor()](#getForeOleColor--) | il colore OLE del primo piano. |
+| [getGroupName()](#getGroupName--) | il nome del gruppo. |
+| [getHeight()](#getHeight--) | l'altezza del controllo in unità di punti. |
+| [getIMEMode()](#getIMEMode--) | la modalità di esecuzione predefinita dell'Input Method Editor per il controllo quando riceve il fuoco. |
+| [getMouseIcon()](#getMouseIcon--) | un'icona personalizzata da visualizzare come puntatore del mouse per il controllo. |
+| [getMousePointer()](#getMousePointer--) | il tipo di icona visualizzata come puntatore del mouse per il controllo. |
+| [getPicture()](#getPicture--) | i dati dell'immagine. |
+| [getPicturePosition()](#getPicturePosition--) | la posizione dell'immagine del controllo rispetto alla sua didascalia. |
+| [getSpecialEffect()](#getSpecialEffect--) | l'effetto speciale del controllo. |
+| [getType()](#getType--) | Ottiene il tipo del controllo ActiveX. |
+| [getValue()](#getValue--) | Indica se il controllo è selezionato o meno. |
+| [getWidth()](#getWidth--) | la larghezza del controllo in unità di punti. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | Indica se il controllo ridimensionerà automaticamente per visualizzare tutto il contenuto. |
+| [isEnabled()](#isEnabled--) | Indica se il controllo può ricevere il focus e rispondere agli eventi generati dall'utente. |
+| [isLocked()](#isLocked--) | Indica se i dati nel controllo sono bloccati per la modifica. |
+| [isTransparent()](#isTransparent--) | Indica se il controllo è trasparente. |
+| [isTripleState()](#isTripleState--) | Indica come il controllo specificato visualizzerà i valori Null. |
+| [isWordWrapped()](#isWordWrapped--) | Indica se il contenuto del controllo avvolge automaticamente alla fine di una riga. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAccelerator(char value)](#setAccelerator-char-) | Per la descrizione di questa proprietà, vedere [getAccelerator()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getAccelerator--) |
+| [setAlignment(int value)](#setAlignment-int-) | Per la descrizione di questa proprietà, vedere [getAlignment()](../../com.aspose.diagram/radiobuttonactivexcontrol\#getAlignment--) |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | Per la descrizione di questa proprietà, vedere [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | Per la descrizione di questa proprietà, vedere [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setCaption(String value)](#setCaption-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getCaption()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getCaption--) |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | Per la descrizione di questa proprietà, vedere [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | Per la descrizione di questa proprietà, vedere [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setGroupName(String value)](#setGroupName-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getGroupName()](../../com.aspose.diagram/radiobuttonactivexcontrol\#getGroupName--) |
+| [setHeight(double value)](#setHeight-double-) | Per la descrizione di questa proprietà, vedere [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setIMEMode(int value)](#setIMEMode-int-) | Per la descrizione di questa proprietà, vedere [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) |
+| [setLocked(boolean value)](#setLocked-boolean-) | Per la descrizione di questa proprietà, vedere [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | Per la descrizione di questa proprietà, vedere [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | Per la descrizione di questa proprietà, vedere [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setPicture(byte[] value)](#setPicture-byte---) | Per la descrizione di questa proprietà, vedere [getPicture()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getPicture--) |
+| [setPicturePosition(int value)](#setPicturePosition-int-) | Per la descrizione di questa proprietà, vedere [getPicturePosition()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getPicturePosition--) |
+| [setSpecialEffect(int value)](#setSpecialEffect-int-) | Per la descrizione di questa proprietà, vedere [getSpecialEffect()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getSpecialEffect--) |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | Per la descrizione di questa proprietà, vedere [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) |
+| [setTripleState(boolean value)](#setTripleState-boolean-) | Per la descrizione di questa proprietà, vedere [isTripleState()](../../com.aspose.diagram/togglebuttonactivexcontrol\#isTripleState--) |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getValue--) |
+| [setWidth(double value)](#setWidth-double-) | Per la descrizione di questa proprietà, vedere [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [setWordWrapped(boolean value)](#setWordWrapped-boolean-) | Per la descrizione di questa proprietà, vedere [isWordWrapped()](../../com.aspose.diagram/radiobuttonactivexcontrol\#isWordWrapped--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAccelerator() {#getAccelerator--}
+```
+public char getAccelerator()
+```
+
+
+il tasto di accelerazione per il controllo.
+
+**Returns:**
+char
+### getAlignment() {#getAlignment--}
+```
+public int getAlignment()
+```
+
+
+la posizione della Caption relativa al controllo.
+
+**Returns:**
+int
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+il colore OLE dello sfondo.
+
+**Returns:**
+int
+### getCaption() {#getCaption--}
+```
+public String getCaption()
+```
+
+
+il testo descrittivo che appare su un controllo.
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+i dati binari del controllo.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+Il colore OLE del primo piano. Non si applica al controllo Image.
+
+**Returns:**
+int
+### getGroupName() {#getGroupName--}
+```
+public String getGroupName()
+```
+
+
+il nome del gruppo.
+
+**Returns:**
+java.lang.String
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+l'altezza del controllo in unità di punti.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+la modalità di esecuzione predefinita dell'Input Method Editor per il controllo quando riceve il fuoco.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+un'icona personalizzata da visualizzare come puntatore del mouse per il controllo.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+il tipo di icona visualizzata come puntatore del mouse per il controllo.
+
+**Returns:**
+int
+### getPicture() {#getPicture--}
+```
+public byte[] getPicture()
+```
+
+
+i dati dell'immagine.
+
+**Returns:**
+byte[]
+### getPicturePosition() {#getPicturePosition--}
+```
+public int getPicturePosition()
+```
+
+
+la posizione dell'immagine del controllo rispetto alla sua didascalia.
+
+**Returns:**
+int
+### getSpecialEffect() {#getSpecialEffect--}
+```
+public int getSpecialEffect()
+```
+
+
+l'effetto speciale del controllo.
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Ottiene il tipo del controllo ActiveX.
+
+**Returns:**
+int
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Indica se il controllo è selezionato o meno.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+la larghezza del controllo in unità di punti.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+Indica se il controllo ridimensionerà automaticamente per visualizzare tutto il contenuto.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+Indica se il controllo può ricevere il focus e rispondere agli eventi generati dall'utente.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+Indica se i dati nel controllo sono bloccati per la modifica.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+Indica se il controllo è trasparente.
+
+**Returns:**
+boolean
+### isTripleState() {#isTripleState--}
+```
+public boolean isTripleState()
+```
+
+
+Indica come il controllo specificato visualizzerà i valori Null.
+
+| ------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| Impostazione | Descrizione |
+| True    | Il controllo ciclerà attraverso gli stati per i valori Sì, No e Null. Il controllo appare attenuato (grigio) quando la sua proprietà Value è impostata su Null. |
+| False   | (Predefinito) Il controllo ciclerà attraverso gli stati per i valori Sì e No. I valori Null vengono visualizzati come se fossero valori No. |
+
+|
+
+**Returns:**
+boolean
+### isWordWrapped() {#isWordWrapped--}
+```
+public boolean isWordWrapped()
+```
+
+
+Indica se il contenuto del controllo avvolge automaticamente alla fine di una riga.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAccelerator(char value) {#setAccelerator-char-}
+```
+public void setAccelerator(char value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getAccelerator()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getAccelerator--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | char |  |
+
+### setAlignment(int value) {#setAlignment-int-}
+```
+public void setAlignment(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getAlignment()](../../com.aspose.diagram/radiobuttonactivexcontrol\#getAlignment--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setCaption(String value) {#setCaption-java.lang.String-}
+```
+public void setCaption(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getCaption()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getCaption--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setGroupName(String value) {#setGroupName-java.lang.String-}
+```
+public void setGroupName(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getGroupName()](../../com.aspose.diagram/radiobuttonactivexcontrol\#getGroupName--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setPicture(byte[] value) {#setPicture-byte---}
+```
+public void setPicture(byte[] value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getPicture()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getPicture--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | byte[] |  |
+
+### setPicturePosition(int value) {#setPicturePosition-int-}
+```
+public void setPicturePosition(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getPicturePosition()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getPicturePosition--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setSpecialEffect(int value) {#setSpecialEffect-int-}
+```
+public void setSpecialEffect(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getSpecialEffect()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getSpecialEffect--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setTripleState(boolean value) {#setTripleState-boolean-}
+```
+public void setTripleState(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isTripleState()](../../com.aspose.diagram/togglebuttonactivexcontrol\#isTripleState--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double |  |
+
+### setWordWrapped(boolean value) {#setWordWrapped-boolean-}
+```
+public void setWordWrapped(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isWordWrapped()](../../com.aspose.diagram/radiobuttonactivexcontrol\#isWordWrapped--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/rectanglealignmenttype/_index.md
+++ b/italian/java/com.aspose.diagram/rectanglealignmenttype/_index.md
@@ -1,0 +1,210 @@
+---
+title: RectangleAlignmentType
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta come posizionare due rettangoli l'uno rispetto all'altro.
+type: docs
+weight: 314
+url: /it/java/com.aspose.diagram/rectanglealignmenttype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class RectangleAlignmentType
+```
+
+Rappresenta come posizionare due rettangoli l'uno rispetto all'altro.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [BOTTOM](#BOTTOM) | Inferiore |
+| [BOTTOM_LEFT](#BOTTOM-LEFT) | BottomLeft |
+| [BOTTOM_RIGHT](#BOTTOM-RIGHT) | BottomRight |
+| [CENTER](#CENTER) | Center |
+| [LEFT](#LEFT) | Left |
+| [RIGHT](#RIGHT) | Right |
+| [TOP](#TOP) | Top |
+| [TOP_LEFT](#TOP-LEFT) | TopLeft |
+| [TOP_RIGHT](#TOP-RIGHT) | TopRight |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOTTOM {#BOTTOM}
+```
+public static final int BOTTOM
+```
+
+
+Inferiore
+
+### BOTTOM_LEFT {#BOTTOM-LEFT}
+```
+public static final int BOTTOM_LEFT
+```
+
+
+BottomLeft
+
+### BOTTOM_RIGHT {#BOTTOM-RIGHT}
+```
+public static final int BOTTOM_RIGHT
+```
+
+
+BottomRight
+
+### CENTER {#CENTER}
+```
+public static final int CENTER
+```
+
+
+Center
+
+### LEFT {#LEFT}
+```
+public static final int LEFT
+```
+
+
+Left
+
+### RIGHT {#RIGHT}
+```
+public static final int RIGHT
+```
+
+
+Right
+
+### TOP {#TOP}
+```
+public static final int TOP
+```
+
+
+Top
+
+### TOP_LEFT {#TOP-LEFT}
+```
+public static final int TOP_LEFT
+```
+
+
+TopLeft
+
+### TOP_RIGHT {#TOP-RIGHT}
+```
+public static final int TOP_RIGHT
+```
+
+
+TopRight
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/reflectioneffecttype/_index.md
+++ b/italian/java/com.aspose.diagram/reflectioneffecttype/_index.md
@@ -1,0 +1,226 @@
+---
+title: ReflectionEffectType
+second_title: Riferimento API di Aspose.Diagram per Java
+description: 
+type: docs
+weight: 315
+url: /it/java/com.aspose.diagram/reflectioneffecttype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ReflectionEffectType
+```
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [CUSTOM](#CUSTOM) | Effetto di riflessione personalizzato. |
+| [FULL_REFLECTION_4_PT_OFFSET](#FULL-REFLECTION-4-PT-OFFSET) | Riflesso completo, offset di 4 pt. |
+| [FULL_REFLECTION_8_PT_OFFSET](#FULL-REFLECTION-8-PT-OFFSET) | Riflesso completo, offset di 8 pt. |
+| [FULL_REFLECTION_TOUCHING](#FULL-REFLECTION-TOUCHING) | Riflesso completo, a contatto. |
+| [HALF_REFLECTION_4_PT_OFFSET](#HALF-REFLECTION-4-PT-OFFSET) | Riflesso a metà, offset di 4 pt. |
+| [HALF_REFLECTION_8_PT_OFFSET](#HALF-REFLECTION-8-PT-OFFSET) | Riflesso a metà, offset di 8 pt. |
+| [HALF_REFLECTION_TOUCHING](#HALF-REFLECTION-TOUCHING) | Riflesso a metà, a contatto. |
+| [NONE](#NONE) | Nessun effetto di riflesso. |
+| [TIGHT_REFLECTION_4_PT_OFFSET](#TIGHT-REFLECTION-4-PT-OFFSET) | Riflesso stretto, offset di 4 pt. |
+| [TIGHT_REFLECTION_8_PT_OFFSET](#TIGHT-REFLECTION-8-PT-OFFSET) | Riflesso stretto, offset di 8 pt. |
+| [TIGHT_REFLECTION_TOUCHING](#TIGHT-REFLECTION-TOUCHING) | Riflesso stretto, a contatto. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CUSTOM {#CUSTOM}
+```
+public static final int CUSTOM
+```
+
+
+Effetto di riflessione personalizzato.
+
+### FULL_REFLECTION_4_PT_OFFSET {#FULL-REFLECTION-4-PT-OFFSET}
+```
+public static final int FULL_REFLECTION_4_PT_OFFSET
+```
+
+
+Riflesso completo, offset di 4 pt.
+
+### FULL_REFLECTION_8_PT_OFFSET {#FULL-REFLECTION-8-PT-OFFSET}
+```
+public static final int FULL_REFLECTION_8_PT_OFFSET
+```
+
+
+Riflesso completo, offset di 8 pt.
+
+### FULL_REFLECTION_TOUCHING {#FULL-REFLECTION-TOUCHING}
+```
+public static final int FULL_REFLECTION_TOUCHING
+```
+
+
+Riflesso completo, a contatto.
+
+### HALF_REFLECTION_4_PT_OFFSET {#HALF-REFLECTION-4-PT-OFFSET}
+```
+public static final int HALF_REFLECTION_4_PT_OFFSET
+```
+
+
+Riflesso a metà, offset di 4 pt.
+
+### HALF_REFLECTION_8_PT_OFFSET {#HALF-REFLECTION-8-PT-OFFSET}
+```
+public static final int HALF_REFLECTION_8_PT_OFFSET
+```
+
+
+Riflesso a metà, offset di 8 pt.
+
+### HALF_REFLECTION_TOUCHING {#HALF-REFLECTION-TOUCHING}
+```
+public static final int HALF_REFLECTION_TOUCHING
+```
+
+
+Riflesso a metà, a contatto.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Nessun effetto di riflesso.
+
+### TIGHT_REFLECTION_4_PT_OFFSET {#TIGHT-REFLECTION-4-PT-OFFSET}
+```
+public static final int TIGHT_REFLECTION_4_PT_OFFSET
+```
+
+
+Riflesso stretto, offset di 4 pt.
+
+### TIGHT_REFLECTION_8_PT_OFFSET {#TIGHT-REFLECTION-8-PT-OFFSET}
+```
+public static final int TIGHT_REFLECTION_8_PT_OFFSET
+```
+
+
+Riflesso stretto, offset di 8 pt.
+
+### TIGHT_REFLECTION_TOUCHING {#TIGHT-REFLECTION-TOUCHING}
+```
+public static final int TIGHT_REFLECTION_TOUCHING
+```
+
+
+Riflesso stretto, a contatto.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/relcubbezto/_index.md
+++ b/italian/java/com.aspose.diagram/relcubbezto/_index.md
@@ -1,0 +1,349 @@
+---
+title: RelCubBezTo
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene le coordinate x e y per i punti di un RelCubBezTo.
+type: docs
+weight: 316
+url: /it/java/com.aspose.diagram/relcubbezto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class RelCubBezTo extends Coordinate
+```
+
+Contiene le coordinate x e y per i punti di un RelCubBezTo.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [RelCubBezTo()](#RelCubBezTo--) | Crea un'istanza della classe [RelCubBezTo](../../com.aspose.diagram/relcubbezto). |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | La coordinata x del punto di controllo all'inizio della curva in coordinate relative. |
+| [getB()](#getB--) | La coordinata y del punto di controllo all'inizio della curva in coordinate relative. |
+| [getC()](#getC--) | La coordinata x del punto di controllo alla fine della curva in coordinate relative. |
+| [getClass()](#getClass--) |  |
+| [getD()](#getD--) | La coordinata y del punto di controllo alla fine della curva in coordinate relative. |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getIX()](#getIX--) | L'indice basato su zero dell'elemento all'interno del suo elemento genitore. |
+| [getX()](#getX--) | La coordinata x del punto finale in coordinate relative. |
+| [getY()](#getY--) | La coordinata y del punto finale in coordinate relative. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getA()](../../com.aspose.diagram/relcubbezto\#getA--) |
+| [setB(DoubleValue value)](#setB-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getB()](../../com.aspose.diagram/relcubbezto\#getB--) |
+| [setC(DoubleValue value)](#setC-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getC()](../../com.aspose.diagram/relcubbezto\#getC--) |
+| [setD(DoubleValue value)](#setD-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getD()](../../com.aspose.diagram/relcubbezto\#getD--) |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/relcubbezto\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Per la descrizione di questa proprietà, vedere [getIX()](../../com.aspose.diagram/relcubbezto\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getX()](../../com.aspose.diagram/relcubbezto\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getY()](../../com.aspose.diagram/relcubbezto\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RelCubBezTo() {#RelCubBezTo--}
+```
+public RelCubBezTo()
+```
+
+
+Crea un'istanza della classe [RelCubBezTo](../../com.aspose.diagram/relcubbezto).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+La coordinata x del punto di controllo all'inizio della curva in coordinate relative.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getB() {#getB--}
+```
+public DoubleValue getB()
+```
+
+
+La coordinata y del punto di controllo all'inizio della curva in coordinate relative.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getC() {#getC--}
+```
+public DoubleValue getC()
+```
+
+
+La coordinata x del punto di controllo alla fine della curva in coordinate relative.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getD() {#getD--}
+```
+public DoubleValue getD()
+```
+
+
+La coordinata y del punto di controllo alla fine della curva in coordinate relative.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+L'indice basato su zero dell'elemento all'interno del suo elemento genitore.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+La coordinata x del punto finale in coordinate relative.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+La coordinata y del punto finale in coordinate relative.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getA()](../../com.aspose.diagram/relcubbezto\#getA--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setB(DoubleValue value) {#setB-com.aspose.diagram.DoubleValue-}
+```
+public void setB(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getB()](../../com.aspose.diagram/relcubbezto\#getB--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setC(DoubleValue value) {#setC-com.aspose.diagram.DoubleValue-}
+```
+public void setC(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getC()](../../com.aspose.diagram/relcubbezto\#getC--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setD(DoubleValue value) {#setD-com.aspose.diagram.DoubleValue-}
+```
+public void setD(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getD()](../../com.aspose.diagram/relcubbezto\#getD--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/relcubbezto\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getIX()](../../com.aspose.diagram/relcubbezto\#getIX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getX()](../../com.aspose.diagram/relcubbezto\#getX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getY()](../../com.aspose.diagram/relcubbezto\#getY--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/relcubbeztocollection/_index.md
+++ b/italian/java/com.aspose.diagram/relcubbeztocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: RelCubBezToCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Raccolta RelCubBezTo.
+type: docs
+weight: 317
+url: /it/java/com.aspose.diagram/relcubbeztocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class RelCubBezToCollection extends Collection
+```
+
+Raccolta RelCubBezTo.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public RelCubBezTo get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[RelCubBezTo](../../com.aspose.diagram/relcubbezto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/relellipticalarcto/_index.md
+++ b/italian/java/com.aspose.diagram/relellipticalarcto/_index.md
@@ -1,0 +1,349 @@
+---
+title: RelEllipticalArcTo
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene elementi che specificano informazioni su un arco ellittico. Le coordinate sono specificate come coordinate relative.
+type: docs
+weight: 318
+url: /it/java/com.aspose.diagram/relellipticalarcto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class RelEllipticalArcTo extends Coordinate
+```
+
+Contiene elementi che specificano informazioni su un arco ellittico. Le coordinate sono specificate come coordinate relative.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [RelEllipticalArcTo()](#RelEllipticalArcTo--) | Crea un'istanza della classe [EllipticalArcTo](../../com.aspose.diagram/ellipticalarcto). |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | La coordinata x del punto di controllo dell'arco. |
+| [getB()](#getB--) | La coordinata y del punto di controllo di un arco. |
+| [getC()](#getC--) | L'angolo dell'asse maggiore di un arco rispetto all'asse x del suo genitore. |
+| [getClass()](#getClass--) |  |
+| [getD()](#getD--) | Il rapporto tra l'asse maggiore e l'asse minore di un arco. |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getIX()](#getIX--) | L'indice basato su zero dell'elemento all'interno del suo elemento genitore. |
+| [getX()](#getX--) | La coordinata x del vertice finale di un arco ellittico. |
+| [getY()](#getY--) | La coordinata y del vertice finale di un arco ellittico. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, consultare [getA()](../../com.aspose.diagram/relellipticalarcto\#getA--) |
+| [setB(DoubleValue value)](#setB-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, consultare [getB()](../../com.aspose.diagram/relellipticalarcto\#getB--) |
+| [setC(DoubleValue value)](#setC-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, consultare [getC()](../../com.aspose.diagram/relellipticalarcto\#getC--) |
+| [setD(DoubleValue value)](#setD-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, consultare [getD()](../../com.aspose.diagram/relellipticalarcto\#getD--) |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, consultare [getDel()](../../com.aspose.diagram/relellipticalarcto\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Per la descrizione di questa proprietà, consultare [getIX()](../../com.aspose.diagram/relellipticalarcto\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, consultare [getX()](../../com.aspose.diagram/relellipticalarcto\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, consultare [getY()](../../com.aspose.diagram/relellipticalarcto\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RelEllipticalArcTo() {#RelEllipticalArcTo--}
+```
+public RelEllipticalArcTo()
+```
+
+
+Crea un'istanza della classe [EllipticalArcTo](../../com.aspose.diagram/ellipticalarcto).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+La coordinata x del punto di controllo dell'arco. Il punto di controllo è meglio posizionato circa a metà tra i vertici iniziale e finale dell'arco. Altrimenti, l'arco potrebbe ingrandirsi in modo estremo per passare attraverso il punto di controllo, con risultati imprevedibili.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getB() {#getB--}
+```
+public DoubleValue getB()
+```
+
+
+La coordinata y del punto di controllo di un arco.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getC() {#getC--}
+```
+public DoubleValue getC()
+```
+
+
+L'angolo dell'asse maggiore di un arco rispetto all'asse x del suo genitore.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getD() {#getD--}
+```
+public DoubleValue getD()
+```
+
+
+Il rapporto tra l'asse maggiore e l'asse minore di un arco. Nonostante il significato comune di questi termini, l'asse maggiore non deve necessariamente essere più grande dell'asse minore, quindi questo rapporto non deve necessariamente superare 1. Impostare questo elemento su un valore minore o uguale a 0 o maggiore di 1000 può portare a risultati imprevedibili.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+L'indice basato su zero dell'elemento all'interno del suo elemento genitore.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+La coordinata x del vertice finale di un arco ellittico.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+La coordinata y del vertice finale di un arco ellittico.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getA()](../../com.aspose.diagram/relellipticalarcto\#getA--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setB(DoubleValue value) {#setB-com.aspose.diagram.DoubleValue-}
+```
+public void setB(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getB()](../../com.aspose.diagram/relellipticalarcto\#getB--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setC(DoubleValue value) {#setC-com.aspose.diagram.DoubleValue-}
+```
+public void setC(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getC()](../../com.aspose.diagram/relellipticalarcto\#getC--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setD(DoubleValue value) {#setD-com.aspose.diagram.DoubleValue-}
+```
+public void setD(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getD()](../../com.aspose.diagram/relellipticalarcto\#getD--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getDel()](../../com.aspose.diagram/relellipticalarcto\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getIX()](../../com.aspose.diagram/relellipticalarcto\#getIX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getX()](../../com.aspose.diagram/relellipticalarcto\#getX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getY()](../../com.aspose.diagram/relellipticalarcto\#getY--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/relellipticalarctocollection/_index.md
+++ b/italian/java/com.aspose.diagram/relellipticalarctocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: RelEllipticalArcToCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: RelEllipticalArcTo  collezione.
+type: docs
+weight: 319
+url: /it/java/com.aspose.diagram/relellipticalarctocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class RelEllipticalArcToCollection extends Collection
+```
+
+Raccolta RelEllipticalArcTo.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public RelEllipticalArcTo get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[RelEllipticalArcTo](../../com.aspose.diagram/relellipticalarcto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/rellineto/_index.md
+++ b/italian/java/com.aspose.diagram/rellineto/_index.md
@@ -1,0 +1,249 @@
+---
+title: RelLineTo
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene le coordinate x e y del vertice finale di un segmento di linea retta.
+type: docs
+weight: 320
+url: /it/java/com.aspose.diagram/rellineto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class RelLineTo extends Coordinate
+```
+
+Contiene le coordinate x e y del vertice finale di un segmento di linea retta. Queste coordinate sono contenute rispettivamente negli elementi X e Y.Coordinate specificate come coordinate relative.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [RelLineTo()](#RelLineTo--) | Crea un'istanza della classe [LineTo](../../com.aspose.diagram/lineto). |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getIX()](#getIX--) | L'indice basato su zero dell'elemento all'interno del suo elemento genitore. |
+| [getX()](#getX--) | La coordinata x del vertice finale di un segmento di linea retta. |
+| [getY()](#getY--) | La coordinata y del vertice finale di un segmento di linea retta. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/rellineto\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Per la descrizione di questa proprietà, vedere [getIX()](../../com.aspose.diagram/rellineto\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getX()](../../com.aspose.diagram/rellineto\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getY()](../../com.aspose.diagram/rellineto\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RelLineTo() {#RelLineTo--}
+```
+public RelLineTo()
+```
+
+
+Crea un'istanza della classe [LineTo](../../com.aspose.diagram/lineto).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+L'indice basato su zero dell'elemento all'interno del suo elemento genitore.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+La coordinata x del vertice finale di un segmento di linea retta.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+La coordinata y del vertice finale di un segmento di linea retta.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/rellineto\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getIX()](../../com.aspose.diagram/rellineto\#getIX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getX()](../../com.aspose.diagram/rellineto\#getX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getY()](../../com.aspose.diagram/rellineto\#getY--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/rellinetocollection/_index.md
+++ b/italian/java/com.aspose.diagram/rellinetocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: RelLineToCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Raccolta RelLineTo.
+type: docs
+weight: 321
+url: /it/java/com.aspose.diagram/rellinetocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class RelLineToCollection extends Collection
+```
+
+Raccolta RelLineTo.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public RelLineTo get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[RelLineTo](../../com.aspose.diagram/rellineto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/relmoveto/_index.md
+++ b/italian/java/com.aspose.diagram/relmoveto/_index.md
@@ -1,0 +1,249 @@
+---
+title: RelMoveTo
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene le coordinate x e y del primo vertice di una forma o contiene le coordinate x e y del primo vertice dopo un'interruzione in un percorso. Le coordinate sono specificate come coordinate relative.
+type: docs
+weight: 322
+url: /it/java/com.aspose.diagram/relmoveto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class RelMoveTo extends Coordinate
+```
+
+Contiene le coordinate x e y del primo vertice di una forma, o contiene le coordinate x e y del primo vertice dopo un'interruzione in un percorso. Le coordinate sono specificate come coordinate relative.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [RelMoveTo()](#RelMoveTo--) | Crea un'istanza della classe [MoveTo](../../com.aspose.diagram/moveto). |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getIX()](#getIX--) | L'indice basato su zero dell'elemento all'interno del suo elemento genitore. |
+| [getX()](#getX--) | L'elemento X rappresenta la coordinata x del primo vertice di un percorso. |
+| [getY()](#getY--) | L'elemento Y rappresenta la coordinata y del primo vertice di un percorso. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/relmoveto\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Per la descrizione di questa proprietà, vedere [getIX()](../../com.aspose.diagram/relmoveto\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getX()](../../com.aspose.diagram/relmoveto\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getY()](../../com.aspose.diagram/relmoveto\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RelMoveTo() {#RelMoveTo--}
+```
+public RelMoveTo()
+```
+
+
+Crea un'istanza della classe [MoveTo](../../com.aspose.diagram/moveto).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+L'indice basato su zero dell'elemento all'interno del suo elemento genitore.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+L'elemento X rappresenta la coordinata x del primo vertice di un percorso. Se l'elemento MoveTo appare tra due elementi, l'elemento X rappresenta la coordinata x del primo vertice dopo l'interruzione nel percorso
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+L'elemento Y rappresenta la coordinata y del primo vertice di un percorso. Se l'elemento MoveTo appare tra due elementi, l'elemento Y rappresenta la coordinata y del primo vertice dopo l'interruzione nel percorso.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/relmoveto\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getIX()](../../com.aspose.diagram/relmoveto\#getIX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getX()](../../com.aspose.diagram/relmoveto\#getX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getY()](../../com.aspose.diagram/relmoveto\#getY--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/relmovetocollection/_index.md
+++ b/italian/java/com.aspose.diagram/relmovetocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: RelMoveToCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Raccolta RelMoveTo.
+type: docs
+weight: 323
+url: /it/java/com.aspose.diagram/relmovetocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class RelMoveToCollection extends Collection
+```
+
+Raccolta RelMoveTo.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public RelMoveTo get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[RelMoveTo](../../com.aspose.diagram/relmoveto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/relquadbezto/_index.md
+++ b/italian/java/com.aspose.diagram/relquadbezto/_index.md
@@ -1,0 +1,299 @@
+---
+title: RelQuadBezTo
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene le coordinate x e y per i punti RelQuadBezTo.
+type: docs
+weight: 324
+url: /it/java/com.aspose.diagram/relquadbezto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class RelQuadBezTo extends Coordinate
+```
+
+Contiene le coordinate x e y per i punti di un RelQuadBezTo.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [RelQuadBezTo()](#RelQuadBezTo--) | Crea un'istanza della classe [RelCubBezTo](../../com.aspose.diagram/relcubbezto). |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | La coordinata x del punto di controllo in coordinate relative. |
+| [getB()](#getB--) | La coordinata y del punto di controllo in coordinate relative. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getIX()](#getIX--) | L'indice basato su zero dell'elemento all'interno del suo elemento genitore. |
+| [getX()](#getX--) | La coordinata x del punto finale in coordinate relative. |
+| [getY()](#getY--) | La coordinata y del punto finale in coordinate relative. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getA()](../../com.aspose.diagram/relquadbezto\#getA--) |
+| [setB(DoubleValue value)](#setB-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getB()](../../com.aspose.diagram/relquadbezto\#getB--) |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/relquadbezto\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Per la descrizione di questa proprietà, vedere [getIX()](../../com.aspose.diagram/relquadbezto\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getX()](../../com.aspose.diagram/relquadbezto\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getY()](../../com.aspose.diagram/relquadbezto\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RelQuadBezTo() {#RelQuadBezTo--}
+```
+public RelQuadBezTo()
+```
+
+
+Crea un'istanza della classe [RelCubBezTo](../../com.aspose.diagram/relcubbezto).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+La coordinata x del punto di controllo in coordinate relative.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getB() {#getB--}
+```
+public DoubleValue getB()
+```
+
+
+La coordinata y del punto di controllo in coordinate relative.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+L'indice basato su zero dell'elemento all'interno del suo elemento genitore.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+La coordinata x del punto finale in coordinate relative.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+La coordinata y del punto finale in coordinate relative.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getA()](../../com.aspose.diagram/relquadbezto\#getA--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setB(DoubleValue value) {#setB-com.aspose.diagram.DoubleValue-}
+```
+public void setB(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getB()](../../com.aspose.diagram/relquadbezto\#getB--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/relquadbezto\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getIX()](../../com.aspose.diagram/relquadbezto\#getIX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getX()](../../com.aspose.diagram/relquadbezto\#getX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getY()](../../com.aspose.diagram/relquadbezto\#getY--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/relquadbeztocollection/_index.md
+++ b/italian/java/com.aspose.diagram/relquadbeztocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: RelQuadBezToCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Raccolta RelQuadBezTo.
+type: docs
+weight: 325
+url: /it/java/com.aspose.diagram/relquadbeztocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class RelQuadBezToCollection extends Collection
+```
+
+Raccolta RelQuadBezTo.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public RelQuadBezTo get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[RelQuadBezTo](../../com.aspose.diagram/relquadbezto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/removehiddeninfoitem/_index.md
+++ b/italian/java/com.aspose.diagram/removehiddeninfoitem/_index.md
@@ -1,0 +1,183 @@
+---
+title: RemoveHiddenInfoItem
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica la rimozione delle informazioni nascoste per il diagramma.
+type: docs
+weight: 326
+url: /it/java/com.aspose.diagram/removehiddeninfoitem/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class RemoveHiddenInfoItem
+```
+
+Specifica la rimozione delle informazioni nascoste per il diagramma.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [DATA_RECORD_SETS](#DATA-RECORD-SETS) | DataRecordSets. |
+| [MASTERS](#MASTERS) | Masters. |
+| [PERSONAL_INFO](#PERSONAL-INFO) | PersonalInfo. |
+| [SHAPES](#SHAPES) | Shapes. |
+| [STYLES](#STYLES) | Styles. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DATA_RECORD_SETS {#DATA-RECORD-SETS}
+```
+public static final int DATA_RECORD_SETS
+```
+
+
+DataRecordSets.
+
+### MASTERS {#MASTERS}
+```
+public static final int MASTERS
+```
+
+
+Masters.
+
+### PERSONAL_INFO {#PERSONAL-INFO}
+```
+public static final int PERSONAL_INFO
+```
+
+
+PersonalInfo.
+
+### SHAPES {#SHAPES}
+```
+public static final int SHAPES
+```
+
+
+Shapes.
+
+### STYLES {#STYLES}
+```
+public static final int STYLES
+```
+
+
+Styles.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/renderingsaveoptions/_index.md
+++ b/italian/java/com.aspose.diagram/renderingsaveoptions/_index.md
@@ -1,0 +1,366 @@
+---
+title: RenderingSaveOptions
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Questa è una classe base astratta per le classi che consentono all'utente di specificare opzioni aggiuntive quando si salva un diagramma in un formato specifico.
+type: docs
+weight: 327
+url: /it/java/com.aspose.diagram/renderingsaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.SaveOptions](../../com.aspose.diagram/saveoptions)
+```
+public abstract class RenderingSaveOptions extends SaveOptions
+```
+
+Questa è una classe base astratta per le classi che consentono all'utente di specificare opzioni aggiuntive quando si salva un diagramma in un formato specifico.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | Crea un oggetto di opzioni di salvataggio di una classe adatta al formato di salvataggio specificato. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDefaultFont()](#getDefaultFont--) | Quando i caratteri nel diagramma sono Unicode e non vengono impostati con il valore di carattere corretto o il carattere non è installato localmente, possono apparire come blocchi in PDF, immagine o XPS. |
+| [getEmfRenderSetting()](#getEmfRenderSetting--) | Impostazione per il rendering del metafile Emf. |
+| [getEnlargePage()](#getEnlargePage--) | Specifica se ingrandire la pagina. |
+| [getExportGuideShapes()](#getExportGuideShapes--) | Definisce se è necessario esportare le forme guida o meno. |
+| [getPageSize()](#getPageSize--) | la dimensione della pagina per le immagini generate. |
+| [getSaveFormat()](#getSaveFormat--) | Specifica il formato in cui il documento verrà salvato se viene utilizzato questo oggetto di opzioni di salvataggio. |
+| [getShapes()](#getShapes--) | forme da renderizzare. |
+| [getWarningCallback()](#getWarningCallback--) | callback di avviso. |
+| [hashCode()](#hashCode--) |  |
+| [isExportComments()](#isExportComments--) | Definisce se è necessario esportare i commenti o meno. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--) |
+| [setEmfRenderSetting(int value)](#setEmfRenderSetting-int-) | Per la descrizione di questa proprietà, vedere [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--) |
+| [setEnlargePage(boolean value)](#setEnlargePage-boolean-) | Per la descrizione di questa proprietà, vedere [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\\#getEnlargePage--) |
+| [setExportComments(boolean value)](#setExportComments-boolean-) | Per la descrizione di questa proprietà, vedere [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\\#isExportComments--) |
+| [setExportGuideShapes(boolean value)](#setExportGuideShapes-boolean-) | Per la descrizione di questa proprietà, vedere [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\\#getExportGuideShapes--) |
+| [setPageSize(PageSize value)](#setPageSize-com.aspose.diagram.PageSize-) | Per la descrizione di questa proprietà, vedere [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\\#getPageSize--) |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | Per la descrizione di questa proprietà, vedere [getSaveFormat()](../../com.aspose.diagram/saveoptions\#getSaveFormat--) |
+| [setShapes(ShapeCollection value)](#setShapes-com.aspose.diagram.ShapeCollection-) | Per la descrizione di questa proprietà, vedere [getShapes()](../../com.aspose.diagram/renderingsaveoptions\\#getShapes--) |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+Crea un oggetto di opzioni di salvataggio di una classe adatta al formato di salvataggio specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| saveFormat | int | Il Aspose.Diagram.SaveFileFormat per il quale creare un oggetto di opzioni di salvataggio. |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+Quando i caratteri nel diagramma sono Unicode e non sono impostati con il valore di font corretto o il font non è installato localmente, possono apparire come blocchi in PDF, immagine o XPS. Impostare il DefaultFont, ad esempio MingLiu o MS Gothic, per visualizzare questi caratteri.
+
+**Returns:**
+java.lang.String
+### getEmfRenderSetting() {#getEmfRenderSetting--}
+```
+public int getEmfRenderSetting()
+```
+
+
+Impostazione per il rendering dei metafile EMF. I metafile EMF identificati come "EMF+ Dual" possono contenere sia record EMF+ sia record EMF. Entrambi i tipi di record possono essere usati per renderizzare l'immagine, solo record EMF+, o solo record EMF. Quando EmfPlusPrefer è impostato, i record EMF+ verranno analizzati, altrimenti verranno analizzati solo i record EMF. Il valore predefinito è EmfOnly"/>.
+
+**Returns:**
+int
+### getEnlargePage() {#getEnlargePage--}
+```
+public boolean getEnlargePage()
+```
+
+
+Specifica se ingrandire la pagina. Se true - ingrandire la pagina. Se false - non ingrandire la pagina. Il valore predefinito è true.
+
+**Returns:**
+boolean
+### getExportGuideShapes() {#getExportGuideShapes--}
+```
+public boolean getExportGuideShapes()
+```
+
+
+Definisce se è necessario esportare le forme guida o meno. Il valore predefinito è true.
+
+**Returns:**
+boolean
+### getPageSize() {#getPageSize--}
+```
+public PageSize getPageSize()
+```
+
+
+la dimensione della pagina per le immagini generate. Può essere [PageSize](../../com.aspose.diagram/pagesize) o null. Il valore predefinito è null. Se PageSize è null, la dimensione della pagina per l'immagine generata viene ottenuta dal diagramma di origine.
+
+**Returns:**
+[PageSize](../../com.aspose.diagram/pagesize)
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+Specifica il formato in cui il documento verrà salvato se viene utilizzato questo oggetto di opzioni di salvataggio.
+
+**Returns:**
+int
+### getShapes() {#getShapes--}
+```
+public ShapeCollection getShapes()
+```
+
+
+forme da renderizzare. Il conteggio predefinito è 0.
+
+**Returns:**
+[ShapeCollection](../../com.aspose.diagram/shapecollection)
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+callback di avviso.
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExportComments() {#isExportComments--}
+```
+public boolean isExportComments()
+```
+
+
+Definisce se è necessario esportare i commenti o meno. Il valore predefinito è false.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setEmfRenderSetting(int value) {#setEmfRenderSetting-int-}
+```
+public void setEmfRenderSetting(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setEnlargePage(boolean value) {#setEnlargePage-boolean-}
+```
+public void setEnlargePage(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\\#getEnlargePage--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setExportComments(boolean value) {#setExportComments-boolean-}
+```
+public void setExportComments(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\\#isExportComments--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setExportGuideShapes(boolean value) {#setExportGuideShapes-boolean-}
+```
+public void setExportGuideShapes(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\\#getExportGuideShapes--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setPageSize(PageSize value) {#setPageSize-com.aspose.diagram.PageSize-}
+```
+public void setPageSize(PageSize value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\\#getPageSize--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [PageSize](../../com.aspose.diagram/pagesize) |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getSaveFormat()](../../com.aspose.diagram/saveoptions\#getSaveFormat--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setShapes(ShapeCollection value) {#setShapes-com.aspose.diagram.ShapeCollection-}
+```
+public void setShapes(ShapeCollection value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getShapes()](../../com.aspose.diagram/renderingsaveoptions\\#getShapes--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [ShapeCollection](../../com.aspose.diagram/shapecollection) |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/resizemode/_index.md
+++ b/italian/java/com.aspose.diagram/resizemode/_index.md
@@ -1,0 +1,204 @@
+---
+title: ResizeMode
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica l'impostazione corrente del comportamento di ridimensionamento per la forma quando è contenuta in un gruppo.
+type: docs
+weight: 328
+url: /it/java/com.aspose.diagram/resizemode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ResizeMode
+```
+
+Specifica l'impostazione corrente del comportamento di ridimensionamento per la forma quando è contenuta in un gruppo.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [ResizeMode(int value)](#ResizeMode-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Specifica l'impostazione corrente del comportamento di ridimensionamento per la forma quando è contenuta in un gruppo. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | For the description of this property, please see [getUfe()](../../com.aspose.diagram/resizemode\#getUfe--) |
+| [setValue(int value)](#setValue-int-) | For the description of this property, please see [getValue()](../../com.aspose.diagram/resizemode\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ResizeMode(int value) {#ResizeMode-int-}
+```
+public ResizeMode(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specifica l'impostazione corrente del comportamento di ridimensionamento per la forma quando è contenuta in un gruppo.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+For the description of this property, please see [getUfe()](../../com.aspose.diagram/resizemode\#getUfe--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+For the description of this property, please see [getValue()](../../com.aspose.diagram/resizemode\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/resizemodevalue/_index.md
+++ b/italian/java/com.aspose.diagram/resizemodevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: ResizeModeValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica l'impostazione corrente del comportamento di ridimensionamento per la forma quando è contenuta in un gruppo.
+type: docs
+weight: 329
+url: /it/java/com.aspose.diagram/resizemodevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ResizeModeValue
+```
+
+Specifica l'impostazione corrente del comportamento di ridimensionamento per la forma quando è contenuta in un gruppo.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [REPOSITION_ONLY](#REPOSITION-ONLY) | Solo riposizionamento. |
+| [SCALE_WITH_GROUP](#SCALE-WITH-GROUP) | Scala con il gruppo. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+| [USE_GROUP_SETTING](#USE-GROUP-SETTING) | Usa le impostazioni del gruppo |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### REPOSITION_ONLY {#REPOSITION-ONLY}
+```
+public static final int REPOSITION_ONLY
+```
+
+
+Solo riposizionamento.
+
+### SCALE_WITH_GROUP {#SCALE-WITH-GROUP}
+```
+public static final int SCALE_WITH_GROUP
+```
+
+
+Scala con il gruppo.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### USE_GROUP_SETTING {#USE-GROUP-SETTING}
+```
+public static final int USE_GROUP_SETTING
+```
+
+
+Usa le impostazioni del gruppo
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/reviewer/_index.md
+++ b/italian/java/com.aspose.diagram/reviewer/_index.md
@@ -1,0 +1,243 @@
+---
+title: Revisore
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene elementi che includono informazioni identificative su un revisore di documento.
+type: docs
+weight: 330
+url: /it/java/com.aspose.diagram/reviewer/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Reviewer
+```
+
+Contiene elementi che includono informazioni identificative su un revisore di documento.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [Reviewer()](#Reviewer--) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getColor()](#getColor--) | L'elemento Color specifica un valore RGB che rappresenta il colore assegnato al markup di un revisore del documento. |
+| [getCurrentIndex()](#getCurrentIndex--) | Indica il valore dell'elemento MarkerIndex che verrà aggiunto quando il revisore corrente aggiunge un altro commento al documento. |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getIX()](#getIX--) | L'indice basato su zero dell'elemento all'interno del suo elemento genitore. |
+| [getInitials()](#getInitials--) | Contiene le iniziali di un revisore del documento. |
+| [getName()](#getName--) | L'elemento Name specifica il nome di un revisore del documento. |
+| [getReviewerID()](#getReviewerID--) | Contiene il numero ID del revisore che aggiunge markup al documento. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/reviewer\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Per la descrizione di questa proprietà, vedere [getIX()](../../com.aspose.diagram/reviewer\#getIX--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Reviewer() {#Reviewer--}
+```
+public Reviewer()
+```
+
+
+Costruttore.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColor() {#getColor--}
+```
+public ColorValue getColor()
+```
+
+
+L'elemento Color specifica un valore RGB che rappresenta il colore assegnato al markup di un revisore del documento.
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getCurrentIndex() {#getCurrentIndex--}
+```
+public IntValue getCurrentIndex()
+```
+
+
+Indica il valore dell'elemento MarkerIndex che verrà aggiunto quando il revisore corrente aggiunge un altro commento al documento.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+L'indice basato su zero dell'elemento all'interno del suo elemento genitore.
+
+**Returns:**
+int
+### getInitials() {#getInitials--}
+```
+public Str2Value getInitials()
+```
+
+
+Contiene le iniziali di un revisore del documento.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getName() {#getName--}
+```
+public Str2Value getName()
+```
+
+
+L'elemento Name specifica il nome di un revisore del documento.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getReviewerID() {#getReviewerID--}
+```
+public IntValue getReviewerID()
+```
+
+
+Contiene il numero ID del revisore che aggiunge markup al documento.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/reviewer\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getIX()](../../com.aspose.diagram/reviewer\#getIX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/reviewercollection/_index.md
+++ b/italian/java/com.aspose.diagram/reviewercollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: ReviewerCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Raccolta Reviewer.
+type: docs
+weight: 331
+url: /it/java/com.aspose.diagram/reviewercollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ReviewerCollection extends Collection
+```
+
+Raccolta Reviewer.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [add(Reviewer item)](#add-com.aspose.diagram.Reviewer-) | Aggiungi l'oggetto Reviewer nella collezione. |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Reviewer item)](#remove-com.aspose.diagram.Reviewer-) | Rimuovi l'oggetto Reviewer dalla collezione. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Reviewer item) {#add-com.aspose.diagram.Reviewer-}
+```
+public int add(Reviewer item)
+```
+
+
+Aggiungi l'oggetto Reviewer nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [Reviewer](../../com.aspose.diagram/reviewer) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Reviewer get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[Reviewer](../../com.aspose.diagram/reviewer) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Reviewer item) {#remove-com.aspose.diagram.Reviewer-}
+```
+public void remove(Reviewer item)
+```
+
+
+Rimuovi l'oggetto Reviewer dalla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [Reviewer](../../com.aspose.diagram/reviewer) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/rotationtype/_index.md
+++ b/italian/java/com.aspose.diagram/rotationtype/_index.md
@@ -1,0 +1,179 @@
+---
+title: RotationType
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica il tipo di ombra per una forma.
+type: docs
+weight: 332
+url: /it/java/com.aspose.diagram/rotationtype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class RotationType
+```
+
+Specifica il tipo di ombra per una forma.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [RotationType(int value)](#RotationType-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Specifica il tipo di smussatura. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/rotationtype\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RotationType(int value) {#RotationType-int-}
+```
+public RotationType(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specifica il tipo di smussatura.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/rotationtype\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/rotationtypevalue/_index.md
+++ b/italian/java/com.aspose.diagram/rotationtypevalue/_index.md
@@ -1,0 +1,201 @@
+---
+title: RotationTypeValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica il tipo di proiezione delle proprietà di effetto di una forma.
+type: docs
+weight: 333
+url: /it/java/com.aspose.diagram/rotationtypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class RotationTypeValue
+```
+
+Specifica il tipo di proiezione delle proprietà di effetto di una forma.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [NONE](#NONE) | Specifica nessuna rotazione di effetti 3D. |
+| [OBLIQUE_FROM_BOTTOM_LEFT](#OBLIQUE-FROM-BOTTOM-LEFT) | Specifica che la forma ruota con proiezione obliqua dall'angolo inferiore sinistro della scatola di delimitazione della forma. |
+| [OBLIQUE_FROM_BOTTOM_RIGHT](#OBLIQUE-FROM-BOTTOM-RIGHT) | Specifica che la forma ruota con proiezione obliqua dall'angolo inferiore destro della scatola di delimitazione della forma. |
+| [OBLIQUE_FROM_TOP_LEFT](#OBLIQUE-FROM-TOP-LEFT) | Specifica che la forma ruota con proiezione obliqua dall'angolo superiore sinistro della scatola di delimitazione della forma. |
+| [OBLIQUE_FROM_TOP_RIGHT](#OBLIQUE-FROM-TOP-RIGHT) | Specifica che la forma ruota con proiezione obliqua dall'angolo superiore destro della scatola di delimitazione della forma. |
+| [PARALLEL](#PARALLEL) | Specifica che una proiezione parallela è applicata alle proprietà di effetto 3D. |
+| [PERSPECTIVE](#PERSPECTIVE) | Specifica che la forma ruota con proiezione prospettica. |
+| [UNDEFINED](#UNDEFINED) | Nessun impianto di luce. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Specifica nessuna rotazione di effetti 3D.
+
+### OBLIQUE_FROM_BOTTOM_LEFT {#OBLIQUE-FROM-BOTTOM-LEFT}
+```
+public static final int OBLIQUE_FROM_BOTTOM_LEFT
+```
+
+
+Specifica che la forma ruota con proiezione obliqua dall'angolo inferiore sinistro della scatola di delimitazione della forma.
+
+### OBLIQUE_FROM_BOTTOM_RIGHT {#OBLIQUE-FROM-BOTTOM-RIGHT}
+```
+public static final int OBLIQUE_FROM_BOTTOM_RIGHT
+```
+
+
+Specifica che la forma ruota con proiezione obliqua dall'angolo inferiore destro della scatola di delimitazione della forma.
+
+### OBLIQUE_FROM_TOP_LEFT {#OBLIQUE-FROM-TOP-LEFT}
+```
+public static final int OBLIQUE_FROM_TOP_LEFT
+```
+
+
+Specifica che la forma ruota con proiezione obliqua dall'angolo superiore sinistro della scatola di delimitazione della forma.
+
+### OBLIQUE_FROM_TOP_RIGHT {#OBLIQUE-FROM-TOP-RIGHT}
+```
+public static final int OBLIQUE_FROM_TOP_RIGHT
+```
+
+
+Specifica che la forma ruota con proiezione obliqua dall'angolo superiore destro della scatola di delimitazione della forma.
+
+### PARALLEL {#PARALLEL}
+```
+public static final int PARALLEL
+```
+
+
+Specifica che una proiezione parallela è applicata alle proprietà di effetto 3D.
+
+### PERSPECTIVE {#PERSPECTIVE}
+```
+public static final int PERSPECTIVE
+```
+
+
+Specifica che la forma ruota con proiezione prospettica.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Nessun impianto di luce.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/routestyle/_index.md
+++ b/italian/java/com.aspose.diagram/routestyle/_index.md
@@ -1,0 +1,179 @@
+---
+title: RouteStyle
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica lo stile di routing e la direzione per tutti i connettori dinamici nella pagina di disegno che non hanno uno stile di routing locale.
+type: docs
+weight: 334
+url: /it/java/com.aspose.diagram/routestyle/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class RouteStyle
+```
+
+Specifica lo stile di instradamento e la direzione per tutti i connettori dinamici nella pagina di disegno che non hanno uno stile di instradamento locale.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [RouteStyle(int value)](#RouteStyle-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Specifica lo stile di instradamento e la direzione per tutti i connettori dinamici nella pagina di disegno che non hanno uno stile di instradamento locale. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/routestyle\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RouteStyle(int value) {#RouteStyle-int-}
+```
+public RouteStyle(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specifica lo stile di instradamento e la direzione per tutti i connettori dinamici nella pagina di disegno che non hanno uno stile di instradamento locale.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/routestyle\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/routestylevalue/_index.md
+++ b/italian/java/com.aspose.diagram/routestylevalue/_index.md
@@ -1,0 +1,345 @@
+---
+title: RouteStyleValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica lo stile di routing e la direzione per tutti i connettori dinamici nella pagina di disegno che non hanno uno stile di routing locale.
+type: docs
+weight: 335
+url: /it/java/com.aspose.diagram/routestylevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class RouteStyleValue
+```
+
+Specifica lo stile di instradamento e la direzione per tutti i connettori dinamici nella pagina di disegno che non hanno uno stile di instradamento locale.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [CENTER_TO_CENTER](#CENTER-TO-CENTER) | Centro a centro. |
+| [DEFAULT_RIGHT_ANGLE](#DEFAULT-RIGHT-ANGLE) | Predefinito. |
+| [FLOWCHART_BOTTOM_TO_TOP](#FLOWCHART-BOTTOM-TO-TOP) | Diagramma di flusso dal basso verso l'alto. |
+| [FLOWCHART_LEFT_TO_RIGHT](#FLOWCHART-LEFT-TO-RIGHT) | Diagramma di flusso da sinistra a destra. |
+| [FLOWCHART_RIGHT_TO_LEFT](#FLOWCHART-RIGHT-TO-LEFT) | Diagramma di flusso da destra a sinistra. |
+| [FLOWCHART_TOP_TO_BOTTOM](#FLOWCHART-TOP-TO-BOTTOM) | Diagramma di flusso dall'alto verso il basso. |
+| [NETWORK](#NETWORK) | Rete. |
+| [ORGANIZATION_CHART_BOTTOM_TO_TOP](#ORGANIZATION-CHART-BOTTOM-TO-TOP) | Organigramma dal basso verso l'alto. |
+| [ORGANIZATION_CHART_LEFT_TO_RIGHT](#ORGANIZATION-CHART-LEFT-TO-RIGHT) | Organigramma da sinistra a destra. |
+| [ORGANIZATION_CHART_RIGHT_TO_LEFT](#ORGANIZATION-CHART-RIGHT-TO-LEFT) | Organigramma da destra a sinistra. |
+| [ORGANIZATION_CHART_TOP_TO_BOTTOM](#ORGANIZATION-CHART-TOP-TO-BOTTOM) | Organigramma dall'alto verso il basso. |
+| [RIGHT_ANGLE](#RIGHT-ANGLE) | Angolo retto. |
+| [SIMPLE_BOTTOM_TO_TOP](#SIMPLE-BOTTOM-TO-TOP) | Semplice dal basso verso l'alto. |
+| [SIMPLE_HORIZONTAL_VERTICAL](#SIMPLE-HORIZONTAL-VERTICAL) | Semplice orizzontale verticale. |
+| [SIMPLE_LEFT_TO_RIGHT](#SIMPLE-LEFT-TO-RIGHT) | Semplice da sinistra a destra. |
+| [SIMPLE_RIGHT_TO_LEFT](#SIMPLE-RIGHT-TO-LEFT) | Semplice da destra a sinistra. |
+| [SIMPLE_TOP_TO_BOTTOM](#SIMPLE-TOP-TO-BOTTOM) | Semplice dall'alto verso il basso. |
+| [SIMPLE_VERTICAL_HORIZONTAL](#SIMPLE-VERTICAL-HORIZONTAL) | Semplice verticale orizzontale. |
+| [STRAIGHT](#STRAIGHT) | Retto. |
+| [TREE_BOTTOM_TO_TOP](#TREE-BOTTOM-TO-TOP) | Albero dal basso verso l'alto. |
+| [TREE_LEFT_TO_RIGHT](#TREE-LEFT-TO-RIGHT) | Albero da sinistra a destra. |
+| [TREE_RIGHT_TO_LEFT](#TREE-RIGHT-TO-LEFT) | Albero da destra a sinistra. |
+| [TREE_TOP_TO_BOTTOM](#TREE-TOP-TO-BOTTOM) | Albero dall'alto verso il basso. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CENTER_TO_CENTER {#CENTER-TO-CENTER}
+```
+public static final int CENTER_TO_CENTER
+```
+
+
+Centro a centro.
+
+### DEFAULT_RIGHT_ANGLE {#DEFAULT-RIGHT-ANGLE}
+```
+public static final int DEFAULT_RIGHT_ANGLE
+```
+
+
+Predefinito. Angolo retto.
+
+### FLOWCHART_BOTTOM_TO_TOP {#FLOWCHART-BOTTOM-TO-TOP}
+```
+public static final int FLOWCHART_BOTTOM_TO_TOP
+```
+
+
+Diagramma di flusso dal basso verso l'alto.
+
+### FLOWCHART_LEFT_TO_RIGHT {#FLOWCHART-LEFT-TO-RIGHT}
+```
+public static final int FLOWCHART_LEFT_TO_RIGHT
+```
+
+
+Diagramma di flusso da sinistra a destra.
+
+### FLOWCHART_RIGHT_TO_LEFT {#FLOWCHART-RIGHT-TO-LEFT}
+```
+public static final int FLOWCHART_RIGHT_TO_LEFT
+```
+
+
+Diagramma di flusso da destra a sinistra.
+
+### FLOWCHART_TOP_TO_BOTTOM {#FLOWCHART-TOP-TO-BOTTOM}
+```
+public static final int FLOWCHART_TOP_TO_BOTTOM
+```
+
+
+Diagramma di flusso dall'alto verso il basso.
+
+### NETWORK {#NETWORK}
+```
+public static final int NETWORK
+```
+
+
+Rete.
+
+### ORGANIZATION_CHART_BOTTOM_TO_TOP {#ORGANIZATION-CHART-BOTTOM-TO-TOP}
+```
+public static final int ORGANIZATION_CHART_BOTTOM_TO_TOP
+```
+
+
+Organigramma dal basso verso l'alto.
+
+### ORGANIZATION_CHART_LEFT_TO_RIGHT {#ORGANIZATION-CHART-LEFT-TO-RIGHT}
+```
+public static final int ORGANIZATION_CHART_LEFT_TO_RIGHT
+```
+
+
+Organigramma da sinistra a destra.
+
+### ORGANIZATION_CHART_RIGHT_TO_LEFT {#ORGANIZATION-CHART-RIGHT-TO-LEFT}
+```
+public static final int ORGANIZATION_CHART_RIGHT_TO_LEFT
+```
+
+
+Organigramma da destra a sinistra.
+
+### ORGANIZATION_CHART_TOP_TO_BOTTOM {#ORGANIZATION-CHART-TOP-TO-BOTTOM}
+```
+public static final int ORGANIZATION_CHART_TOP_TO_BOTTOM
+```
+
+
+Organigramma dall'alto verso il basso.
+
+### RIGHT_ANGLE {#RIGHT-ANGLE}
+```
+public static final int RIGHT_ANGLE
+```
+
+
+Angolo retto.
+
+### SIMPLE_BOTTOM_TO_TOP {#SIMPLE-BOTTOM-TO-TOP}
+```
+public static final int SIMPLE_BOTTOM_TO_TOP
+```
+
+
+Semplice dal basso verso l'alto.
+
+### SIMPLE_HORIZONTAL_VERTICAL {#SIMPLE-HORIZONTAL-VERTICAL}
+```
+public static final int SIMPLE_HORIZONTAL_VERTICAL
+```
+
+
+Semplice orizzontale verticale.
+
+### SIMPLE_LEFT_TO_RIGHT {#SIMPLE-LEFT-TO-RIGHT}
+```
+public static final int SIMPLE_LEFT_TO_RIGHT
+```
+
+
+Semplice da sinistra a destra.
+
+### SIMPLE_RIGHT_TO_LEFT {#SIMPLE-RIGHT-TO-LEFT}
+```
+public static final int SIMPLE_RIGHT_TO_LEFT
+```
+
+
+Semplice da destra a sinistra.
+
+### SIMPLE_TOP_TO_BOTTOM {#SIMPLE-TOP-TO-BOTTOM}
+```
+public static final int SIMPLE_TOP_TO_BOTTOM
+```
+
+
+Semplice dall'alto verso il basso.
+
+### SIMPLE_VERTICAL_HORIZONTAL {#SIMPLE-VERTICAL-HORIZONTAL}
+```
+public static final int SIMPLE_VERTICAL_HORIZONTAL
+```
+
+
+Semplice verticale orizzontale.
+
+### STRAIGHT {#STRAIGHT}
+```
+public static final int STRAIGHT
+```
+
+
+Retto.
+
+### TREE_BOTTOM_TO_TOP {#TREE-BOTTOM-TO-TOP}
+```
+public static final int TREE_BOTTOM_TO_TOP
+```
+
+
+Albero dal basso verso l'alto.
+
+### TREE_LEFT_TO_RIGHT {#TREE-LEFT-TO-RIGHT}
+```
+public static final int TREE_LEFT_TO_RIGHT
+```
+
+
+Albero da sinistra a destra.
+
+### TREE_RIGHT_TO_LEFT {#TREE-RIGHT-TO-LEFT}
+```
+public static final int TREE_RIGHT_TO_LEFT
+```
+
+
+Albero da destra a sinistra.
+
+### TREE_TOP_TO_BOTTOM {#TREE-TOP-TO-BOTTOM}
+```
+public static final int TREE_TOP_TO_BOTTOM
+```
+
+
+Albero dall'alto verso il basso.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/row/_index.md
+++ b/italian/java/com.aspose.diagram/row/_index.md
@@ -1,0 +1,213 @@
+---
+title: Row
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Indica una riga nel set di record dei dati.
+type: docs
+weight: 336
+url: /it/java/com.aspose.diagram/row/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Row
+```
+
+Indica una riga nel set di record dei dati.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [Row()](#Row--) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getPageID()](#getPageID--) | ID pagina della shape. |
+| [getRowID()](#getRowID--) | L'ID riga originale. |
+| [getShapeID()](#getShapeID--) | ID shape della shape. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setPageID(long value)](#setPageID-long-) | Per la descrizione di questa proprietà, vedere [getPageID()](../../com.aspose.diagram/row\#getPageID--) |
+| [setRowID(long value)](#setRowID-long-) | Per la descrizione di questa proprietà, vedere [getRowID()](../../com.aspose.diagram/row\#getRowID--) |
+| [setShapeID(long value)](#setShapeID-long-) | Per la descrizione di questa proprietà, vedere [getShapeID()](../../com.aspose.diagram/row\#getShapeID--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Row() {#Row--}
+```
+public Row()
+```
+
+
+Costruttore.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getPageID() {#getPageID--}
+```
+public long getPageID()
+```
+
+
+ID pagina della shape.
+
+**Returns:**
+long
+### getRowID() {#getRowID--}
+```
+public long getRowID()
+```
+
+
+L'ID riga originale.
+
+**Returns:**
+long
+### getShapeID() {#getShapeID--}
+```
+public long getShapeID()
+```
+
+
+ID shape della shape.
+
+**Returns:**
+long
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setPageID(long value) {#setPageID-long-}
+```
+public void setPageID(long value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getPageID()](../../com.aspose.diagram/row\#getPageID--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | long |  |
+
+### setRowID(long value) {#setRowID-long-}
+```
+public void setRowID(long value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getRowID()](../../com.aspose.diagram/row\#getRowID--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | long |  |
+
+### setShapeID(long value) {#setShapeID-long-}
+```
+public void setShapeID(long value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getShapeID()](../../com.aspose.diagram/row\#getShapeID--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | long |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/rowcollection/_index.md
+++ b/italian/java/com.aspose.diagram/rowcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: RowCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Raccolta Row.
+type: docs
+weight: 337
+url: /it/java/com.aspose.diagram/rowcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class RowCollection extends Collection
+```
+
+Raccolta Row.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [add(Row row)](#add-com.aspose.diagram.Row-) | Aggiungi la riga nella collezione. |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Row row)](#remove-com.aspose.diagram.Row-) | Rimuovi la riga dalla collezione. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Row row) {#add-com.aspose.diagram.Row-}
+```
+public int add(Row row)
+```
+
+
+Aggiungi la riga nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| row | [Row](../../com.aspose.diagram/row) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Row get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[Row](../../com.aspose.diagram/row) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Row row) {#remove-com.aspose.diagram.Row-}
+```
+public void remove(Row row)
+```
+
+
+Rimuovi la riga dalla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| row | [Row](../../com.aspose.diagram/row) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/rule/_index.md
+++ b/italian/java/com.aspose.diagram/rule/_index.md
@@ -1,0 +1,338 @@
+---
+title: Rule
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta una singola regola di convalida in un set di regole di convalida del diagramma.
+type: docs
+weight: 338
+url: /it/java/com.aspose.diagram/rule/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Rule
+```
+
+Rappresenta una singola regola di convalida in un set di regole di convalida del diagramma.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [Rule()](#Rule--) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCategory()](#getCategory--) | Specifica il testo visualizzato nella colonna Categoria della finestra Issues. |
+| [getClass()](#getClass--) |  |
+| [getDescription()](#getDescription--) | la descrizione della regola di convalida che appare nell'interfaccia utente. |
+| [getID()](#getID--) | Specifica l'identificatore univoco della regola di convalida. |
+| [getIgnored()](#getIgnored--) | Specifica se la regola di convalida è attualmente ignorata. |
+| [getNameU()](#getNameU--) | Specifica il nome universale della regola di convalida. |
+| [getRuleFilter()](#getRuleFilter--) | Specifica l'espressione logica che determina se la regola di convalida deve essere applicata a un oggetto target. |
+| [getRuleTarget()](#getRuleTarget--) | Specifica il tipo di oggetto a cui si applica la regola di convalida. |
+| [getRuleTest()](#getRuleTest--) | Specifica l'espressione logica che determina se l'oggetto target soddisfa la regola di convalida |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCategory(String value)](#setCategory-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getCategory()](../../com.aspose.diagram/rule\#getCategory--) |
+| [setDescription(String value)](#setDescription-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getDescription()](../../com.aspose.diagram/rule\#getDescription--) |
+| [setID(long value)](#setID-long-) | Per la descrizione di questa proprietà, vedere [getID()](../../com.aspose.diagram/rule\#getID--) |
+| [setIgnored(int value)](#setIgnored-int-) | Per la descrizione di questa proprietà, vedere [getIgnored()](../../com.aspose.diagram/rule\#getIgnored--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getNameU()](../../com.aspose.diagram/rule\#getNameU--) |
+| [setRuleFilter(RuleValue value)](#setRuleFilter-com.aspose.diagram.RuleValue-) | Per la descrizione di questa proprietà, vedere [getRuleFilter()](../../com.aspose.diagram/rule\#getRuleFilter--) |
+| [setRuleTarget(int value)](#setRuleTarget-int-) | Per la descrizione di questa proprietà, vedere [getRuleTarget()](../../com.aspose.diagram/rule\#getRuleTarget--) |
+| [setRuleTest(RuleValue value)](#setRuleTest-com.aspose.diagram.RuleValue-) | Per la descrizione di questa proprietà, vedere [getRuleTest()](../../com.aspose.diagram/rule\#getRuleTest--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Rule() {#Rule--}
+```
+public Rule()
+```
+
+
+Costruttore.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCategory() {#getCategory--}
+```
+public String getCategory()
+```
+
+
+Specifica il testo visualizzato nella colonna Categoria della finestra Issues. Il valore predefinito è una stringa vuota.
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDescription() {#getDescription--}
+```
+public String getDescription()
+```
+
+
+la descrizione della regola di convalida che appare nell'interfaccia utente. Il valore predefinito è "Unknown".
+
+**Returns:**
+java.lang.String
+### getID() {#getID--}
+```
+public long getID()
+```
+
+
+Specifica l'identificatore univoco della regola di convalida.
+
+**Returns:**
+long
+### getIgnored() {#getIgnored--}
+```
+public int getIgnored()
+```
+
+
+Specifica se la regola di convalida è attualmente ignorata. Il valore predefinito è False.
+
+**Returns:**
+int
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+Specifica il nome universale della regola di convalida.
+
+**Returns:**
+java.lang.String
+### getRuleFilter() {#getRuleFilter--}
+```
+public RuleValue getRuleFilter()
+```
+
+
+Specifica l'espressione logica che determina se la regola di convalida deve essere applicata a un oggetto target.
+
+**Returns:**
+[RuleValue](../../com.aspose.diagram/rulevalue)
+### getRuleTarget() {#getRuleTarget--}
+```
+public int getRuleTarget()
+```
+
+
+Specifica il tipo di oggetto a cui si applica la regola di convalida.
+
+**Returns:**
+int
+### getRuleTest() {#getRuleTest--}
+```
+public RuleValue getRuleTest()
+```
+
+
+Specifica l'espressione logica che determina se l'oggetto target soddisfa la regola di convalida
+
+**Returns:**
+[RuleValue](../../com.aspose.diagram/rulevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCategory(String value) {#setCategory-java.lang.String-}
+```
+public void setCategory(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getCategory()](../../com.aspose.diagram/rule\#getCategory--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setDescription(String value) {#setDescription-java.lang.String-}
+```
+public void setDescription(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDescription()](../../com.aspose.diagram/rule\#getDescription--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setID(long value) {#setID-long-}
+```
+public void setID(long value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getID()](../../com.aspose.diagram/rule\#getID--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | long |  |
+
+### setIgnored(int value) {#setIgnored-int-}
+```
+public void setIgnored(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getIgnored()](../../com.aspose.diagram/rule\#getIgnored--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getNameU()](../../com.aspose.diagram/rule\#getNameU--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setRuleFilter(RuleValue value) {#setRuleFilter-com.aspose.diagram.RuleValue-}
+```
+public void setRuleFilter(RuleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getRuleFilter()](../../com.aspose.diagram/rule\#getRuleFilter--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [RuleValue](../../com.aspose.diagram/rulevalue) |  |
+
+### setRuleTarget(int value) {#setRuleTarget-int-}
+```
+public void setRuleTarget(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getRuleTarget()](../../com.aspose.diagram/rule\#getRuleTarget--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setRuleTest(RuleValue value) {#setRuleTest-com.aspose.diagram.RuleValue-}
+```
+public void setRuleTest(RuleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getRuleTest()](../../com.aspose.diagram/rule\#getRuleTest--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [RuleValue](../../com.aspose.diagram/rulevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/rulecollection/_index.md
+++ b/italian/java/com.aspose.diagram/rulecollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: RuleCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Raccolta Rule.
+type: docs
+weight: 339
+url: /it/java/com.aspose.diagram/rulecollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class RuleCollection extends Collection
+```
+
+Raccolta Rule.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [add(Rule rule)](#add-com.aspose.diagram.Rule-) | Aggiungi la regola nella raccolta. |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Rule rule)](#remove-com.aspose.diagram.Rule-) | Rimuovi la regola dalla raccolta. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Rule rule) {#add-com.aspose.diagram.Rule-}
+```
+public int add(Rule rule)
+```
+
+
+Aggiungi la regola nella raccolta.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| rule | [Rule](../../com.aspose.diagram/rule) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Rule get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[Rule](../../com.aspose.diagram/rule) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Rule rule) {#remove-com.aspose.diagram.Rule-}
+```
+public void remove(Rule rule)
+```
+
+
+Rimuovi la regola dalla raccolta.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| rule | [Rule](../../com.aspose.diagram/rule) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/ruleinfo/_index.md
+++ b/italian/java/com.aspose.diagram/ruleinfo/_index.md
@@ -1,0 +1,194 @@
+---
+title: RuleInfo
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica le informazioni sulla regola di convalida a cui si riferisce il problema di convalida padre.
+type: docs
+weight: 340
+url: /it/java/com.aspose.diagram/ruleinfo/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class RuleInfo
+```
+
+Specifica le informazioni sulla regola di convalida a cui si riferisce il problema di convalida padre.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [RuleInfo(long ruleSetID, long ruleID)](#RuleInfo-long-long-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getRuleId()](#getRuleId--) | Specifica l'identificatore univoco della regola di convalida a cui si riferisce il problema padre. |
+| [getRuleSetId()](#getRuleSetId--) | Specifies the unique identifier of the validation rule set that the parent issue pertains to. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setRuleId(long value)](#setRuleId-long-) | For the description of this property, please see [getRuleId()](../../com.aspose.diagram/ruleinfo\#getRuleId--) |
+| [setRuleSetId(long value)](#setRuleSetId-long-) | For the description of this property, please see [getRuleSetId()](../../com.aspose.diagram/ruleinfo\#getRuleSetId--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RuleInfo(long ruleSetID, long ruleID) {#RuleInfo-long-long-}
+```
+public RuleInfo(long ruleSetID, long ruleID)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| ruleSetID | long |  |
+| ruleID | long |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getRuleId() {#getRuleId--}
+```
+public long getRuleId()
+```
+
+
+Specifica l'identificatore univoco della regola di convalida a cui si riferisce il problema padre.
+
+**Returns:**
+long
+### getRuleSetId() {#getRuleSetId--}
+```
+public long getRuleSetId()
+```
+
+
+Specifies the unique identifier of the validation rule set that the parent issue pertains to.
+
+**Returns:**
+long
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setRuleId(long value) {#setRuleId-long-}
+```
+public void setRuleId(long value)
+```
+
+
+For the description of this property, please see [getRuleId()](../../com.aspose.diagram/ruleinfo\#getRuleId--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | long |  |
+
+### setRuleSetId(long value) {#setRuleSetId-long-}
+```
+public void setRuleSetId(long value)
+```
+
+
+For the description of this property, please see [getRuleSetId()](../../com.aspose.diagram/ruleinfo\#getRuleSetId--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | long |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/rulerdensity/_index.md
+++ b/italian/java/com.aspose.diagram/rulerdensity/_index.md
@@ -1,0 +1,179 @@
+---
+title: RulerDensity
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica le suddivisioni orizzontali sul righello per la pagina.
+type: docs
+weight: 344
+url: /it/java/com.aspose.diagram/rulerdensity/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class RulerDensity
+```
+
+Specifica le suddivisioni orizzontali sul righello per la pagina.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [RulerDensity(int value)](#RulerDensity-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Specifica le suddivisioni orizzontali sul righello per la pagina. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, consultare [getValue()](../../com.aspose.diagram/rulerdensity\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RulerDensity(int value) {#RulerDensity-int-}
+```
+public RulerDensity(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specifica le suddivisioni orizzontali sul righello per la pagina.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getValue()](../../com.aspose.diagram/rulerdensity\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/rulerdensityvalue/_index.md
+++ b/italian/java/com.aspose.diagram/rulerdensityvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: RulerDensityValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica le suddivisioni orizzontali sul righello per la pagina.
+type: docs
+weight: 345
+url: /it/java/com.aspose.diagram/rulerdensityvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class RulerDensityValue
+```
+
+Specifica le suddivisioni orizzontali sul righello per la pagina.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [COARSE](#COARSE) | Grossa. |
+| [FINE](#FINE) | Fine. |
+| [NORMAL](#NORMAL) | Normale. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### COARSE {#COARSE}
+```
+public static final int COARSE
+```
+
+
+Grossa.
+
+### FINE {#FINE}
+```
+public static final int FINE
+```
+
+
+Fine.
+
+### NORMAL {#NORMAL}
+```
+public static final int NORMAL
+```
+
+
+Normale.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/rulergrid/_index.md
+++ b/italian/java/com.aspose.diagram/rulergrid/_index.md
@@ -1,0 +1,260 @@
+---
+title: RulerGrid
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene elementi che specificano le impostazioni dei righelli e della griglia delle pagine.
+type: docs
+weight: 346
+url: /it/java/com.aspose.diagram/rulergrid/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class RulerGrid
+```
+
+Contiene elementi che specificano le impostazioni dei righelli e della griglia della pagina.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getXGridDensity()](#getXGridDensity--) | Specifica il punto zero sul righello dell'asse y (verticale) per la pagina. |
+| [getXGridOrigin()](#getXGridOrigin--) | Specifica la coordinata orizzontale dell'origine della griglia per una pagina. |
+| [getXGridSpacing()](#getXGridSpacing--) | Specifica la distanza tra le linee orizzontali in una griglia fissa (cioè, un elemento RulerGrid in cui l'elemento XGridDensity è impostato a 0). |
+| [getXRulerDensity()](#getXRulerDensity--) | Specifica le suddivisioni orizzontali sul righello per la pagina. |
+| [getXRulerOrigin()](#getXRulerOrigin--) | Specifica il punto zero sul righello dell'asse x (orizzontale) per la pagina. |
+| [getYGridDensity()](#getYGridDensity--) | Specifica il tipo di griglia verticale da utilizzare per una pagina. |
+| [getYGridOrigin()](#getYGridOrigin--) | Specifica l'origine verticale della griglia sulla pagina. |
+| [getYGridSpacing()](#getYGridSpacing--) | Specifica la distanza tra le linee verticali in una griglia fissa (cioè, un elemento RulerGrid in cui l'elemento YGridDensity è impostato a 0). |
+| [getYRulerDensity()](#getYRulerDensity--) | Specifica le suddivisioni verticali sul righello per la pagina. |
+| [getYRulerOrigin()](#getYRulerOrigin--) | Specifica il punto zero sul righello dell'asse y (verticale) per la pagina. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, consultare [getDel()](../../com.aspose.diagram/rulergrid\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getXGridDensity() {#getXGridDensity--}
+```
+public GridDensity getXGridDensity()
+```
+
+
+Specifica il punto zero sul righello dell'asse y (verticale) per la pagina.
+
+**Returns:**
+[GridDensity](../../com.aspose.diagram/griddensity)
+### getXGridOrigin() {#getXGridOrigin--}
+```
+public DoubleValue getXGridOrigin()
+```
+
+
+Specifica la coordinata orizzontale dell'origine della griglia per una pagina.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getXGridSpacing() {#getXGridSpacing--}
+```
+public DoubleValue getXGridSpacing()
+```
+
+
+Specifica la distanza tra le linee orizzontali in una griglia fissa (cioè, un elemento RulerGrid in cui l'elemento XGridDensity è impostato a 0).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getXRulerDensity() {#getXRulerDensity--}
+```
+public RulerDensity getXRulerDensity()
+```
+
+
+Specifica le suddivisioni orizzontali sul righello per la pagina.
+
+**Returns:**
+[RulerDensity](../../com.aspose.diagram/rulerdensity)
+### getXRulerOrigin() {#getXRulerOrigin--}
+```
+public DoubleValue getXRulerOrigin()
+```
+
+
+Specifica il punto zero sul righello dell'asse x (orizzontale) per la pagina.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getYGridDensity() {#getYGridDensity--}
+```
+public GridDensity getYGridDensity()
+```
+
+
+Specifica il tipo di griglia verticale da utilizzare per una pagina.
+
+**Returns:**
+[GridDensity](../../com.aspose.diagram/griddensity)
+### getYGridOrigin() {#getYGridOrigin--}
+```
+public DoubleValue getYGridOrigin()
+```
+
+
+Specifica l'origine verticale della griglia sulla pagina.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getYGridSpacing() {#getYGridSpacing--}
+```
+public DoubleValue getYGridSpacing()
+```
+
+
+Specifica la distanza tra le linee verticali in una griglia fissa (cioè, un elemento RulerGrid in cui l'elemento YGridDensity è impostato a 0).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getYRulerDensity() {#getYRulerDensity--}
+```
+public RulerDensity getYRulerDensity()
+```
+
+
+Specifica le suddivisioni verticali sul righello per la pagina.
+
+**Returns:**
+[RulerDensity](../../com.aspose.diagram/rulerdensity)
+### getYRulerOrigin() {#getYRulerOrigin--}
+```
+public DoubleValue getYRulerOrigin()
+```
+
+
+Specifica il punto zero sul righello dell'asse y (verticale) per la pagina.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getDel()](../../com.aspose.diagram/rulergrid\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/ruleset/_index.md
+++ b/italian/java/com.aspose.diagram/ruleset/_index.md
@@ -1,0 +1,299 @@
+---
+title: RuleSet
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta un set di regole di convalida del diagramma.
+type: docs
+weight: 341
+url: /it/java/com.aspose.diagram/ruleset/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class RuleSet
+```
+
+Rappresenta un set di regole di convalida del diagramma.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [RuleSet()](#RuleSet--) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDescription()](#getDescription--) | Specifica la descrizione del set di regole di convalida che appare nell'interfaccia utente. |
+| [getEnabled()](#getEnabled--) | Specifica se le regole nel set di regole di convalida specificato vengono verificate quando la convalida è avviata per il documento corrente. |
+| [getID()](#getID--) | Specifica l'identificatore univoco del set di regole di convalida. |
+| [getName()](#getName--) | Specifica il nome locale del set di regole di convalida. |
+| [getNameU()](#getNameU--) | Specifica il nome universale del set di regole di convalida. |
+| [getRuleSetFlags()](#getRuleSetFlags--) | Specifica se il set di regole appare nell'elenco Regole da verificare. |
+| [getRules()](#getRules--) | Raccolta Rule. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDescription(String value)](#setDescription-java.lang.String-) | Per la descrizione di questa proprietà, consultare [getDescription()](../../com.aspose.diagram/ruleset\#getDescription--) |
+| [setEnabled(int value)](#setEnabled-int-) | Per la descrizione di questa proprietà, consultare [getEnabled()](../../com.aspose.diagram/ruleset\#getEnabled--) |
+| [setID(long value)](#setID-long-) | Per la descrizione di questa proprietà, consultare [getID()](../../com.aspose.diagram/ruleset\#getID--) |
+| [setName(String value)](#setName-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getName()](../../com.aspose.diagram/ruleset\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getNameU()](../../com.aspose.diagram/ruleset\#getNameU--) |
+| [setRuleSetFlags(int value)](#setRuleSetFlags-int-) | Per la descrizione di questa proprietà, vedere [getRuleSetFlags()](../../com.aspose.diagram/ruleset\#getRuleSetFlags--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RuleSet() {#RuleSet--}
+```
+public RuleSet()
+```
+
+
+Costruttore.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDescription() {#getDescription--}
+```
+public String getDescription()
+```
+
+
+Specifica la descrizione del set di regole di convalida che appare nell'interfaccia utente. Il valore predefinito è una stringa vuota.
+
+**Returns:**
+java.lang.String
+### getEnabled() {#getEnabled--}
+```
+public int getEnabled()
+```
+
+
+Specifica se le regole nel set di regole di convalida specificato vengono verificate quando la convalida è attivata per il documento corrente. Il valore predefinito è True.
+
+**Returns:**
+int
+### getID() {#getID--}
+```
+public long getID()
+```
+
+
+Specifica l'identificatore univoco del set di regole di convalida.
+
+**Returns:**
+long
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Specifica il nome locale del set di regole di convalida. Il valore predefinito è il valore dell'attributo NameU.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+Specifica il nome universale del set di regole di convalida.
+
+**Returns:**
+java.lang.String
+### getRuleSetFlags() {#getRuleSetFlags--}
+```
+public int getRuleSetFlags()
+```
+
+
+Specifica se il set di regole appare nell'elenco Regole da verificare.
+
+**Returns:**
+int
+### getRules() {#getRules--}
+```
+public RuleCollection getRules()
+```
+
+
+Raccolta Rule.
+
+**Returns:**
+[RuleCollection](../../com.aspose.diagram/rulecollection)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDescription(String value) {#setDescription-java.lang.String-}
+```
+public void setDescription(String value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getDescription()](../../com.aspose.diagram/ruleset\#getDescription--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setEnabled(int value) {#setEnabled-int-}
+```
+public void setEnabled(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getEnabled()](../../com.aspose.diagram/ruleset\#getEnabled--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setID(long value) {#setID-long-}
+```
+public void setID(long value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getID()](../../com.aspose.diagram/ruleset\#getID--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | long |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getName()](../../com.aspose.diagram/ruleset\#getName--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getNameU()](../../com.aspose.diagram/ruleset\#getNameU--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setRuleSetFlags(int value) {#setRuleSetFlags-int-}
+```
+public void setRuleSetFlags(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getRuleSetFlags()](../../com.aspose.diagram/ruleset\#getRuleSetFlags--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/rulesetcollection/_index.md
+++ b/italian/java/com.aspose.diagram/rulesetcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: RuleSetCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Raccolta RuleSet.
+type: docs
+weight: 342
+url: /it/java/com.aspose.diagram/rulesetcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class RuleSetCollection extends Collection
+```
+
+Raccolta RuleSet.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [add(RuleSet ruleSet)](#add-com.aspose.diagram.RuleSet-) | Aggiungi il ruleSet nella collezione. |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(RuleSet ruleSet)](#remove-com.aspose.diagram.RuleSet-) | Rimuovi il ruleSet dalla collezione. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(RuleSet ruleSet) {#add-com.aspose.diagram.RuleSet-}
+```
+public int add(RuleSet ruleSet)
+```
+
+
+Aggiungi il ruleSet nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| ruleSet | [RuleSet](../../com.aspose.diagram/ruleset) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public RuleSet get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[RuleSet](../../com.aspose.diagram/ruleset) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(RuleSet ruleSet) {#remove-com.aspose.diagram.RuleSet-}
+```
+public void remove(RuleSet ruleSet)
+```
+
+
+Rimuovi il ruleSet dalla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| ruleSet | [RuleSet](../../com.aspose.diagram/ruleset) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/rulevalue/_index.md
+++ b/italian/java/com.aspose.diagram/rulevalue/_index.md
@@ -1,0 +1,194 @@
+---
+title: RuleValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Valore della regola.
+type: docs
+weight: 343
+url: /it/java/com.aspose.diagram/rulevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class RuleValue
+```
+
+Valore della regola.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [RuleValue(String formula, String value)](#RuleValue-java.lang.String-java.lang.String-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFormula()](#getFormula--) | Rappresenta la formula dell'elemento. |
+| [getValue()](#getValue--) | Valore della regola. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setFormula(String value)](#setFormula-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getFormula()](../../com.aspose.diagram/rulevalue\#getFormula--) |
+| [setValue(String value)](#setValue-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/rulevalue\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RuleValue(String formula, String value) {#RuleValue-java.lang.String-java.lang.String-}
+```
+public RuleValue(String formula, String value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| formula | java.lang.String |  |
+| valore | java.lang.String |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFormula() {#getFormula--}
+```
+public String getFormula()
+```
+
+
+Rappresenta la formula dell'elemento. Questo attributo può contenere una delle seguenti stringhe: "someFormula" se la formula esiste localmente, "No Formula" se la formula è stata cancellata o bloccata localmente, oppure "Inh" se la formula è ereditata. Se l'attributo non è presente, la formula dell'elemento è una costante semplice.
+
+**Returns:**
+java.lang.String
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+Valore della regola.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setFormula(String value) {#setFormula-java.lang.String-}
+```
+public void setFormula(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getFormula()](../../com.aspose.diagram/rulevalue\#getFormula--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setValue(String value) {#setValue-java.lang.String-}
+```
+public void setValue(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/rulevalue\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/savefileformat/_index.md
+++ b/italian/java/com.aspose.diagram/savefileformat/_index.md
@@ -1,0 +1,309 @@
+---
+title: SaveFileFormat
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Enumerazione per la selezione del formato di salvataggio del diagramma.
+type: docs
+weight: 348
+url: /it/java/com.aspose.diagram/savefileformat/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class SaveFileFormat
+```
+
+Enumerazione per la selezione del formato di salvataggio del diagramma.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [BMP](#BMP) | Formato immagine Bmp. |
+| [EMF](#EMF) | Formato immagine EMF. |
+| [GIF](#GIF) | Formato Gif. |
+| [HTML](#HTML) | Formato Html. |
+| [JPEG](#JPEG) | Formato immagine Jpeg. |
+| [PDF](#PDF) | Formato Pdf. |
+| [PNG](#PNG) | Formato immagine Png. |
+| [SVG](#SVG) | Formato Svg. |
+| [TIFF](#TIFF) | Formato immagine Tiff. |
+| [VDX](#VDX) | Formato xml Vdx di MS Visio. |
+| [VSDM](#VSDM) | Formato file Vsdm di MS Visio che consente macro. |
+| [VSDX](#VSDX) | Formato file Vsdx di MS Visio 2013. |
+| [VSSM](#VSSM) | Formato file Vssm di MS Visio che consente macro. |
+| [VSSX](#VSSX) | Formato file Vssx di MS Visio 2013 |
+| [VSTM](#VSTM) | Formato file Vstm di MS Visio che consente macro. |
+| [VSTX](#VSTX) | Formato file Vstx di MS Visio 2013, file modello. |
+| [VSX](#VSX) | Formato stencil xml Vsx di MS Visio. |
+| [VTX](#VTX) | Formato modello xml Vst di MS Visio. |
+| [XAML](#XAML) | Formato Xaml. |
+| [XPS](#XPS) | Formato Xps. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BMP {#BMP}
+```
+public static final int BMP
+```
+
+
+Formato immagine Bmp.
+
+### EMF {#EMF}
+```
+public static final int EMF
+```
+
+
+Formato immagine EMF.
+
+### GIF {#GIF}
+```
+public static final int GIF
+```
+
+
+Formato Gif.
+
+### HTML {#HTML}
+```
+public static final int HTML
+```
+
+
+Formato Html.
+
+### JPEG {#JPEG}
+```
+public static final int JPEG
+```
+
+
+Formato immagine Jpeg.
+
+### PDF {#PDF}
+```
+public static final int PDF
+```
+
+
+Formato Pdf.
+
+### PNG {#PNG}
+```
+public static final int PNG
+```
+
+
+Formato immagine Png.
+
+### SVG {#SVG}
+```
+public static final int SVG
+```
+
+
+Formato Svg.
+
+### TIFF {#TIFF}
+```
+public static final int TIFF
+```
+
+
+Formato immagine Tiff.
+
+### VDX {#VDX}
+```
+public static final int VDX
+```
+
+
+Formato xml Vdx di MS Visio.
+
+### VSDM {#VSDM}
+```
+public static final int VSDM
+```
+
+
+Formato file Vsdm di MS Visio che consente macro.
+
+### VSDX {#VSDX}
+```
+public static final int VSDX
+```
+
+
+Formato file Vsdx di MS Visio 2013.
+
+### VSSM {#VSSM}
+```
+public static final int VSSM
+```
+
+
+Formato file Vssm di MS Visio che consente macro.
+
+### VSSX {#VSSX}
+```
+public static final int VSSX
+```
+
+
+Formato file Vssx di MS Visio 2013
+
+### VSTM {#VSTM}
+```
+public static final int VSTM
+```
+
+
+Formato file Vstm di MS Visio che consente macro.
+
+### VSTX {#VSTX}
+```
+public static final int VSTX
+```
+
+
+Formato file Vstx di MS Visio 2013, file modello.
+
+### VSX {#VSX}
+```
+public static final int VSX
+```
+
+
+Formato stencil xml Vsx di MS Visio.
+
+### VTX {#VTX}
+```
+public static final int VTX
+```
+
+
+Formato modello xml Vst di MS Visio.
+
+### XAML {#XAML}
+```
+public static final int XAML
+```
+
+
+Formato Xaml.
+
+### XPS {#XPS}
+```
+public static final int XPS
+```
+
+
+Formato Xps.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/saveoptions/_index.md
+++ b/italian/java/com.aspose.diagram/saveoptions/_index.md
@@ -1,0 +1,216 @@
+---
+title: SaveOptions
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Questa è una classe base astratta per le classi che consentono all'utente di specificare opzioni aggiuntive quando si salva un diagramma in un formato specifico.
+type: docs
+weight: 349
+url: /it/java/com.aspose.diagram/saveoptions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public abstract class SaveOptions
+```
+
+Questa è una classe base astratta per le classi che consentono all'utente di specificare opzioni aggiuntive durante il salvataggio di un diagramma in un formato particolare. Un'istanza della classe SaveOptions o di qualsiasi classe derivata viene passata ai sovraccarichi di Save (stream) o Save (stringa) affinché l'utente possa definire opzioni personalizzate durante il salvataggio di un documento.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | Crea un oggetto di opzioni di salvataggio di una classe adatta al formato di salvataggio specificato. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDefaultFont()](#getDefaultFont--) | Quando i caratteri nel diagramma sono Unicode e non vengono impostati con il valore di carattere corretto o il carattere non è installato localmente, possono apparire come blocchi in PDF, immagine o XPS. |
+| [getSaveFormat()](#getSaveFormat--) | Specifica il formato in cui il documento verrà salvato se viene utilizzato questo oggetto di opzioni di salvataggio. |
+| [getWarningCallback()](#getWarningCallback--) | callback di avviso. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--) |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | Per la descrizione di questa proprietà, vedere [getSaveFormat()](../../com.aspose.diagram/saveoptions\#getSaveFormat--) |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+Crea un oggetto di opzioni di salvataggio di una classe adatta al formato di salvataggio specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| saveFormat | int | Il Aspose.Diagram.SaveFileFormat per il quale creare un oggetto di opzioni di salvataggio. |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+Quando i caratteri nel diagramma sono Unicode e non sono impostati con il valore di font corretto o il font non è installato localmente, possono apparire come blocchi in PDF, immagine o XPS. Impostare il DefaultFont, ad esempio MingLiu o MS Gothic, per visualizzare questi caratteri.
+
+**Returns:**
+java.lang.String
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+Specifica il formato in cui il documento verrà salvato se viene utilizzato questo oggetto di opzioni di salvataggio.
+
+**Returns:**
+int
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+callback di avviso.
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getSaveFormat()](../../com.aspose.diagram/saveoptions\#getSaveFormat--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/scratch/_index.md
+++ b/italian/java/com.aspose.diagram/scratch/_index.md
@@ -1,0 +1,349 @@
+---
+title: Scratch
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene un'area di lavoro per inserire e testare formule a cui fanno riferimento altri elementi.
+type: docs
+weight: 350
+url: /it/java/com.aspose.diagram/scratch/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Scratch
+```
+
+Contiene un'area di lavoro per inserire e testare formule a cui si fa riferimento da altri elementi. Questo elemento è tipicamente usato per isolare calcoli complessi ripetuti.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [Scratch()](#Scratch--) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | Un elemento di uso generale. |
+| [getB()](#getB--) | Un elemento scratch di uso generale. |
+| [getC()](#getC--) | Un elemento di uso generale. |
+| [getClass()](#getClass--) |  |
+| [getD()](#getD--) | Un elemento di uso generale. |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getIX()](#getIX--) | L'indice basato su zero dell'elemento all'interno del suo elemento genitore. |
+| [getX()](#getX--) | Specifica una coordinata x su una forma in coordinate locali. |
+| [getY()](#getY--) | Specifica una coordinata y su una forma in coordinate locali. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(Value value)](#setA-com.aspose.diagram.Value-) | Per la descrizione di questa proprietà, vedere [getA()](../../com.aspose.diagram/scratch\#getA--) |
+| [setB(Value value)](#setB-com.aspose.diagram.Value-) | Per la descrizione di questa proprietà, consultare [getB()](../../com.aspose.diagram/scratch\#getB--) |
+| [setC(Value value)](#setC-com.aspose.diagram.Value-) | Per la descrizione di questa proprietà, consultare [getC()](../../com.aspose.diagram/scratch\#getC--) |
+| [setD(Value value)](#setD-com.aspose.diagram.Value-) | Per la descrizione di questa proprietà, consultare [getD()](../../com.aspose.diagram/scratch\#getD--) |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, consultare [getDel()](../../com.aspose.diagram/scratch\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Per la descrizione di questa proprietà, consultare [getIX()](../../com.aspose.diagram/scratch\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, consultare [getX()](../../com.aspose.diagram/scratch\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, consultare [getY()](../../com.aspose.diagram/scratch\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Scratch() {#Scratch--}
+```
+public Scratch()
+```
+
+
+Costruttore.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public Value getA()
+```
+
+
+Un elemento di uso generale.
+
+**Returns:**
+[Value](../../com.aspose.diagram/value)
+### getB() {#getB--}
+```
+public Value getB()
+```
+
+
+Un elemento scratch di uso generale.
+
+**Returns:**
+[Value](../../com.aspose.diagram/value)
+### getC() {#getC--}
+```
+public Value getC()
+```
+
+
+Un elemento di uso generale.
+
+**Returns:**
+[Value](../../com.aspose.diagram/value)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getD() {#getD--}
+```
+public Value getD()
+```
+
+
+Un elemento di uso generale.
+
+**Returns:**
+[Value](../../com.aspose.diagram/value)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+L'indice basato su zero dell'elemento all'interno del suo elemento genitore.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+Specifica una coordinata x su una forma in coordinate locali. La tabella seguente descrive l'elemento X in base all'elemento che lo contiene.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+Specifica una coordinata y su una forma in coordinate locali. Le coordinate locali sono quelle il cui riferimento è la forma, anziché la pagina.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(Value value) {#setA-com.aspose.diagram.Value-}
+```
+public void setA(Value value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getA()](../../com.aspose.diagram/scratch\#getA--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [Value](../../com.aspose.diagram/value) |  |
+
+### setB(Value value) {#setB-com.aspose.diagram.Value-}
+```
+public void setB(Value value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getB()](../../com.aspose.diagram/scratch\#getB--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [Value](../../com.aspose.diagram/value) |  |
+
+### setC(Value value) {#setC-com.aspose.diagram.Value-}
+```
+public void setC(Value value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getC()](../../com.aspose.diagram/scratch\#getC--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [Value](../../com.aspose.diagram/value) |  |
+
+### setD(Value value) {#setD-com.aspose.diagram.Value-}
+```
+public void setD(Value value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getD()](../../com.aspose.diagram/scratch\#getD--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [Value](../../com.aspose.diagram/value) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getDel()](../../com.aspose.diagram/scratch\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getIX()](../../com.aspose.diagram/scratch\#getIX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getX()](../../com.aspose.diagram/scratch\#getX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getY()](../../com.aspose.diagram/scratch\#getY--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/scratchcollection/_index.md
+++ b/italian/java/com.aspose.diagram/scratchcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: ScratchCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Raccolta Scratch.
+type: docs
+weight: 351
+url: /it/java/com.aspose.diagram/scratchcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ScratchCollection extends Collection
+```
+
+Raccolta Scratch.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [add(Scratch item)](#add-com.aspose.diagram.Scratch-) | Aggiungi l'oggetto Scratch nella collezione. |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Scratch item)](#remove-com.aspose.diagram.Scratch-) | Rimuovi l'oggetto Scratch dalla collezione. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Scratch item) {#add-com.aspose.diagram.Scratch-}
+```
+public int add(Scratch item)
+```
+
+
+Aggiungi l'oggetto Scratch nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [Scratch](../../com.aspose.diagram/scratch) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Scratch get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[Scratch](../../com.aspose.diagram/scratch) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Scratch item) {#remove-com.aspose.diagram.Scratch-}
+```
+public void remove(Scratch item)
+```
+
+
+Rimuovi l'oggetto Scratch dalla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [Scratch](../../com.aspose.diagram/scratch) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/scrollbaractivexcontrol/_index.md
+++ b/italian/java/com.aspose.diagram/scrollbaractivexcontrol/_index.md
@@ -1,0 +1,572 @@
+---
+title: ScrollBarActiveXControl
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta il controllo ScrollBar.
+type: docs
+weight: 352
+url: /it/java/com.aspose.diagram/scrollbaractivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol), [com.aspose.diagram.SpinButtonActiveXControl](../../com.aspose.diagram/spinbuttonactivexcontrol)
+```
+public class ScrollBarActiveXControl extends SpinButtonActiveXControl
+```
+
+Rappresenta il controllo ScrollBar.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBackOleColor()](#getBackOleColor--) | il colore OLE dello sfondo. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | i dati binari del controllo. |
+| [getForeOleColor()](#getForeOleColor--) | il colore OLE del primo piano. |
+| [getHeight()](#getHeight--) | l'altezza del controllo in unità di punti. |
+| [getIMEMode()](#getIMEMode--) | la modalità di esecuzione predefinita dell'Input Method Editor per il controllo quando riceve il fuoco. |
+| [getLargeChange()](#getLargeChange--) | la quantità di cui la proprietà Position cambia |
+| [getMax()](#getMax--) | il valore massimo accettabile. |
+| [getMin()](#getMin--) | il valore minimo accettabile. |
+| [getMouseIcon()](#getMouseIcon--) | un'icona personalizzata da visualizzare come puntatore del mouse per il controllo. |
+| [getMousePointer()](#getMousePointer--) | il tipo di icona visualizzata come puntatore del mouse per il controllo. |
+| [getOrientation()](#getOrientation--) | se il SpinButton o lo ScrollBar è orientato verticalmente o orizzontalmente. |
+| [getPosition()](#getPosition--) | il valore. |
+| [getSmallChange()](#getSmallChange--) | la quantità di cui la proprietà Position cambia |
+| [getType()](#getType--) | Ottiene il tipo del controllo ActiveX. |
+| [getWidth()](#getWidth--) | la larghezza del controllo in unità di punti. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | Indica se il controllo ridimensionerà automaticamente per visualizzare tutto il contenuto. |
+| [isEnabled()](#isEnabled--) | Indica se il controllo può ricevere il focus e rispondere agli eventi generati dall'utente. |
+| [isLocked()](#isLocked--) | Indica se i dati nel controllo sono bloccati per la modifica. |
+| [isTransparent()](#isTransparent--) | Indica se il controllo è trasparente. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | Per la descrizione di questa proprietà, vedere [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | Per la descrizione di questa proprietà, vedere [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | Per la descrizione di questa proprietà, vedere [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | Per la descrizione di questa proprietà, vedere [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setHeight(double value)](#setHeight-double-) | Per la descrizione di questa proprietà, vedere [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setIMEMode(int value)](#setIMEMode-int-) | Per la descrizione di questa proprietà, vedere [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) |
+| [setLargeChange(int value)](#setLargeChange-int-) | Per la descrizione di questa proprietà, consultare [getLargeChange()](../../com.aspose.diagram/scrollbaractivexcontrol\\#getLargeChange--) |
+| [setLocked(boolean value)](#setLocked-boolean-) | Per la descrizione di questa proprietà, vedere [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) |
+| [setMax(int value)](#setMax-int-) | Per la descrizione di questa proprietà, consultare [getMax()](../../com.aspose.diagram/spinbuttonactivexcontrol\\#getMax--) |
+| [setMin(int value)](#setMin-int-) | Per la descrizione di questa proprietà, consultare [getMin()](../../com.aspose.diagram/spinbuttonactivexcontrol\\#getMin--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | Per la descrizione di questa proprietà, vedere [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | Per la descrizione di questa proprietà, vedere [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setOrientation(int value)](#setOrientation-int-) | Per la descrizione di questa proprietà, consultare [getOrientation()](../../com.aspose.diagram/spinbuttonactivexcontrol\\#getOrientation--) |
+| [setPosition(int value)](#setPosition-int-) | Per la descrizione di questa proprietà, consultare [getPosition()](../../com.aspose.diagram/spinbuttonactivexcontrol\\#getPosition--) |
+| [setSmallChange(int value)](#setSmallChange-int-) | Per la descrizione di questa proprietà, consultare [getSmallChange()](../../com.aspose.diagram/spinbuttonactivexcontrol\\#getSmallChange--) |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | Per la descrizione di questa proprietà, vedere [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) |
+| [setWidth(double value)](#setWidth-double-) | Per la descrizione di questa proprietà, vedere [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+il colore OLE dello sfondo.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+i dati binari del controllo.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+Il colore OLE del primo piano. Non si applica al controllo Image.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+l'altezza del controllo in unità di punti.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+la modalità di esecuzione predefinita dell'Input Method Editor per il controllo quando riceve il fuoco.
+
+**Returns:**
+int
+### getLargeChange() {#getLargeChange--}
+```
+public int getLargeChange()
+```
+
+
+la quantità di cui la proprietà Position cambia
+
+**Returns:**
+int
+### getMax() {#getMax--}
+```
+public int getMax()
+```
+
+
+il valore massimo accettabile.
+
+**Returns:**
+int
+### getMin() {#getMin--}
+```
+public int getMin()
+```
+
+
+il valore minimo accettabile.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+un'icona personalizzata da visualizzare come puntatore del mouse per il controllo.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+il tipo di icona visualizzata come puntatore del mouse per il controllo.
+
+**Returns:**
+int
+### getOrientation() {#getOrientation--}
+```
+public int getOrientation()
+```
+
+
+se il SpinButton o lo ScrollBar è orientato verticalmente o orizzontalmente.
+
+**Returns:**
+int
+### getPosition() {#getPosition--}
+```
+public int getPosition()
+```
+
+
+il valore.
+
+**Returns:**
+int
+### getSmallChange() {#getSmallChange--}
+```
+public int getSmallChange()
+```
+
+
+la quantità di cui la proprietà Position cambia
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Ottiene il tipo del controllo ActiveX.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+la larghezza del controllo in unità di punti.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+Indica se il controllo ridimensionerà automaticamente per visualizzare tutto il contenuto.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+Indica se il controllo può ricevere il focus e rispondere agli eventi generati dall'utente.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+Indica se i dati nel controllo sono bloccati per la modifica.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+Indica se il controllo è trasparente.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setLargeChange(int value) {#setLargeChange-int-}
+```
+public void setLargeChange(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getLargeChange()](../../com.aspose.diagram/scrollbaractivexcontrol\\#getLargeChange--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setMax(int value) {#setMax-int-}
+```
+public void setMax(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getMax()](../../com.aspose.diagram/spinbuttonactivexcontrol\\#getMax--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setMin(int value) {#setMin-int-}
+```
+public void setMin(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getMin()](../../com.aspose.diagram/spinbuttonactivexcontrol\\#getMin--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setOrientation(int value) {#setOrientation-int-}
+```
+public void setOrientation(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getOrientation()](../../com.aspose.diagram/spinbuttonactivexcontrol\\#getOrientation--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setPosition(int value) {#setPosition-int-}
+```
+public void setPosition(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getPosition()](../../com.aspose.diagram/spinbuttonactivexcontrol\\#getPosition--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setSmallChange(int value) {#setSmallChange-int-}
+```
+public void setSmallChange(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getSmallChange()](../../com.aspose.diagram/spinbuttonactivexcontrol\\#getSmallChange--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/selectmode/_index.md
+++ b/italian/java/com.aspose.diagram/selectmode/_index.md
@@ -1,0 +1,179 @@
+---
+title: SelectMode
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica come l'utente seleziona una forma di gruppo e i suoi membri.
+type: docs
+weight: 353
+url: /it/java/com.aspose.diagram/selectmode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class SelectMode
+```
+
+Specifica come l'utente seleziona una forma di gruppo e i suoi membri.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [SelectMode(int value)](#SelectMode-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Specifica come l'utente seleziona una forma di gruppo e i suoi membri. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/selectmode\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SelectMode(int value) {#SelectMode-int-}
+```
+public SelectMode(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specifica come l'utente seleziona una forma di gruppo e i suoi membri.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/selectmode\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/selectmodevalue/_index.md
+++ b/italian/java/com.aspose.diagram/selectmodevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: SelectModeValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica come l'utente seleziona una forma di gruppo e i suoi membri.
+type: docs
+weight: 354
+url: /it/java/com.aspose.diagram/selectmodevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class SelectModeValue
+```
+
+Specifica come l'utente seleziona una forma di gruppo e i suoi membri.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [GROUP_SHAPE_FIRST](#GROUP-SHAPE-FIRST) | Seleziona prima la forma del gruppo. |
+| [GROUP_SHAPE_ONLY](#GROUP-SHAPE-ONLY) | Seleziona solo la forma del gruppo. |
+| [MEMBERS_GROUP_FIRST](#MEMBERS-GROUP-FIRST) | Seleziona prima i membri del gruppo. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GROUP_SHAPE_FIRST {#GROUP-SHAPE-FIRST}
+```
+public static final int GROUP_SHAPE_FIRST
+```
+
+
+Seleziona prima la forma del gruppo.
+
+### GROUP_SHAPE_ONLY {#GROUP-SHAPE-ONLY}
+```
+public static final int GROUP_SHAPE_ONLY
+```
+
+
+Seleziona solo la forma del gruppo.
+
+### MEMBERS_GROUP_FIRST {#MEMBERS-GROUP-FIRST}
+```
+public static final int MEMBERS_GROUP_FIRST
+```
+
+
+Seleziona prima i membri del gruppo.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/shape/_index.md
+++ b/italian/java/com.aspose.diagram/shape/_index.md
@@ -1,0 +1,1760 @@
+---
+title: Shape
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene elementi che definiscono una forma in una pagina master o in un elemento forma di gruppo.
+type: docs
+weight: 355
+url: /it/java/com.aspose.diagram/shape/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Shape
+```
+
+Contiene elementi che definiscono una forma in un elemento Master, Pagina o forma di gruppo.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [Shape()](#Shape--) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [bringForward()](#bringForward--) | Sposta la forma in avanti di una posizione nell'ordine Z. |
+| [bringToFront()](#bringToFront--) | Sposta la forma in primo piano nell'ordine Z. |
+| [centerDrawing()](#centerDrawing--) | Centra la forma rispetto all'estensione della pagina |
+| [connectedShapes(int flag, String categoryFilter)](#connectedShapes-int-java.lang.String-) | Restituisce un array che contiene gli identificatori (ID) delle forme collegate alla forma. |
+| [copy(Shape source)](#copy-com.aspose.diagram.Shape-) |  |
+| [dependsOnShapes()](#dependsOnShapes--) | Restituisce un array che contiene gli identificatori delle forme che dipendono da una forma. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getActiveXControl()](#getActiveXControl--) | Ottiene il controllo ActiveX. |
+| [getActs()](#getActs--) | Contiene una raccolta di elementi Act. |
+| [getAlign()](#getAlign--) | Indica l'allineamento di una forma rispetto alla guida o al punto guida a cui la forma è incollata. |
+| [getChars()](#getChars--) | Contiene una raccolta di elementi Char. |
+| [getClass()](#getClass--) |  |
+| [getClippingPath()](#getClippingPath--) |  |
+| [getConnectionABCDs()](#getConnectionABCDs--) | Contiene una raccolta di elementi ConnectionABCD. |
+| [getConnections()](#getConnections--) | Contiene una raccolta di elementi Connection. |
+| [getConnectorRule()](#getConnectorRule--) | Restituisce un connectorRule che contiene l'ID della forma e la connessione collegata alla forma. |
+| [getConnectorsType()](#getConnectorsType--) | Ottieni il tipo di connettori |
+| [getControlData()](#getControlData--) | Ottiene i dati del controllo. |
+| [getControls()](#getControls--) | Contiene una raccolta di elementi Control. |
+| [getData1()](#getData1--) | Contiene un valore stringa arbitrario utilizzato per fornire informazioni aggiuntive su una forma. |
+| [getData2()](#getData2--) | Contiene un valore stringa arbitrario utilizzato per fornire informazioni aggiuntive su una forma. |
+| [getData3()](#getData3--) | Contiene un valore stringa arbitrario utilizzato per fornire informazioni aggiuntive su una forma. |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getDiagram()](#getDiagram--) | Elemento radice della gerarchia degli oggetti Visio. |
+| [getDisplayText()](#getDisplayText--) | Ottieni il testo visualizzato sull'interfaccia |
+| [getEvent()](#getEvent--) | Contiene elementi che specificano formule che controllano gli eventi della forma. |
+| [getFields()](#getFields--) | Contiene una raccolta di elementi Field. |
+| [getFill()](#getFill--) | Contiene i valori di formattazione di riempimento attuali per la forma e l'ombra della forma, inclusi modello, colore di primo piano e colore di sfondo. |
+| [getFillStyle()](#getFillStyle--) | Foglio di stile da cui questa forma eredita la formattazione di riempimento. |
+| [getForeign()](#getForeign--) | Contiene elementi che specificano la larghezza e l'altezza di un oggetto proveniente da un altro programma utilizzato in un documento Microsoft Visio. |
+| [getForeignData()](#getForeignData--) | Contiene un BLOB codificato MIME (Multipurpose Internet Mail Extensions) di dati immagine, come metafile Windows, bitmap o dati OLE. |
+| [getGeoms()](#getGeoms--) | Contiene una raccolta di elementi Geom. |
+| [getGroup()](#getGroup--) | Contiene gli elementi che controllano come aggiungere forme a un gruppo, spostare i membri di un gruppo e selezionare i gruppi. |
+| [getHelp()](#getHelp--) | Contiene gli elementi che specificano l'argomento del file di aiuto dell'elemento Shape e le informazioni sul copyright. |
+| [getHyperlinks()](#getHyperlinks--) | Contiene una raccolta di elementi Hyperlink. |
+| [getID()](#getID--) | L'ID univoco dell'elemento all'interno del suo elemento genitore. |
+| [getImage()](#getImage--) | Contiene i valori di gamma, luminosità, contrasto, sfocatura, nitidezza, riduzione del rumore e trasparenza per un bitmap. |
+| [getInheritChars()](#getInheritChars--) | Contiene i valori char per la forma ereditati dalla forma master. |
+| [getInheritFill()](#getInheritFill--) | Contiene i valori di formattazione di riempimento per la forma ereditati dallo stile genitore e dalla forma master. |
+| [getInheritGeoms()](#getInheritGeoms--) | Contiene i valori Geoms per la forma ereditata dalla forma master. |
+| [getInheritLine()](#getInheritLine--) | Contiene i valori di formattazione delle linee per la forma ereditata dallo stile genitore e dalla forma master. |
+| [getInheritParas()](#getInheritParas--) | Contiene i paras per la forma ereditata dallo stile genitore e dalla forma master. |
+| [getInheritProps()](#getInheritProps--) | Contiene le props per la forma ereditata dalla forma master. |
+| [getInheritTextBlock()](#getInheritTextBlock--) | Contiene i valori del blocco di testo per la forma ereditata dallo stile genitore e dalla forma master. |
+| [getInheritUsers()](#getInheritUsers--) | Contiene gli utenti per la forma ereditata dalla forma master. |
+| [getLayerMem()](#getLayerMem--) | Contiene l'elemento LayerMember, che specifica ogni livello a cui la forma è assegnata. |
+| [getLayout()](#getLayout--) | Contiene elementi che controllano il posizionamento delle forme e le impostazioni di instradamento dei connettori. |
+| [getLine()](#getLine--) | Contiene elementi che controllano gli attributi di linea per una forma, come modello, spessore e colore. |
+| [getLineStyle()](#getLineStyle--) | Foglio di stile da cui questa forma eredita la formattazione delle linee |
+| [getMaster()](#getMaster--) | Il master da cui la forma eredita i suoi dati. |
+| [getMasterShape()](#getMasterShape--) | Questo attributo può essere presente solo nelle forme che sono membri di una forma di gruppo, e il gruppo è un'istanza di un master. |
+| [getMisc()](#getMisc--) | Contiene gli elementi che specificano l'argomento del file di aiuto dell'elemento Shape e le informazioni sul copyright. |
+| [getName()](#getName--) | Il nome dell'elemento. |
+| [getNameU()](#getNameU--) | Il nome universale dell'elemento. |
+| [getOneD()](#getOneD--) | Determina se la forma si comporta come un oggetto unidimensionale (1-D). |
+| [getPage()](#getPage--) | Elemento radice della gerarchia degli oggetti Visio. |
+| [getParas()](#getParas--) | Contiene una raccolta di elementi Para. |
+| [getParentShape()](#getParentShape--) | Genitore della forma. |
+| [getProps()](#getProps--) | Contiene una raccolta di elementi Prop. |
+| [getProtection()](#getProtection--) | Il blocco aiuta a prevenire modifiche involontarie alla forma ma non impedisce a Microsoft Visio di ripristinare i valori in altre circostanze. |
+| [getPureText()](#getPureText--) | Ottieni la stringa di testo |
+| [getRootShape()](#getRootShape--) | Restituisce la forma di livello superiore di un'istanza se questa forma fa parte di un'istanza master. |
+| [getScratchs()](#getScratchs--) | Contiene una raccolta di elementi Scratch. |
+| [getShapes()](#getShapes--) | Contiene una collezione di elementi Shape. |
+| [getSmartTagDefs()](#getSmartTagDefs--) | Contiene una raccolta di elementi SmartTagDef. |
+| [getTabsCollection()](#getTabsCollection--) | Contiene una raccolta di elementi Tab. |
+| [getText()](#getText--) | Contiene il testo di una forma. |
+| [getTextBlock()](#getTextBlock--) | Contiene elementi che specificano l'allineamento, i margini e le posizioni predefinite delle tabulazioni del testo nel blocco di testo di una forma. |
+| [getTextStyle()](#getTextStyle--) | Foglio di stile da cui questa forma eredita la formattazione del testo. |
+| [getTextXForm()](#getTextXForm--) | Contiene elementi che specificano le informazioni di posizionamento del blocco di testo di una forma. |
+| [getThreeDFormat()](#getThreeDFormat--) | Ottiene il ThreeDFormat. |
+| [getTwoD()](#getTwoD--) | Determina se la forma si comporta come un oggetto bidimensionale (2-D). |
+| [getType()](#getType--) | Il tipo di una forma. |
+| [getUniqueID()](#getUniqueID--) | Un GUID (identificatore unico globale) assegnato alla forma. |
+| [getUsers()](#getUsers--) | Contiene una raccolta di elementi Utente. |
+| [getXForm()](#getXForm--) | Contiene elementi che specificano informazioni generali di posizionamento su una forma. |
+| [getXForm1D()](#getXForm1D--) | Contiene le coordinate x e y del punto iniziale e del punto finale di una forma 1-D. |
+| [getZOrderIndex()](#getZOrderIndex--) | Restituisce l'indice di una forma nell'ordine Z, esclusa la forma guida. |
+| [gluedShapes(int flag, String categoryFilter, Shape otherShape)](#gluedShapes-int-java.lang.String-com.aspose.diagram.Shape-) | Restituisce un array che contiene gli identificatori delle forme incollate a una forma. |
+| [hashCode()](#hashCode--) |  |
+| [isConnected(Shape shape)](#isConnected-com.aspose.diagram.Shape-) | Indica se queste due forme sono connesse. |
+| [isContain(Shape shape)](#isContain-com.aspose.diagram.Shape-) | Indica se questa forma contiene un'altra forma. |
+| [isGlued(Shape shape)](#isGlued-com.aspose.diagram.Shape-) | Indica se queste due forme sono incollate. |
+| [isInGroup()](#isInGroup--) | Indica se questa forma è in una forma di gruppo. |
+| [isIntersect(Shape shape)](#isIntersect-com.aspose.diagram.Shape-) | Indica se questa forma interseca un'altra forma. |
+| [isTextEmpty()](#isTextEmpty--) | Indica se la forma contiene testo e se il testo è vuoto o meno. |
+| [move(double dX, double dY)](#move-double-double-) | Sposta la forma di dX e dY pollici dalla posizione corrente. |
+| [moveTo(double newPinX, double newPinY)](#moveTo-double-double-) | Sposta la forma a una nuova posizione assoluta nella pagina. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [refreshData()](#refreshData--) | Aggiorna la posizione della forma includendo xform, connection e geom quando si modifica il testo della forma o di altri. |
+| [replaceText(String text, String replaceText)](#replaceText-java.lang.String-java.lang.String-) | Sostituisce la stringa di testo di una forma. |
+| [sendBackward()](#sendBackward--) | Sposta la forma indietro di una posizione nell'ordine Z. |
+| [sendToBack()](#sendToBack--) | Sposta la forma in fondo all'ordine Z. |
+| [setAngle(double angle)](#setAngle-double-) | Imposta il nuovo angolo della forma. |
+| [setClippingPath(String value)](#setClippingPath-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getClippingPath()](../../com.aspose.diagram/shape\#getClippingPath--) |
+| [setConnectorsType(int type)](#setConnectorsType-int-) | Imposta il tipo di connettori |
+| [setData1(String value)](#setData1-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getData1()](../../com.aspose.diagram/shape\#getData1--) |
+| [setData2(String value)](#setData2-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getData2()](../../com.aspose.diagram/shape\#getData2--) |
+| [setData3(String value)](#setData3-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getData3()](../../com.aspose.diagram/shape\#getData3--) |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/shape\#getDel--) |
+| [setDiagram(Diagram value)](#setDiagram-com.aspose.diagram.Diagram-) | Per la descrizione di questa proprietà, vedere [getDiagram()](../../com.aspose.diagram/shape\#getDiagram--) |
+| [setEvent(Event value)](#setEvent-com.aspose.diagram.Event-) | Per la descrizione di questa proprietà, vedere [getEvent()](../../com.aspose.diagram/shape\#getEvent--) |
+| [setFillStyle(StyleSheet value)](#setFillStyle-com.aspose.diagram.StyleSheet-) | Per la descrizione di questa proprietà, vedere [getFillStyle()](../../com.aspose.diagram/shape\#getFillStyle--) |
+| [setHeight(double height)](#setHeight-double-) | Imposta la nuova altezza della forma. |
+| [setID(long value)](#setID-long-) | Per la descrizione di questa proprietà, vedere [getID()](../../com.aspose.diagram/shape\#getID--) |
+| [setLineStyle(StyleSheet value)](#setLineStyle-com.aspose.diagram.StyleSheet-) | Per la descrizione di questa proprietà, vedere [getLineStyle()](../../com.aspose.diagram/shape\#getLineStyle--) |
+| [setMaster(Master value)](#setMaster-com.aspose.diagram.Master-) | Per la descrizione di questa proprietà, vedere [getMaster()](../../com.aspose.diagram/shape\#getMaster--) |
+| [setMasterShape(Shape value)](#setMasterShape-com.aspose.diagram.Shape-) | Per la descrizione di questa proprietà, vedere [getMasterShape()](../../com.aspose.diagram/shape\#getMasterShape--) |
+| [setName(String value)](#setName-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getName()](../../com.aspose.diagram/shape\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getNameU()](../../com.aspose.diagram/shape\#getNameU--) |
+| [setPage(Page value)](#setPage-com.aspose.diagram.Page-) | Per la descrizione di questa proprietà, vedere [getPage()](../../com.aspose.diagram/shape\#getPage--) |
+| [setParentShape(Shape value)](#setParentShape-com.aspose.diagram.Shape-) | Per la descrizione di questa proprietà, vedere [getParentShape()](../../com.aspose.diagram/shape\#getParentShape--) |
+| [setPresetTheme(int value)](#setPresetTheme-int-) | Applica un tema predefinito a questa forma |
+| [setPresetThemeQuickStyle(int value)](#setPresetThemeQuickStyle-int-) | Applica una variante di tema predefinita quickstyle a questa forma |
+| [setPresetThemeStyleMatrics(int styleIndex, int colorIndex)](#setPresetThemeStyleMatrics-int-int-) | Applica una variante di tema predefinita quickstyle a questa forma, come le opzioni di stili tema nell'elenco a discesa degli stili della forma |
+| [setPresetThemeVariant(int value)](#setPresetThemeVariant-int-) | Applica una variante di tema predefinita a questa forma |
+| [setProps(PropCollection value)](#setProps-com.aspose.diagram.PropCollection-) | Per la descrizione di questa proprietà, vedere [getProps()](../../com.aspose.diagram/shape\#getProps--) |
+| [setText(Text value)](#setText-com.aspose.diagram.Text-) | Per la descrizione di questa proprietà, vedere [getText()](../../com.aspose.diagram/shape\#getText--) |
+| [setTextStyle(StyleSheet value)](#setTextStyle-com.aspose.diagram.StyleSheet-) | Per la descrizione di questa proprietà, vedere [getTextStyle()](../../com.aspose.diagram/shape\#getTextStyle--) |
+| [setTwoD(boolean value)](#setTwoD-boolean-) | Per la descrizione di questa proprietà, vedere [getTwoD()](../../com.aspose.diagram/shape\#getTwoD--) |
+| [setType(int value)](#setType-int-) | Per la descrizione di questa proprietà, vedere [getType()](../../com.aspose.diagram/shape\#getType--) |
+| [setUniqueID(UUID value)](#setUniqueID-java.util.UUID-) | Per la descrizione di questa proprietà, vedere [getUniqueID()](../../com.aspose.diagram/shape\#getUniqueID--) |
+| [setWidth(double width)](#setWidth-double-) | Imposta la nuova larghezza della forma. |
+| [setXForm(XForm value)](#setXForm-com.aspose.diagram.XForm-) | Per la descrizione di questa proprietà, vedere [getXForm()](../../com.aspose.diagram/shape\#getXForm--) |
+| [setXForm1D(XForm1D value)](#setXForm1D-com.aspose.diagram.XForm1D-) | Per la descrizione di questa proprietà, vedere [getXForm1D()](../../com.aspose.diagram/shape\#getXForm1D--) |
+| [toHTML(InputStream stream, HTMLSaveOptions options)](#toHTML-java.io.InputStream-com.aspose.diagram.HTMLSaveOptions-) | Crea l'html della forma e lo salva in uno stream nel formato specificato. |
+| [toHTML(OutputStream stream, HTMLSaveOptions options)](#toHTML-java.io.OutputStream-com.aspose.diagram.HTMLSaveOptions-) | Crea l'html della forma e lo salva in uno stream nel formato specificato. |
+| [toHTML(String fileName, HTMLSaveOptions options)](#toHTML-java.lang.String-com.aspose.diagram.HTMLSaveOptions-) | Crea l'html e lo salva in un file. |
+| [toImage(InputStream stream, ImageSaveOptions options)](#toImage-java.io.InputStream-com.aspose.diagram.ImageSaveOptions-) | Crea l'immagine della forma e la salva in uno stream nel formato specificato. |
+| [toImage(OutputStream stream, ImageSaveOptions options)](#toImage-java.io.OutputStream-com.aspose.diagram.ImageSaveOptions-) | Crea l'immagine della forma e la salva in uno stream nel formato specificato. |
+| [toImage(String imageFile, ImageSaveOptions options)](#toImage-java.lang.String-com.aspose.diagram.ImageSaveOptions-) | Crea l'immagine della forma e la salva in un file. |
+| [toPdf(InputStream stream)](#toPdf-java.io.InputStream-) | Crea il pdf della forma e lo salva in uno stream. |
+| [toPdf(OutputStream stream)](#toPdf-java.io.OutputStream-) | Crea il pdf della forma e lo salva in uno stream. |
+| [toPdf(String fileName)](#toPdf-java.lang.String-) | Salva la forma in un file pdf. |
+| [toString()](#toString--) |  |
+| [toSvg(String imageFile, SVGSaveOptions options)](#toSvg-java.lang.String-com.aspose.diagram.SVGSaveOptions-) | Salva la forma in un file svg. |
+| [ungroup()](#ungroup--) | Separa forma |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Shape() {#Shape--}
+```
+public Shape()
+```
+
+
+Costruttore.
+
+### bringForward() {#bringForward--}
+```
+public void bringForward()
+```
+
+
+Sposta la forma in avanti di una posizione nell'ordine Z.
+
+### bringToFront() {#bringToFront--}
+```
+public void bringToFront()
+```
+
+
+Sposta la forma in primo piano nell'ordine Z.
+
+### centerDrawing() {#centerDrawing--}
+```
+public void centerDrawing()
+```
+
+
+Centra la forma rispetto all'estensione della pagina
+
+### connectedShapes(int flag, String categoryFilter) {#connectedShapes-int-java.lang.String-}
+```
+public long[] connectedShapes(int flag, String categoryFilter)
+```
+
+
+Restituisce un array che contiene gli identificatori (ID) delle forme collegate alla forma.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| flag | int | Filtra l'array di ID di forma restituiti in base alla direzionalità dei connettori. Vedere le Osservazioni per i valori possibili Aspose.Diagram.ConnectedShapesFlags. |
+| categoryFilter | java.lang.String | Filtra l'array di ID di forma restituiti limitandolo agli ID delle forme che corrispondono alla categoryString specificata. |
+
+**Returns:**
+long[] - array di ID long.
+### copy(Shape source) {#copy-com.aspose.diagram.Shape-}
+```
+public void copy(Shape source)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| source | [Shape](../../com.aspose.diagram/shape) |  |
+
+### dependsOnShapes() {#dependsOnShapes--}
+```
+public long[] dependsOnShapes()
+```
+
+
+Restituisce un array che contiene gli identificatori delle forme che dipendono da una forma.
+
+**Returns:**
+long[] - array di ID long.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getActiveXControl() {#getActiveXControl--}
+```
+public ActiveXControl getActiveXControl()
+```
+
+
+Ottiene il controllo ActiveX.
+
+**Returns:**
+[ActiveXControl](../../com.aspose.diagram/activexcontrol)
+### getActs() {#getActs--}
+```
+public ActCollection getActs()
+```
+
+
+Contiene una raccolta di elementi Act.
+
+**Returns:**
+[ActCollection](../../com.aspose.diagram/actcollection)
+### getAlign() {#getAlign--}
+```
+public Align getAlign()
+```
+
+
+Indica l'allineamento di una forma rispetto alla guida o al punto guida a cui la forma è incollata. L'elemento Align appare solo per le forme che sono incollate a guide o punti guida.
+
+**Returns:**
+[Align](../../com.aspose.diagram/align)
+### getChars() {#getChars--}
+```
+public CharCollection getChars()
+```
+
+
+Contiene una raccolta di elementi Char.
+
+**Returns:**
+[CharCollection](../../com.aspose.diagram/charcollection)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getClippingPath() {#getClippingPath--}
+```
+public String getClippingPath()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getConnectionABCDs() {#getConnectionABCDs--}
+```
+public ConnectionABCDCollection getConnectionABCDs()
+```
+
+
+Contiene una raccolta di elementi ConnectionABCD.
+
+**Returns:**
+[ConnectionABCDCollection](../../com.aspose.diagram/connectionabcdcollection)
+### getConnections() {#getConnections--}
+```
+public ConnectionCollection getConnections()
+```
+
+
+Contiene una raccolta di elementi Connection.
+
+**Returns:**
+[ConnectionCollection](../../com.aspose.diagram/connectioncollection)
+### getConnectorRule() {#getConnectorRule--}
+```
+public ConnectorRule getConnectorRule()
+```
+
+
+Restituisce un connectorRule che contiene l'ID della forma e la connessione collegata alla forma.
+
+**Returns:**
+[ConnectorRule](../../com.aspose.diagram/connectorrule) - ConnectorRule.
+### getConnectorsType() {#getConnectorsType--}
+```
+public int getConnectorsType()
+```
+
+
+Ottieni il tipo di connettori
+
+**Returns:**
+int
+### getControlData() {#getControlData--}
+```
+public byte[] getControlData()
+```
+
+
+Ottiene i dati del controllo.
+
+**Returns:**
+byte[]
+### getControls() {#getControls--}
+```
+public ControlCollection getControls()
+```
+
+
+Contiene una raccolta di elementi Control.
+
+**Returns:**
+[ControlCollection](../../com.aspose.diagram/controlcollection)
+### getData1() {#getData1--}
+```
+public String getData1()
+```
+
+
+Contiene un valore stringa arbitrario utilizzato per fornire informazioni aggiuntive su una forma.
+
+**Returns:**
+java.lang.String
+### getData2() {#getData2--}
+```
+public String getData2()
+```
+
+
+Contiene un valore stringa arbitrario utilizzato per fornire informazioni aggiuntive su una forma.
+
+**Returns:**
+java.lang.String
+### getData3() {#getData3--}
+```
+public String getData3()
+```
+
+
+Contiene un valore stringa arbitrario utilizzato per fornire informazioni aggiuntive su una forma.
+
+**Returns:**
+java.lang.String
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è eliminato localmente. Un valore di 1 indica che l'elemento è eliminato localmente.
+
+**Returns:**
+int
+### getDiagram() {#getDiagram--}
+```
+public Diagram getDiagram()
+```
+
+
+Elemento radice della gerarchia degli oggetti Visio.
+
+**Returns:**
+[Diagram](../../com.aspose.diagram/diagram)
+### getDisplayText() {#getDisplayText--}
+```
+public String getDisplayText()
+```
+
+
+Ottieni il testo visualizzato sull'interfaccia
+
+**Returns:**
+java.lang.String
+### getEvent() {#getEvent--}
+```
+public Event getEvent()
+```
+
+
+Contiene elementi che specificano formule che controllano gli eventi della forma.
+
+**Returns:**
+[Event](../../com.aspose.diagram/event)
+### getFields() {#getFields--}
+```
+public FieldCollection getFields()
+```
+
+
+Contiene una raccolta di elementi Field.
+
+**Returns:**
+[FieldCollection](../../com.aspose.diagram/fieldcollection)
+### getFill() {#getFill--}
+```
+public Fill getFill()
+```
+
+
+Contiene i valori di formattazione di riempimento attuali per la forma e l'ombra della forma, inclusi modello, colore di primo piano e colore di sfondo.
+
+**Returns:**
+[Fill](../../com.aspose.diagram/fill)
+### getFillStyle() {#getFillStyle--}
+```
+public StyleSheet getFillStyle()
+```
+
+
+Foglio di stile da cui questa forma eredita la formattazione di riempimento.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getForeign() {#getForeign--}
+```
+public Foreign getForeign()
+```
+
+
+Contiene elementi che specificano la larghezza e l'altezza di un oggetto proveniente da un altro programma utilizzato in un documento Microsoft Visio. Include anche elementi che specificano la distanza di offset dell'immagine dell'oggetto all'interno dei suoi bordi.
+
+**Returns:**
+[Foreign](../../com.aspose.diagram/foreign)
+### getForeignData() {#getForeignData--}
+```
+public ForeignData getForeignData()
+```
+
+
+Contiene un BLOB codificato MIME (Multipurpose Internet Mail Extensions) di dati immagine, come metafile Windows, bitmap o dati OLE.
+
+**Returns:**
+[ForeignData](../../com.aspose.diagram/foreigndata)
+### getGeoms() {#getGeoms--}
+```
+public GeomCollection getGeoms()
+```
+
+
+Contiene una raccolta di elementi Geom.
+
+**Returns:**
+[GeomCollection](../../com.aspose.diagram/geomcollection)
+### getGroup() {#getGroup--}
+```
+public Group getGroup()
+```
+
+
+Contiene gli elementi che controllano come aggiungere forme a un gruppo, spostare i membri di un gruppo e selezionare i gruppi.
+
+**Returns:**
+[Group](../../com.aspose.diagram/group)
+### getHelp() {#getHelp--}
+```
+public Help getHelp()
+```
+
+
+Contiene gli elementi che specificano l'argomento del file di aiuto dell'elemento Shape e le informazioni sul copyright.
+
+**Returns:**
+[Help](../../com.aspose.diagram/help)
+### getHyperlinks() {#getHyperlinks--}
+```
+public HyperlinkCollection getHyperlinks()
+```
+
+
+Contiene una raccolta di elementi Hyperlink.
+
+**Returns:**
+[HyperlinkCollection](../../com.aspose.diagram/hyperlinkcollection)
+### getID() {#getID--}
+```
+public long getID()
+```
+
+
+L'ID univoco dell'elemento all'interno del suo elemento genitore.
+
+**Returns:**
+long
+### getImage() {#getImage--}
+```
+public Image getImage()
+```
+
+
+Contiene i valori di gamma, luminosità, contrasto, sfocatura, nitidezza, riduzione del rumore e trasparenza per un bitmap.
+
+**Returns:**
+[Image](../../com.aspose.diagram/image)
+### getInheritChars() {#getInheritChars--}
+```
+public CharCollection getInheritChars()
+```
+
+
+Contiene i valori char per la forma ereditati dalla forma master.
+
+**Returns:**
+[CharCollection](../../com.aspose.diagram/charcollection)
+### getInheritFill() {#getInheritFill--}
+```
+public Fill getInheritFill()
+```
+
+
+Contiene i valori di formattazione di riempimento per la forma ereditati dallo stile genitore e dalla forma master.
+
+**Returns:**
+[Fill](../../com.aspose.diagram/fill)
+### getInheritGeoms() {#getInheritGeoms--}
+```
+public GeomCollection getInheritGeoms()
+```
+
+
+Contiene i valori Geoms per la forma ereditata dalla forma master.
+
+**Returns:**
+[GeomCollection](../../com.aspose.diagram/geomcollection)
+### getInheritLine() {#getInheritLine--}
+```
+public Line getInheritLine()
+```
+
+
+Contiene i valori di formattazione delle linee per la forma ereditata dallo stile genitore e dalla forma master.
+
+**Returns:**
+[Line](../../com.aspose.diagram/line)
+### getInheritParas() {#getInheritParas--}
+```
+public ParaCollection getInheritParas()
+```
+
+
+Contiene i paras per la forma ereditata dallo stile genitore e dalla forma master.
+
+**Returns:**
+[ParaCollection](../../com.aspose.diagram/paracollection)
+### getInheritProps() {#getInheritProps--}
+```
+public PropCollection getInheritProps()
+```
+
+
+Contiene le props per la forma ereditata dalla forma master.
+
+**Returns:**
+[PropCollection](../../com.aspose.diagram/propcollection)
+### getInheritTextBlock() {#getInheritTextBlock--}
+```
+public TextBlock getInheritTextBlock()
+```
+
+
+Contiene i valori del blocco di testo per la forma ereditata dallo stile genitore e dalla forma master.
+
+**Returns:**
+[TextBlock](../../com.aspose.diagram/textblock)
+### getInheritUsers() {#getInheritUsers--}
+```
+public UserCollection getInheritUsers()
+```
+
+
+Contiene gli utenti per la forma ereditata dalla forma master.
+
+**Returns:**
+[UserCollection](../../com.aspose.diagram/usercollection)
+### getLayerMem() {#getLayerMem--}
+```
+public LayerMem getLayerMem()
+```
+
+
+Contiene l'elemento LayerMember, che specifica ogni livello a cui la forma è assegnata.
+
+**Returns:**
+[LayerMem](../../com.aspose.diagram/layermem)
+### getLayout() {#getLayout--}
+```
+public Layout getLayout()
+```
+
+
+Contiene elementi che controllano il posizionamento delle forme e le impostazioni di instradamento dei connettori.
+
+**Returns:**
+[Layout](../../com.aspose.diagram/layout)
+### getLine() {#getLine--}
+```
+public Line getLine()
+```
+
+
+Contiene elementi che controllano gli attributi della linea per una forma, come modello, spessore e colore. Questi elementi determinano se le estremità della linea sono formattate (ad esempio, con una punta di freccia), la dimensione dei formati delle estremità della linea, il raggio del cerchio di arrotondamento applicato alla linea e lo stile del cappuccio della linea (rotondo o quadrato).
+
+**Returns:**
+[Line](../../com.aspose.diagram/line)
+### getLineStyle() {#getLineStyle--}
+```
+public StyleSheet getLineStyle()
+```
+
+
+Foglio di stile da cui questa forma eredita la formattazione delle linee
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getMaster() {#getMaster--}
+```
+public Master getMaster()
+```
+
+
+Il master da cui la forma eredita i suoi dati.
+
+**Returns:**
+[Master](../../com.aspose.diagram/master)
+### getMasterShape() {#getMasterShape--}
+```
+public Shape getMasterShape()
+```
+
+
+Questo attributo può essere presente solo nelle forme che sono membri di una forma di gruppo, e il gruppo è un'istanza di un master. L'attributo contiene un ID che fa riferimento alla sottoforma corrispondente nel master.
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape)
+### getMisc() {#getMisc--}
+```
+public Misc getMisc()
+```
+
+
+Contiene gli elementi che specificano l'argomento del file di aiuto dell'elemento Shape e le informazioni sul copyright.
+
+**Returns:**
+[Misc](../../com.aspose.diagram/misc)
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Il nome dell'elemento.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+Il nome universale dell'elemento.
+
+**Returns:**
+java.lang.String
+### getOneD() {#getOneD--}
+```
+public boolean getOneD()
+```
+
+
+Determina se la forma si comporta come un oggetto unidimensionale (1-D). Sola lettura.
+
+**Returns:**
+boolean
+### getPage() {#getPage--}
+```
+public Page getPage()
+```
+
+
+Elemento radice della gerarchia degli oggetti Visio.
+
+**Returns:**
+[Page](../../com.aspose.diagram/page)
+### getParas() {#getParas--}
+```
+public ParaCollection getParas()
+```
+
+
+Contiene una raccolta di elementi Para.
+
+**Returns:**
+[ParaCollection](../../com.aspose.diagram/paracollection)
+### getParentShape() {#getParentShape--}
+```
+public Shape getParentShape()
+```
+
+
+Genitore della forma.
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape)
+### getProps() {#getProps--}
+```
+public PropCollection getProps()
+```
+
+
+Contiene una raccolta di elementi Prop.
+
+**Returns:**
+[PropCollection](../../com.aspose.diagram/propcollection)
+### getProtection() {#getProtection--}
+```
+public Protection getProtection()
+```
+
+
+Il blocco aiuta a prevenire modifiche involontarie alla forma ma non impedisce a Microsoft Visio di ripristinare i valori in altre circostanze. Inoltre non protegge dalle modifiche apportate nella finestra ShapeSheet.
+
+**Returns:**
+[Protection](../../com.aspose.diagram/protection)
+### getPureText() {#getPureText--}
+```
+public String getPureText()
+```
+
+
+Ottieni la stringa di testo
+
+**Returns:**
+java.lang.String
+### getRootShape() {#getRootShape--}
+```
+public Shape getRootShape()
+```
+
+
+Restituisce la forma di livello superiore di un'istanza se questa forma fa parte di un'istanza master. Sola lettura.
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape)
+### getScratchs() {#getScratchs--}
+```
+public ScratchCollection getScratchs()
+```
+
+
+Contiene una raccolta di elementi Scratch.
+
+**Returns:**
+[ScratchCollection](../../com.aspose.diagram/scratchcollection)
+### getShapes() {#getShapes--}
+```
+public ShapeCollection getShapes()
+```
+
+
+Contiene una collezione di elementi Shape.
+
+**Returns:**
+[ShapeCollection](../../com.aspose.diagram/shapecollection)
+### getSmartTagDefs() {#getSmartTagDefs--}
+```
+public SmartTagDefCollection getSmartTagDefs()
+```
+
+
+Contiene una raccolta di elementi SmartTagDef.
+
+**Returns:**
+[SmartTagDefCollection](../../com.aspose.diagram/smarttagdefcollection)
+### getTabsCollection() {#getTabsCollection--}
+```
+public TabsCollection getTabsCollection()
+```
+
+
+Contiene una raccolta di elementi Tab.
+
+**Returns:**
+[TabsCollection](../../com.aspose.diagram/tabscollection)
+### getText() {#getText--}
+```
+public Text getText()
+```
+
+
+Contiene il testo di una forma.
+
+**Returns:**
+[Text](../../com.aspose.diagram/text)
+### getTextBlock() {#getTextBlock--}
+```
+public TextBlock getTextBlock()
+```
+
+
+Contiene elementi che specificano l'allineamento, i margini e le posizioni predefinite delle tabulazioni del testo nel blocco di testo di una forma.
+
+**Returns:**
+[TextBlock](../../com.aspose.diagram/textblock)
+### getTextStyle() {#getTextStyle--}
+```
+public StyleSheet getTextStyle()
+```
+
+
+Foglio di stile da cui questa forma eredita la formattazione del testo.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getTextXForm() {#getTextXForm--}
+```
+public TextXForm getTextXForm()
+```
+
+
+Contiene elementi che specificano le informazioni di posizionamento del blocco di testo di una forma.
+
+**Returns:**
+[TextXForm](../../com.aspose.diagram/textxform)
+### getThreeDFormat() {#getThreeDFormat--}
+```
+public ThreeDFormat getThreeDFormat()
+```
+
+
+Ottiene il ThreeDFormat.
+
+**Returns:**
+[ThreeDFormat](../../com.aspose.diagram/threedformat)
+### getTwoD() {#getTwoD--}
+```
+public boolean getTwoD()
+```
+
+
+Determina se la forma si comporta come un oggetto bidimensionale (2-D).
+
+**Returns:**
+boolean
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Il tipo di una forma. Può essere uno dei seguenti valori: Group, Shape, Guide o Foreign.
+
+**Returns:**
+int
+### getUniqueID() {#getUniqueID--}
+```
+public UUID getUniqueID()
+```
+
+
+Un GUID (identificatore unico globale) assegnato alla forma.
+
+**Returns:**
+java.util.UUID
+### getUsers() {#getUsers--}
+```
+public UserCollection getUsers()
+```
+
+
+Contiene una raccolta di elementi Utente.
+
+**Returns:**
+[UserCollection](../../com.aspose.diagram/usercollection)
+### getXForm() {#getXForm--}
+```
+public XForm getXForm()
+```
+
+
+Contiene elementi che specificano informazioni generali di posizionamento su una forma.
+
+**Returns:**
+[XForm](../../com.aspose.diagram/xform)
+### getXForm1D() {#getXForm1D--}
+```
+public XForm1D getXForm1D()
+```
+
+
+Contiene le coordinate x e y del punto iniziale e del punto finale di una forma 1-D. Questo elemento appare solo per forme 1-D.
+
+**Returns:**
+[XForm1D](../../com.aspose.diagram/xform1d)
+### getZOrderIndex() {#getZOrderIndex--}
+```
+public int getZOrderIndex()
+```
+
+
+Restituisce l'indice di una forma nell'ordine Z, esclusa la forma guida.
+
+**Returns:**
+int
+### gluedShapes(int flag, String categoryFilter, Shape otherShape) {#gluedShapes-int-java.lang.String-com.aspose.diagram.Shape-}
+```
+public long[] gluedShapes(int flag, String categoryFilter, Shape otherShape)
+```
+
+
+Restituisce un array che contiene gli identificatori delle forme incollate a una forma.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| flag | int | La dimensionalità e la direzionalità dei punti di connessione delle forme da restituire. Vedi Note per i possibili valori Aspose.Diagram.GluedShapesFlags. |
+| categoryFilter | java.lang.String | Filtra l'array di ID di forma restituiti limitandolo agli ID delle forme che corrispondono alla categoryString specificata. |
+| otherShape | [Shape](../../com.aspose.diagram/shape) | Opzionale: forma aggiuntiva a cui le forme restituite devono anche essere incollate, può essere [Shape](../../com.aspose.diagram/shape) o null. |
+
+**Returns:**
+long[] - array di ID long.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isConnected(Shape shape) {#isConnected-com.aspose.diagram.Shape-}
+```
+public boolean isConnected(Shape shape)
+```
+
+
+Indica se queste due forme sono connesse.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| shape | [Shape](../../com.aspose.diagram/shape) | shape |
+
+**Returns:**
+boolean
+### isContain(Shape shape) {#isContain-com.aspose.diagram.Shape-}
+```
+public boolean isContain(Shape shape)
+```
+
+
+Indica se questa forma contiene un'altra forma.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| shape | [Shape](../../com.aspose.diagram/shape) |  |
+
+**Returns:**
+boolean
+### isGlued(Shape shape) {#isGlued-com.aspose.diagram.Shape-}
+```
+public boolean isGlued(Shape shape)
+```
+
+
+Indica se queste due forme sono incollate.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| shape | [Shape](../../com.aspose.diagram/shape) | shape |
+
+**Returns:**
+boolean
+### isInGroup() {#isInGroup--}
+```
+public boolean isInGroup()
+```
+
+
+Indica se questa forma è in una forma di gruppo.
+
+**Returns:**
+boolean
+### isIntersect(Shape shape) {#isIntersect-com.aspose.diagram.Shape-}
+```
+public boolean isIntersect(Shape shape)
+```
+
+
+Indica se questa forma interseca un'altra forma.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| shape | [Shape](../../com.aspose.diagram/shape) |  |
+
+**Returns:**
+boolean
+### isTextEmpty() {#isTextEmpty--}
+```
+public boolean isTextEmpty()
+```
+
+
+Indica se la forma contiene testo e se il testo è vuoto o meno.
+
+**Returns:**
+boolean
+### move(double dX, double dY) {#move-double-double-}
+```
+public void move(double dX, double dY)
+```
+
+
+Sposta la forma di dX e dY pollici dalla posizione corrente.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| dX | double | Offset X double. |
+| dY | double | Offset Y double. |
+
+### moveTo(double newPinX, double newPinY) {#moveTo-double-double-}
+```
+public void moveTo(double newPinX, double newPinY)
+```
+
+
+Sposta la forma a una nuova posizione assoluta nella pagina.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| newPinX | double | Nuova coordinata x del pin della forma (centro di rotazione) in relazione all'origine del suo genitore. double. |
+| newPinY | double | Nuova coordinata y del pin della forma (centro di rotazione) in relazione all'origine del suo genitore. double. |
+
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### refreshData() {#refreshData--}
+```
+public void refreshData()
+```
+
+
+Aggiorna la posizione della forma includendo xform, connection e geom quando si modifica il testo della forma o di altri. Raccoglieremo i dati della forma, come il testo della forma, quindi calcoleremo la posizione della forma. Questo metodo è usato solo per aggiornare i dati della forma.
+
+### replaceText(String text, String replaceText) {#replaceText-java.lang.String-java.lang.String-}
+```
+public void replaceText(String text, String replaceText)
+```
+
+
+Sostituisce la stringa di testo di una forma.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| text | java.lang.String |  |
+| replaceText | java.lang.String |  |
+
+### sendBackward() {#sendBackward--}
+```
+public void sendBackward()
+```
+
+
+Sposta la forma indietro di una posizione nell'ordine Z.
+
+### sendToBack() {#sendToBack--}
+```
+public void sendToBack()
+```
+
+
+Sposta la forma in fondo all'ordine Z.
+
+### setAngle(double angle) {#setAngle-double-}
+```
+public void setAngle(double angle)
+```
+
+
+Imposta il nuovo angolo della forma. L'unità dell'angolo è il radiante.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| angle | double | Nuovo angolo la cui unità è radiante, non grado double. |
+
+### setClippingPath(String value) {#setClippingPath-java.lang.String-}
+```
+public void setClippingPath(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getClippingPath()](../../com.aspose.diagram/shape\#getClippingPath--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setConnectorsType(int type) {#setConnectorsType-int-}
+```
+public void setConnectorsType(int type)
+```
+
+
+Imposta il tipo di connettori
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| tipo | int |  |
+
+### setData1(String value) {#setData1-java.lang.String-}
+```
+public void setData1(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getData1()](../../com.aspose.diagram/shape\#getData1--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setData2(String value) {#setData2-java.lang.String-}
+```
+public void setData2(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getData2()](../../com.aspose.diagram/shape\#getData2--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setData3(String value) {#setData3-java.lang.String-}
+```
+public void setData3(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getData3()](../../com.aspose.diagram/shape\#getData3--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/shape\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setDiagram(Diagram value) {#setDiagram-com.aspose.diagram.Diagram-}
+```
+public void setDiagram(Diagram value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDiagram()](../../com.aspose.diagram/shape\#getDiagram--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [Diagram](../../com.aspose.diagram/diagram) |  |
+
+### setEvent(Event value) {#setEvent-com.aspose.diagram.Event-}
+```
+public void setEvent(Event value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getEvent()](../../com.aspose.diagram/shape\#getEvent--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [Event](../../com.aspose.diagram/event) |  |
+
+### setFillStyle(StyleSheet value) {#setFillStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setFillStyle(StyleSheet value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getFillStyle()](../../com.aspose.diagram/shape\#getFillStyle--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setHeight(double height) {#setHeight-double-}
+```
+public void setHeight(double height)
+```
+
+
+Imposta la nuova altezza della forma.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| height | double | New heightdouble. |
+
+### setID(long value) {#setID-long-}
+```
+public void setID(long value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getID()](../../com.aspose.diagram/shape\#getID--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | long |  |
+
+### setLineStyle(StyleSheet value) {#setLineStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setLineStyle(StyleSheet value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getLineStyle()](../../com.aspose.diagram/shape\#getLineStyle--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setMaster(Master value) {#setMaster-com.aspose.diagram.Master-}
+```
+public void setMaster(Master value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getMaster()](../../com.aspose.diagram/shape\#getMaster--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [Master](../../com.aspose.diagram/master) |  |
+
+### setMasterShape(Shape value) {#setMasterShape-com.aspose.diagram.Shape-}
+```
+public void setMasterShape(Shape value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getMasterShape()](../../com.aspose.diagram/shape\#getMasterShape--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [Shape](../../com.aspose.diagram/shape) |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getName()](../../com.aspose.diagram/shape\#getName--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getNameU()](../../com.aspose.diagram/shape\#getNameU--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setPage(Page value) {#setPage-com.aspose.diagram.Page-}
+```
+public void setPage(Page value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getPage()](../../com.aspose.diagram/shape\#getPage--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [Page](../../com.aspose.diagram/page) |  |
+
+### setParentShape(Shape value) {#setParentShape-com.aspose.diagram.Shape-}
+```
+public void setParentShape(Shape value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getParentShape()](../../com.aspose.diagram/shape\#getParentShape--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [Shape](../../com.aspose.diagram/shape) |  |
+
+### setPresetTheme(int value) {#setPresetTheme-int-}
+```
+public void setPresetTheme(int value)
+```
+
+
+Applica un tema predefinito a questa forma
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setPresetThemeQuickStyle(int value) {#setPresetThemeQuickStyle-int-}
+```
+public void setPresetThemeQuickStyle(int value)
+```
+
+
+Applica una variante di tema predefinita quickstyle a questa forma
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setPresetThemeStyleMatrics(int styleIndex, int colorIndex) {#setPresetThemeStyleMatrics-int-int-}
+```
+public void setPresetThemeStyleMatrics(int styleIndex, int colorIndex)
+```
+
+
+Applica una variante di tema predefinita quickstyle a questa forma, come le opzioni di stili tema nell'elenco a discesa degli stili della forma
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| styleIndex | int | the row of style matrics |
+| colorIndex | int | the column of style matrics |
+
+### setPresetThemeVariant(int value) {#setPresetThemeVariant-int-}
+```
+public void setPresetThemeVariant(int value)
+```
+
+
+Applica una variante di tema predefinita a questa forma
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setProps(PropCollection value) {#setProps-com.aspose.diagram.PropCollection-}
+```
+public void setProps(PropCollection value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getProps()](../../com.aspose.diagram/shape\#getProps--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [PropCollection](../../com.aspose.diagram/propcollection) |  |
+
+### setText(Text value) {#setText-com.aspose.diagram.Text-}
+```
+public void setText(Text value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getText()](../../com.aspose.diagram/shape\#getText--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [Text](../../com.aspose.diagram/text) |  |
+
+### setTextStyle(StyleSheet value) {#setTextStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setTextStyle(StyleSheet value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getTextStyle()](../../com.aspose.diagram/shape\#getTextStyle--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setTwoD(boolean value) {#setTwoD-boolean-}
+```
+public void setTwoD(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getTwoD()](../../com.aspose.diagram/shape\#getTwoD--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setType(int value) {#setType-int-}
+```
+public void setType(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getType()](../../com.aspose.diagram/shape\#getType--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setUniqueID(UUID value) {#setUniqueID-java.util.UUID-}
+```
+public void setUniqueID(UUID value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getUniqueID()](../../com.aspose.diagram/shape\#getUniqueID--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.util.UUID |  |
+
+### setWidth(double width) {#setWidth-double-}
+```
+public void setWidth(double width)
+```
+
+
+Imposta la nuova larghezza della forma.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| width | double | New widthdouble. |
+
+### setXForm(XForm value) {#setXForm-com.aspose.diagram.XForm-}
+```
+public void setXForm(XForm value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getXForm()](../../com.aspose.diagram/shape\#getXForm--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [XForm](../../com.aspose.diagram/xform) |  |
+
+### setXForm1D(XForm1D value) {#setXForm1D-com.aspose.diagram.XForm1D-}
+```
+public void setXForm1D(XForm1D value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getXForm1D()](../../com.aspose.diagram/shape\#getXForm1D--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [XForm1D](../../com.aspose.diagram/xform1d) |  |
+
+### toHTML(InputStream stream, HTMLSaveOptions options) {#toHTML-java.io.InputStream-com.aspose.diagram.HTMLSaveOptions-}
+```
+public void toHTML(InputStream stream, HTMLSaveOptions options)
+```
+
+
+Crea l'html della forma e lo salva in uno stream nel formato specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| flusso | java.io.InputStream | The output stream. |
+| options | [HTMLSaveOptions](../../com.aspose.diagram/htmlsaveoptions) | Addtional html creation options |
+
+### toHTML(OutputStream stream, HTMLSaveOptions options) {#toHTML-java.io.OutputStream-com.aspose.diagram.HTMLSaveOptions-}
+```
+public void toHTML(OutputStream stream, HTMLSaveOptions options)
+```
+
+
+Crea l'html della forma e lo salva in uno stream nel formato specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| flusso | java.io.OutputStream | The output stream. |
+| options | [HTMLSaveOptions](../../com.aspose.diagram/htmlsaveoptions) | Addtional html creation options |
+
+### toHTML(String fileName, HTMLSaveOptions options) {#toHTML-java.lang.String-com.aspose.diagram.HTMLSaveOptions-}
+```
+public void toHTML(String fileName, HTMLSaveOptions options)
+```
+
+
+Crea l'html e lo salva in un file.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fileName | java.lang.String |  |
+| options | [HTMLSaveOptions](../../com.aspose.diagram/htmlsaveoptions) | html save options |
+
+### toImage(InputStream stream, ImageSaveOptions options) {#toImage-java.io.InputStream-com.aspose.diagram.ImageSaveOptions-}
+```
+public void toImage(InputStream stream, ImageSaveOptions options)
+```
+
+
+Crea l'immagine della forma e la salva in uno stream nel formato specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| flusso | java.io.InputStream | The output stream. |
+| options | [ImageSaveOptions](../../com.aspose.diagram/imagesaveoptions) | Additional image creation options |
+
+### toImage(OutputStream stream, ImageSaveOptions options) {#toImage-java.io.OutputStream-com.aspose.diagram.ImageSaveOptions-}
+```
+public void toImage(OutputStream stream, ImageSaveOptions options)
+```
+
+
+Crea l'immagine della forma e la salva in uno stream nel formato specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| flusso | java.io.OutputStream | The output stream. |
+| options | [ImageSaveOptions](../../com.aspose.diagram/imagesaveoptions) | Additional image creation options |
+
+### toImage(String imageFile, ImageSaveOptions options) {#toImage-java.lang.String-com.aspose.diagram.ImageSaveOptions-}
+```
+public void toImage(String imageFile, ImageSaveOptions options)
+```
+
+
+Creates the shape image and saves it to a file. The extension of the file name determines the format of the image.
+
+The format of the image is specified by using the extension of the file name. For example, if you specify "myfile.png", then the image will be saved in the PNG format. The following file extensions are recognized: .bmp, .gif, .png, .jpg, .jpeg, .tiff, .tif, .emf.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| imageFile | java.lang.String | The image file name with full path. |
+| options | [ImageSaveOptions](../../com.aspose.diagram/imagesaveoptions) | Additional image creation options |
+
+### toPdf(InputStream stream) {#toPdf-java.io.InputStream-}
+```
+public void toPdf(InputStream stream)
+```
+
+
+Crea il pdf della forma e lo salva in uno stream.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| flusso | java.io.InputStream | The output stream. |
+
+### toPdf(OutputStream stream) {#toPdf-java.io.OutputStream-}
+```
+public void toPdf(OutputStream stream)
+```
+
+
+Crea il pdf della forma e lo salva in uno stream.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| flusso | java.io.OutputStream | The output stream. |
+
+### toPdf(String fileName) {#toPdf-java.lang.String-}
+```
+public void toPdf(String fileName)
+```
+
+
+Salva la forma in un file pdf.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fileName | java.lang.String | the pdf file name with full path |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### toSvg(String imageFile, SVGSaveOptions options) {#toSvg-java.lang.String-com.aspose.diagram.SVGSaveOptions-}
+```
+public void toSvg(String imageFile, SVGSaveOptions options)
+```
+
+
+Salva la forma in un file svg.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| imageFile | java.lang.String |  |
+| options | [SVGSaveOptions](../../com.aspose.diagram/svgsaveoptions) |  |
+
+### ungroup() {#ungroup--}
+```
+public void ungroup()
+```
+
+
+Separa forma
+
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/shapecollection/_index.md
+++ b/italian/java/com.aspose.diagram/shapecollection/_index.md
@@ -1,0 +1,326 @@
+---
+title: ShapeCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Raccolta di forme.
+type: docs
+weight: 356
+url: /it/java/com.aspose.diagram/shapecollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ShapeCollection extends Collection
+```
+
+Raccolta di forme.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [add(Shape item)](#add-com.aspose.diagram.Shape-) | Aggiungi la forma nella collezione. |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [getShape(String name)](#getShape-java.lang.String-) | Restituisce l'elemento con il nome specificato. |
+| [getShape(long ID)](#getShape-long-) | Restituisce l'elemento con l'ID specificato. |
+| [getShapeIncludingChild(int id)](#getShapeIncludingChild-int-) | Ottiene l'elemento includendo la sua forma figlia all'ID specificato. |
+| [getShapeIncludingChild(String name)](#getShapeIncludingChild-java.lang.String-) | Ottiene l'elemento includendo la sua forma figlia al nome specificato. |
+| [group(Shape[] groupItems)](#group-com.aspose.diagram.Shape---) | Raggruppa le forme. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Shape item)](#remove-com.aspose.diagram.Shape-) | Remove the shape from the collection. |
+| [removeDependsOn(Shape item)](#removeDependsOn-com.aspose.diagram.Shape-) | Remove the shapes including DEPENDSON shapes from the collection. |
+| [toString()](#toString--) |  |
+| [unGroup(Shape groupShape)](#unGroup-com.aspose.diagram.Shape-) | UnGroup the shape. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Shape item) {#add-com.aspose.diagram.Shape-}
+```
+public int add(Shape item)
+```
+
+
+Aggiungi la forma nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [Shape](../../com.aspose.diagram/shape) |  |
+
+**Returns:**
+int - ID
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Shape get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### getShape(String name) {#getShape-java.lang.String-}
+```
+public Shape getShape(String name)
+```
+
+
+Restituisce l'elemento con il nome specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| nome | java.lang.String |  |
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape) - 
+### getShape(long ID) {#getShape-long-}
+```
+public Shape getShape(long ID)
+```
+
+
+Restituisce l'elemento con l'ID specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| ID | long |  |
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape) - 
+### getShapeIncludingChild(int id) {#getShapeIncludingChild-int-}
+```
+public Shape getShapeIncludingChild(int id)
+```
+
+
+Ottiene l'elemento includendo la sua forma figlia all'ID specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| id | int |  |
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape) - 
+### getShapeIncludingChild(String name) {#getShapeIncludingChild-java.lang.String-}
+```
+public Shape getShapeIncludingChild(String name)
+```
+
+
+Ottiene l'elemento includendo la sua forma figlia al nome specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| nome | java.lang.String |  |
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape) - 
+### group(Shape[] groupItems) {#group-com.aspose.diagram.Shape---}
+```
+public Shape group(Shape[] groupItems)
+```
+
+
+Group the shapes. The shape in the groupItems should not be grouped. The shape must be in this Shapes collection.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| groupItems | [Shape\[\]](../../com.aspose.diagram/shape) | the group items. |
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape) - Return the group shape.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Shape item) {#remove-com.aspose.diagram.Shape-}
+```
+public void remove(Shape item)
+```
+
+
+Remove the shape from the collection.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [Shape](../../com.aspose.diagram/shape) | Shape |
+
+### removeDependsOn(Shape item) {#removeDependsOn-com.aspose.diagram.Shape-}
+```
+public void removeDependsOn(Shape item)
+```
+
+
+Remove the shapes including DEPENDSON shapes from the collection.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [Shape](../../com.aspose.diagram/shape) | Shape |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### unGroup(Shape groupShape) {#unGroup-com.aspose.diagram.Shape-}
+```
+public void unGroup(Shape groupShape)
+```
+
+
+UnGroup the shape.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| groupShape | [Shape](../../com.aspose.diagram/shape) | the group shape. |
+
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/shapefixedcode/_index.md
+++ b/italian/java/com.aspose.diagram/shapefixedcode/_index.md
@@ -1,0 +1,179 @@
+---
+title: ShapeFixedCode
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica il comportamento di posizionamento per una forma posizionabile.
+type: docs
+weight: 357
+url: /it/java/com.aspose.diagram/shapefixedcode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ShapeFixedCode
+```
+
+Specifica il comportamento di posizionamento per una forma posizionabile.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [ShapeFixedCode(int value)](#ShapeFixedCode-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Specifica il comportamento di posizionamento per una forma posizionabile. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/shapefixedcode\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ShapeFixedCode(int value) {#ShapeFixedCode-int-}
+```
+public ShapeFixedCode(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specifica il comportamento di posizionamento per una forma posizionabile.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/shapefixedcode\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/shapefixedcodevalue/_index.md
+++ b/italian/java/com.aspose.diagram/shapefixedcodevalue/_index.md
@@ -1,0 +1,192 @@
+---
+title: ShapeFixedCodeValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica il comportamento di posizionamento per una forma posizionabile.
+type: docs
+weight: 358
+url: /it/java/com.aspose.diagram/shapefixedcodevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ShapeFixedCodeValue
+```
+
+Specifica il comportamento di posizionamento per una forma posizionabile.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [ALLOW_ROUTING_TO_SIDES_WITH_CONNECTION_POINTS](#ALLOW-ROUTING-TO-SIDES-WITH-CONNECTION-POINTS) | Consenti il routing solo ai lati con punti di connessione. |
+| [IGNORE_CONNECTION_POINT](#IGNORE-CONNECTION-POINT) | Ignora le posizioni dei punti di connessione durante il routing. |
+| [NO_GLUE_TO_PERIMETER](#NO-GLUE-TO-PERIMETER) | Non incollare al perimetro di questa forma. |
+| [NO_MOVE_ALLOW_SHAPES_PLACED](#NO-MOVE-ALLOW-SHAPES-PLACED) | Non spostare questa forma ma consenti comunque che altre forme posizionabili vengano collocate su di essa. |
+| [NO_MOVE_AND_NO_ALLOW_SHAPES_PLACED](#NO-MOVE-AND-NO-ALLOW-SHAPES-PLACED) | Non spostare questa forma e non consentire che altre forme posizionabili vengano collocate su di essa. |
+| [NO_MOVE_USING_LAY_OUT_SHAPES](#NO-MOVE-USING-LAY-OUT-SHAPES) | Non spostare questa forma quando si utilizza il comando Lay Out Shapes in Microsoft Visio. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALLOW_ROUTING_TO_SIDES_WITH_CONNECTION_POINTS {#ALLOW-ROUTING-TO-SIDES-WITH-CONNECTION-POINTS}
+```
+public static final int ALLOW_ROUTING_TO_SIDES_WITH_CONNECTION_POINTS
+```
+
+
+Consenti il routing solo ai lati con punti di connessione.
+
+### IGNORE_CONNECTION_POINT {#IGNORE-CONNECTION-POINT}
+```
+public static final int IGNORE_CONNECTION_POINT
+```
+
+
+Ignora le posizioni dei punti di connessione durante il routing.
+
+### NO_GLUE_TO_PERIMETER {#NO-GLUE-TO-PERIMETER}
+```
+public static final int NO_GLUE_TO_PERIMETER
+```
+
+
+Non incollare al perimetro di questa forma. Incolla invece alla casella di allineamento della forma.
+
+### NO_MOVE_ALLOW_SHAPES_PLACED {#NO-MOVE-ALLOW-SHAPES-PLACED}
+```
+public static final int NO_MOVE_ALLOW_SHAPES_PLACED
+```
+
+
+Non spostare questa forma ma consenti comunque che altre forme posizionabili vengano collocate su di essa.
+
+### NO_MOVE_AND_NO_ALLOW_SHAPES_PLACED {#NO-MOVE-AND-NO-ALLOW-SHAPES-PLACED}
+```
+public static final int NO_MOVE_AND_NO_ALLOW_SHAPES_PLACED
+```
+
+
+Non spostare questa forma e non consentire che altre forme posizionabili vengano collocate su di essa.
+
+### NO_MOVE_USING_LAY_OUT_SHAPES {#NO-MOVE-USING-LAY-OUT-SHAPES}
+```
+public static final int NO_MOVE_USING_LAY_OUT_SHAPES
+```
+
+
+Non spostare questa forma quando si utilizza il comando Lay Out Shapes in Microsoft Visio.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/shapeplaceflip/_index.md
+++ b/italian/java/com.aspose.diagram/shapeplaceflip/_index.md
@@ -1,0 +1,179 @@
+---
+title: ShapePlaceFlip
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica come una forma posizionabile viene capovolta e/o ruotata nella pagina quando l'utente seleziona il menu Lay Out Shapes Shapes.
+type: docs
+weight: 359
+url: /it/java/com.aspose.diagram/shapeplaceflip/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ShapePlaceFlip
+```
+
+Specifica come una forma posizionabile si capovolge e/o ruota nella pagina quando l'utente seleziona Disposizione forme (menu Forme).
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [ShapePlaceFlip(int value)](#ShapePlaceFlip-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Specifica come una forma posizionabile si capovolge e/o ruota nella pagina quando l'utente seleziona Disposizione forme (menu Forme). |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, consultare [getValue()](../../com.aspose.diagram/shapeplaceflip\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ShapePlaceFlip(int value) {#ShapePlaceFlip-int-}
+```
+public ShapePlaceFlip(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specifica come una forma posizionabile si capovolge e/o ruota nella pagina quando l'utente seleziona Disposizione forme (menu Forme).
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getValue()](../../com.aspose.diagram/shapeplaceflip\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/shapeplaceflipvalue/_index.md
+++ b/italian/java/com.aspose.diagram/shapeplaceflipvalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: ShapePlaceFlipValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica come una forma posizionabile viene capovolta e/o ruotata nella pagina quando l'utente seleziona il menu Lay Out Shapes Shapes.
+type: docs
+weight: 360
+url: /it/java/com.aspose.diagram/shapeplaceflipvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ShapePlaceFlipValue
+```
+
+Specifica come una forma posizionabile si capovolge e/o ruota nella pagina quando l'utente seleziona Disposizione forme (menu Forme).
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [FLIP_90_DEGREE_INCREMENT_BETWEEN_0_AND_270](#FLIP-90-DEGREE-INCREMENT-BETWEEN-0-AND-270) | Capovolgi a incrementi di 90 gradi tra 0 e 270. |
+| [FLIP_HORIZONTAL](#FLIP-HORIZONTAL) | Flip horizontal. |
+| [FLIP_VERTICAL](#FLIP-VERTICAL) | Flip vertical. |
+| [NO_FLIP](#NO-FLIP) | No flip. |
+| [UNDEFINED](#UNDEFINED) | Non definito |
+| [USE_PAGE_DEFAULT](#USE-PAGE-DEFAULT) | Usa il valore predefinito della pagina. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FLIP_90_DEGREE_INCREMENT_BETWEEN_0_AND_270 {#FLIP-90-DEGREE-INCREMENT-BETWEEN-0-AND-270}
+```
+public static final int FLIP_90_DEGREE_INCREMENT_BETWEEN_0_AND_270
+```
+
+
+Capovolgi a incrementi di 90 gradi tra 0 e 270.
+
+### FLIP_HORIZONTAL {#FLIP-HORIZONTAL}
+```
+public static final int FLIP_HORIZONTAL
+```
+
+
+Flip horizontal.
+
+### FLIP_VERTICAL {#FLIP-VERTICAL}
+```
+public static final int FLIP_VERTICAL
+```
+
+
+Flip vertical.
+
+### NO_FLIP {#NO-FLIP}
+```
+public static final int NO_FLIP
+```
+
+
+No flip.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito
+
+### USE_PAGE_DEFAULT {#USE-PAGE-DEFAULT}
+```
+public static final int USE_PAGE_DEFAULT
+```
+
+
+Usa il valore predefinito della pagina.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/shapeplacestyle/_index.md
+++ b/italian/java/com.aspose.diagram/shapeplacestyle/_index.md
@@ -1,0 +1,179 @@
+---
+title: ShapePlaceStyle
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Determina lo stile di posizionamento per i figli.
+type: docs
+weight: 361
+url: /it/java/com.aspose.diagram/shapeplacestyle/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ShapePlaceStyle
+```
+
+Determina lo stile di posizionamento per i figli.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [ShapePlaceStyle(int value)](#ShapePlaceStyle-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Determina l'aspetto di un connettore. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/shapeplacestyle\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ShapePlaceStyle(int value) {#ShapePlaceStyle-int-}
+```
+public ShapePlaceStyle(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Determina l'aspetto di un connettore.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/shapeplacestyle\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/shapeplacestylevalue/_index.md
+++ b/italian/java/com.aspose.diagram/shapeplacestylevalue/_index.md
@@ -1,0 +1,390 @@
+---
+title: ShapePlaceStyleValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Determina lo stile di posizionamento per i figli.
+type: docs
+weight: 362
+url: /it/java/com.aspose.diagram/shapeplacestylevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ShapePlaceStyleValue
+```
+
+Determina lo stile di posizionamento per i figli.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [PLACE_BOTTOM_TO_TOP](#PLACE-BOTTOM-TO-TOP) | Posiziona dal basso verso l'alto. |
+| [PLACE_CIRCULAR](#PLACE-CIRCULAR) | Posiziona in modo circolare. |
+| [PLACE_COMPACT_DOWN_LEFT](#PLACE-COMPACT-DOWN-LEFT) | Posiziona compatto in basso a sinistra. |
+| [PLACE_COMPACT_DOWN_RIGHT](#PLACE-COMPACT-DOWN-RIGHT) | Posiziona compatto in basso a destra. |
+| [PLACE_COMPACT_LEFT_DOWN](#PLACE-COMPACT-LEFT-DOWN) | Posiziona compatto a sinistra in basso. |
+| [PLACE_COMPACT_LEFT_UP](#PLACE-COMPACT-LEFT-UP) | Posiziona compatto a sinistra in alto. |
+| [PLACE_COMPACT_RIGHT_DOWN](#PLACE-COMPACT-RIGHT-DOWN) | Posiziona compatto a destra in basso. |
+| [PLACE_COMPACT_RIGHT_UP](#PLACE-COMPACT-RIGHT-UP) | Posiziona compatto a destra in alto. |
+| [PLACE_COMPACT_UP_LEFT](#PLACE-COMPACT-UP-LEFT) | Posiziona compatto in alto a sinistra. |
+| [PLACE_COMPACT_UP_RIGHT](#PLACE-COMPACT-UP-RIGHT) | Posiziona compatto in alto a destra. |
+| [PLACE_DEFAULT](#PLACE-DEFAULT) | Posizione predefinita. |
+| [PLACE_HIERARCHY_BOTTOM_TO_CENTER](#PLACE-HIERARCHY-BOTTOM-TO-CENTER) | Posiziona la gerarchia dal basso al centro. |
+| [PLACE_HIERARCHY_BOTTOM_TO_LEFT](#PLACE-HIERARCHY-BOTTOM-TO-LEFT) | Posiziona la gerarchia dal basso a sinistra. |
+| [PLACE_HIERARCHY_BOTTOM_TO_RIGHT](#PLACE-HIERARCHY-BOTTOM-TO-RIGHT) | Posiziona la gerarchia dal basso a destra. |
+| [PLACE_HIERARCHY_LEFT_TO_RIGHT_BOTTOM](#PLACE-HIERARCHY-LEFT-TO-RIGHT-BOTTOM) | posiziona la gerarchia da sinistra a destra in basso. |
+| [PLACE_HIERARCHY_LEFT_TO_RIGHT_MIDDLE](#PLACE-HIERARCHY-LEFT-TO-RIGHT-MIDDLE) | Posiziona la gerarchia da sinistra a destra al centro. |
+| [PLACE_HIERARCHY_LEFT_TO_RIGHT_TOP](#PLACE-HIERARCHY-LEFT-TO-RIGHT-TOP) | Posiziona la gerarchia da sinistra a destra in alto. |
+| [PLACE_HIERARCHY_RIGHT_TO_LEFT_BOTTOM](#PLACE-HIERARCHY-RIGHT-TO-LEFT-BOTTOM) | Posiziona la gerarchia da destra a sinistra in basso. |
+| [PLACE_HIERARCHY_RIGHT_TO_LEFT_MIDDLE](#PLACE-HIERARCHY-RIGHT-TO-LEFT-MIDDLE) | Posiziona la gerarchia da destra a sinistra in alto. |
+| [PLACE_HIERARCHY_RIGHT_TO_LEFT_TOP](#PLACE-HIERARCHY-RIGHT-TO-LEFT-TOP) | Posiziona la gerarchia da destra a sinistra in alto. |
+| [PLACE_HIERARCHY_TOP_TO_BOTTOM_CENTER](#PLACE-HIERARCHY-TOP-TO-BOTTOM-CENTER) | Posiziona la gerarchia dall'alto al basso al centro. |
+| [PLACE_HIERARCHY_TOP_TO_BOTTOM_LEFT](#PLACE-HIERARCHY-TOP-TO-BOTTOM-LEFT) | Posiziona la gerarchia dall'alto al basso a sinistra. |
+| [PLACE_HIERARCHY_TOP_TO_BOTTOM_RIGHT](#PLACE-HIERARCHY-TOP-TO-BOTTOM-RIGHT) | Posiziona la gerarchia dall'alto al basso a destra. |
+| [PLACE_PARENT_DEFAULT](#PLACE-PARENT-DEFAULT) | Posiziona il genitore predefinito. |
+| [PLACE_RADIAL](#PLACE-RADIAL) | Posiziona radiale. |
+| [PLACE_RIGHT_TO_LEFT](#PLACE-RIGHT-TO-LEFT) | Posiziona da destra a sinistra. |
+| [PLACE_TOP_TO_BOTTOM](#PLACE-TOP-TO-BOTTOM) | Posiziona dall'alto al basso. |
+| [PLACE_TO_RIGHT](#PLACE-TO-RIGHT) | Posiziona a destra. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PLACE_BOTTOM_TO_TOP {#PLACE-BOTTOM-TO-TOP}
+```
+public static final int PLACE_BOTTOM_TO_TOP
+```
+
+
+Posiziona dal basso verso l'alto.
+
+### PLACE_CIRCULAR {#PLACE-CIRCULAR}
+```
+public static final int PLACE_CIRCULAR
+```
+
+
+Posiziona in modo circolare.
+
+### PLACE_COMPACT_DOWN_LEFT {#PLACE-COMPACT-DOWN-LEFT}
+```
+public static final int PLACE_COMPACT_DOWN_LEFT
+```
+
+
+Posiziona compatto in basso a sinistra.
+
+### PLACE_COMPACT_DOWN_RIGHT {#PLACE-COMPACT-DOWN-RIGHT}
+```
+public static final int PLACE_COMPACT_DOWN_RIGHT
+```
+
+
+Posiziona compatto in basso a destra.
+
+### PLACE_COMPACT_LEFT_DOWN {#PLACE-COMPACT-LEFT-DOWN}
+```
+public static final int PLACE_COMPACT_LEFT_DOWN
+```
+
+
+Posiziona compatto a sinistra in basso.
+
+### PLACE_COMPACT_LEFT_UP {#PLACE-COMPACT-LEFT-UP}
+```
+public static final int PLACE_COMPACT_LEFT_UP
+```
+
+
+Posiziona compatto a sinistra in alto.
+
+### PLACE_COMPACT_RIGHT_DOWN {#PLACE-COMPACT-RIGHT-DOWN}
+```
+public static final int PLACE_COMPACT_RIGHT_DOWN
+```
+
+
+Posiziona compatto a destra in basso.
+
+### PLACE_COMPACT_RIGHT_UP {#PLACE-COMPACT-RIGHT-UP}
+```
+public static final int PLACE_COMPACT_RIGHT_UP
+```
+
+
+Posiziona compatto a destra in alto.
+
+### PLACE_COMPACT_UP_LEFT {#PLACE-COMPACT-UP-LEFT}
+```
+public static final int PLACE_COMPACT_UP_LEFT
+```
+
+
+Posiziona compatto in alto a sinistra.
+
+### PLACE_COMPACT_UP_RIGHT {#PLACE-COMPACT-UP-RIGHT}
+```
+public static final int PLACE_COMPACT_UP_RIGHT
+```
+
+
+Posiziona compatto in alto a destra.
+
+### PLACE_DEFAULT {#PLACE-DEFAULT}
+```
+public static final int PLACE_DEFAULT
+```
+
+
+Posizione predefinita.
+
+### PLACE_HIERARCHY_BOTTOM_TO_CENTER {#PLACE-HIERARCHY-BOTTOM-TO-CENTER}
+```
+public static final int PLACE_HIERARCHY_BOTTOM_TO_CENTER
+```
+
+
+Posiziona la gerarchia dal basso al centro.
+
+### PLACE_HIERARCHY_BOTTOM_TO_LEFT {#PLACE-HIERARCHY-BOTTOM-TO-LEFT}
+```
+public static final int PLACE_HIERARCHY_BOTTOM_TO_LEFT
+```
+
+
+Posiziona la gerarchia dal basso a sinistra.
+
+### PLACE_HIERARCHY_BOTTOM_TO_RIGHT {#PLACE-HIERARCHY-BOTTOM-TO-RIGHT}
+```
+public static final int PLACE_HIERARCHY_BOTTOM_TO_RIGHT
+```
+
+
+Posiziona la gerarchia dal basso a destra.
+
+### PLACE_HIERARCHY_LEFT_TO_RIGHT_BOTTOM {#PLACE-HIERARCHY-LEFT-TO-RIGHT-BOTTOM}
+```
+public static final int PLACE_HIERARCHY_LEFT_TO_RIGHT_BOTTOM
+```
+
+
+posiziona la gerarchia da sinistra a destra in basso.
+
+### PLACE_HIERARCHY_LEFT_TO_RIGHT_MIDDLE {#PLACE-HIERARCHY-LEFT-TO-RIGHT-MIDDLE}
+```
+public static final int PLACE_HIERARCHY_LEFT_TO_RIGHT_MIDDLE
+```
+
+
+Posiziona la gerarchia da sinistra a destra al centro.
+
+### PLACE_HIERARCHY_LEFT_TO_RIGHT_TOP {#PLACE-HIERARCHY-LEFT-TO-RIGHT-TOP}
+```
+public static final int PLACE_HIERARCHY_LEFT_TO_RIGHT_TOP
+```
+
+
+Posiziona la gerarchia da sinistra a destra in alto.
+
+### PLACE_HIERARCHY_RIGHT_TO_LEFT_BOTTOM {#PLACE-HIERARCHY-RIGHT-TO-LEFT-BOTTOM}
+```
+public static final int PLACE_HIERARCHY_RIGHT_TO_LEFT_BOTTOM
+```
+
+
+Posiziona la gerarchia da destra a sinistra in basso.
+
+### PLACE_HIERARCHY_RIGHT_TO_LEFT_MIDDLE {#PLACE-HIERARCHY-RIGHT-TO-LEFT-MIDDLE}
+```
+public static final int PLACE_HIERARCHY_RIGHT_TO_LEFT_MIDDLE
+```
+
+
+Posiziona la gerarchia da destra a sinistra in alto.
+
+### PLACE_HIERARCHY_RIGHT_TO_LEFT_TOP {#PLACE-HIERARCHY-RIGHT-TO-LEFT-TOP}
+```
+public static final int PLACE_HIERARCHY_RIGHT_TO_LEFT_TOP
+```
+
+
+Posiziona la gerarchia da destra a sinistra in alto.
+
+### PLACE_HIERARCHY_TOP_TO_BOTTOM_CENTER {#PLACE-HIERARCHY-TOP-TO-BOTTOM-CENTER}
+```
+public static final int PLACE_HIERARCHY_TOP_TO_BOTTOM_CENTER
+```
+
+
+Posiziona la gerarchia dall'alto al basso al centro.
+
+### PLACE_HIERARCHY_TOP_TO_BOTTOM_LEFT {#PLACE-HIERARCHY-TOP-TO-BOTTOM-LEFT}
+```
+public static final int PLACE_HIERARCHY_TOP_TO_BOTTOM_LEFT
+```
+
+
+Posiziona la gerarchia dall'alto al basso a sinistra.
+
+### PLACE_HIERARCHY_TOP_TO_BOTTOM_RIGHT {#PLACE-HIERARCHY-TOP-TO-BOTTOM-RIGHT}
+```
+public static final int PLACE_HIERARCHY_TOP_TO_BOTTOM_RIGHT
+```
+
+
+Posiziona la gerarchia dall'alto al basso a destra.
+
+### PLACE_PARENT_DEFAULT {#PLACE-PARENT-DEFAULT}
+```
+public static final int PLACE_PARENT_DEFAULT
+```
+
+
+Posiziona il genitore predefinito.
+
+### PLACE_RADIAL {#PLACE-RADIAL}
+```
+public static final int PLACE_RADIAL
+```
+
+
+Posiziona radiale.
+
+### PLACE_RIGHT_TO_LEFT {#PLACE-RIGHT-TO-LEFT}
+```
+public static final int PLACE_RIGHT_TO_LEFT
+```
+
+
+Posiziona da destra a sinistra.
+
+### PLACE_TOP_TO_BOTTOM {#PLACE-TOP-TO-BOTTOM}
+```
+public static final int PLACE_TOP_TO_BOTTOM
+```
+
+
+Posiziona dall'alto al basso.
+
+### PLACE_TO_RIGHT {#PLACE-TO-RIGHT}
+```
+public static final int PLACE_TO_RIGHT
+```
+
+
+Posiziona a destra.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/shapeplowcode/_index.md
+++ b/italian/java/com.aspose.diagram/shapeplowcode/_index.md
@@ -1,0 +1,179 @@
+---
+title: ShapePlowCode
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica se una forma posizionabile si allontana quando trascini un'altra forma posizionabile vicino alla forma nella pagina di disegno.
+type: docs
+weight: 363
+url: /it/java/com.aspose.diagram/shapeplowcode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ShapePlowCode
+```
+
+Specifica se una forma posizionabile si allontana quando trascini un'altra forma posizionabile vicino alla forma nella pagina di disegno.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [ShapePlowCode(int value)](#ShapePlowCode-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Specifica se una forma posizionabile si allontana quando trascini un'altra forma posizionabile vicino alla forma nella pagina di disegno. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/shapeplowcode\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ShapePlowCode(int value) {#ShapePlowCode-int-}
+```
+public ShapePlowCode(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specifica se una forma posizionabile si allontana quando trascini un'altra forma posizionabile vicino alla forma nella pagina di disegno.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/shapeplowcode\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/shapeplowcodevalue/_index.md
+++ b/italian/java/com.aspose.diagram/shapeplowcodevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: ShapePlowCodeValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica se una forma posizionabile si allontana quando trascini un'altra forma posizionabile vicino alla forma nella pagina di disegno.
+type: docs
+weight: 364
+url: /it/java/com.aspose.diagram/shapeplowcodevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ShapePlowCodeValue
+```
+
+Specifica se una forma posizionabile si allontana quando trascini un'altra forma posizionabile vicino alla forma nella pagina di disegno.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [MOVE_SHAPE](#MOVE-SHAPE) | Sposta forma. |
+| [NOMOVE_SHAPE](#NOMOVE-SHAPE) | Non spostare forma. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+| [USE_PAGE_DEFAULT](#USE-PAGE-DEFAULT) | Usa il valore predefinito della pagina. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### MOVE_SHAPE {#MOVE-SHAPE}
+```
+public static final int MOVE_SHAPE
+```
+
+
+Sposta forma.
+
+### NOMOVE_SHAPE {#NOMOVE-SHAPE}
+```
+public static final int NOMOVE_SHAPE
+```
+
+
+Non spostare forma.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### USE_PAGE_DEFAULT {#USE-PAGE-DEFAULT}
+```
+public static final int USE_PAGE_DEFAULT
+```
+
+
+Usa il valore predefinito della pagina.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/shaperoutestyle/_index.md
+++ b/italian/java/com.aspose.diagram/shaperoutestyle/_index.md
@@ -1,0 +1,179 @@
+---
+title: ShapeRouteStyle
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica lo stile di instradamento e la direzione per un connettore nella pagina di disegno.
+type: docs
+weight: 365
+url: /it/java/com.aspose.diagram/shaperoutestyle/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ShapeRouteStyle
+```
+
+Specifica lo stile di instradamento e la direzione per un connettore nella pagina di disegno.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [ShapeRouteStyle(int value)](#ShapeRouteStyle-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Specifica lo stile di instradamento e la direzione per un connettore nella pagina di disegno. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/shaperoutestyle\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ShapeRouteStyle(int value) {#ShapeRouteStyle-int-}
+```
+public ShapeRouteStyle(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specifica lo stile di instradamento e la direzione per un connettore nella pagina di disegno.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/shaperoutestyle\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/shaperoutestylevalue/_index.md
+++ b/italian/java/com.aspose.diagram/shaperoutestylevalue/_index.md
@@ -1,0 +1,345 @@
+---
+title: ShapeRouteStyleValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica lo stile di instradamento e la direzione per un connettore nella pagina di disegno.
+type: docs
+weight: 366
+url: /it/java/com.aspose.diagram/shaperoutestylevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ShapeRouteStyleValue
+```
+
+Specifica lo stile di instradamento e la direzione per un connettore nella pagina di disegno.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [CENTER_TO_CENTER](#CENTER-TO-CENTER) | Centro a centro. |
+| [FLOWCHART_BOTTOM_TO_TOP](#FLOWCHART-BOTTOM-TO-TOP) | Diagramma di flusso. |
+| [FLOWCHART_LEFT_TO_RIGHT](#FLOWCHART-LEFT-TO-RIGHT) | Diagramma di flusso. |
+| [FLOWCHART_RIGHT_TO_LEFT](#FLOWCHART-RIGHT-TO-LEFT) | Diagramma di flusso. |
+| [FLOWCHART_TOP_TO_BOTTOM](#FLOWCHART-TOP-TO-BOTTOM) | Diagramma di flusso. |
+| [NETWORK](#NETWORK) | Rete |
+| [ORGANIZATION_CHART_BOTTOM_TO_TOP](#ORGANIZATION-CHART-BOTTOM-TO-TOP) | Organigramma. |
+| [ORGANIZATION_CHART_LEFT_TO_RIGHT](#ORGANIZATION-CHART-LEFT-TO-RIGHT) | Organigramma. |
+| [ORGANIZATION_CHART_RIGHT_TO_LEFT](#ORGANIZATION-CHART-RIGHT-TO-LEFT) | Organigramma. |
+| [ORGANIZATION_CHART_TOP_TO_BOTTOM](#ORGANIZATION-CHART-TOP-TO-BOTTOM) | Organigramma. |
+| [PAGE_DEFAULT](#PAGE-DEFAULT) | Pagina predefinita. |
+| [RIGHT_ANGLE](#RIGHT-ANGLE) | Angolo retto. |
+| [SIMPLE_BOTTOM_TO_TOP](#SIMPLE-BOTTOM-TO-TOP) | Semplice. |
+| [SIMPLE_HORIZONTAL_VERTICAL](#SIMPLE-HORIZONTAL-VERTICAL) | Semplice orizzontale-verticale. |
+| [SIMPLE_LEFT_TO_RIGHT](#SIMPLE-LEFT-TO-RIGHT) | Semplice. |
+| [SIMPLE_RIGHT_TO_LEFT](#SIMPLE-RIGHT-TO-LEFT) | Semplice. |
+| [SIMPLE_TOP_TO_BOTTOM](#SIMPLE-TOP-TO-BOTTOM) | Semplice. |
+| [SIMPLE_VERTICAL_HORIZONTAL](#SIMPLE-VERTICAL-HORIZONTAL) | Semplice verticale-orizzontale. |
+| [STRAIGHT](#STRAIGHT) | Retto. |
+| [TREE_BOTTOM_TO_TOP](#TREE-BOTTOM-TO-TOP) | Albero. |
+| [TREE_LEFT_TO_RIGHT](#TREE-LEFT-TO-RIGHT) | Albero. |
+| [TREE_RIGHT_TO_LEFT](#TREE-RIGHT-TO-LEFT) | Albero. |
+| [TREE_TOP_TO_BOTTOM](#TREE-TOP-TO-BOTTOM) | Albero. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CENTER_TO_CENTER {#CENTER-TO-CENTER}
+```
+public static final int CENTER_TO_CENTER
+```
+
+
+Centro a centro.
+
+### FLOWCHART_BOTTOM_TO_TOP {#FLOWCHART-BOTTOM-TO-TOP}
+```
+public static final int FLOWCHART_BOTTOM_TO_TOP
+```
+
+
+Diagramma di flusso. Dal basso verso l'alto.
+
+### FLOWCHART_LEFT_TO_RIGHT {#FLOWCHART-LEFT-TO-RIGHT}
+```
+public static final int FLOWCHART_LEFT_TO_RIGHT
+```
+
+
+Diagramma di flusso. Da sinistra a destra.
+
+### FLOWCHART_RIGHT_TO_LEFT {#FLOWCHART-RIGHT-TO-LEFT}
+```
+public static final int FLOWCHART_RIGHT_TO_LEFT
+```
+
+
+Diagramma di flusso. Da destra a sinistra.
+
+### FLOWCHART_TOP_TO_BOTTOM {#FLOWCHART-TOP-TO-BOTTOM}
+```
+public static final int FLOWCHART_TOP_TO_BOTTOM
+```
+
+
+Diagramma di flusso. D'alto verso il basso.
+
+### NETWORK {#NETWORK}
+```
+public static final int NETWORK
+```
+
+
+Rete
+
+### ORGANIZATION_CHART_BOTTOM_TO_TOP {#ORGANIZATION-CHART-BOTTOM-TO-TOP}
+```
+public static final int ORGANIZATION_CHART_BOTTOM_TO_TOP
+```
+
+
+Organigramma. Dal basso verso l'alto.
+
+### ORGANIZATION_CHART_LEFT_TO_RIGHT {#ORGANIZATION-CHART-LEFT-TO-RIGHT}
+```
+public static final int ORGANIZATION_CHART_LEFT_TO_RIGHT
+```
+
+
+Organigramma. Da sinistra a destra.
+
+### ORGANIZATION_CHART_RIGHT_TO_LEFT {#ORGANIZATION-CHART-RIGHT-TO-LEFT}
+```
+public static final int ORGANIZATION_CHART_RIGHT_TO_LEFT
+```
+
+
+Organigramma. Da destra a sinistra.
+
+### ORGANIZATION_CHART_TOP_TO_BOTTOM {#ORGANIZATION-CHART-TOP-TO-BOTTOM}
+```
+public static final int ORGANIZATION_CHART_TOP_TO_BOTTOM
+```
+
+
+Organigramma. Direzione dall'alto verso il basso.
+
+### PAGE_DEFAULT {#PAGE-DEFAULT}
+```
+public static final int PAGE_DEFAULT
+```
+
+
+Pagina predefinita.
+
+### RIGHT_ANGLE {#RIGHT-ANGLE}
+```
+public static final int RIGHT_ANGLE
+```
+
+
+Angolo retto.
+
+### SIMPLE_BOTTOM_TO_TOP {#SIMPLE-BOTTOM-TO-TOP}
+```
+public static final int SIMPLE_BOTTOM_TO_TOP
+```
+
+
+Semplice. Dal basso verso l'alto.
+
+### SIMPLE_HORIZONTAL_VERTICAL {#SIMPLE-HORIZONTAL-VERTICAL}
+```
+public static final int SIMPLE_HORIZONTAL_VERTICAL
+```
+
+
+Semplice orizzontale-verticale.
+
+### SIMPLE_LEFT_TO_RIGHT {#SIMPLE-LEFT-TO-RIGHT}
+```
+public static final int SIMPLE_LEFT_TO_RIGHT
+```
+
+
+Semplice. Da sinistra a destra.
+
+### SIMPLE_RIGHT_TO_LEFT {#SIMPLE-RIGHT-TO-LEFT}
+```
+public static final int SIMPLE_RIGHT_TO_LEFT
+```
+
+
+Semplice. Da destra a sinistra.
+
+### SIMPLE_TOP_TO_BOTTOM {#SIMPLE-TOP-TO-BOTTOM}
+```
+public static final int SIMPLE_TOP_TO_BOTTOM
+```
+
+
+Semplice. Dall'alto verso il basso.
+
+### SIMPLE_VERTICAL_HORIZONTAL {#SIMPLE-VERTICAL-HORIZONTAL}
+```
+public static final int SIMPLE_VERTICAL_HORIZONTAL
+```
+
+
+Semplice verticale-orizzontale.
+
+### STRAIGHT {#STRAIGHT}
+```
+public static final int STRAIGHT
+```
+
+
+Retto.
+
+### TREE_BOTTOM_TO_TOP {#TREE-BOTTOM-TO-TOP}
+```
+public static final int TREE_BOTTOM_TO_TOP
+```
+
+
+Albero. Dal basso verso l'alto.
+
+### TREE_LEFT_TO_RIGHT {#TREE-LEFT-TO-RIGHT}
+```
+public static final int TREE_LEFT_TO_RIGHT
+```
+
+
+Albero. Da sinistra a destra
+
+### TREE_RIGHT_TO_LEFT {#TREE-RIGHT-TO-LEFT}
+```
+public static final int TREE_RIGHT_TO_LEFT
+```
+
+
+Albero. Da destra a sinistra.
+
+### TREE_TOP_TO_BOTTOM {#TREE-TOP-TO-BOTTOM}
+```
+public static final int TREE_TOP_TO_BOTTOM
+```
+
+
+Albero. Dall'alto verso il basso.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/shapeshdwshow/_index.md
+++ b/italian/java/com.aspose.diagram/shapeshdwshow/_index.md
@@ -1,0 +1,179 @@
+---
+title: ShapeShdwShow
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica il tipo di ombra per una forma.
+type: docs
+weight: 367
+url: /it/java/com.aspose.diagram/shapeshdwshow/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ShapeShdwShow
+```
+
+Specifica il tipo di ombra per una forma.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [ShapeShdwShow(int value)](#ShapeShdwShow-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Specifica il tipo di ombra per una forma. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/shapeshdwshow\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ShapeShdwShow(int value) {#ShapeShdwShow-int-}
+```
+public ShapeShdwShow(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specifica il tipo di ombra per una forma.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/shapeshdwshow\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/shapeshdwshowvalue/_index.md
+++ b/italian/java/com.aspose.diagram/shapeshdwshowvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: ShapeShdwShowValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica il tipo di ombra per una forma.
+type: docs
+weight: 368
+url: /it/java/com.aspose.diagram/shapeshdwshowvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ShapeShdwShowValue
+```
+
+Specifica il tipo di ombra per una forma.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [ALWAYS_SHOW](#ALWAYS-SHOW) | Specifica che il set di effetti ombra è sempre visualizzato. |
+| [HAS_GEOM_SHOW](#HAS-GEOM-SHOW) | Specifica che il set di effetti ombra è visualizzato solo se la forma ha un Geometry Section\_Type. |
+| [TOP_LEVEL_SHOW](#TOP-LEVEL-SHOW) | Specifica che il set di effetti ombra è visualizzato solo se la forma ha un Geometry Section\_Type e la forma è una forma di livello superiore. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALWAYS_SHOW {#ALWAYS-SHOW}
+```
+public static final int ALWAYS_SHOW
+```
+
+
+Specifica che il set di effetti ombra è sempre visualizzato.
+
+### HAS_GEOM_SHOW {#HAS-GEOM-SHOW}
+```
+public static final int HAS_GEOM_SHOW
+```
+
+
+Specifica che il set di effetti ombra è visualizzato solo se la forma ha un Geometry Section\_Type.
+
+### TOP_LEVEL_SHOW {#TOP-LEVEL-SHOW}
+```
+public static final int TOP_LEVEL_SHOW
+```
+
+
+Specifica che il set di effetti ombra è visualizzato solo se la forma ha un Geometry Section\_Type e la forma è una forma di livello superiore.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/shapeshdwtype/_index.md
+++ b/italian/java/com.aspose.diagram/shapeshdwtype/_index.md
@@ -1,0 +1,179 @@
+---
+title: ShapeShdwType
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica il tipo di ombra per una forma.
+type: docs
+weight: 369
+url: /it/java/com.aspose.diagram/shapeshdwtype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ShapeShdwType
+```
+
+Specifica il tipo di ombra per una forma.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [ShapeShdwType(int value)](#ShapeShdwType-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Specifica il tipo di ombra per una forma. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/shapeshdwtype\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ShapeShdwType(int value) {#ShapeShdwType-int-}
+```
+public ShapeShdwType(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specifica il tipo di ombra per una forma.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/shapeshdwtype\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/shapeshdwtypevalue/_index.md
+++ b/italian/java/com.aspose.diagram/shapeshdwtypevalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: ShapeShdwTypeValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica il tipo di ombra per una forma.
+type: docs
+weight: 370
+url: /it/java/com.aspose.diagram/shapeshdwtypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ShapeShdwTypeValue
+```
+
+Specifica il tipo di ombra per una forma.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [INNER](#INNER) | Inner |
+| [OBLIQUE](#OBLIQUE) | Oblique. |
+| [SIMPLE](#SIMPLE) | Semplice. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+| [USE_PAGE](#USE-PAGE) | Use page default (the default). |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### INNER {#INNER}
+```
+public static final int INNER
+```
+
+
+Inner
+
+### OBLIQUE {#OBLIQUE}
+```
+public static final int OBLIQUE
+```
+
+
+Oblique.
+
+### SIMPLE {#SIMPLE}
+```
+public static final int SIMPLE
+```
+
+
+Semplice.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### USE_PAGE {#USE-PAGE}
+```
+public static final int USE_PAGE
+```
+
+
+Use page default (the default).
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/shdwtype/_index.md
+++ b/italian/java/com.aspose.diagram/shdwtype/_index.md
@@ -1,0 +1,179 @@
+---
+title: ShdwType
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Indica il tipo di ombra predefinito per una pagina.
+type: docs
+weight: 371
+url: /it/java/com.aspose.diagram/shdwtype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ShdwType
+```
+
+Indica il tipo di ombra predefinito per una pagina.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [ShdwType(int value)](#ShdwType-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Indica il tipo di ombra predefinito per una pagina. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/shdwtype\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ShdwType(int value) {#ShdwType-int-}
+```
+public ShdwType(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Indica il tipo di ombra predefinito per una pagina.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/shdwtype\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/shdwtypevalue/_index.md
+++ b/italian/java/com.aspose.diagram/shdwtypevalue/_index.md
@@ -1,0 +1,156 @@
+---
+title: ShdwTypeValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Indica il tipo di ombra predefinito per una pagina.
+type: docs
+weight: 372
+url: /it/java/com.aspose.diagram/shdwtypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ShdwTypeValue
+```
+
+Indica il tipo di ombra predefinito per una pagina.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [OBLIQUE](#OBLIQUE) | Oblique. |
+| [SIMPLE](#SIMPLE) | Semplice. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### OBLIQUE {#OBLIQUE}
+```
+public static final int OBLIQUE
+```
+
+
+Oblique.
+
+### SIMPLE {#SIMPLE}
+```
+public static final int SIMPLE
+```
+
+
+Semplice.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/showdropbuttontype/_index.md
+++ b/italian/java/com.aspose.diagram/showdropbuttontype/_index.md
@@ -1,0 +1,156 @@
+---
+title: ShowDropButtonType
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica quando mostrare il pulsante di rilascio
+type: docs
+weight: 373
+url: /it/java/com.aspose.diagram/showdropbuttontype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ShowDropButtonType
+```
+
+Specifica quando mostrare il pulsante di rilascio
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [ALWAYS](#ALWAYS) | Mostra sempre il pulsante a discesa. |
+| [FOCUS](#FOCUS) | Mostra il pulsante a discesa quando il controllo ha il focus. |
+| [NEVER](#NEVER) | Non mostrare mai il pulsante a discesa. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALWAYS {#ALWAYS}
+```
+public static final int ALWAYS
+```
+
+
+Mostra sempre il pulsante a discesa.
+
+### FOCUS {#FOCUS}
+```
+public static final int FOCUS
+```
+
+
+Mostra il pulsante a discesa quando il controllo ha il focus.
+
+### NEVER {#NEVER}
+```
+public static final int NEVER
+```
+
+
+Non mostrare mai il pulsante a discesa.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/smarttagdef/_index.md
+++ b/italian/java/com.aspose.diagram/smarttagdef/_index.md
@@ -1,0 +1,337 @@
+---
+title: SmartTagDef
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene elementi che includono informazioni per ogni smart tag definito per una forma o una pagina.
+type: docs
+weight: 374
+url: /it/java/com.aspose.diagram/smarttagdef/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class SmartTagDef
+```
+
+Contiene elementi che includono informazioni per ogni smart tag definito per una forma o una pagina.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [SmartTagDef()](#SmartTagDef--) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getButtonFace()](#getButtonFace--) | Contiene l'ID dell'immagine della faccia del pulsante che appare sul pulsante smart tag. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getDescription()](#getDescription--) | L'elemento Description contiene una stringa che descrive lo smart tag, che appare come suggerimento quando l'utente ferma il mouse sopra il tag. |
+| [getDisabled()](#getDisabled--) | L'elemento Disabled determina se lo smart tag appare nella finestra di disegno. |
+| [getDisplayMode()](#getDisplayMode--) | L'elemento DisplayMode determina se il tag intelligente appare quando l'utente ferma il mouse sul tag, quando la forma è selezionata, o in ogni momento. |
+| [getID()](#getID--) | L'ID univoco dell'elemento all'interno del suo elemento genitore. |
+| [getName()](#getName--) | Il nome dell'elemento. |
+| [getNameU()](#getNameU--) | Il nome universale dell'elemento. |
+| [getTagName()](#getTagName--) | Contiene il nome dello smart tag che viene usato come chiave per associare lo smart tag alle sue azioni. |
+| [getX()](#getX--) | La posizione della coordinata x nelle coordinate locali della forma attorno alla quale viene posizionato il pulsante dello smart tag. |
+| [getXJustify()](#getXJustify--) | L'offset x del pulsante smart tag rispetto al punto definito dagli elementi X e Y. |
+| [getY()](#getY--) | La posizione della coordinata y nelle coordinate locali della forma attorno alla quale viene posizionato il pulsante dello smart tag. |
+| [getYJustify()](#getYJustify--) | Specifica l'offset y del pulsante smart tag rispetto al punto definito dagli elementi X e Y. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, consultare [getDel()](../../com.aspose.diagram/smarttagdef\#getDel--) |
+| [setID(int value)](#setID-int-) | Per la descrizione di questa proprietà, consultare [getID()](../../com.aspose.diagram/smarttagdef\#getID--) |
+| [setName(String value)](#setName-java.lang.String-) | Per la descrizione di questa proprietà, consultare [getName()](../../com.aspose.diagram/smarttagdef\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | Per la descrizione di questa proprietà, consultare [getNameU()](../../com.aspose.diagram/smarttagdef\#getNameU--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SmartTagDef() {#SmartTagDef--}
+```
+public SmartTagDef()
+```
+
+
+Costruttore.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getButtonFace() {#getButtonFace--}
+```
+public Str2Value getButtonFace()
+```
+
+
+Contiene l'ID dell'immagine della faccia del pulsante che appare sul pulsante smart tag.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getDescription() {#getDescription--}
+```
+public Str2Value getDescription()
+```
+
+
+L'elemento Description contiene una stringa che descrive lo smart tag, che appare come suggerimento quando l'utente ferma il mouse sopra il tag.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getDisabled() {#getDisabled--}
+```
+public BoolValue getDisabled()
+```
+
+
+L'elemento Disabled determina se lo smart tag appare nella finestra di disegno.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getDisplayMode() {#getDisplayMode--}
+```
+public DisplayModeSmartTagDef getDisplayMode()
+```
+
+
+L'elemento DisplayMode determina se il tag intelligente appare quando l'utente ferma il mouse sul tag, quando la forma è selezionata, o in ogni momento.
+
+**Returns:**
+[DisplayModeSmartTagDef](../../com.aspose.diagram/displaymodesmarttagdef)
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+L'ID univoco dell'elemento all'interno del suo elemento genitore.
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Il nome dell'elemento.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+Il nome universale dell'elemento.
+
+**Returns:**
+java.lang.String
+### getTagName() {#getTagName--}
+```
+public Str2Value getTagName()
+```
+
+
+Contiene il nome dello smart tag che viene usato come chiave per associare lo smart tag alle sue azioni.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+La posizione della coordinata x nelle coordinate locali della forma attorno alla quale viene posizionato il pulsante dello smart tag.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getXJustify() {#getXJustify--}
+```
+public XJustify getXJustify()
+```
+
+
+L'offset x del pulsante smart tag rispetto al punto definito dagli elementi X e Y.
+
+**Returns:**
+[XJustify](../../com.aspose.diagram/xjustify)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+La posizione della coordinata y nelle coordinate locali della forma attorno alla quale viene posizionato il pulsante dello smart tag.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getYJustify() {#getYJustify--}
+```
+public YJustify getYJustify()
+```
+
+
+Specifica l'offset y del pulsante smart tag rispetto al punto definito dagli elementi X e Y.
+
+**Returns:**
+[YJustify](../../com.aspose.diagram/yjustify)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getDel()](../../com.aspose.diagram/smarttagdef\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getID()](../../com.aspose.diagram/smarttagdef\#getID--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getName()](../../com.aspose.diagram/smarttagdef\#getName--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getNameU()](../../com.aspose.diagram/smarttagdef\#getNameU--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/smarttagdefcollection/_index.md
+++ b/italian/java/com.aspose.diagram/smarttagdefcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: SmartTagDefCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Raccolta SmartTagDef.
+type: docs
+weight: 375
+url: /it/java/com.aspose.diagram/smarttagdefcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class SmartTagDefCollection extends Collection
+```
+
+Raccolta SmartTagDef.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [add(SmartTagDef item)](#add-com.aspose.diagram.SmartTagDef-) | Aggiungi l'oggetto SmartTagDef nella collezione. |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(SmartTagDef item)](#remove-com.aspose.diagram.SmartTagDef-) | Rimuovi l'oggetto SmartTagDef dalla collezione. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(SmartTagDef item) {#add-com.aspose.diagram.SmartTagDef-}
+```
+public int add(SmartTagDef item)
+```
+
+
+Aggiungi l'oggetto SmartTagDef nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [SmartTagDef](../../com.aspose.diagram/smarttagdef) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public SmartTagDef get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[SmartTagDef](../../com.aspose.diagram/smarttagdef) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(SmartTagDef item) {#remove-com.aspose.diagram.SmartTagDef-}
+```
+public void remove(SmartTagDef item)
+```
+
+
+Rimuovi l'oggetto SmartTagDef dalla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [SmartTagDef](../../com.aspose.diagram/smarttagdef) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/smoothingmode/_index.md
+++ b/italian/java/com.aspose.diagram/smoothingmode/_index.md
@@ -1,0 +1,183 @@
+---
+title: SmoothingMode
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica se l'antialiasing di smoothing è applicato a linee, curve e ai bordi delle aree riempite.
+type: docs
+weight: 376
+url: /it/java/com.aspose.diagram/smoothingmode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class SmoothingMode
+```
+
+Specifica se l'anti-aliasing (smussatura) è applicato a linee e curve e ai bordi delle aree riempite.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [ANTI_ALIAS](#ANTI-ALIAS) | Specifica il rendering antialiasato. |
+| [DEFAULT](#DEFAULT) | Specifica nessun antialiasing. |
+| [HIGH_QUALITY](#HIGH-QUALITY) | Specifica il rendering antialiasato. |
+| [HIGH_SPEED](#HIGH-SPEED) | Specifica nessun antialiasing. |
+| [INVALID](#INVALID) | Specifica una modalità non valida. |
+| [NONE](#NONE) | Specifica nessun antialiasing. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ANTI_ALIAS {#ANTI-ALIAS}
+```
+public static final int ANTI_ALIAS
+```
+
+
+Specifica il rendering antialiasato.
+
+### DEFAULT {#DEFAULT}
+```
+public static final int DEFAULT
+```
+
+
+Specifica nessun antialiasing.
+
+### HIGH_QUALITY {#HIGH-QUALITY}
+```
+public static final int HIGH_QUALITY
+```
+
+
+Specifica il rendering antialiasato.
+
+### HIGH_SPEED {#HIGH-SPEED}
+```
+public static final int HIGH_SPEED
+```
+
+
+Specifica nessun antialiasing.
+
+### INVALID {#INVALID}
+```
+public static final int INVALID
+```
+
+
+Specifica una modalità non valida.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Specifica nessun antialiasing.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/snapextensions/_index.md
+++ b/italian/java/com.aspose.diagram/snapextensions/_index.md
@@ -1,0 +1,264 @@
+---
+title: SnapExtensions
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica se un'impostazione specifica di estensione snap è abilitata o disabilitata per la finestra attiva.
+type: docs
+weight: 377
+url: /it/java/com.aspose.diagram/snapextensions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class SnapExtensions
+```
+
+Specifica se un'impostazione specifica di snap extension è abilitata o disabilitata per la finestra attiva. Il valore può essere una somma dei valori.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [ALIGNMENT_BOX_EXTENSION](#ALIGNMENT-BOX-EXTENSION) | Estensione di aggancio alla casella di allineamento. |
+| [CENTER_AXES](#CENTER-AXES) | Estensione di aggancio all'asse centrale. |
+| [CURVE_EXTENSION](#CURVE-EXTENSION) | Estensione di aggancio alla curva. |
+| [CURVE_TANGENT](#CURVE-TANGENT) | Estensione di aggancio alla tangente della curva. |
+| [ELLIPSE_CENTER](#ELLIPSE-CENTER) | Estensione di aggancio al centro dell'ellisse. |
+| [ENDPOINT](#ENDPOINT) | Estensione di aggancio al punto finale. |
+| [ENDPOINT_HORIZONTAL](#ENDPOINT-HORIZONTAL) | Estensione di aggancio al punto finale orizzontale. |
+| [ENDPOINT_PERPENDICULAR](#ENDPOINT-PERPENDICULAR) | Estensione di aggancio al punto finale perpendicolare. |
+| [ENDPOINT_VERTICAL](#ENDPOINT-VERTICAL) | Estensione di aggancio al punto finale verticale. |
+| [ISOMETRIC_ANGLES](#ISOMETRIC-ANGLES) | Estensione di aggancio agli angoli isometrici. |
+| [LINEAR_EXTENSION](#LINEAR-EXTENSION) | Estensione di aggancio lineare. |
+| [MIDPOINT](#MIDPOINT) | Estensione di aggancio al punto medio. |
+| [MIDPOINT_PERPENDICULAR](#MIDPOINT-PERPENDICULAR) | Estensione di aggancio al punto medio perpendicolare. |
+| [NONE](#NONE) | Nessun aggancio. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALIGNMENT_BOX_EXTENSION {#ALIGNMENT-BOX-EXTENSION}
+```
+public static final int ALIGNMENT_BOX_EXTENSION
+```
+
+
+Estensione di aggancio alla casella di allineamento.
+
+### CENTER_AXES {#CENTER-AXES}
+```
+public static final int CENTER_AXES
+```
+
+
+Estensione di aggancio all'asse centrale.
+
+### CURVE_EXTENSION {#CURVE-EXTENSION}
+```
+public static final int CURVE_EXTENSION
+```
+
+
+Estensione di aggancio alla curva.
+
+### CURVE_TANGENT {#CURVE-TANGENT}
+```
+public static final int CURVE_TANGENT
+```
+
+
+Estensione di aggancio alla tangente della curva.
+
+### ELLIPSE_CENTER {#ELLIPSE-CENTER}
+```
+public static final int ELLIPSE_CENTER
+```
+
+
+Estensione di aggancio al centro dell'ellisse.
+
+### ENDPOINT {#ENDPOINT}
+```
+public static final int ENDPOINT
+```
+
+
+Estensione di aggancio al punto finale.
+
+### ENDPOINT_HORIZONTAL {#ENDPOINT-HORIZONTAL}
+```
+public static final int ENDPOINT_HORIZONTAL
+```
+
+
+Estensione di aggancio al punto finale orizzontale.
+
+### ENDPOINT_PERPENDICULAR {#ENDPOINT-PERPENDICULAR}
+```
+public static final int ENDPOINT_PERPENDICULAR
+```
+
+
+Estensione di aggancio al punto finale perpendicolare.
+
+### ENDPOINT_VERTICAL {#ENDPOINT-VERTICAL}
+```
+public static final int ENDPOINT_VERTICAL
+```
+
+
+Estensione di aggancio al punto finale verticale.
+
+### ISOMETRIC_ANGLES {#ISOMETRIC-ANGLES}
+```
+public static final int ISOMETRIC_ANGLES
+```
+
+
+Estensione di aggancio agli angoli isometrici.
+
+### LINEAR_EXTENSION {#LINEAR-EXTENSION}
+```
+public static final int LINEAR_EXTENSION
+```
+
+
+Estensione di aggancio lineare.
+
+### MIDPOINT {#MIDPOINT}
+```
+public static final int MIDPOINT
+```
+
+
+Estensione di aggancio al punto medio.
+
+### MIDPOINT_PERPENDICULAR {#MIDPOINT-PERPENDICULAR}
+```
+public static final int MIDPOINT_PERPENDICULAR
+```
+
+
+Estensione di aggancio al punto medio perpendicolare.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Nessun aggancio.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/snapextensionsvalue/_index.md
+++ b/italian/java/com.aspose.diagram/snapextensionsvalue/_index.md
@@ -1,0 +1,264 @@
+---
+title: SnapExtensionsValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica se un'impostazione specifica di estensione snap è abilitata o disabilitata per la finestra attiva.
+type: docs
+weight: 378
+url: /it/java/com.aspose.diagram/snapextensionsvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class SnapExtensionsValue
+```
+
+Specifica se un'impostazione di estensione di aggancio specifica è abilitata o disabilitata per la finestra attiva. Il valore può essere la somma dei valori nella tabella seguente.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [SNAP_TO_ALIGNMENT_BOX_EXTENSION](#SNAP-TO-ALIGNMENT-BOX-EXTENSION) | Estensione di aggancio alla casella di allineamento. |
+| [SNAP_TO_CENTER_AXIS_EXTENSION](#SNAP-TO-CENTER-AXIS-EXTENSION) | Estensione di aggancio all'asse centrale. |
+| [SNAP_TO_CURVE_EXTENSION](#SNAP-TO-CURVE-EXTENSION) | Estensione di aggancio alla curva. |
+| [SNAP_TO_CURVE_TANGENT_EXTENSION](#SNAP-TO-CURVE-TANGENT-EXTENSION) | Estensione di aggancio alla tangente della curva. |
+| [SNAP_TO_ELLIPSE_CENTER_EXTENSION](#SNAP-TO-ELLIPSE-CENTER-EXTENSION) | Estensione di aggancio al centro dell'ellisse. |
+| [SNAP_TO_END_POINT_EXTENSION](#SNAP-TO-END-POINT-EXTENSION) | Estensione di aggancio al punto finale. |
+| [SNAP_TO_END_POINT_HORIZONTAL_EXTENSION](#SNAP-TO-END-POINT-HORIZONTAL-EXTENSION) | Estensione di aggancio al punto finale orizzontale. |
+| [SNAP_TO_END_POINT_PERPENDICULAR_EXTENSION](#SNAP-TO-END-POINT-PERPENDICULAR-EXTENSION) | Estensione di aggancio al punto finale perpendicolare. |
+| [SNAP_TO_END_POINT_VERTICAL_EXTENSION](#SNAP-TO-END-POINT-VERTICAL-EXTENSION) | Estensione di aggancio al punto finale verticale. |
+| [SNAP_TO_ISOMETRIC_ANGLES_EXTENSION](#SNAP-TO-ISOMETRIC-ANGLES-EXTENSION) | Estensione di aggancio agli angoli isometrici. |
+| [SNAP_TO_LINEAR_EXTENSION](#SNAP-TO-LINEAR-EXTENSION) | Estensione di aggancio lineare. |
+| [SNAP_TO_MID_POINT_EXTENSION](#SNAP-TO-MID-POINT-EXTENSION) | Estensione di aggancio al punto medio. |
+| [SNAP_TO_MID_POINT_PERPENDICULAR_EXTENSION](#SNAP-TO-MID-POINT-PERPENDICULAR-EXTENSION) | Estensione di aggancio al punto medio perpendicolare. |
+| [SNAP_TO_NOTHING](#SNAP-TO-NOTHING) | Nessun aggancio. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SNAP_TO_ALIGNMENT_BOX_EXTENSION {#SNAP-TO-ALIGNMENT-BOX-EXTENSION}
+```
+public static final int SNAP_TO_ALIGNMENT_BOX_EXTENSION
+```
+
+
+Estensione di aggancio alla casella di allineamento.
+
+### SNAP_TO_CENTER_AXIS_EXTENSION {#SNAP-TO-CENTER-AXIS-EXTENSION}
+```
+public static final int SNAP_TO_CENTER_AXIS_EXTENSION
+```
+
+
+Estensione di aggancio all'asse centrale.
+
+### SNAP_TO_CURVE_EXTENSION {#SNAP-TO-CURVE-EXTENSION}
+```
+public static final int SNAP_TO_CURVE_EXTENSION
+```
+
+
+Estensione di aggancio alla curva.
+
+### SNAP_TO_CURVE_TANGENT_EXTENSION {#SNAP-TO-CURVE-TANGENT-EXTENSION}
+```
+public static final int SNAP_TO_CURVE_TANGENT_EXTENSION
+```
+
+
+Estensione di aggancio alla tangente della curva.
+
+### SNAP_TO_ELLIPSE_CENTER_EXTENSION {#SNAP-TO-ELLIPSE-CENTER-EXTENSION}
+```
+public static final int SNAP_TO_ELLIPSE_CENTER_EXTENSION
+```
+
+
+Estensione di aggancio al centro dell'ellisse.
+
+### SNAP_TO_END_POINT_EXTENSION {#SNAP-TO-END-POINT-EXTENSION}
+```
+public static final int SNAP_TO_END_POINT_EXTENSION
+```
+
+
+Estensione di aggancio al punto finale.
+
+### SNAP_TO_END_POINT_HORIZONTAL_EXTENSION {#SNAP-TO-END-POINT-HORIZONTAL-EXTENSION}
+```
+public static final int SNAP_TO_END_POINT_HORIZONTAL_EXTENSION
+```
+
+
+Estensione di aggancio al punto finale orizzontale.
+
+### SNAP_TO_END_POINT_PERPENDICULAR_EXTENSION {#SNAP-TO-END-POINT-PERPENDICULAR-EXTENSION}
+```
+public static final int SNAP_TO_END_POINT_PERPENDICULAR_EXTENSION
+```
+
+
+Estensione di aggancio al punto finale perpendicolare.
+
+### SNAP_TO_END_POINT_VERTICAL_EXTENSION {#SNAP-TO-END-POINT-VERTICAL-EXTENSION}
+```
+public static final int SNAP_TO_END_POINT_VERTICAL_EXTENSION
+```
+
+
+Estensione di aggancio al punto finale verticale.
+
+### SNAP_TO_ISOMETRIC_ANGLES_EXTENSION {#SNAP-TO-ISOMETRIC-ANGLES-EXTENSION}
+```
+public static final int SNAP_TO_ISOMETRIC_ANGLES_EXTENSION
+```
+
+
+Estensione di aggancio agli angoli isometrici.
+
+### SNAP_TO_LINEAR_EXTENSION {#SNAP-TO-LINEAR-EXTENSION}
+```
+public static final int SNAP_TO_LINEAR_EXTENSION
+```
+
+
+Estensione di aggancio lineare.
+
+### SNAP_TO_MID_POINT_EXTENSION {#SNAP-TO-MID-POINT-EXTENSION}
+```
+public static final int SNAP_TO_MID_POINT_EXTENSION
+```
+
+
+Estensione di aggancio al punto medio.
+
+### SNAP_TO_MID_POINT_PERPENDICULAR_EXTENSION {#SNAP-TO-MID-POINT-PERPENDICULAR-EXTENSION}
+```
+public static final int SNAP_TO_MID_POINT_PERPENDICULAR_EXTENSION
+```
+
+
+Estensione di aggancio al punto medio perpendicolare.
+
+### SNAP_TO_NOTHING {#SNAP-TO-NOTHING}
+```
+public static final int SNAP_TO_NOTHING
+```
+
+
+Nessun aggancio.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/snapsettings/_index.md
+++ b/italian/java/com.aspose.diagram/snapsettings/_index.md
@@ -1,0 +1,246 @@
+---
+title: SnapSettings
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica gli oggetti a cui le forme si agganciano quando lo snap è attivo nella finestra.
+type: docs
+weight: 379
+url: /it/java/com.aspose.diagram/snapsettings/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class SnapSettings
+```
+
+Specifies the objects that shapes snap to when snap is active in the window. The value may be a sum of the values.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [ALIGNMENT_BOX](#ALIGNMENT-BOX) | Aggancia alla casella di allineamento. |
+| [CONNECTION_POINTS](#CONNECTION-POINTS) | Aggancia ai punti di connessione. |
+| [DISABLED](#DISABLED) | Aggancio disabilitato. |
+| [EXTENSIONS](#EXTENSIONS) | Aggancia alle opzioni di estensioni della forma. |
+| [GEOMETRY](#GEOMETRY) | Aggancia ai bordi visibili delle forme. |
+| [GRID](#GRID) | Aggancia alla griglia. |
+| [GUIDES](#GUIDES) | Aggancia alle guide. |
+| [HANDLES](#HANDLES) | Aggancia alle maniglie di selezione. |
+| [INTERSECTIONS](#INTERSECTIONS) | Aggancia alle intersezioni. |
+| [NONE](#NONE) | Nessun aggancio. |
+| [RULER_SUBDIVISIONS](#RULER-SUBDIVISIONS) | Aggancia alle suddivisioni del righello. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+| [VERTICES](#VERTICES) | Aggancia ai vertici. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALIGNMENT_BOX {#ALIGNMENT-BOX}
+```
+public static final int ALIGNMENT_BOX
+```
+
+
+Aggancia alla casella di allineamento.
+
+### CONNECTION_POINTS {#CONNECTION-POINTS}
+```
+public static final int CONNECTION_POINTS
+```
+
+
+Aggancia ai punti di connessione.
+
+### DISABLED {#DISABLED}
+```
+public static final int DISABLED
+```
+
+
+Aggancio disabilitato.
+
+### EXTENSIONS {#EXTENSIONS}
+```
+public static final int EXTENSIONS
+```
+
+
+Aggancia alle opzioni di estensioni della forma.
+
+### GEOMETRY {#GEOMETRY}
+```
+public static final int GEOMETRY
+```
+
+
+Aggancia ai bordi visibili delle forme.
+
+### GRID {#GRID}
+```
+public static final int GRID
+```
+
+
+Aggancia alla griglia.
+
+### GUIDES {#GUIDES}
+```
+public static final int GUIDES
+```
+
+
+Aggancia alle guide.
+
+### HANDLES {#HANDLES}
+```
+public static final int HANDLES
+```
+
+
+Aggancia alle maniglie di selezione.
+
+### INTERSECTIONS {#INTERSECTIONS}
+```
+public static final int INTERSECTIONS
+```
+
+
+Aggancia alle intersezioni.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Nessun aggancio.
+
+### RULER_SUBDIVISIONS {#RULER-SUBDIVISIONS}
+```
+public static final int RULER_SUBDIVISIONS
+```
+
+
+Aggancia alle suddivisioni del righello.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### VERTICES {#VERTICES}
+```
+public static final int VERTICES
+```
+
+
+Aggancia ai vertici.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/snapsettingsvalue/_index.md
+++ b/italian/java/com.aspose.diagram/snapsettingsvalue/_index.md
@@ -1,0 +1,246 @@
+---
+title: SnapSettingsValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica gli oggetti a cui le forme si agganciano quando lo snap è attivo nella finestra
+type: docs
+weight: 380
+url: /it/java/com.aspose.diagram/snapsettingsvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class SnapSettingsValue
+```
+
+Specifica gli oggetti a cui le forme si agganciano quando lo snap è attivo nella finestra
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [SNAP_DISABLED](#SNAP-DISABLED) | Aggancio disabilitato. |
+| [SNAP_TO_ALIGNMENT_BOX](#SNAP-TO-ALIGNMENT-BOX) | Aggancia alla casella di allineamento. |
+| [SNAP_TO_CONNECTION_POINTS](#SNAP-TO-CONNECTION-POINTS) | Aggancia ai punti di connessione. |
+| [SNAP_TO_GRID](#SNAP-TO-GRID) | Aggancia alla griglia. |
+| [SNAP_TO_GUIDES](#SNAP-TO-GUIDES) | Aggancia alle guide. |
+| [SNAP_TO_INTERSECTIONS](#SNAP-TO-INTERSECTIONS) | Aggancia alle intersezioni. |
+| [SNAP_TO_NOTHING](#SNAP-TO-NOTHING) | Nessun aggancio. |
+| [SNAP_TO_RULER_SUBDIVISIONS](#SNAP-TO-RULER-SUBDIVISIONS) | Aggancia alle suddivisioni del righello. |
+| [SNAP_TO_SELECTION_HANDLES](#SNAP-TO-SELECTION-HANDLES) | Aggancia alle maniglie di selezione. |
+| [SNAP_TO_SHAPE_EXTENSIONS_OPTIONS](#SNAP-TO-SHAPE-EXTENSIONS-OPTIONS) | Aggancia alle opzioni di estensioni della forma. |
+| [SNAP_TO_THE_VISIBLE_EDGES_OF_SHAPES](#SNAP-TO-THE-VISIBLE-EDGES-OF-SHAPES) | Aggancia ai bordi visibili delle forme. |
+| [SNAP_TO_VERTICES](#SNAP-TO-VERTICES) | Aggancia ai vertici. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SNAP_DISABLED {#SNAP-DISABLED}
+```
+public static final int SNAP_DISABLED
+```
+
+
+Aggancio disabilitato.
+
+### SNAP_TO_ALIGNMENT_BOX {#SNAP-TO-ALIGNMENT-BOX}
+```
+public static final int SNAP_TO_ALIGNMENT_BOX
+```
+
+
+Aggancia alla casella di allineamento.
+
+### SNAP_TO_CONNECTION_POINTS {#SNAP-TO-CONNECTION-POINTS}
+```
+public static final int SNAP_TO_CONNECTION_POINTS
+```
+
+
+Aggancia ai punti di connessione.
+
+### SNAP_TO_GRID {#SNAP-TO-GRID}
+```
+public static final int SNAP_TO_GRID
+```
+
+
+Aggancia alla griglia.
+
+### SNAP_TO_GUIDES {#SNAP-TO-GUIDES}
+```
+public static final int SNAP_TO_GUIDES
+```
+
+
+Aggancia alle guide.
+
+### SNAP_TO_INTERSECTIONS {#SNAP-TO-INTERSECTIONS}
+```
+public static final int SNAP_TO_INTERSECTIONS
+```
+
+
+Aggancia alle intersezioni.
+
+### SNAP_TO_NOTHING {#SNAP-TO-NOTHING}
+```
+public static final int SNAP_TO_NOTHING
+```
+
+
+Nessun aggancio.
+
+### SNAP_TO_RULER_SUBDIVISIONS {#SNAP-TO-RULER-SUBDIVISIONS}
+```
+public static final int SNAP_TO_RULER_SUBDIVISIONS
+```
+
+
+Aggancia alle suddivisioni del righello.
+
+### SNAP_TO_SELECTION_HANDLES {#SNAP-TO-SELECTION-HANDLES}
+```
+public static final int SNAP_TO_SELECTION_HANDLES
+```
+
+
+Aggancia alle maniglie di selezione.
+
+### SNAP_TO_SHAPE_EXTENSIONS_OPTIONS {#SNAP-TO-SHAPE-EXTENSIONS-OPTIONS}
+```
+public static final int SNAP_TO_SHAPE_EXTENSIONS_OPTIONS
+```
+
+
+Aggancia alle opzioni di estensioni della forma.
+
+### SNAP_TO_THE_VISIBLE_EDGES_OF_SHAPES {#SNAP-TO-THE-VISIBLE-EDGES-OF-SHAPES}
+```
+public static final int SNAP_TO_THE_VISIBLE_EDGES_OF_SHAPES
+```
+
+
+Aggancia ai bordi visibili delle forme.
+
+### SNAP_TO_VERTICES {#SNAP-TO-VERTICES}
+```
+public static final int SNAP_TO_VERTICES
+```
+
+
+Aggancia ai vertici.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/solutionxml/_index.md
+++ b/italian/java/com.aspose.diagram/solutionxml/_index.md
@@ -1,0 +1,214 @@
+---
+title: SolutionXML
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene dati XML ben formati specifici della soluzione, con prefisso in uno spazio dei nomi esplicito e memorizzati con un documento.
+type: docs
+weight: 381
+url: /it/java/com.aspose.diagram/solutionxml/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class SolutionXML
+```
+
+Contiene dati XML ben formati specifici della soluzione, con prefisso in uno spazio dei nomi esplicito e memorizzati con un documento.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [SolutionXML(String name, String xmlValue)](#SolutionXML-java.lang.String-java.lang.String-) | Costruttore. |
+| [SolutionXML()](#SolutionXML--) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | Un nome univoco per identificare il set di dati XML. |
+| [getXmlValue()](#getXmlValue--) | Contiene dati XML ben formati specifici della soluzione, con prefisso in uno spazio dei nomi esplicito e memorizzati con un documento. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setName(String value)](#setName-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getName()](../../com.aspose.diagram/solutionxml\#getName--) |
+| [setXmlValue(String value)](#setXmlValue-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getXmlValue()](../../com.aspose.diagram/solutionxml\#getXmlValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SolutionXML(String name, String xmlValue) {#SolutionXML-java.lang.String-java.lang.String-}
+```
+public SolutionXML(String name, String xmlValue)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| nome | java.lang.String |  |
+| xmlValue | java.lang.String |  |
+
+### SolutionXML() {#SolutionXML--}
+```
+public SolutionXML()
+```
+
+
+Costruttore.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Un nome univoco per identificare il set di dati XML.
+
+**Returns:**
+java.lang.String
+### getXmlValue() {#getXmlValue--}
+```
+public String getXmlValue()
+```
+
+
+Contiene dati XML ben formati specifici della soluzione, con prefisso in uno spazio dei nomi esplicito e memorizzati con un documento.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getName()](../../com.aspose.diagram/solutionxml\#getName--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setXmlValue(String value) {#setXmlValue-java.lang.String-}
+```
+public void setXmlValue(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getXmlValue()](../../com.aspose.diagram/solutionxml\#getXmlValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/solutionxmlcollection/_index.md
+++ b/italian/java/com.aspose.diagram/solutionxmlcollection/_index.md
@@ -1,0 +1,234 @@
+---
+title: SolutionXMLCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Raccolta SolutionXML.
+type: docs
+weight: 382
+url: /it/java/com.aspose.diagram/solutionxmlcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class SolutionXMLCollection extends Collection
+```
+
+Raccolta SolutionXML.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [add(SolutionXML solutionXml)](#add-com.aspose.diagram.SolutionXML-) | Aggiungi il SolutionXML nella collezione. |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [get(String name)](#get-java.lang.String-) | Restituisce l'elemento con l'attributo Name specificato. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(SolutionXML solutionXml)](#remove-com.aspose.diagram.SolutionXML-) | Rimuovi il SolutionXML dalla collezione. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(SolutionXML solutionXml) {#add-com.aspose.diagram.SolutionXML-}
+```
+public int add(SolutionXML solutionXml)
+```
+
+
+Aggiungi il SolutionXML nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| solutionXml | [SolutionXML](../../com.aspose.diagram/solutionxml) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public SolutionXML get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[SolutionXML](../../com.aspose.diagram/solutionxml) - 
+### get(String name) {#get-java.lang.String-}
+```
+public SolutionXML get(String name)
+```
+
+
+Restituisce l'elemento con l'attributo Name specificato. Restituisce null se un elemento non esiste.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| nome | java.lang.String |  |
+
+**Returns:**
+[SolutionXML](../../com.aspose.diagram/solutionxml) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(SolutionXML solutionXml) {#remove-com.aspose.diagram.SolutionXML-}
+```
+public void remove(SolutionXML solutionXml)
+```
+
+
+Rimuovi il SolutionXML dalla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| solutionXml | [SolutionXML](../../com.aspose.diagram/solutionxml) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/spinbuttonactivexcontrol/_index.md
+++ b/italian/java/com.aspose.diagram/spinbuttonactivexcontrol/_index.md
@@ -1,0 +1,547 @@
+---
+title: SpinButtonActiveXControl
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta il controllo SpinButton.
+type: docs
+weight: 383
+url: /it/java/com.aspose.diagram/spinbuttonactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class SpinButtonActiveXControl extends ActiveXControl
+```
+
+Rappresenta il controllo SpinButton.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBackOleColor()](#getBackOleColor--) | il colore OLE dello sfondo. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | i dati binari del controllo. |
+| [getForeOleColor()](#getForeOleColor--) | il colore OLE del primo piano. |
+| [getHeight()](#getHeight--) | l'altezza del controllo in unità di punti. |
+| [getIMEMode()](#getIMEMode--) | la modalità di esecuzione predefinita dell'Input Method Editor per il controllo quando riceve il fuoco. |
+| [getMax()](#getMax--) | il valore massimo accettabile. |
+| [getMin()](#getMin--) | il valore minimo accettabile. |
+| [getMouseIcon()](#getMouseIcon--) | un'icona personalizzata da visualizzare come puntatore del mouse per il controllo. |
+| [getMousePointer()](#getMousePointer--) | il tipo di icona visualizzata come puntatore del mouse per il controllo. |
+| [getOrientation()](#getOrientation--) | se il SpinButton o lo ScrollBar è orientato verticalmente o orizzontalmente. |
+| [getPosition()](#getPosition--) | il valore. |
+| [getSmallChange()](#getSmallChange--) | la quantità di cui la proprietà Position cambia |
+| [getType()](#getType--) | Ottiene il tipo del controllo ActiveX. |
+| [getWidth()](#getWidth--) | la larghezza del controllo in unità di punti. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | Indica se il controllo ridimensionerà automaticamente per visualizzare tutto il contenuto. |
+| [isEnabled()](#isEnabled--) | Indica se il controllo può ricevere il focus e rispondere agli eventi generati dall'utente. |
+| [isLocked()](#isLocked--) | Indica se i dati nel controllo sono bloccati per la modifica. |
+| [isTransparent()](#isTransparent--) | Indica se il controllo è trasparente. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | Per la descrizione di questa proprietà, vedere [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | Per la descrizione di questa proprietà, vedere [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | Per la descrizione di questa proprietà, vedere [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | Per la descrizione di questa proprietà, vedere [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setHeight(double value)](#setHeight-double-) | Per la descrizione di questa proprietà, vedere [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setIMEMode(int value)](#setIMEMode-int-) | Per la descrizione di questa proprietà, vedere [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) |
+| [setLocked(boolean value)](#setLocked-boolean-) | Per la descrizione di questa proprietà, vedere [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) |
+| [setMax(int value)](#setMax-int-) | Per la descrizione di questa proprietà, consultare [getMax()](../../com.aspose.diagram/spinbuttonactivexcontrol\\#getMax--) |
+| [setMin(int value)](#setMin-int-) | Per la descrizione di questa proprietà, consultare [getMin()](../../com.aspose.diagram/spinbuttonactivexcontrol\\#getMin--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | Per la descrizione di questa proprietà, vedere [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | Per la descrizione di questa proprietà, vedere [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setOrientation(int value)](#setOrientation-int-) | Per la descrizione di questa proprietà, consultare [getOrientation()](../../com.aspose.diagram/spinbuttonactivexcontrol\\#getOrientation--) |
+| [setPosition(int value)](#setPosition-int-) | Per la descrizione di questa proprietà, consultare [getPosition()](../../com.aspose.diagram/spinbuttonactivexcontrol\\#getPosition--) |
+| [setSmallChange(int value)](#setSmallChange-int-) | Per la descrizione di questa proprietà, consultare [getSmallChange()](../../com.aspose.diagram/spinbuttonactivexcontrol\\#getSmallChange--) |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | Per la descrizione di questa proprietà, vedere [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) |
+| [setWidth(double value)](#setWidth-double-) | Per la descrizione di questa proprietà, vedere [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+il colore OLE dello sfondo.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+i dati binari del controllo.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+Il colore OLE del primo piano. Non si applica al controllo Image.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+l'altezza del controllo in unità di punti.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+la modalità di esecuzione predefinita dell'Input Method Editor per il controllo quando riceve il fuoco.
+
+**Returns:**
+int
+### getMax() {#getMax--}
+```
+public int getMax()
+```
+
+
+il valore massimo accettabile.
+
+**Returns:**
+int
+### getMin() {#getMin--}
+```
+public int getMin()
+```
+
+
+il valore minimo accettabile.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+un'icona personalizzata da visualizzare come puntatore del mouse per il controllo.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+il tipo di icona visualizzata come puntatore del mouse per il controllo.
+
+**Returns:**
+int
+### getOrientation() {#getOrientation--}
+```
+public int getOrientation()
+```
+
+
+se il SpinButton o lo ScrollBar è orientato verticalmente o orizzontalmente.
+
+**Returns:**
+int
+### getPosition() {#getPosition--}
+```
+public int getPosition()
+```
+
+
+il valore.
+
+**Returns:**
+int
+### getSmallChange() {#getSmallChange--}
+```
+public int getSmallChange()
+```
+
+
+la quantità di cui la proprietà Position cambia
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Ottiene il tipo del controllo ActiveX.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+la larghezza del controllo in unità di punti.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+Indica se il controllo ridimensionerà automaticamente per visualizzare tutto il contenuto.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+Indica se il controllo può ricevere il focus e rispondere agli eventi generati dall'utente.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+Indica se i dati nel controllo sono bloccati per la modifica.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+Indica se il controllo è trasparente.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setMax(int value) {#setMax-int-}
+```
+public void setMax(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getMax()](../../com.aspose.diagram/spinbuttonactivexcontrol\\#getMax--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setMin(int value) {#setMin-int-}
+```
+public void setMin(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getMin()](../../com.aspose.diagram/spinbuttonactivexcontrol\\#getMin--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setOrientation(int value) {#setOrientation-int-}
+```
+public void setOrientation(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getOrientation()](../../com.aspose.diagram/spinbuttonactivexcontrol\\#getOrientation--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setPosition(int value) {#setPosition-int-}
+```
+public void setPosition(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getPosition()](../../com.aspose.diagram/spinbuttonactivexcontrol\\#getPosition--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setSmallChange(int value) {#setSmallChange-int-}
+```
+public void setSmallChange(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getSmallChange()](../../com.aspose.diagram/spinbuttonactivexcontrol\\#getSmallChange--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/splineknot/_index.md
+++ b/italian/java/com.aspose.diagram/splineknot/_index.md
@@ -1,0 +1,274 @@
+---
+title: SplineKnot
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene le coordinate x e y per un punto di controllo di una spline e un nodo di spline rappresentati rispettivamente dagli elementi X, Y e A.
+type: docs
+weight: 384
+url: /it/java/com.aspose.diagram/splineknot/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class SplineKnot extends Coordinate
+```
+
+Contiene le coordinate x e y per il punto di controllo di una spline e per un nodo della spline, rappresentati rispettivamente dagli elementi X, Y e A.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [SplineKnot()](#SplineKnot--) | Crea un'istanza della classe [SplineKnot](../../com.aspose.diagram/splineknot). |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | Uno dei nodi della spline (diverso dall'ultimo o dai primi due). |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getIX()](#getIX--) | L'indice basato su zero dell'elemento all'interno del suo elemento genitore. |
+| [getX()](#getX--) | La coordinata x di un punto di controllo. |
+| [getY()](#getY--) | La coordinata y di un punto di controllo. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, consulta [getA()](../../com.aspose.diagram/splineknot\#getA--) |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, consulta [getDel()](../../com.aspose.diagram/splineknot\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Per la descrizione di questa proprietà, consulta [getIX()](../../com.aspose.diagram/splineknot\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, consulta [getX()](../../com.aspose.diagram/splineknot\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, consulta [getY()](../../com.aspose.diagram/splineknot\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SplineKnot() {#SplineKnot--}
+```
+public SplineKnot()
+```
+
+
+Crea un'istanza della classe [SplineKnot](../../com.aspose.diagram/splineknot).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+Uno dei nodi della spline (diverso dall'ultimo o dai primi due).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+L'indice basato su zero dell'elemento all'interno del suo elemento genitore.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+La coordinata x di un punto di controllo.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+La coordinata y di un punto di controllo.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, consulta [getA()](../../com.aspose.diagram/splineknot\#getA--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, consulta [getDel()](../../com.aspose.diagram/splineknot\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Per la descrizione di questa proprietà, consulta [getIX()](../../com.aspose.diagram/splineknot\#getIX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, consulta [getX()](../../com.aspose.diagram/splineknot\#getX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, consulta [getY()](../../com.aspose.diagram/splineknot\#getY--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/splineknotcollection/_index.md
+++ b/italian/java/com.aspose.diagram/splineknotcollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: SplineKnotCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Raccolta SplineKnot.
+type: docs
+weight: 385
+url: /it/java/com.aspose.diagram/splineknotcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class SplineKnotCollection extends Collection
+```
+
+Raccolta SplineKnot.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public SplineKnot get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[SplineKnot](../../com.aspose.diagram/splineknot) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/splinestart/_index.md
+++ b/italian/java/com.aspose.diagram/splinestart/_index.md
@@ -1,0 +1,349 @@
+---
+title: SplineStart
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene le coordinate x e y per il secondo punto di controllo di una spline, il suo secondo nodo, il suo primo nodo, l'ultimo nodo e il grado della spline.
+type: docs
+weight: 386
+url: /it/java/com.aspose.diagram/splinestart/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class SplineStart extends Coordinate
+```
+
+Contiene le coordinate x e y per il secondo punto di controllo di una spline, il suo secondo nodo, il suo primo nodo, l'ultimo nodo e il grado della spline. Queste informazioni sono contenute rispettivamente negli elementi X, Y, A, B, C e D.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [SplineStart()](#SplineStart--) | Crea un'istanza della classe [SplineStart](../../com.aspose.diagram/splinestart). |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | Il secondo nodo della spline. |
+| [getB()](#getB--) | Il primo nodo di una spline. |
+| [getC()](#getC--) | L'ultimo nodo della spline. |
+| [getClass()](#getClass--) |  |
+| [getD()](#getD--) | Il grado della spline (un intero da 1 a 25). |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getIX()](#getIX--) | L'indice basato su zero dell'elemento all'interno del suo elemento genitore. |
+| [getX()](#getX--) | La coordinata x del secondo punto di controllo di una spline. |
+| [getY()](#getY--) | La coordinata y del secondo punto di controllo di una spline. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getA()](../../com.aspose.diagram/splinestart\#getA--) |
+| [setB(DoubleValue value)](#setB-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getB()](../../com.aspose.diagram/splinestart\#getB--) |
+| [setC(DoubleValue value)](#setC-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getC()](../../com.aspose.diagram/splinestart\#getC--) |
+| [setD(IntValue value)](#setD-com.aspose.diagram.IntValue-) | Per la descrizione di questa proprietà, vedere [getD()](../../com.aspose.diagram/splinestart\#getD--) |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/splinestart\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Per la descrizione di questa proprietà, vedere [getIX()](../../com.aspose.diagram/splinestart\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getX()](../../com.aspose.diagram/splinestart\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getY()](../../com.aspose.diagram/splinestart\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SplineStart() {#SplineStart--}
+```
+public SplineStart()
+```
+
+
+Crea un'istanza della classe [SplineStart](../../com.aspose.diagram/splinestart).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+Il secondo nodo della spline.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getB() {#getB--}
+```
+public DoubleValue getB()
+```
+
+
+Il primo nodo di una spline.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getC() {#getC--}
+```
+public DoubleValue getC()
+```
+
+
+L'ultimo nodo della spline.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getD() {#getD--}
+```
+public IntValue getD()
+```
+
+
+Il grado della spline (un intero da 1 a 25).
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+L'indice basato su zero dell'elemento all'interno del suo elemento genitore.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+La coordinata x del secondo punto di controllo di una spline.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+La coordinata y del secondo punto di controllo di una spline.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getA()](../../com.aspose.diagram/splinestart\#getA--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setB(DoubleValue value) {#setB-com.aspose.diagram.DoubleValue-}
+```
+public void setB(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getB()](../../com.aspose.diagram/splinestart\#getB--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setC(DoubleValue value) {#setC-com.aspose.diagram.DoubleValue-}
+```
+public void setC(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getC()](../../com.aspose.diagram/splinestart\#getC--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setD(IntValue value) {#setD-com.aspose.diagram.IntValue-}
+```
+public void setD(IntValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getD()](../../com.aspose.diagram/splinestart\#getD--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/splinestart\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getIX()](../../com.aspose.diagram/splinestart\#getIX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getX()](../../com.aspose.diagram/splinestart\#getX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getY()](../../com.aspose.diagram/splinestart\#getY--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/splinestartcollection/_index.md
+++ b/italian/java/com.aspose.diagram/splinestartcollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: SplineStartCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Raccolta SplineStart.
+type: docs
+weight: 387
+url: /it/java/com.aspose.diagram/splinestartcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class SplineStartCollection extends Collection
+```
+
+Raccolta SplineStart.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public SplineStart get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[SplineStart](../../com.aspose.diagram/splinestart) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/str2value/_index.md
+++ b/italian/java/com.aspose.diagram/str2value/_index.md
@@ -1,0 +1,244 @@
+---
+title: Str2Value
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Valore stringa.
+type: docs
+weight: 388
+url: /it/java/com.aspose.diagram/str2value/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.StrValue](../../com.aspose.diagram/strvalue)
+```
+public class Str2Value extends StrValue
+```
+
+Valore stringa.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [Str2Value(String value)](#Str2Value-java.lang.String-) | Costruttore. |
+| [Str2Value(String value, UnitFormulaErrV ufev)](#Str2Value-java.lang.String-com.aspose.diagram.UnitFormulaErrV-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Attributi di un elemento. |
+| [getUfev()](#getUfev--) | Attributi di un elemento. |
+| [getValue()](#getValue--) | Valore stringa. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | Per la descrizione di questa proprietà, vedere [getUfe()](../../com.aspose.diagram/strvalue\#getUfe--) |
+| [setUfev(UnitFormulaErrV value)](#setUfev-com.aspose.diagram.UnitFormulaErrV-) | Per la descrizione di questa proprietà, vedere [getUfev()](../../com.aspose.diagram/str2value\#getUfev--) |
+| [setValue(String value)](#setValue-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/strvalue\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Str2Value(String value) {#Str2Value-java.lang.String-}
+```
+public Str2Value(String value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### Str2Value(String value, UnitFormulaErrV ufev) {#Str2Value-java.lang.String-com.aspose.diagram.UnitFormulaErrV-}
+```
+public Str2Value(String value, UnitFormulaErrV ufev)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+| ufev | [UnitFormulaErrV](../../com.aspose.diagram/unitformulaerrv) |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getUfev() {#getUfev--}
+```
+public UnitFormulaErrV getUfev()
+```
+
+
+Attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErrV](../../com.aspose.diagram/unitformulaerrv)
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+Valore stringa.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getUfe()](../../com.aspose.diagram/strvalue\#getUfe--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setUfev(UnitFormulaErrV value) {#setUfev-com.aspose.diagram.UnitFormulaErrV-}
+```
+public void setUfev(UnitFormulaErrV value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getUfev()](../../com.aspose.diagram/str2value\#getUfev--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [UnitFormulaErrV](../../com.aspose.diagram/unitformulaerrv) |  |
+
+### setValue(String value) {#setValue-java.lang.String-}
+```
+public void setValue(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/strvalue\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/streamprovideroptions/_index.md
+++ b/italian/java/com.aspose.diagram/streamprovideroptions/_index.md
@@ -1,0 +1,186 @@
+---
+title: StreamProviderOptions
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta le opzioni di flusso.
+type: docs
+weight: 390
+url: /it/java/com.aspose.diagram/streamprovideroptions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class StreamProviderOptions
+```
+
+Rappresenta le opzioni di flusso.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [StreamProviderOptions()](#StreamProviderOptions--) |  |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDefaultPath()](#getDefaultPath--) | Il percorso predefinito (URL) salvato nel file HTML generato per la fonte di riferimento. |
+| [getStream()](#getStream--) | Ottiene/Imposta lo stream di output per scrivere i dati salvati |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCustomPath(String value)](#setCustomPath-java.lang.String-) | Il percorso personalizzato (URL) dell'utente salvato nel file HTML generato per la fonte di riferimento. |
+| [setStream(OutputStream value)](#setStream-java.io.OutputStream-) | Per la descrizione di questa proprietà, vedere [getStream()](../../com.aspose.diagram/streamprovideroptions\#getStream--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### StreamProviderOptions() {#StreamProviderOptions--}
+```
+public StreamProviderOptions()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultPath() {#getDefaultPath--}
+```
+public String getDefaultPath()
+```
+
+
+Il percorso predefinito (URL) salvato nel file HTML generato per la fonte di riferimento. Ad esempio, i dati del foglio salvati in xxx\_files/sheet001.htm, l'URL utilizzato nel file HTML principale dovrebbe essere simile a "src=\"xxx\_files/sheet001.htm\""
+
+**Returns:**
+java.lang.String
+### getStream() {#getStream--}
+```
+public OutputStream getStream()
+```
+
+
+Ottiene/Imposta lo stream di output per scrivere i dati salvati
+
+**Returns:**
+java.io.OutputStream
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCustomPath(String value) {#setCustomPath-java.lang.String-}
+```
+public void setCustomPath(String value)
+```
+
+
+Il percorso personalizzato (URL) dell'utente salvato nel file HTML generato per la fonte di riferimento. Se non definito dall'utente, verrà utilizzato DefaultPath. Ad esempio, i dati del foglio saranno salvati dall'utente in d:/sheet001.htm, l'URL utilizzato nel file HTML principale dovrebbe essere "d:/sheet001.htm" o un altro percorso relativo valido che possa essere accessibile dal file HTML principale.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setStream(OutputStream value) {#setStream-java.io.OutputStream-}
+```
+public void setStream(OutputStream value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getStream()](../../com.aspose.diagram/streamprovideroptions\#getStream--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.io.OutputStream |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/strvalue/_index.md
+++ b/italian/java/com.aspose.diagram/strvalue/_index.md
@@ -1,0 +1,234 @@
+---
+title: StrValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Valore stringa
+type: docs
+weight: 389
+url: /it/java/com.aspose.diagram/strvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class StrValue
+```
+
+Valore stringa
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [StrValue(String value)](#StrValue-java.lang.String-) | Costruttore. |
+| [StrValue(String value, UnitFormulaErr ufe)](#StrValue-java.lang.String-com.aspose.diagram.UnitFormulaErr-) | Costruttore. |
+| [StrValue(String value, int unit)](#StrValue-java.lang.String-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Attributi di un elemento. |
+| [getValue()](#getValue--) | Valore stringa. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | Per la descrizione di questa proprietà, vedere [getUfe()](../../com.aspose.diagram/strvalue\#getUfe--) |
+| [setValue(String value)](#setValue-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/strvalue\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### StrValue(String value) {#StrValue-java.lang.String-}
+```
+public StrValue(String value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### StrValue(String value, UnitFormulaErr ufe) {#StrValue-java.lang.String-com.aspose.diagram.UnitFormulaErr-}
+```
+public StrValue(String value, UnitFormulaErr ufe)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+| ufe | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### StrValue(String value, int unit) {#StrValue-java.lang.String-int-}
+```
+public StrValue(String value, int unit)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+| unità | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+Valore stringa.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getUfe()](../../com.aspose.diagram/strvalue\#getUfe--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(String value) {#setValue-java.lang.String-}
+```
+public void setValue(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/strvalue\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/style/_index.md
+++ b/italian/java/com.aspose.diagram/style/_index.md
@@ -1,0 +1,204 @@
+---
+title: Style
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica la formattazione dei caratteri applicata a un intervallo di testo nel blocco di testo delle forme.
+type: docs
+weight: 391
+url: /it/java/com.aspose.diagram/style/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Style
+```
+
+Specifica la formattazione dei caratteri applicata a un intervallo di testo nel blocco di testo della forma.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [Style(int value)](#Style-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Specifica la formattazione dei caratteri applicata a un intervallo di testo nel blocco di testo della forma. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | For the description of this property, please see [getUfe()](../../com.aspose.diagram/style\#getUfe--) |
+| [setValue(int value)](#setValue-int-) | For the description of this property, please see [getValue()](../../com.aspose.diagram/style\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Style(int value) {#Style-int-}
+```
+public Style(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specifica la formattazione dei caratteri applicata a un intervallo di testo nel blocco di testo della forma.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+For the description of this property, please see [getUfe()](../../com.aspose.diagram/style\#getUfe--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+For the description of this property, please see [getValue()](../../com.aspose.diagram/style\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/styleprop/_index.md
+++ b/italian/java/com.aspose.diagram/styleprop/_index.md
@@ -1,0 +1,194 @@
+---
+title: StyleProp
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene elementi che controllano il comportamento dello stile, ad esempio se uno stile include attributi di linea di testo e di riempimento.
+type: docs
+weight: 392
+url: /it/java/com.aspose.diagram/styleprop/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class StyleProp
+```
+
+Contiene elementi che controllano il comportamento dello stile, ad esempio se uno stile include attributi di testo, linea e riempimento.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getEnableFillProps()](#getEnableFillProps--) | Specifica se uno stile include proprietà di riempimento. |
+| [getEnableLineProps()](#getEnableLineProps--) | Specifica se uno stile include proprietà di linea |
+| [getEnableTextProps()](#getEnableTextProps--) | Specifica se uno stile include proprietà di testo. |
+| [getHideForApply()](#getHideForApply--) | Specifica dove viene mostrato uno stile nell'interfaccia utente di Microsoft Visio. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/styleprop\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getEnableFillProps() {#getEnableFillProps--}
+```
+public BoolValue getEnableFillProps()
+```
+
+
+Specifica se uno stile include proprietà di riempimento.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getEnableLineProps() {#getEnableLineProps--}
+```
+public BoolValue getEnableLineProps()
+```
+
+
+Specifica se uno stile include proprietà di linea
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getEnableTextProps() {#getEnableTextProps--}
+```
+public BoolValue getEnableTextProps()
+```
+
+
+Specifica se uno stile include proprietà di testo.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getHideForApply() {#getHideForApply--}
+```
+public BoolValue getHideForApply()
+```
+
+
+Specifica dove viene mostrato uno stile nell'interfaccia utente di Microsoft Visio.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/styleprop\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/stylesheet/_index.md
+++ b/italian/java/com.aspose.diagram/stylesheet/_index.md
@@ -1,0 +1,519 @@
+---
+title: StyleSheet
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta uno stile definito in un documento.
+type: docs
+weight: 393
+url: /it/java/com.aspose.diagram/stylesheet/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class StyleSheet
+```
+
+Rappresenta uno stile definito in un documento.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [StyleSheet()](#StyleSheet--) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getChars()](#getChars--) | Contiene una raccolta di elementi Char. |
+| [getClass()](#getClass--) |  |
+| [getConnectionABCDs()](#getConnectionABCDs--) | Contiene una raccolta di elementi ConnectionABCD. |
+| [getConnections()](#getConnections--) | Contiene una raccolta di elementi Connection. |
+| [getEvent()](#getEvent--) | Contiene elementi che specificano formule che controllano gli eventi della forma. |
+| [getFill()](#getFill--) | Contiene i valori di formattazione di riempimento attuali per la forma e l'ombra della forma, inclusi modello, colore di primo piano e colore di sfondo. |
+| [getFillStyle()](#getFillStyle--) | Elemento StyleSheet da cui questo stile eredita la formattazione di riempimento. |
+| [getForeign()](#getForeign--) | Contiene elementi che specificano la larghezza e l'altezza di un oggetto proveniente da un altro programma utilizzato in un documento Microsoft Visio. |
+| [getForeignData()](#getForeignData--) | Contiene un BLOB codificato MIME (Multipurpose Internet Mail Extensions) di dati immagine, come metafile Windows, bitmap o dati OLE. |
+| [getGroup()](#getGroup--) | Contiene gli elementi che controllano come aggiungere forme a un gruppo, spostare i membri di un gruppo e selezionare i gruppi. |
+| [getHelp()](#getHelp--) | Contiene gli elementi che specificano l'argomento del file di aiuto dell'elemento Shape e le informazioni sul copyright. |
+| [getID()](#getID--) | L'ID univoco dell'elemento all'interno del suo elemento genitore. |
+| [getImage()](#getImage--) | Contiene i valori di gamma, luminosità, contrasto, sfocatura, nitidezza, riduzione del rumore e trasparenza per un bitmap. |
+| [getLayout()](#getLayout--) | Contiene elementi che controllano il posizionamento delle forme e le impostazioni di instradamento dei connettori. |
+| [getLine()](#getLine--) | Contiene elementi che controllano gli attributi di linea per una forma, come modello, spessore e colore. |
+| [getLineStyle()](#getLineStyle--) | Elemento StyleSheet da cui questo stile eredita la formattazione della linea. |
+| [getMisc()](#getMisc--) | Contiene gli elementi che specificano l'argomento del file di aiuto dell'elemento Shape e le informazioni sul copyright. |
+| [getName()](#getName--) | Il nome dell'elemento. |
+| [getNameU()](#getNameU--) | Il nome universale dell'elemento. |
+| [getPageLayout()](#getPageLayout--) | Contiene Diagram che controlla le impostazioni di layout della pagina per forme e connettori, come la spaziatura tra tutte le forme sulla pagina, la spaziatura tra tutti i connettori sulla pagina e lo stile di instradamento per tutti i connettori sulla pagina. |
+| [getParas()](#getParas--) | Contiene una raccolta di elementi Para. |
+| [getProtection()](#getProtection--) | Il blocco aiuta a prevenire modifiche involontarie alla forma ma non impedisce a Microsoft Visio di ripristinare i valori in altre circostanze. |
+| [getRulerGrid()](#getRulerGrid--) | Contiene elementi che specificano le impostazioni dei righelli e della griglia della pagina. |
+| [getStyleProp()](#getStyleProp--) | Contiene elementi che controllano il comportamento dello stile, ad esempio se uno stile include attributi di testo, linea e riempimento. |
+| [getTabsCollection()](#getTabsCollection--) | Contiene una raccolta di elementi Tab. |
+| [getTextBlock()](#getTextBlock--) | Contiene elementi che specificano l'allineamento, i margini e le posizioni predefinite delle tabulazioni del testo nel blocco di testo di una forma. |
+| [getTextStyle()](#getTextStyle--) | Elemento StyleSheet da cui questo stile eredita la formattazione del testo. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setFillStyle(StyleSheet value)](#setFillStyle-com.aspose.diagram.StyleSheet-) | Per la descrizione di questa proprietà, vedere [getFillStyle()](../../com.aspose.diagram/stylesheet\#getFillStyle--) |
+| [setID(int value)](#setID-int-) | Per la descrizione di questa proprietà, vedere [getID()](../../com.aspose.diagram/stylesheet\#getID--) |
+| [setLineStyle(StyleSheet value)](#setLineStyle-com.aspose.diagram.StyleSheet-) | Per la descrizione di questa proprietà, vedere [getLineStyle()](../../com.aspose.diagram/stylesheet\#getLineStyle--) |
+| [setName(String value)](#setName-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getName()](../../com.aspose.diagram/stylesheet\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getNameU()](../../com.aspose.diagram/stylesheet\#getNameU--) |
+| [setTextStyle(StyleSheet value)](#setTextStyle-com.aspose.diagram.StyleSheet-) | Per la descrizione di questa proprietà, vedere [getTextStyle()](../../com.aspose.diagram/stylesheet\#getTextStyle--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### StyleSheet() {#StyleSheet--}
+```
+public StyleSheet()
+```
+
+
+Costruttore.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getChars() {#getChars--}
+```
+public CharCollection getChars()
+```
+
+
+Contiene una raccolta di elementi Char.
+
+**Returns:**
+[CharCollection](../../com.aspose.diagram/charcollection)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConnectionABCDs() {#getConnectionABCDs--}
+```
+public ConnectionABCDCollection getConnectionABCDs()
+```
+
+
+Contiene una raccolta di elementi ConnectionABCD.
+
+**Returns:**
+[ConnectionABCDCollection](../../com.aspose.diagram/connectionabcdcollection)
+### getConnections() {#getConnections--}
+```
+public ConnectionCollection getConnections()
+```
+
+
+Contiene una raccolta di elementi Connection.
+
+**Returns:**
+[ConnectionCollection](../../com.aspose.diagram/connectioncollection)
+### getEvent() {#getEvent--}
+```
+public Event getEvent()
+```
+
+
+Contiene elementi che specificano formule che controllano gli eventi della forma.
+
+**Returns:**
+[Event](../../com.aspose.diagram/event)
+### getFill() {#getFill--}
+```
+public Fill getFill()
+```
+
+
+Contiene i valori di formattazione di riempimento attuali per la forma e l'ombra della forma, inclusi modello, colore di primo piano e colore di sfondo.
+
+**Returns:**
+[Fill](../../com.aspose.diagram/fill)
+### getFillStyle() {#getFillStyle--}
+```
+public StyleSheet getFillStyle()
+```
+
+
+Elemento StyleSheet da cui questo stile eredita la formattazione di riempimento.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getForeign() {#getForeign--}
+```
+public Foreign getForeign()
+```
+
+
+Contiene elementi che specificano la larghezza e l'altezza di un oggetto proveniente da un altro programma utilizzato in un documento Microsoft Visio. Include anche elementi che specificano la distanza di offset dell'immagine dell'oggetto all'interno dei suoi bordi.
+
+**Returns:**
+[Foreign](../../com.aspose.diagram/foreign)
+### getForeignData() {#getForeignData--}
+```
+public ForeignData getForeignData()
+```
+
+
+Contiene un BLOB codificato MIME (Multipurpose Internet Mail Extensions) di dati immagine, come metafile Windows, bitmap o dati OLE.
+
+**Returns:**
+[ForeignData](../../com.aspose.diagram/foreigndata)
+### getGroup() {#getGroup--}
+```
+public Group getGroup()
+```
+
+
+Contiene gli elementi che controllano come aggiungere forme a un gruppo, spostare i membri di un gruppo e selezionare i gruppi.
+
+**Returns:**
+[Group](../../com.aspose.diagram/group)
+### getHelp() {#getHelp--}
+```
+public Help getHelp()
+```
+
+
+Contiene gli elementi che specificano l'argomento del file di aiuto dell'elemento Shape e le informazioni sul copyright.
+
+**Returns:**
+[Help](../../com.aspose.diagram/help)
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+L'ID univoco dell'elemento all'interno del suo elemento genitore.
+
+**Returns:**
+int
+### getImage() {#getImage--}
+```
+public Image getImage()
+```
+
+
+Contiene i valori di gamma, luminosità, contrasto, sfocatura, nitidezza, riduzione del rumore e trasparenza per un bitmap.
+
+**Returns:**
+[Image](../../com.aspose.diagram/image)
+### getLayout() {#getLayout--}
+```
+public Layout getLayout()
+```
+
+
+Contiene elementi che controllano il posizionamento delle forme e le impostazioni di instradamento dei connettori.
+
+**Returns:**
+[Layout](../../com.aspose.diagram/layout)
+### getLine() {#getLine--}
+```
+public Line getLine()
+```
+
+
+Contiene elementi che controllano gli attributi della linea per una forma, come modello, spessore e colore. Questi elementi determinano se le estremità della linea sono formattate (ad esempio, con una punta di freccia), la dimensione dei formati delle estremità della linea, il raggio del cerchio di arrotondamento applicato alla linea e lo stile del cappuccio della linea (rotondo o quadrato).
+
+**Returns:**
+[Line](../../com.aspose.diagram/line)
+### getLineStyle() {#getLineStyle--}
+```
+public StyleSheet getLineStyle()
+```
+
+
+Elemento StyleSheet da cui questo stile eredita la formattazione della linea.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getMisc() {#getMisc--}
+```
+public Misc getMisc()
+```
+
+
+Contiene gli elementi che specificano l'argomento del file di aiuto dell'elemento Shape e le informazioni sul copyright.
+
+**Returns:**
+[Misc](../../com.aspose.diagram/misc)
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Il nome dell'elemento.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+Il nome universale dell'elemento.
+
+**Returns:**
+java.lang.String
+### getPageLayout() {#getPageLayout--}
+```
+public PageLayout getPageLayout()
+```
+
+
+Contiene Diagram che controlla le impostazioni di layout della pagina per forme e connettori, come la spaziatura tra tutte le forme sulla pagina, la spaziatura tra tutti i connettori sulla pagina e lo stile di instradamento per tutti i connettori sulla pagina.
+
+**Returns:**
+[PageLayout](../../com.aspose.diagram/pagelayout)
+### getParas() {#getParas--}
+```
+public ParaCollection getParas()
+```
+
+
+Contiene una raccolta di elementi Para.
+
+**Returns:**
+[ParaCollection](../../com.aspose.diagram/paracollection)
+### getProtection() {#getProtection--}
+```
+public Protection getProtection()
+```
+
+
+Il blocco aiuta a prevenire modifiche involontarie alla forma ma non impedisce a Microsoft Visio di ripristinare i valori in altre circostanze. Inoltre non protegge dalle modifiche apportate nella finestra ShapeSheet.
+
+**Returns:**
+[Protection](../../com.aspose.diagram/protection)
+### getRulerGrid() {#getRulerGrid--}
+```
+public RulerGrid getRulerGrid()
+```
+
+
+Contiene elementi che specificano le impostazioni dei righelli e della griglia della pagina.
+
+**Returns:**
+[RulerGrid](../../com.aspose.diagram/rulergrid)
+### getStyleProp() {#getStyleProp--}
+```
+public StyleProp getStyleProp()
+```
+
+
+Contiene elementi che controllano il comportamento dello stile, ad esempio se uno stile include attributi di testo, linea e riempimento.
+
+**Returns:**
+[StyleProp](../../com.aspose.diagram/styleprop)
+### getTabsCollection() {#getTabsCollection--}
+```
+public TabsCollection getTabsCollection()
+```
+
+
+Contiene una raccolta di elementi Tab.
+
+**Returns:**
+[TabsCollection](../../com.aspose.diagram/tabscollection)
+### getTextBlock() {#getTextBlock--}
+```
+public TextBlock getTextBlock()
+```
+
+
+Contiene elementi che specificano l'allineamento, i margini e le posizioni predefinite delle tabulazioni del testo nel blocco di testo di una forma.
+
+**Returns:**
+[TextBlock](../../com.aspose.diagram/textblock)
+### getTextStyle() {#getTextStyle--}
+```
+public StyleSheet getTextStyle()
+```
+
+
+Elemento StyleSheet da cui questo stile eredita la formattazione del testo.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setFillStyle(StyleSheet value) {#setFillStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setFillStyle(StyleSheet value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getFillStyle()](../../com.aspose.diagram/stylesheet\#getFillStyle--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getID()](../../com.aspose.diagram/stylesheet\#getID--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setLineStyle(StyleSheet value) {#setLineStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setLineStyle(StyleSheet value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getLineStyle()](../../com.aspose.diagram/stylesheet\#getLineStyle--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getName()](../../com.aspose.diagram/stylesheet\#getName--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getNameU()](../../com.aspose.diagram/stylesheet\#getNameU--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setTextStyle(StyleSheet value) {#setTextStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setTextStyle(StyleSheet value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getTextStyle()](../../com.aspose.diagram/stylesheet\#getTextStyle--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/stylesheetcollection/_index.md
+++ b/italian/java/com.aspose.diagram/stylesheetcollection/_index.md
@@ -1,0 +1,234 @@
+---
+title: StyleSheetCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Raccolta di fogli di stile.
+type: docs
+weight: 394
+url: /it/java/com.aspose.diagram/stylesheetcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class StyleSheetCollection extends Collection
+```
+
+Raccolta di fogli di stile.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [add(StyleSheet item)](#add-com.aspose.diagram.StyleSheet-) | Aggiungi StyleSheet nella collezione. |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [getStyleSheet(int ID)](#getStyleSheet-int-) | Restituisce l'elemento con l'ID specificato. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(StyleSheet item)](#remove-com.aspose.diagram.StyleSheet-) | Rimuovi StyleSheet dalla collezione. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(StyleSheet item) {#add-com.aspose.diagram.StyleSheet-}
+```
+public int add(StyleSheet item)
+```
+
+
+Aggiungi StyleSheet nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public StyleSheet get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### getStyleSheet(int ID) {#getStyleSheet-int-}
+```
+public StyleSheet getStyleSheet(int ID)
+```
+
+
+Restituisce l'elemento con l'ID specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| ID | int |  |
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet) - 
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(StyleSheet item) {#remove-com.aspose.diagram.StyleSheet-}
+```
+public void remove(StyleSheet item)
+```
+
+
+Rimuovi StyleSheet dalla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/stylevalue/_index.md
+++ b/italian/java/com.aspose.diagram/stylevalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: StyleValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica la formattazione dei caratteri applicata a un intervallo di testo nel blocco di testo delle forme.
+type: docs
+weight: 395
+url: /it/java/com.aspose.diagram/stylevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class StyleValue
+```
+
+Specifica la formattazione dei caratteri applicata a un intervallo di testo nel blocco di testo della forma.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [BOLD](#BOLD) | Grassetto. |
+| [ITALIC](#ITALIC) | Corsivo. |
+| [SMALL_CAPS](#SMALL-CAPS) | Maiuscole piccole. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+| [UNDERLINE](#UNDERLINE) | Sottolineato. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOLD {#BOLD}
+```
+public static final int BOLD
+```
+
+
+Grassetto.
+
+### ITALIC {#ITALIC}
+```
+public static final int ITALIC
+```
+
+
+Corsivo.
+
+### SMALL_CAPS {#SMALL-CAPS}
+```
+public static final int SMALL_CAPS
+```
+
+
+Maiuscole piccole.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### UNDERLINE {#UNDERLINE}
+```
+public static final int UNDERLINE
+```
+
+
+Sottolineato.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/svgsaveoptions/_index.md
+++ b/italian/java/com.aspose.diagram/svgsaveoptions/_index.md
@@ -1,0 +1,604 @@
+---
+title: SVGSaveOptions
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Consente di specificare opzioni aggiuntive durante il rendering delle pagine del diagramma in SVG.
+type: docs
+weight: 347
+url: /it/java/com.aspose.diagram/svgsaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.SaveOptions](../../com.aspose.diagram/saveoptions), [com.aspose.diagram.RenderingSaveOptions](../../com.aspose.diagram/renderingsaveoptions)
+```
+public class SVGSaveOptions extends RenderingSaveOptions
+```
+
+Consente di specificare opzioni aggiuntive durante il rendering delle pagine del diagramma in SVG.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [SVGSaveOptions()](#SVGSaveOptions--) | Inizializza una nuova istanza di questa classe che può essere utilizzata per salvare un documento nel formato Aspose.Diagram.SaveFileFormat. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | Crea un oggetto di opzioni di salvataggio di una classe adatta al formato di salvataggio specificato. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCustomImagePath()](#getCustomImagePath--) | Il percorso personalizzato dell'utente (URL) salvato nel file SVG generato per l'immagine. |
+| [getDefaultFont()](#getDefaultFont--) | Quando i caratteri nel diagramma sono Unicode e non vengono impostati con il valore di carattere corretto o il carattere non è installato localmente, possono apparire come blocchi in PDF, immagine o XPS. |
+| [getEmfRenderSetting()](#getEmfRenderSetting--) | Impostazione per il rendering del metafile Emf. |
+| [getEnlargePage()](#getEnlargePage--) | Specifica se ingrandire la pagina. |
+| [getExportElementAsRectTag()](#getExportElementAsRectTag--) | Definisce se è necessario esportare gli elementi rettangolo come tag rect o meno. |
+| [getExportGuideShapes()](#getExportGuideShapes--) | Definisce se è necessario esportare le forme guida o meno. |
+| [getExportHiddenPage()](#getExportHiddenPage--) | Definisce se è necessario esportare la pagina nascosta o meno. |
+| [getPageIndex()](#getPageIndex--) | l'indice basato su zero della pagina da renderizzare. |
+| [getPageSize()](#getPageSize--) | la dimensione della pagina per le immagini generate. |
+| [getQuality()](#getQuality--) | un valore che determina la qualità delle immagini generate da applicare solo quando si salvano le pagine nel formato JPEG. |
+| [getSVGFitToViewPort()](#getSVGFitToViewPort--) | se questa proprietà è vera, l'SVG generato si adatterà alla viewport. |
+| [getSaveFormat()](#getSaveFormat--) | Specifica il formato in cui il documento verrà salvato se viene utilizzato questo oggetto di opzioni di salvataggio. |
+| [getShapes()](#getShapes--) | forme da renderizzare. |
+| [getWarningCallback()](#getWarningCallback--) | callback di avviso. |
+| [hashCode()](#hashCode--) |  |
+| [isExportComments()](#isExportComments--) | Definisce se è necessario esportare i commenti o meno. |
+| [isExportScaleInMatrix()](#isExportScaleInMatrix--) | Definisce se è necessario esportare la scala in matrice o meno. |
+| [isSavingCustomLinePattern()](#isSavingCustomLinePattern--) | Definisce se salvare il modello di linea personalizzato. |
+| [isSavingImageSeparately()](#isSavingImageSeparately--) | Definisce se salvare l'immagine separatamente. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCustomImagePath(String value)](#setCustomImagePath-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getCustomImagePath()](../../com.aspose.diagram/svgsaveoptions\#getCustomImagePath--) |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--) |
+| [setEmfRenderSetting(int value)](#setEmfRenderSetting-int-) | Per la descrizione di questa proprietà, vedere [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--) |
+| [setEnlargePage(boolean value)](#setEnlargePage-boolean-) | Per la descrizione di questa proprietà, vedere [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\\#getEnlargePage--) |
+| [setExportComments(boolean value)](#setExportComments-boolean-) | Per la descrizione di questa proprietà, vedere [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\\#isExportComments--) |
+| [setExportElementAsRectTag(boolean value)](#setExportElementAsRectTag-boolean-) | Per la descrizione di questa proprietà, vedere [getExportElementAsRectTag()](../../com.aspose.diagram/svgsaveoptions\#getExportElementAsRectTag--) |
+| [setExportGuideShapes(boolean value)](#setExportGuideShapes-boolean-) | Per la descrizione di questa proprietà, vedere [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\\#getExportGuideShapes--) |
+| [setExportHiddenPage(boolean value)](#setExportHiddenPage-boolean-) | Per la descrizione di questa proprietà, vedere [getExportHiddenPage()](../../com.aspose.diagram/svgsaveoptions\#getExportHiddenPage--) |
+| [setExportScaleInMatrix(boolean value)](#setExportScaleInMatrix-boolean-) | Per la descrizione di questa proprietà, vedere [isExportScaleInMatrix()](../../com.aspose.diagram/svgsaveoptions\#isExportScaleInMatrix--) |
+| [setPageIndex(int value)](#setPageIndex-int-) | Per la descrizione di questa proprietà, vedere [getPageIndex()](../../com.aspose.diagram/svgsaveoptions\#getPageIndex--) |
+| [setPageSize(PageSize value)](#setPageSize-com.aspose.diagram.PageSize-) | Per la descrizione di questa proprietà, vedere [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\\#getPageSize--) |
+| [setQuality(int value)](#setQuality-int-) | Per la descrizione di questa proprietà, vedere [getQuality()](../../com.aspose.diagram/svgsaveoptions\#getQuality--) |
+| [setSVGFitToViewPort(boolean value)](#setSVGFitToViewPort-boolean-) | Per la descrizione di questa proprietà, vedere [getSVGFitToViewPort()](../../com.aspose.diagram/svgsaveoptions\#getSVGFitToViewPort--) |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | Per la descrizione di questa proprietà, vedere [getSaveFormat()](../../com.aspose.diagram/saveoptions\#getSaveFormat--) |
+| [setSavingCustomLinePattern(boolean value)](#setSavingCustomLinePattern-boolean-) | Per la descrizione di questa proprietà, vedere [isSavingCustomLinePattern()](../../com.aspose.diagram/svgsaveoptions\#isSavingCustomLinePattern--) |
+| [setSavingImageSeparately(boolean value)](#setSavingImageSeparately-boolean-) | Per la descrizione di questa proprietà, vedere [isSavingImageSeparately()](../../com.aspose.diagram/svgsaveoptions\#isSavingImageSeparately--) |
+| [setShapes(ShapeCollection value)](#setShapes-com.aspose.diagram.ShapeCollection-) | Per la descrizione di questa proprietà, vedere [getShapes()](../../com.aspose.diagram/renderingsaveoptions\\#getShapes--) |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SVGSaveOptions() {#SVGSaveOptions--}
+```
+public SVGSaveOptions()
+```
+
+
+Inizializza una nuova istanza di questa classe che può essere utilizzata per salvare un documento nel formato Aspose.Diagram.SaveFileFormat.
+
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+Crea un oggetto di opzioni di salvataggio di una classe adatta al formato di salvataggio specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| saveFormat | int | Il Aspose.Diagram.SaveFileFormat per il quale creare un oggetto di opzioni di salvataggio. |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCustomImagePath() {#getCustomImagePath--}
+```
+public String getCustomImagePath()
+```
+
+
+Il percorso personalizzato dell'utente (URL) salvato nel file SVG generato per l'immagine. Se non definito dall'utente, verrà utilizzata la directory corrente.
+
+**Returns:**
+java.lang.String
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+Quando i caratteri nel diagramma sono Unicode e non sono impostati con il valore di font corretto o il font non è installato localmente, possono apparire come blocchi in PDF, immagine o XPS. Impostare il DefaultFont, ad esempio MingLiu o MS Gothic, per visualizzare questi caratteri.
+
+**Returns:**
+java.lang.String
+### getEmfRenderSetting() {#getEmfRenderSetting--}
+```
+public int getEmfRenderSetting()
+```
+
+
+Impostazione per il rendering dei metafile EMF. I metafile EMF identificati come "EMF+ Dual" possono contenere sia record EMF+ sia record EMF. Entrambi i tipi di record possono essere usati per renderizzare l'immagine, solo record EMF+, o solo record EMF. Quando EmfPlusPrefer è impostato, i record EMF+ verranno analizzati, altrimenti verranno analizzati solo i record EMF. Il valore predefinito è EmfOnly"/>.
+
+**Returns:**
+int
+### getEnlargePage() {#getEnlargePage--}
+```
+public boolean getEnlargePage()
+```
+
+
+Specifica se ingrandire la pagina. Se true - ingrandire la pagina. Se false - non ingrandire la pagina. Il valore predefinito è true.
+
+**Returns:**
+boolean
+### getExportElementAsRectTag() {#getExportElementAsRectTag--}
+```
+public boolean getExportElementAsRectTag()
+```
+
+
+Definisce se è necessario esportare gli elementi rettangolo come tag rect o meno. Il valore predefinito è false.
+
+**Returns:**
+boolean
+### getExportGuideShapes() {#getExportGuideShapes--}
+```
+public boolean getExportGuideShapes()
+```
+
+
+Definisce se è necessario esportare le forme guida o meno. Il valore predefinito è true.
+
+**Returns:**
+boolean
+### getExportHiddenPage() {#getExportHiddenPage--}
+```
+public boolean getExportHiddenPage()
+```
+
+
+Definisce se è necessario esportare la pagina nascosta o meno. Il valore predefinito è true.
+
+**Returns:**
+boolean
+### getPageIndex() {#getPageIndex--}
+```
+public int getPageIndex()
+```
+
+
+l'indice basato su zero della pagina da renderizzare. Il valore predefinito è 0.
+
+**Returns:**
+int
+### getPageSize() {#getPageSize--}
+```
+public PageSize getPageSize()
+```
+
+
+la dimensione della pagina per le immagini generate. Può essere [PageSize](../../com.aspose.diagram/pagesize) o null. Il valore predefinito è null. Se PageSize è null, la dimensione della pagina per l'immagine generata viene ottenuta dal diagramma di origine.
+
+**Returns:**
+[PageSize](../../com.aspose.diagram/pagesize)
+### getQuality() {#getQuality--}
+```
+public int getQuality()
+```
+
+
+un valore che determina la qualità delle immagini generate da applicare solo quando si salvano le pagine nel formato Jpeg. Il valore predefinito è 100. Ha effetto solo quando si salva in JPEG. Il valore deve essere compreso tra 0 e 100. Il valore predefinito è 100.
+
+**Returns:**
+int
+### getSVGFitToViewPort() {#getSVGFitToViewPort--}
+```
+public boolean getSVGFitToViewPort()
+```
+
+
+se questa proprietà è vera, l'SVG generato si adatterà alla viewport.
+
+**Returns:**
+boolean
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+Specifica il formato in cui il documento verrà salvato se viene utilizzato questo oggetto di opzioni di salvataggio.
+
+**Returns:**
+int
+### getShapes() {#getShapes--}
+```
+public ShapeCollection getShapes()
+```
+
+
+forme da renderizzare. Il conteggio predefinito è 0.
+
+**Returns:**
+[ShapeCollection](../../com.aspose.diagram/shapecollection)
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+callback di avviso.
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExportComments() {#isExportComments--}
+```
+public boolean isExportComments()
+```
+
+
+Definisce se è necessario esportare i commenti o meno. Il valore predefinito è false.
+
+**Returns:**
+boolean
+### isExportScaleInMatrix() {#isExportScaleInMatrix--}
+```
+public boolean isExportScaleInMatrix()
+```
+
+
+Definisce se è necessario esportare la scala in una matrice o meno. Il valore predefinito è true.
+
+**Returns:**
+boolean
+### isSavingCustomLinePattern() {#isSavingCustomLinePattern--}
+```
+public boolean isSavingCustomLinePattern()
+```
+
+
+Definisce se salvare il modello di linea personalizzato.
+
+**Returns:**
+boolean
+### isSavingImageSeparately() {#isSavingImageSeparately--}
+```
+public boolean isSavingImageSeparately()
+```
+
+
+Definisce se salvare l'immagine separatamente.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCustomImagePath(String value) {#setCustomImagePath-java.lang.String-}
+```
+public void setCustomImagePath(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getCustomImagePath()](../../com.aspose.diagram/svgsaveoptions\#getCustomImagePath--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setEmfRenderSetting(int value) {#setEmfRenderSetting-int-}
+```
+public void setEmfRenderSetting(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setEnlargePage(boolean value) {#setEnlargePage-boolean-}
+```
+public void setEnlargePage(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\\#getEnlargePage--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setExportComments(boolean value) {#setExportComments-boolean-}
+```
+public void setExportComments(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\\#isExportComments--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setExportElementAsRectTag(boolean value) {#setExportElementAsRectTag-boolean-}
+```
+public void setExportElementAsRectTag(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getExportElementAsRectTag()](../../com.aspose.diagram/svgsaveoptions\#getExportElementAsRectTag--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setExportGuideShapes(boolean value) {#setExportGuideShapes-boolean-}
+```
+public void setExportGuideShapes(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\\#getExportGuideShapes--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setExportHiddenPage(boolean value) {#setExportHiddenPage-boolean-}
+```
+public void setExportHiddenPage(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getExportHiddenPage()](../../com.aspose.diagram/svgsaveoptions\#getExportHiddenPage--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setExportScaleInMatrix(boolean value) {#setExportScaleInMatrix-boolean-}
+```
+public void setExportScaleInMatrix(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isExportScaleInMatrix()](../../com.aspose.diagram/svgsaveoptions\#isExportScaleInMatrix--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setPageIndex(int value) {#setPageIndex-int-}
+```
+public void setPageIndex(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getPageIndex()](../../com.aspose.diagram/svgsaveoptions\#getPageIndex--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setPageSize(PageSize value) {#setPageSize-com.aspose.diagram.PageSize-}
+```
+public void setPageSize(PageSize value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\\#getPageSize--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [PageSize](../../com.aspose.diagram/pagesize) |  |
+
+### setQuality(int value) {#setQuality-int-}
+```
+public void setQuality(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getQuality()](../../com.aspose.diagram/svgsaveoptions\#getQuality--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setSVGFitToViewPort(boolean value) {#setSVGFitToViewPort-boolean-}
+```
+public void setSVGFitToViewPort(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getSVGFitToViewPort()](../../com.aspose.diagram/svgsaveoptions\#getSVGFitToViewPort--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getSaveFormat()](../../com.aspose.diagram/saveoptions\#getSaveFormat--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setSavingCustomLinePattern(boolean value) {#setSavingCustomLinePattern-boolean-}
+```
+public void setSavingCustomLinePattern(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isSavingCustomLinePattern()](../../com.aspose.diagram/svgsaveoptions\#isSavingCustomLinePattern--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setSavingImageSeparately(boolean value) {#setSavingImageSeparately-boolean-}
+```
+public void setSavingImageSeparately(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isSavingImageSeparately()](../../com.aspose.diagram/svgsaveoptions\#isSavingImageSeparately--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setShapes(ShapeCollection value) {#setShapes-com.aspose.diagram.ShapeCollection-}
+```
+public void setShapes(ShapeCollection value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getShapes()](../../com.aspose.diagram/renderingsaveoptions\\#getShapes--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [ShapeCollection](../../com.aspose.diagram/shapecollection) |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/tab/_index.md
+++ b/italian/java/com.aspose.diagram/tab/_index.md
@@ -1,0 +1,261 @@
+---
+title: Tab
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene una raccolta di elementi Tab.
+type: docs
+weight: 396
+url: /it/java/com.aspose.diagram/tab/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Tab
+```
+
+Contiene una raccolta di elementi Tab.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAlignment()](#getAlignment--) | Specifica l'allineamento della scheda. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getIX()](#getIX--) | L'indice basato su zero dell'elemento all'interno del suo elemento genitore. |
+| [getLeader()](#getLeader--) | Specificato il leader. |
+| [getPosition()](#getPosition--) | Specifica la posizione di una tabulazione. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAlignment(Alignment value)](#setAlignment-com.aspose.diagram.Alignment-) | Per la descrizione di questa proprietà, consultare [getAlignment()](../../com.aspose.diagram/tab\#getAlignment--) |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, consultare [getDel()](../../com.aspose.diagram/tab\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Per la descrizione di questa proprietà, consultare [getIX()](../../com.aspose.diagram/tab\#getIX--) |
+| [setLeader(StrValue value)](#setLeader-com.aspose.diagram.StrValue-) | Per la descrizione di questa proprietà, consultare [getLeader()](../../com.aspose.diagram/tab\#getLeader--) |
+| [setPosition(DoubleValue value)](#setPosition-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, consultare [getPosition()](../../com.aspose.diagram/tab\#getPosition--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAlignment() {#getAlignment--}
+```
+public Alignment getAlignment()
+```
+
+
+Specifica l'allineamento della scheda.
+
+**Returns:**
+[Alignment](../../com.aspose.diagram/alignment)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+L'indice basato su zero dell'elemento all'interno del suo elemento genitore.
+
+**Returns:**
+int
+### getLeader() {#getLeader--}
+```
+public StrValue getLeader()
+```
+
+
+Specificato il leader.
+
+**Returns:**
+[StrValue](../../com.aspose.diagram/strvalue)
+### getPosition() {#getPosition--}
+```
+public DoubleValue getPosition()
+```
+
+
+Specifica la posizione di una tabulazione.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAlignment(Alignment value) {#setAlignment-com.aspose.diagram.Alignment-}
+```
+public void setAlignment(Alignment value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getAlignment()](../../com.aspose.diagram/tab\#getAlignment--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [Alignment](../../com.aspose.diagram/alignment) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getDel()](../../com.aspose.diagram/tab\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getIX()](../../com.aspose.diagram/tab\#getIX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setLeader(StrValue value) {#setLeader-com.aspose.diagram.StrValue-}
+```
+public void setLeader(StrValue value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getLeader()](../../com.aspose.diagram/tab\#getLeader--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [StrValue](../../com.aspose.diagram/strvalue) |  |
+
+### setPosition(DoubleValue value) {#setPosition-com.aspose.diagram.DoubleValue-}
+```
+public void setPosition(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getPosition()](../../com.aspose.diagram/tab\#getPosition--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/tabcollection/_index.md
+++ b/italian/java/com.aspose.diagram/tabcollection/_index.md
@@ -1,0 +1,268 @@
+---
+title: TabCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene una raccolta di elementi Tab
+type: docs
+weight: 397
+url: /it/java/com.aspose.diagram/tabcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class TabCollection extends Collection
+```
+
+Contiene una raccolta di elementi Tab
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [add(Tab item)](#add-com.aspose.diagram.Tab-) | Aggiungi l'oggetto Tab nella collezione. |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getIX()](#getIX--) | L'indice basato su zero dell'elemento all'interno del suo elemento genitore. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Tab item)](#remove-com.aspose.diagram.Tab-) | Rimuovi l'oggetto Tab dalla collezione. |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/tabcollection\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Per la descrizione di questa proprietà, vedere [getIX()](../../com.aspose.diagram/tabcollection\#getIX--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Tab item) {#add-com.aspose.diagram.Tab-}
+```
+public int add(Tab item)
+```
+
+
+Aggiungi l'oggetto Tab nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [Tab](../../com.aspose.diagram/tab) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Tab get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[Tab](../../com.aspose.diagram/tab) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+L'indice basato su zero dell'elemento all'interno del suo elemento genitore.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Tab item) {#remove-com.aspose.diagram.Tab-}
+```
+public void remove(Tab item)
+```
+
+
+Rimuovi l'oggetto Tab dalla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [Tab](../../com.aspose.diagram/tab) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/tabcollection\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getIX()](../../com.aspose.diagram/tabcollection\#getIX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/tabscollection/_index.md
+++ b/italian/java/com.aspose.diagram/tabscollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: TabsCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene una raccolta di elementi TabCollection
+type: docs
+weight: 398
+url: /it/java/com.aspose.diagram/tabscollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class TabsCollection extends Collection
+```
+
+Contiene una raccolta di elementi TabCollection
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [add(TabCollection item)](#add-com.aspose.diagram.TabCollection-) | Aggiungi l'oggetto Tab nella collezione. |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(TabCollection item)](#remove-com.aspose.diagram.TabCollection-) | Rimuovi l'oggetto Tab dalla collezione. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(TabCollection item) {#add-com.aspose.diagram.TabCollection-}
+```
+public int add(TabCollection item)
+```
+
+
+Aggiungi l'oggetto Tab nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [TabCollection](../../com.aspose.diagram/tabcollection) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public TabCollection get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[TabCollection](../../com.aspose.diagram/tabcollection) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(TabCollection item) {#remove-com.aspose.diagram.TabCollection-}
+```
+public void remove(TabCollection item)
+```
+
+
+Rimuovi l'oggetto Tab dalla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [TabCollection](../../com.aspose.diagram/tabcollection) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/text/_index.md
+++ b/italian/java/com.aspose.diagram/text/_index.md
@@ -1,0 +1,160 @@
+---
+title: Testo
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene il testo di una forma.
+type: docs
+weight: 399
+url: /it/java/com.aspose.diagram/text/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Text
+```
+
+Contiene il testo di una forma.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [Text()](#Text--) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getValue()](#getValue--) | Raccolta FormatTxt che contiene il testo di una forma. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Text() {#Text--}
+```
+public Text()
+```
+
+
+Costruttore.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getValue() {#getValue--}
+```
+public FormatTxtCollection getValue()
+```
+
+
+Raccolta FormatTxt che contiene il testo di una forma.
+
+**Returns:**
+[FormatTxtCollection](../../com.aspose.diagram/formattxtcollection)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/textblock/_index.md
+++ b/italian/java/com.aspose.diagram/textblock/_index.md
@@ -1,0 +1,386 @@
+---
+title: TextBlock
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene elementi che specificano i margini di allineamento e le posizioni predefinite delle tabulazioni del testo in un blocco di testo di una forma.
+type: docs
+weight: 400
+url: /it/java/com.aspose.diagram/textblock/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class TextBlock
+```
+
+Contiene elementi che specificano l'allineamento, i margini e le posizioni predefinite delle tabulazioni del testo nel blocco di testo di una forma.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBottomMargin()](#getBottomMargin--) | Determina la distanza tra il bordo inferiore del blocco di testo e l'ultima riga di testo che contiene. |
+| [getClass()](#getClass--) |  |
+| [getDefaultTabStop()](#getDefaultTabStop--) | Specifica l'intervallo delle tabulazioni predefinite in un blocco di testo. |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getLeftMargin()](#getLeftMargin--) | Specifica la distanza tra il bordo sinistro del blocco di testo e il testo che contiene. |
+| [getRightMargin()](#getRightMargin--) | Specifica la distanza tra il bordo destro del blocco di testo e il testo che contiene. |
+| [getTextBkgnd()](#getTextBkgnd--) | Specifica il colore di sfondo del testo per una forma. |
+| [getTextBkgndTrans()](#getTextBkgndTrans--) | Specifica il livello di trasparenza per il colore di sfondo del blocco di testo di una forma, da 0 (completamente opaco) a 1 (completamente trasparente). |
+| [getTextDirection()](#getTextDirection--) | Specifica la direzione dei caratteri in un blocco di testo. |
+| [getTopMargin()](#getTopMargin--) | Specifica la distanza tra il bordo superiore del blocco di testo e la prima riga di testo che contiene. |
+| [getVerticalAlign()](#getVerticalAlign--) | Specifica l'allineamento verticale del testo all'interno del blocco di testo. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setBottomMargin(DoubleValue value)](#setBottomMargin-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, consultare [getBottomMargin()](../../com.aspose.diagram/textblock\#getBottomMargin--) |
+| [setDefaultTabStop(DoubleValue value)](#setDefaultTabStop-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, consultare [getDefaultTabStop()](../../com.aspose.diagram/textblock\#getDefaultTabStop--) |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, consultare [getDel()](../../com.aspose.diagram/textblock\#getDel--) |
+| [setLeftMargin(DoubleValue value)](#setLeftMargin-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, consultare [getLeftMargin()](../../com.aspose.diagram/textblock\#getLeftMargin--) |
+| [setRightMargin(DoubleValue value)](#setRightMargin-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, consultare [getRightMargin()](../../com.aspose.diagram/textblock\#getRightMargin--) |
+| [setTextBkgnd(ColorValue value)](#setTextBkgnd-com.aspose.diagram.ColorValue-) | Per la descrizione di questa proprietà, consultare [getTextBkgnd()](../../com.aspose.diagram/textblock\#getTextBkgnd--) |
+| [setTextBkgndTrans(DoubleValue value)](#setTextBkgndTrans-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, consultare [getTextBkgndTrans()](../../com.aspose.diagram/textblock\#getTextBkgndTrans--) |
+| [setTextDirection(TextDirection value)](#setTextDirection-com.aspose.diagram.TextDirection-) | Per la descrizione di questa proprietà, vedere [getTextDirection()](../../com.aspose.diagram/textblock\#getTextDirection--) |
+| [setTopMargin(DoubleValue value)](#setTopMargin-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getTopMargin()](../../com.aspose.diagram/textblock\#getTopMargin--) |
+| [setVerticalAlign(VerticalAlign value)](#setVerticalAlign-com.aspose.diagram.VerticalAlign-) | Per la descrizione di questa proprietà, vedere [getVerticalAlign()](../../com.aspose.diagram/textblock\#getVerticalAlign--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBottomMargin() {#getBottomMargin--}
+```
+public DoubleValue getBottomMargin()
+```
+
+
+Determina la distanza tra il bordo inferiore del blocco di testo e l'ultima riga di testo che contiene. Il valore predefinito è 4 pt. Questo valore è indipendente dalla scala del disegno. Se il disegno è scalato, il margine inferiore rimane lo stesso.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultTabStop() {#getDefaultTabStop--}
+```
+public DoubleValue getDefaultTabStop()
+```
+
+
+Specifica l'intervallo delle tabulazioni predefinite in un blocco di testo.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getLeftMargin() {#getLeftMargin--}
+```
+public DoubleValue getLeftMargin()
+```
+
+
+Specifica la distanza tra il bordo sinistro del blocco di testo e il testo che contiene. Questo valore è indipendente dalla scala del disegno. Se il disegno è scalato, il margine sinistro rimane lo stesso.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getRightMargin() {#getRightMargin--}
+```
+public DoubleValue getRightMargin()
+```
+
+
+Specifica la distanza tra il bordo destro del blocco di testo e il testo che contiene. Questo valore è indipendente dalla scala del disegno. Se il disegno è scalato, il margine destro rimane lo stesso.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTextBkgnd() {#getTextBkgnd--}
+```
+public ColorValue getTextBkgnd()
+```
+
+
+Specifica il colore di sfondo del testo per una forma.
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getTextBkgndTrans() {#getTextBkgndTrans--}
+```
+public DoubleValue getTextBkgndTrans()
+```
+
+
+Specifica il livello di trasparenza per il colore di sfondo del blocco di testo di una forma, da 0 (completamente opaco) a 1 (completamente trasparente).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTextDirection() {#getTextDirection--}
+```
+public TextDirection getTextDirection()
+```
+
+
+Specifica la direzione dei caratteri in un blocco di testo.
+
+**Returns:**
+[TextDirection](../../com.aspose.diagram/textdirection)
+### getTopMargin() {#getTopMargin--}
+```
+public DoubleValue getTopMargin()
+```
+
+
+Specifica la distanza tra il bordo superiore del blocco di testo e la prima riga di testo che contiene.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getVerticalAlign() {#getVerticalAlign--}
+```
+public VerticalAlign getVerticalAlign()
+```
+
+
+Specifica l'allineamento verticale del testo all'interno del blocco di testo.
+
+**Returns:**
+[VerticalAlign](../../com.aspose.diagram/verticalalign)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setBottomMargin(DoubleValue value) {#setBottomMargin-com.aspose.diagram.DoubleValue-}
+```
+public void setBottomMargin(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getBottomMargin()](../../com.aspose.diagram/textblock\#getBottomMargin--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDefaultTabStop(DoubleValue value) {#setDefaultTabStop-com.aspose.diagram.DoubleValue-}
+```
+public void setDefaultTabStop(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getDefaultTabStop()](../../com.aspose.diagram/textblock\#getDefaultTabStop--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getDel()](../../com.aspose.diagram/textblock\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setLeftMargin(DoubleValue value) {#setLeftMargin-com.aspose.diagram.DoubleValue-}
+```
+public void setLeftMargin(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getLeftMargin()](../../com.aspose.diagram/textblock\#getLeftMargin--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setRightMargin(DoubleValue value) {#setRightMargin-com.aspose.diagram.DoubleValue-}
+```
+public void setRightMargin(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getRightMargin()](../../com.aspose.diagram/textblock\#getRightMargin--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTextBkgnd(ColorValue value) {#setTextBkgnd-com.aspose.diagram.ColorValue-}
+```
+public void setTextBkgnd(ColorValue value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getTextBkgnd()](../../com.aspose.diagram/textblock\#getTextBkgnd--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setTextBkgndTrans(DoubleValue value) {#setTextBkgndTrans-com.aspose.diagram.DoubleValue-}
+```
+public void setTextBkgndTrans(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getTextBkgndTrans()](../../com.aspose.diagram/textblock\#getTextBkgndTrans--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTextDirection(TextDirection value) {#setTextDirection-com.aspose.diagram.TextDirection-}
+```
+public void setTextDirection(TextDirection value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getTextDirection()](../../com.aspose.diagram/textblock\#getTextDirection--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [TextDirection](../../com.aspose.diagram/textdirection) |  |
+
+### setTopMargin(DoubleValue value) {#setTopMargin-com.aspose.diagram.DoubleValue-}
+```
+public void setTopMargin(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getTopMargin()](../../com.aspose.diagram/textblock\#getTopMargin--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setVerticalAlign(VerticalAlign value) {#setVerticalAlign-com.aspose.diagram.VerticalAlign-}
+```
+public void setVerticalAlign(VerticalAlign value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getVerticalAlign()](../../com.aspose.diagram/textblock\#getVerticalAlign--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [VerticalAlign](../../com.aspose.diagram/verticalalign) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/textboxactivexcontrol/_index.md
+++ b/italian/java/com.aspose.diagram/textboxactivexcontrol/_index.md
@@ -1,0 +1,922 @@
+---
+title: TextBoxActiveXControl
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta un controllo ActiveX casella di testo.
+type: docs
+weight: 401
+url: /it/java/com.aspose.diagram/textboxactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class TextBoxActiveXControl extends ActiveXControl
+```
+
+Rappresenta un controllo ActiveX casella di testo.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBackOleColor()](#getBackOleColor--) | il colore OLE dello sfondo. |
+| [getBorderOleColor()](#getBorderOleColor--) | il colore OLE dello sfondo. |
+| [getBorderStyle()](#getBorderStyle--) | il tipo di bordo usato dal controllo. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | i dati binari del controllo. |
+| [getDropButtonStyle()](#getDropButtonStyle--) | Specifica il simbolo visualizzato sul pulsante a discesa |
+| [getEnterFieldBehavior()](#getEnterFieldBehavior--) | Specifica il comportamento di selezione quando si entra nel controllo. |
+| [getEnterKeyBehavior()](#getEnterKeyBehavior--) | Specifica il comportamento del tasto ENTER. |
+| [getForeOleColor()](#getForeOleColor--) | il colore OLE del primo piano. |
+| [getHeight()](#getHeight--) | l'altezza del controllo in unità di punti. |
+| [getHideSelection()](#getHideSelection--) | Indica se il testo selezionato nel controllo appare evidenziato quando il controllo non ha il fuoco. |
+| [getIMEMode()](#getIMEMode--) | la modalità di esecuzione predefinita dell'Input Method Editor per il controllo quando riceve il fuoco. |
+| [getIntegralHeight()](#getIntegralHeight--) | Indica se il controllo mostrerà solo linee di testo complete senza mostrare linee parziali. |
+| [getMaxLength()](#getMaxLength--) | il numero massimo di caratteri |
+| [getMouseIcon()](#getMouseIcon--) | un'icona personalizzata da visualizzare come puntatore del mouse per il controllo. |
+| [getMousePointer()](#getMousePointer--) | il tipo di icona visualizzata come puntatore del mouse per il controllo. |
+| [getPasswordChar()](#getPasswordChar--) | un carattere da visualizzare al posto dei caratteri inseriti. |
+| [getScrollBars()](#getScrollBars--) | Indica se il controllo ha barre di scorrimento verticali, barre di scorrimento orizzontali, entrambe o nessuna. |
+| [getShowDropButtonTypeWhen()](#getShowDropButtonTypeWhen--) | Specifica il simbolo visualizzato sul pulsante a discesa |
+| [getSpecialEffect()](#getSpecialEffect--) | l'effetto speciale del controllo. |
+| [getTabKeyBehavior()](#getTabKeyBehavior--) | Indica se i caratteri di tabulazione sono consentiti nel testo del controllo. |
+| [getText()](#getText--) | testo del controllo. |
+| [getType()](#getType--) | Ottiene il tipo del controllo ActiveX. |
+| [getWidth()](#getWidth--) | la larghezza del controllo in unità di punti. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | Indica se il controllo ridimensionerà automaticamente per visualizzare tutto il contenuto. |
+| [isAutoTab()](#isAutoTab--) | Indica se il focus si sposterà automaticamente al controllo successivo quando l'utente inserisce il numero massimo di caratteri. |
+| [isAutoWordSelected()](#isAutoWordSelected--) | Specifica l'unità di base utilizzata per estendere una selezione. |
+| [isDragBehaviorEnabled()](#isDragBehaviorEnabled--) | Indica se il trascinamento e il rilascio sono abilitati per il controllo. |
+| [isEditable()](#isEditable--) | Indica se l'utente può digitare nel controllo. |
+| [isEnabled()](#isEnabled--) | Indica se il controllo può ricevere il focus e rispondere agli eventi generati dall'utente. |
+| [isLocked()](#isLocked--) | Indica se i dati nel controllo sono bloccati per la modifica. |
+| [isMultiLine()](#isMultiLine--) | Indica se il controllo può visualizzare più di una riga di testo. |
+| [isTransparent()](#isTransparent--) | Indica se il controllo è trasparente. |
+| [isWordWrapped()](#isWordWrapped--) | Indica se il contenuto del controllo avvolge automaticamente alla fine di una riga. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | Per la descrizione di questa proprietà, vedere [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) |
+| [setAutoTab(boolean value)](#setAutoTab-boolean-) | Per la descrizione di questa proprietà, consultare [isAutoTab()](../../com.aspose.diagram/textboxactivexcontrol\#isAutoTab--) |
+| [setAutoWordSelected(boolean value)](#setAutoWordSelected-boolean-) | Per la descrizione di questa proprietà, consultare [isAutoWordSelected()](../../com.aspose.diagram/textboxactivexcontrol\#isAutoWordSelected--) |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | Per la descrizione di questa proprietà, vedere [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setBorderOleColor(int value)](#setBorderOleColor-int-) | Per la descrizione di questa proprietà, consultare [getBorderOleColor()](../../com.aspose.diagram/textboxactivexcontrol\#getBorderOleColor--) |
+| [setBorderStyle(int value)](#setBorderStyle-int-) | Per la descrizione di questa proprietà, consultare [getBorderStyle()](../../com.aspose.diagram/textboxactivexcontrol\#getBorderStyle--) |
+| [setDragBehaviorEnabled(boolean value)](#setDragBehaviorEnabled-boolean-) | Per la descrizione di questa proprietà, consultare [isDragBehaviorEnabled()](../../com.aspose.diagram/textboxactivexcontrol\#isDragBehaviorEnabled--) |
+| [setDropButtonStyle(int value)](#setDropButtonStyle-int-) | Per la descrizione di questa proprietà, consultare [getDropButtonStyle()](../../com.aspose.diagram/textboxactivexcontrol\#getDropButtonStyle--) |
+| [setEditable(boolean value)](#setEditable-boolean-) | Per la descrizione di questa proprietà, consultare [isEditable()](../../com.aspose.diagram/textboxactivexcontrol\#isEditable--) |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | Per la descrizione di questa proprietà, vedere [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) |
+| [setEnterFieldBehavior(boolean value)](#setEnterFieldBehavior-boolean-) | Per la descrizione di questa proprietà, consultare [getEnterFieldBehavior()](../../com.aspose.diagram/textboxactivexcontrol\#getEnterFieldBehavior--) |
+| [setEnterKeyBehavior(boolean value)](#setEnterKeyBehavior-boolean-) | Per la descrizione di questa proprietà, consultare [getEnterKeyBehavior()](../../com.aspose.diagram/textboxactivexcontrol\#getEnterKeyBehavior--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | Per la descrizione di questa proprietà, vedere [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setHeight(double value)](#setHeight-double-) | Per la descrizione di questa proprietà, vedere [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setHideSelection(boolean value)](#setHideSelection-boolean-) | Per la descrizione di questa proprietà, consultare [getHideSelection()](../../com.aspose.diagram/textboxactivexcontrol\#getHideSelection--) |
+| [setIMEMode(int value)](#setIMEMode-int-) | Per la descrizione di questa proprietà, vedere [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) |
+| [setIntegralHeight(boolean value)](#setIntegralHeight-boolean-) | Per la descrizione di questa proprietà, consultare [getIntegralHeight()](../../com.aspose.diagram/textboxactivexcontrol\#getIntegralHeight--) |
+| [setLocked(boolean value)](#setLocked-boolean-) | Per la descrizione di questa proprietà, vedere [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) |
+| [setMaxLength(int value)](#setMaxLength-int-) | Per la descrizione di questa proprietà, consultare [getMaxLength()](../../com.aspose.diagram/textboxactivexcontrol\#getMaxLength--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | Per la descrizione di questa proprietà, vedere [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | Per la descrizione di questa proprietà, vedere [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setMultiLine(boolean value)](#setMultiLine-boolean-) | Per la descrizione di questa proprietà, consultare [isMultiLine()](../../com.aspose.diagram/textboxactivexcontrol\#isMultiLine--) |
+| [setPasswordChar(char value)](#setPasswordChar-char-) | Per la descrizione di questa proprietà, consultare [getPasswordChar()](../../com.aspose.diagram/textboxactivexcontrol\#getPasswordChar--) |
+| [setScrollBars(int value)](#setScrollBars-int-) | Per la descrizione di questa proprietà, consultare [getScrollBars()](../../com.aspose.diagram/textboxactivexcontrol\#getScrollBars--) |
+| [setShowDropButtonTypeWhen(int value)](#setShowDropButtonTypeWhen-int-) | Per la descrizione di questa proprietà, consultare [getShowDropButtonTypeWhen()](../../com.aspose.diagram/textboxactivexcontrol\#getShowDropButtonTypeWhen--) |
+| [setSpecialEffect(int value)](#setSpecialEffect-int-) | Per la descrizione di questa proprietà, consultare [getSpecialEffect()](../../com.aspose.diagram/textboxactivexcontrol\#getSpecialEffect--) |
+| [setTabKeyBehavior(boolean value)](#setTabKeyBehavior-boolean-) | Per la descrizione di questa proprietà, consultare [getTabKeyBehavior()](../../com.aspose.diagram/textboxactivexcontrol\#getTabKeyBehavior--) |
+| [setText(String value)](#setText-java.lang.String-) | Per la descrizione di questa proprietà, consultare [getText()](../../com.aspose.diagram/textboxactivexcontrol\#getText--) |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | Per la descrizione di questa proprietà, vedere [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) |
+| [setWidth(double value)](#setWidth-double-) | Per la descrizione di questa proprietà, vedere [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [setWordWrapped(boolean value)](#setWordWrapped-boolean-) | Per la descrizione di questa proprietà, consultare [isWordWrapped()](../../com.aspose.diagram/textboxactivexcontrol\#isWordWrapped--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+il colore OLE dello sfondo.
+
+**Returns:**
+int
+### getBorderOleColor() {#getBorderOleColor--}
+```
+public int getBorderOleColor()
+```
+
+
+il colore OLE dello sfondo.
+
+**Returns:**
+int
+### getBorderStyle() {#getBorderStyle--}
+```
+public int getBorderStyle()
+```
+
+
+il tipo di bordo usato dal controllo.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+i dati binari del controllo.
+
+**Returns:**
+byte[]
+### getDropButtonStyle() {#getDropButtonStyle--}
+```
+public int getDropButtonStyle()
+```
+
+
+Specifica il simbolo visualizzato sul pulsante a discesa
+
+**Returns:**
+int
+### getEnterFieldBehavior() {#getEnterFieldBehavior--}
+```
+public boolean getEnterFieldBehavior()
+```
+
+
+Specifica il comportamento di selezione all'ingresso del controllo. True specifica che la selezione rimane invariata rispetto all'ultima volta che il controllo era attivo. False specifica che tutto il testo nel controllo sarà selezionato all'ingresso del controllo.
+
+**Returns:**
+boolean
+### getEnterKeyBehavior() {#getEnterKeyBehavior--}
+```
+public boolean getEnterKeyBehavior()
+```
+
+
+Specifica il comportamento del tasto INVIO. True indica che premendo INVIO verrà creata una nuova riga. False indica che premendo INVIO il focus si sposterà all'oggetto successivo nell'ordine di tabulazione.
+
+**Returns:**
+boolean
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+Il colore OLE del primo piano. Non si applica al controllo Image.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+l'altezza del controllo in unità di punti.
+
+**Returns:**
+double
+### getHideSelection() {#getHideSelection--}
+```
+public boolean getHideSelection()
+```
+
+
+Indica se il testo selezionato nel controllo appare evidenziato quando il controllo non ha il fuoco.
+
+**Returns:**
+boolean
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+la modalità di esecuzione predefinita dell'Input Method Editor per il controllo quando riceve il fuoco.
+
+**Returns:**
+int
+### getIntegralHeight() {#getIntegralHeight--}
+```
+public boolean getIntegralHeight()
+```
+
+
+Indica se il controllo mostrerà solo linee di testo complete senza mostrare linee parziali.
+
+**Returns:**
+boolean
+### getMaxLength() {#getMaxLength--}
+```
+public int getMaxLength()
+```
+
+
+il numero massimo di caratteri
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+un'icona personalizzata da visualizzare come puntatore del mouse per il controllo.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+il tipo di icona visualizzata come puntatore del mouse per il controllo.
+
+**Returns:**
+int
+### getPasswordChar() {#getPasswordChar--}
+```
+public char getPasswordChar()
+```
+
+
+un carattere da visualizzare al posto dei caratteri inseriti.
+
+**Returns:**
+char
+### getScrollBars() {#getScrollBars--}
+```
+public int getScrollBars()
+```
+
+
+Indica se il controllo ha barre di scorrimento verticali, barre di scorrimento orizzontali, entrambe o nessuna.
+
+**Returns:**
+int
+### getShowDropButtonTypeWhen() {#getShowDropButtonTypeWhen--}
+```
+public int getShowDropButtonTypeWhen()
+```
+
+
+Specifica il simbolo visualizzato sul pulsante a discesa
+
+**Returns:**
+int
+### getSpecialEffect() {#getSpecialEffect--}
+```
+public int getSpecialEffect()
+```
+
+
+l'effetto speciale del controllo.
+
+**Returns:**
+int
+### getTabKeyBehavior() {#getTabKeyBehavior--}
+```
+public boolean getTabKeyBehavior()
+```
+
+
+Indica se i caratteri di tabulazione sono consentiti nel testo del controllo.
+
+**Returns:**
+boolean
+### getText() {#getText--}
+```
+public String getText()
+```
+
+
+testo del controllo.
+
+**Returns:**
+java.lang.String
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Ottiene il tipo del controllo ActiveX.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+la larghezza del controllo in unità di punti.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+Indica se il controllo ridimensionerà automaticamente per visualizzare tutto il contenuto.
+
+**Returns:**
+boolean
+### isAutoTab() {#isAutoTab--}
+```
+public boolean isAutoTab()
+```
+
+
+Indica se il focus si sposterà automaticamente al controllo successivo quando l'utente inserisce il numero massimo di caratteri.
+
+**Returns:**
+boolean
+### isAutoWordSelected() {#isAutoWordSelected--}
+```
+public boolean isAutoWordSelected()
+```
+
+
+Specifica l'unità di base utilizzata per estendere una selezione. True specifica che l'unità di base è un singolo carattere. false specifica che l'unità di base è una parola intera.
+
+**Returns:**
+boolean
+### isDragBehaviorEnabled() {#isDragBehaviorEnabled--}
+```
+public boolean isDragBehaviorEnabled()
+```
+
+
+Indica se il trascinamento e il rilascio sono abilitati per il controllo.
+
+**Returns:**
+boolean
+### isEditable() {#isEditable--}
+```
+public boolean isEditable()
+```
+
+
+Indica se l'utente può digitare nel controllo.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+Indica se il controllo può ricevere il focus e rispondere agli eventi generati dall'utente.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+Indica se i dati nel controllo sono bloccati per la modifica.
+
+**Returns:**
+boolean
+### isMultiLine() {#isMultiLine--}
+```
+public boolean isMultiLine()
+```
+
+
+Indica se il controllo può visualizzare più di una riga di testo.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+Indica se il controllo è trasparente.
+
+**Returns:**
+boolean
+### isWordWrapped() {#isWordWrapped--}
+```
+public boolean isWordWrapped()
+```
+
+
+Indica se il contenuto del controllo avvolge automaticamente alla fine di una riga.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setAutoTab(boolean value) {#setAutoTab-boolean-}
+```
+public void setAutoTab(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [isAutoTab()](../../com.aspose.diagram/textboxactivexcontrol\#isAutoTab--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setAutoWordSelected(boolean value) {#setAutoWordSelected-boolean-}
+```
+public void setAutoWordSelected(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [isAutoWordSelected()](../../com.aspose.diagram/textboxactivexcontrol\#isAutoWordSelected--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setBorderOleColor(int value) {#setBorderOleColor-int-}
+```
+public void setBorderOleColor(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getBorderOleColor()](../../com.aspose.diagram/textboxactivexcontrol\#getBorderOleColor--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setBorderStyle(int value) {#setBorderStyle-int-}
+```
+public void setBorderStyle(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getBorderStyle()](../../com.aspose.diagram/textboxactivexcontrol\#getBorderStyle--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setDragBehaviorEnabled(boolean value) {#setDragBehaviorEnabled-boolean-}
+```
+public void setDragBehaviorEnabled(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [isDragBehaviorEnabled()](../../com.aspose.diagram/textboxactivexcontrol\#isDragBehaviorEnabled--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setDropButtonStyle(int value) {#setDropButtonStyle-int-}
+```
+public void setDropButtonStyle(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getDropButtonStyle()](../../com.aspose.diagram/textboxactivexcontrol\#getDropButtonStyle--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setEditable(boolean value) {#setEditable-boolean-}
+```
+public void setEditable(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [isEditable()](../../com.aspose.diagram/textboxactivexcontrol\#isEditable--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setEnterFieldBehavior(boolean value) {#setEnterFieldBehavior-boolean-}
+```
+public void setEnterFieldBehavior(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getEnterFieldBehavior()](../../com.aspose.diagram/textboxactivexcontrol\#getEnterFieldBehavior--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setEnterKeyBehavior(boolean value) {#setEnterKeyBehavior-boolean-}
+```
+public void setEnterKeyBehavior(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getEnterKeyBehavior()](../../com.aspose.diagram/textboxactivexcontrol\#getEnterKeyBehavior--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double |  |
+
+### setHideSelection(boolean value) {#setHideSelection-boolean-}
+```
+public void setHideSelection(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getHideSelection()](../../com.aspose.diagram/textboxactivexcontrol\#getHideSelection--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setIntegralHeight(boolean value) {#setIntegralHeight-boolean-}
+```
+public void setIntegralHeight(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getIntegralHeight()](../../com.aspose.diagram/textboxactivexcontrol\#getIntegralHeight--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setMaxLength(int value) {#setMaxLength-int-}
+```
+public void setMaxLength(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getMaxLength()](../../com.aspose.diagram/textboxactivexcontrol\#getMaxLength--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setMultiLine(boolean value) {#setMultiLine-boolean-}
+```
+public void setMultiLine(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [isMultiLine()](../../com.aspose.diagram/textboxactivexcontrol\#isMultiLine--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setPasswordChar(char value) {#setPasswordChar-char-}
+```
+public void setPasswordChar(char value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getPasswordChar()](../../com.aspose.diagram/textboxactivexcontrol\#getPasswordChar--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | char |  |
+
+### setScrollBars(int value) {#setScrollBars-int-}
+```
+public void setScrollBars(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getScrollBars()](../../com.aspose.diagram/textboxactivexcontrol\#getScrollBars--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setShowDropButtonTypeWhen(int value) {#setShowDropButtonTypeWhen-int-}
+```
+public void setShowDropButtonTypeWhen(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getShowDropButtonTypeWhen()](../../com.aspose.diagram/textboxactivexcontrol\#getShowDropButtonTypeWhen--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setSpecialEffect(int value) {#setSpecialEffect-int-}
+```
+public void setSpecialEffect(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getSpecialEffect()](../../com.aspose.diagram/textboxactivexcontrol\#getSpecialEffect--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setTabKeyBehavior(boolean value) {#setTabKeyBehavior-boolean-}
+```
+public void setTabKeyBehavior(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getTabKeyBehavior()](../../com.aspose.diagram/textboxactivexcontrol\#getTabKeyBehavior--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setText(String value) {#setText-java.lang.String-}
+```
+public void setText(String value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getText()](../../com.aspose.diagram/textboxactivexcontrol\#getText--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double |  |
+
+### setWordWrapped(boolean value) {#setWordWrapped-boolean-}
+```
+public void setWordWrapped(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [isWordWrapped()](../../com.aspose.diagram/textboxactivexcontrol\#isWordWrapped--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/textcollection/_index.md
+++ b/italian/java/com.aspose.diagram/textcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: TextCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene il testo di una forma.
+type: docs
+weight: 402
+url: /it/java/com.aspose.diagram/textcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class TextCollection extends Collection
+```
+
+Contiene il testo di una forma. Ogni elemento è testo con proprietà di carattere, paragrafo e tabulazioni.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [add(Text item)](#add-com.aspose.diagram.Text-) | Aggiungi l'oggetto Text nella collezione. |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Text item)](#remove-com.aspose.diagram.Text-) | Rimuovi l'oggetto Text dalla collezione. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Text item) {#add-com.aspose.diagram.Text-}
+```
+public int add(Text item)
+```
+
+
+Aggiungi l'oggetto Text nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [Text](../../com.aspose.diagram/text) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Text get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[Text](../../com.aspose.diagram/text) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Text item) {#remove-com.aspose.diagram.Text-}
+```
+public void remove(Text item)
+```
+
+
+Rimuovi l'oggetto Text dalla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [Text](../../com.aspose.diagram/text) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/textdirection/_index.md
+++ b/italian/java/com.aspose.diagram/textdirection/_index.md
@@ -1,0 +1,204 @@
+---
+title: TextDirection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica la direzione dei caratteri in un blocco di testo.
+type: docs
+weight: 403
+url: /it/java/com.aspose.diagram/textdirection/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class TextDirection
+```
+
+Specifica la direzione dei caratteri in un blocco di testo.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [TextDirection(int value)](#TextDirection-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Specifica la direzione dei caratteri in un blocco di testo. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | Per la descrizione di questa proprietà, vedere [getUfe()](../../com.aspose.diagram/textdirection\#getUfe--) |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/textdirection\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### TextDirection(int value) {#TextDirection-int-}
+```
+public TextDirection(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specifica la direzione dei caratteri in un blocco di testo.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getUfe()](../../com.aspose.diagram/textdirection\#getUfe--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/textdirection\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/textdirectionvalue/_index.md
+++ b/italian/java/com.aspose.diagram/textdirectionvalue/_index.md
@@ -1,0 +1,156 @@
+---
+title: TextDirectionValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica la direzione dei caratteri in un blocco di testo.
+type: docs
+weight: 404
+url: /it/java/com.aspose.diagram/textdirectionvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class TextDirectionValue
+```
+
+Specifica la direzione dei caratteri in un blocco di testo.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [HORIZONTAL](#HORIZONTAL) | Orizzontale. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+| [VERTICAL](#VERTICAL) | Verticale. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### HORIZONTAL {#HORIZONTAL}
+```
+public static final int HORIZONTAL
+```
+
+
+Orizzontale.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### VERTICAL {#VERTICAL}
+```
+public static final int VERTICAL
+```
+
+
+Verticale.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/textxform/_index.md
+++ b/italian/java/com.aspose.diagram/textxform/_index.md
@@ -1,0 +1,336 @@
+---
+title: TextXForm
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene elementi che specificano le informazioni di posizionamento relative al blocco di testo di una forma.
+type: docs
+weight: 405
+url: /it/java/com.aspose.diagram/textxform/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class TextXForm
+```
+
+Contiene elementi che specificano le informazioni di posizionamento del blocco di testo di una forma.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getTxtAngle()](#getTxtAngle--) | Specifica l'angolo di rotazione corrente del blocco di testo in relazione all'asse x della forma. |
+| [getTxtHeight()](#getTxtHeight--) | Specifica l'altezza del blocco di testo. |
+| [getTxtLocPinX()](#getTxtLocPinX--) | Specifica la coordinata x del centro di rotazione del blocco di testo in relazione all'origine del blocco di testo. |
+| [getTxtLocPinY()](#getTxtLocPinY--) | Specifica la coordinata y del centro di rotazione del blocco di testo rispetto all'origine del blocco di testo. |
+| [getTxtPinX()](#getTxtPinX--) | Specifica la coordinata x del centro di rotazione del blocco di testo in relazione all'origine della forma. |
+| [getTxtPinY()](#getTxtPinY--) | Specifica la coordinata y del centro di rotazione del blocco di testo in relazione all'origine della forma. |
+| [getTxtWidth()](#getTxtWidth--) | Specifica la larghezza del blocco di testo. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, consultare [getDel()](../../com.aspose.diagram/textxform\#getDel--) |
+| [setTxtAngle(DoubleValue value)](#setTxtAngle-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, consultare [getTxtAngle()](../../com.aspose.diagram/textxform\#getTxtAngle--) |
+| [setTxtHeight(DoubleValue value)](#setTxtHeight-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, consultare [getTxtHeight()](../../com.aspose.diagram/textxform\#getTxtHeight--) |
+| [setTxtLocPinX(DoubleValue value)](#setTxtLocPinX-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, consultare [getTxtLocPinX()](../../com.aspose.diagram/textxform\#getTxtLocPinX--) |
+| [setTxtLocPinY(DoubleValue value)](#setTxtLocPinY-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, consultare [getTxtLocPinY()](../../com.aspose.diagram/textxform\#getTxtLocPinY--) |
+| [setTxtPinX(DoubleValue value)](#setTxtPinX-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, consultare [getTxtPinX()](../../com.aspose.diagram/textxform\#getTxtPinX--) |
+| [setTxtPinY(DoubleValue value)](#setTxtPinY-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, consultare [getTxtPinY()](../../com.aspose.diagram/textxform\#getTxtPinY--) |
+| [setTxtWidth(DoubleValue value)](#setTxtWidth-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, consultare [getTxtWidth()](../../com.aspose.diagram/textxform\#getTxtWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getTxtAngle() {#getTxtAngle--}
+```
+public DoubleValue getTxtAngle()
+```
+
+
+Specifica l'angolo di rotazione corrente del blocco di testo in relazione all'asse x della forma. Il valore predefinito è 0 gradi.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTxtHeight() {#getTxtHeight--}
+```
+public DoubleValue getTxtHeight()
+```
+
+
+Specifica l'altezza del blocco di testo. La formula predefinita, che restituisce l'altezza della forma, è F="Height\*1".
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTxtLocPinX() {#getTxtLocPinX--}
+```
+public DoubleValue getTxtLocPinX()
+```
+
+
+Specifica la coordinata x del centro di rotazione del blocco di testo in relazione all'origine del blocco di testo. La formula predefinita, che restituisce il centro orizzontale del blocco di testo, è F="TxtWidth\*0.5".
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTxtLocPinY() {#getTxtLocPinY--}
+```
+public DoubleValue getTxtLocPinY()
+```
+
+
+Specifica la coordinata y del centro di rotazione del blocco di testo rispetto all'origine del blocco di testo. La formula predefinita, che restituisce il centro verticale del blocco di testo, è F="TxtHeight\*0.5".
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTxtPinX() {#getTxtPinX--}
+```
+public DoubleValue getTxtPinX()
+```
+
+
+Specifica la coordinata x del centro di rotazione del blocco di testo in relazione all'origine della forma. La formula predefinita, che restituisce il centro orizzontale della forma, è F="Width\*0.5".
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTxtPinY() {#getTxtPinY--}
+```
+public DoubleValue getTxtPinY()
+```
+
+
+Specifica la coordinata y del centro di rotazione del blocco di testo in relazione all'origine della forma. La formula predefinita, che restituisce il centro verticale della forma, è F="Height\*0.5".
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTxtWidth() {#getTxtWidth--}
+```
+public DoubleValue getTxtWidth()
+```
+
+
+Specifica la larghezza del blocco di testo. La formula predefinita, che restituisce la larghezza della forma, è F="Width\*1".
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getDel()](../../com.aspose.diagram/textxform\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setTxtAngle(DoubleValue value) {#setTxtAngle-com.aspose.diagram.DoubleValue-}
+```
+public void setTxtAngle(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getTxtAngle()](../../com.aspose.diagram/textxform\#getTxtAngle--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTxtHeight(DoubleValue value) {#setTxtHeight-com.aspose.diagram.DoubleValue-}
+```
+public void setTxtHeight(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getTxtHeight()](../../com.aspose.diagram/textxform\#getTxtHeight--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTxtLocPinX(DoubleValue value) {#setTxtLocPinX-com.aspose.diagram.DoubleValue-}
+```
+public void setTxtLocPinX(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getTxtLocPinX()](../../com.aspose.diagram/textxform\#getTxtLocPinX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTxtLocPinY(DoubleValue value) {#setTxtLocPinY-com.aspose.diagram.DoubleValue-}
+```
+public void setTxtLocPinY(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getTxtLocPinY()](../../com.aspose.diagram/textxform\#getTxtLocPinY--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTxtPinX(DoubleValue value) {#setTxtPinX-com.aspose.diagram.DoubleValue-}
+```
+public void setTxtPinX(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getTxtPinX()](../../com.aspose.diagram/textxform\#getTxtPinX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTxtPinY(DoubleValue value) {#setTxtPinY-com.aspose.diagram.DoubleValue-}
+```
+public void setTxtPinY(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getTxtPinY()](../../com.aspose.diagram/textxform\#getTxtPinY--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTxtWidth(DoubleValue value) {#setTxtWidth-com.aspose.diagram.DoubleValue-}
+```
+public void setTxtWidth(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getTxtWidth()](../../com.aspose.diagram/textxform\#getTxtWidth--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/threedformat/_index.md
+++ b/italian/java/com.aspose.diagram/threedformat/_index.md
@@ -1,0 +1,625 @@
+---
+title: ThreeDFormat
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta la formattazione tridimensionale di una forma.
+type: docs
+weight: 406
+url: /it/java/com.aspose.diagram/threedformat/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ThreeDFormat
+```
+
+Rappresenta la formattazione tridimensionale di una forma.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object obj)](#equals-java.lang.Object-) |  |
+| [getBevelBottomHeight()](#getBevelBottomHeight--) | Specifica l'altezza dello smusso inferiore su una forma 3D. |
+| [getBevelBottomType()](#getBevelBottomType--) | Specifica il tipo di smusso predefinito per lo smusso inferiore su una forma 3D |
+| [getBevelBottomWidth()](#getBevelBottomWidth--) | Specifica la larghezza dello smusso inferiore su una forma 3D. |
+| [getBevelContourColor()](#getBevelContourColor--) | Specifica il colore del contorno su una forma 3D |
+| [getBevelContourSize()](#getBevelContourSize--) | Specifica lo spessore del contorno su una forma 3D |
+| [getBevelDepthColor()](#getBevelDepthColor--) | Specifica il colore dell'estrusione su una forma 3D |
+| [getBevelDepthSize()](#getBevelDepthSize--) | Specifica la profondità dell'estrusione su una forma 3D |
+| [getBevelLightingAngle()](#getBevelLightingAngle--) | Specifica la direzione dell'illuminazione su una forma 3D. |
+| [getBevelLightingType()](#getBevelLightingType--) | Specifica il tipo di illuminazione predefinito su una forma 3D |
+| [getBevelMaterialType()](#getBevelMaterialType--) | Specifica l'aspetto della superficie predefinito su una forma 3D |
+| [getBevelTopHeight()](#getBevelTopHeight--) | Specifica l'altezza dello smusso superiore su una forma 3D |
+| [getBevelTopType()](#getBevelTopType--) | Specifica il tipo di smusso predefinito per lo smusso superiore su una forma 3D |
+| [getBevelTopWidth()](#getBevelTopWidth--) | Specifica la larghezza dello smusso superiore su una forma 3D. |
+| [getClass()](#getClass--) |  |
+| [getDistanceFromGround()](#getDistanceFromGround--) | Specifica la distanza che una forma con proprietà di rotazione 3D |
+| [getKeepTextFlat()](#getKeepTextFlat--) | Specifica se le proprietà di rotazione 3D si applicano al testo di una forma |
+| [getPerspective()](#getPerspective--) | Specifica l'angolo di visualizzazione per una forma con proprietà di rotazione 3D |
+| [getRotationType()](#getRotationType--) | Specifica il tipo di proiezione delle proprietà di effetto di una forma. |
+| [getRotationXAngle()](#getRotationXAngle--) | Specifica l'angolo di rotazione antiorario di una forma attorno all'asse y. |
+| [getRotationYAngle()](#getRotationYAngle--) | Specifica l'angolo di rotazione antiorario di una forma attorno all'asse x |
+| [getRotationZAngle()](#getRotationZAngle--) | Specifica l'angolo di rotazione antiorario di una forma attorno all'asse z. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setBevelBottomHeight(DoubleValue value)](#setBevelBottomHeight-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, consultare [getBevelBottomHeight()](../../com.aspose.diagram/threedformat\#getBevelBottomHeight--) |
+| [setBevelBottomType(BevelType value)](#setBevelBottomType-com.aspose.diagram.BevelType-) | Per la descrizione di questa proprietà, consultare [getBevelBottomType()](../../com.aspose.diagram/threedformat\#getBevelBottomType--) |
+| [setBevelBottomWidth(DoubleValue value)](#setBevelBottomWidth-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, consultare [getBevelBottomWidth()](../../com.aspose.diagram/threedformat\#getBevelBottomWidth--) |
+| [setBevelContourColor(ColorValue value)](#setBevelContourColor-com.aspose.diagram.ColorValue-) | Per la descrizione di questa proprietà, consultare [getBevelContourColor()](../../com.aspose.diagram/threedformat\#getBevelContourColor--) |
+| [setBevelContourSize(DoubleValue value)](#setBevelContourSize-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, consultare [getBevelContourSize()](../../com.aspose.diagram/threedformat\#getBevelContourSize--) |
+| [setBevelDepthColor(ColorValue value)](#setBevelDepthColor-com.aspose.diagram.ColorValue-) | Per la descrizione di questa proprietà, vedere [getBevelDepthColor()](../../com.aspose.diagram/threedformat\#getBevelDepthColor--) |
+| [setBevelDepthSize(DoubleValue value)](#setBevelDepthSize-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getBevelDepthSize()](../../com.aspose.diagram/threedformat\#getBevelDepthSize--) |
+| [setBevelLightingAngle(DoubleValue value)](#setBevelLightingAngle-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getBevelLightingAngle()](../../com.aspose.diagram/threedformat\#getBevelLightingAngle--) |
+| [setBevelLightingType(BevelLightingType value)](#setBevelLightingType-com.aspose.diagram.BevelLightingType-) | Per la descrizione di questa proprietà, vedere [getBevelLightingType()](../../com.aspose.diagram/threedformat\#getBevelLightingType--) |
+| [setBevelMaterialType(BevelMaterialType value)](#setBevelMaterialType-com.aspose.diagram.BevelMaterialType-) | Per la descrizione di questa proprietà, vedere [getBevelMaterialType()](../../com.aspose.diagram/threedformat\#getBevelMaterialType--) |
+| [setBevelTopHeight(DoubleValue value)](#setBevelTopHeight-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getBevelTopHeight()](../../com.aspose.diagram/threedformat\#getBevelTopHeight--) |
+| [setBevelTopType(BevelType value)](#setBevelTopType-com.aspose.diagram.BevelType-) | Per la descrizione di questa proprietà, vedere [getBevelTopType()](../../com.aspose.diagram/threedformat\#getBevelTopType--) |
+| [setBevelTopWidth(DoubleValue value)](#setBevelTopWidth-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getBevelTopWidth()](../../com.aspose.diagram/threedformat\#getBevelTopWidth--) |
+| [setDistanceFromGround(DoubleValue value)](#setDistanceFromGround-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getDistanceFromGround()](../../com.aspose.diagram/threedformat\#getDistanceFromGround--) |
+| [setKeepTextFlat(BoolValue value)](#setKeepTextFlat-com.aspose.diagram.BoolValue-) | Per la descrizione di questa proprietà, vedere [getKeepTextFlat()](../../com.aspose.diagram/threedformat\#getKeepTextFlat--) |
+| [setPerspective(DoubleValue value)](#setPerspective-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getPerspective()](../../com.aspose.diagram/threedformat\#getPerspective--) |
+| [setRotationType(RotationType value)](#setRotationType-com.aspose.diagram.RotationType-) | Per la descrizione di questa proprietà, vedere [getRotationType()](../../com.aspose.diagram/threedformat\#getRotationType--) |
+| [setRotationXAngle(DoubleValue value)](#setRotationXAngle-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getRotationXAngle()](../../com.aspose.diagram/threedformat\#getRotationXAngle--) |
+| [setRotationYAngle(DoubleValue value)](#setRotationYAngle-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getRotationYAngle()](../../com.aspose.diagram/threedformat\#getRotationYAngle--) |
+| [setRotationZAngle(DoubleValue value)](#setRotationZAngle-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getRotationZAngle()](../../com.aspose.diagram/threedformat\#getRotationZAngle--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| obj | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getBevelBottomHeight() {#getBevelBottomHeight--}
+```
+public DoubleValue getBevelBottomHeight()
+```
+
+
+Specifica l'altezza dello smusso inferiore su una forma 3D.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBevelBottomType() {#getBevelBottomType--}
+```
+public BevelType getBevelBottomType()
+```
+
+
+Specifica il tipo di smusso predefinito per lo smusso inferiore su una forma 3D
+
+**Returns:**
+[BevelType](../../com.aspose.diagram/beveltype)
+### getBevelBottomWidth() {#getBevelBottomWidth--}
+```
+public DoubleValue getBevelBottomWidth()
+```
+
+
+Specifica la larghezza dello smusso inferiore su una forma 3D.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBevelContourColor() {#getBevelContourColor--}
+```
+public ColorValue getBevelContourColor()
+```
+
+
+Specifica il colore del contorno su una forma 3D
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getBevelContourSize() {#getBevelContourSize--}
+```
+public DoubleValue getBevelContourSize()
+```
+
+
+Specifica lo spessore del contorno su una forma 3D
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBevelDepthColor() {#getBevelDepthColor--}
+```
+public ColorValue getBevelDepthColor()
+```
+
+
+Specifica il colore dell'estrusione su una forma 3D
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getBevelDepthSize() {#getBevelDepthSize--}
+```
+public DoubleValue getBevelDepthSize()
+```
+
+
+Specifica la profondità dell'estrusione su una forma 3D
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBevelLightingAngle() {#getBevelLightingAngle--}
+```
+public DoubleValue getBevelLightingAngle()
+```
+
+
+Specifica la direzione dell'illuminazione su una forma 3D.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBevelLightingType() {#getBevelLightingType--}
+```
+public BevelLightingType getBevelLightingType()
+```
+
+
+Specifica il tipo di illuminazione predefinito su una forma 3D
+
+**Returns:**
+[BevelLightingType](../../com.aspose.diagram/bevellightingtype)
+### getBevelMaterialType() {#getBevelMaterialType--}
+```
+public BevelMaterialType getBevelMaterialType()
+```
+
+
+Specifica l'aspetto della superficie predefinito su una forma 3D
+
+**Returns:**
+[BevelMaterialType](../../com.aspose.diagram/bevelmaterialtype)
+### getBevelTopHeight() {#getBevelTopHeight--}
+```
+public DoubleValue getBevelTopHeight()
+```
+
+
+Specifica l'altezza dello smusso superiore su una forma 3D
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBevelTopType() {#getBevelTopType--}
+```
+public BevelType getBevelTopType()
+```
+
+
+Specifica il tipo di smusso predefinito per lo smusso superiore su una forma 3D
+
+**Returns:**
+[BevelType](../../com.aspose.diagram/beveltype)
+### getBevelTopWidth() {#getBevelTopWidth--}
+```
+public DoubleValue getBevelTopWidth()
+```
+
+
+Specifica la larghezza dello smusso superiore su una forma 3D.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDistanceFromGround() {#getDistanceFromGround--}
+```
+public DoubleValue getDistanceFromGround()
+```
+
+
+Specifica la distanza che una forma con proprietà di rotazione 3D
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getKeepTextFlat() {#getKeepTextFlat--}
+```
+public BoolValue getKeepTextFlat()
+```
+
+
+Specifica se le proprietà di rotazione 3D si applicano al testo di una forma
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getPerspective() {#getPerspective--}
+```
+public DoubleValue getPerspective()
+```
+
+
+Specifica l'angolo di visualizzazione per una forma con proprietà di rotazione 3D
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getRotationType() {#getRotationType--}
+```
+public RotationType getRotationType()
+```
+
+
+Specifica il tipo di proiezione delle proprietà di effetto di una forma.
+
+**Returns:**
+[RotationType](../../com.aspose.diagram/rotationtype)
+### getRotationXAngle() {#getRotationXAngle--}
+```
+public DoubleValue getRotationXAngle()
+```
+
+
+Specifica l'angolo di rotazione antiorario di una forma attorno all'asse y.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getRotationYAngle() {#getRotationYAngle--}
+```
+public DoubleValue getRotationYAngle()
+```
+
+
+Specifica l'angolo di rotazione antiorario di una forma attorno all'asse x
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getRotationZAngle() {#getRotationZAngle--}
+```
+public DoubleValue getRotationZAngle()
+```
+
+
+Specifica l'angolo di rotazione antiorario di una forma attorno all'asse z.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setBevelBottomHeight(DoubleValue value) {#setBevelBottomHeight-com.aspose.diagram.DoubleValue-}
+```
+public void setBevelBottomHeight(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getBevelBottomHeight()](../../com.aspose.diagram/threedformat\#getBevelBottomHeight--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setBevelBottomType(BevelType value) {#setBevelBottomType-com.aspose.diagram.BevelType-}
+```
+public void setBevelBottomType(BevelType value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getBevelBottomType()](../../com.aspose.diagram/threedformat\#getBevelBottomType--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [BevelType](../../com.aspose.diagram/beveltype) |  |
+
+### setBevelBottomWidth(DoubleValue value) {#setBevelBottomWidth-com.aspose.diagram.DoubleValue-}
+```
+public void setBevelBottomWidth(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getBevelBottomWidth()](../../com.aspose.diagram/threedformat\#getBevelBottomWidth--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setBevelContourColor(ColorValue value) {#setBevelContourColor-com.aspose.diagram.ColorValue-}
+```
+public void setBevelContourColor(ColorValue value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getBevelContourColor()](../../com.aspose.diagram/threedformat\#getBevelContourColor--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setBevelContourSize(DoubleValue value) {#setBevelContourSize-com.aspose.diagram.DoubleValue-}
+```
+public void setBevelContourSize(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getBevelContourSize()](../../com.aspose.diagram/threedformat\#getBevelContourSize--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setBevelDepthColor(ColorValue value) {#setBevelDepthColor-com.aspose.diagram.ColorValue-}
+```
+public void setBevelDepthColor(ColorValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getBevelDepthColor()](../../com.aspose.diagram/threedformat\#getBevelDepthColor--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setBevelDepthSize(DoubleValue value) {#setBevelDepthSize-com.aspose.diagram.DoubleValue-}
+```
+public void setBevelDepthSize(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getBevelDepthSize()](../../com.aspose.diagram/threedformat\#getBevelDepthSize--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setBevelLightingAngle(DoubleValue value) {#setBevelLightingAngle-com.aspose.diagram.DoubleValue-}
+```
+public void setBevelLightingAngle(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getBevelLightingAngle()](../../com.aspose.diagram/threedformat\#getBevelLightingAngle--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setBevelLightingType(BevelLightingType value) {#setBevelLightingType-com.aspose.diagram.BevelLightingType-}
+```
+public void setBevelLightingType(BevelLightingType value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getBevelLightingType()](../../com.aspose.diagram/threedformat\#getBevelLightingType--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [BevelLightingType](../../com.aspose.diagram/bevellightingtype) |  |
+
+### setBevelMaterialType(BevelMaterialType value) {#setBevelMaterialType-com.aspose.diagram.BevelMaterialType-}
+```
+public void setBevelMaterialType(BevelMaterialType value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getBevelMaterialType()](../../com.aspose.diagram/threedformat\#getBevelMaterialType--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [BevelMaterialType](../../com.aspose.diagram/bevelmaterialtype) |  |
+
+### setBevelTopHeight(DoubleValue value) {#setBevelTopHeight-com.aspose.diagram.DoubleValue-}
+```
+public void setBevelTopHeight(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getBevelTopHeight()](../../com.aspose.diagram/threedformat\#getBevelTopHeight--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setBevelTopType(BevelType value) {#setBevelTopType-com.aspose.diagram.BevelType-}
+```
+public void setBevelTopType(BevelType value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getBevelTopType()](../../com.aspose.diagram/threedformat\#getBevelTopType--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [BevelType](../../com.aspose.diagram/beveltype) |  |
+
+### setBevelTopWidth(DoubleValue value) {#setBevelTopWidth-com.aspose.diagram.DoubleValue-}
+```
+public void setBevelTopWidth(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getBevelTopWidth()](../../com.aspose.diagram/threedformat\#getBevelTopWidth--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDistanceFromGround(DoubleValue value) {#setDistanceFromGround-com.aspose.diagram.DoubleValue-}
+```
+public void setDistanceFromGround(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDistanceFromGround()](../../com.aspose.diagram/threedformat\#getDistanceFromGround--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setKeepTextFlat(BoolValue value) {#setKeepTextFlat-com.aspose.diagram.BoolValue-}
+```
+public void setKeepTextFlat(BoolValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getKeepTextFlat()](../../com.aspose.diagram/threedformat\#getKeepTextFlat--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setPerspective(DoubleValue value) {#setPerspective-com.aspose.diagram.DoubleValue-}
+```
+public void setPerspective(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getPerspective()](../../com.aspose.diagram/threedformat\#getPerspective--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setRotationType(RotationType value) {#setRotationType-com.aspose.diagram.RotationType-}
+```
+public void setRotationType(RotationType value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getRotationType()](../../com.aspose.diagram/threedformat\#getRotationType--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [RotationType](../../com.aspose.diagram/rotationtype) |  |
+
+### setRotationXAngle(DoubleValue value) {#setRotationXAngle-com.aspose.diagram.DoubleValue-}
+```
+public void setRotationXAngle(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getRotationXAngle()](../../com.aspose.diagram/threedformat\#getRotationXAngle--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setRotationYAngle(DoubleValue value) {#setRotationYAngle-com.aspose.diagram.DoubleValue-}
+```
+public void setRotationYAngle(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getRotationYAngle()](../../com.aspose.diagram/threedformat\#getRotationYAngle--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setRotationZAngle(DoubleValue value) {#setRotationZAngle-com.aspose.diagram.DoubleValue-}
+```
+public void setRotationZAngle(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getRotationZAngle()](../../com.aspose.diagram/threedformat\#getRotationZAngle--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/tiffcompression/_index.md
+++ b/italian/java/com.aspose.diagram/tiffcompression/_index.md
@@ -1,0 +1,174 @@
+---
+title: TiffCompression
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica quale tipo di compressione applicare durante il salvataggio delle pagine nel formato TIFF.
+type: docs
+weight: 407
+url: /it/java/com.aspose.diagram/tiffcompression/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class TiffCompression
+```
+
+Specifica quale tipo di compressione applicare durante il salvataggio delle pagine nel formato TIFF.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [CCITT_3](#CCITT-3) | Specifica lo schema di compressione CCITT3. |
+| [CCITT_4](#CCITT-4) | Specifica lo schema di compressione CCITT4. |
+| [LZW](#LZW) | Specifica lo schema di compressione LZW. |
+| [NONE](#NONE) | Specifica nessuna compressione. |
+| [RLE](#RLE) | Specifica lo schema di compressione RLE. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CCITT_3 {#CCITT-3}
+```
+public static final int CCITT_3
+```
+
+
+Specifica lo schema di compressione CCITT3.
+
+### CCITT_4 {#CCITT-4}
+```
+public static final int CCITT_4
+```
+
+
+Specifica lo schema di compressione CCITT4.
+
+### LZW {#LZW}
+```
+public static final int LZW
+```
+
+
+Specifica lo schema di compressione LZW.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Specifica nessuna compressione.
+
+### RLE {#RLE}
+```
+public static final int RLE
+```
+
+
+Specifica lo schema di compressione RLE.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/timelinehelper/_index.md
+++ b/italian/java/com.aspose.diagram/timelinehelper/_index.md
@@ -1,0 +1,512 @@
+---
+title: TimeLineHelper
+second_title: Riferimento API di Aspose.Diagram per Java
+description: TimeLineHelper per impostare la proprietà della forma della timeline.
+type: docs
+weight: 408
+url: /it/java/com.aspose.diagram/timelinehelper/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class TimeLineHelper
+```
+
+TimeLineHelper per impostare la proprietà della forma della timeline.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [TimeLineHelper(Shape shape)](#TimeLineHelper-com.aspose.diagram.Shape-) | TimeLineHelper. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDoubleStringFromDateTime(DateTime dateTime)](#getDoubleStringFromDateTime-com.aspose.diagram.DateTime-) | Converti la data e ora in valore double. |
+| [getTimePeriodFinish()](#getTimePeriodFinish--) | Periodo di tempo per il termine della forma timeline |
+| [getTimePeriodStart()](#getTimePeriodStart--) | Periodo di tempo per l'inizio della forma timeline |
+| [getTimeScale()](#getTimeScale--) | scala della forma timeline |
+| [getWeekEnd(DateTime startDate, int weekStart)](#getWeekEnd-com.aspose.diagram.DateTime-int-) | getweekstart |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [refreshTimeLine()](#refreshTimeLine--) | Aggiorna il tempo delle forme timeline |
+| [setArrowHead(int value)](#setArrowHead-int-) | Testa della freccia della forma timeline |
+| [setAutoUpdate(boolean value)](#setAutoUpdate-boolean-) | se aggiornare i dati per i marcatori (milestones, intervals) mentre vengono spostati sulla timeline |
+| [setBeginWeek(int value)](#setBeginWeek-int-) | Settimana di inizio della forma timeline |
+|  | [setDateFormatForBE(int value)](#setDateFormatForBE-int-) | DateFormat per l'inizio e la fine della forma timeline /// |
+
+| ----------------------- | ------------------------------- |
+| **Value**\u9286\u20ac | **Format String**\u9286\u20ac |
+| 0                       | dddd, yyyy-M-d                  |
+| 1                       | yyyy-MM-dd                      |
+| 2                       | yy-MMM-d                        |
+| 3                       | yyyy/M/d                        |
+| 4                       | yy-MMM.                         | |
+|  | [setDateFormatForIntm(int value)](#setDateFormatForIntm-int-) | DateFormat per Intm della forma timeline /// |
+
+| ----------------------- | ------------------------------- |
+| **Value**\u9286\u20ac | **Format String**\u9286\u20ac |
+| 0                       | dddd, yyyy-M-d                  |
+| 1                       | yyyy-MM-dd                      |
+| 2                       | yy-MMM-d                        |
+| 3                       | yyyy/M/d                        |
+| 4                       | yy-MMM.                         | |
+| [setDateFormatStringForBE(String value)](#setDateFormatStringForBE-java.lang.String-) | Stringa DateFormat per l'inizio e la fine della forma timeline |
+| [setDateFormatStringForIntm(String value)](#setDateFormatStringForIntm-java.lang.String-) | Stringa DateFormat per Intm della forma timeline |
+| [setDisplayBE(boolean value)](#setDisplayBE-boolean-) | se visualizzare le date Begin e End sulla timeline |
+| [setDisplayIntm(boolean value)](#setDisplayIntm-boolean-) | se visualizzare i tick interim di data/ora sulla timeline |
+| [setDisplayIntmDates(boolean value)](#setDisplayIntmDates-boolean-) | se visualizzare le date interim sui tick interim |
+| [setFiscalStart(DateTime value)](#setFiscalStart-com.aspose.diagram.DateTime-) | Primo giorno dell'anno fiscale |
+| [setTimeLineType(int value)](#setTimeLineType-int-) | Settimana di inizio della forma timeline |
+| [setTimePeriodFinish(DateTime value)](#setTimePeriodFinish-com.aspose.diagram.DateTime-) |  |
+| [setTimePeriodStart(DateTime value)](#setTimePeriodStart-com.aspose.diagram.DateTime-) |  |
+| [setTimeScale(int value)](#setTimeScale-int-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### TimeLineHelper(Shape shape) {#TimeLineHelper-com.aspose.diagram.Shape-}
+```
+public TimeLineHelper(Shape shape)
+```
+
+
+TimeLineHelper.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| shape | [Shape](../../com.aspose.diagram/shape) |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDoubleStringFromDateTime(DateTime dateTime) {#getDoubleStringFromDateTime-com.aspose.diagram.DateTime-}
+```
+public static String getDoubleStringFromDateTime(DateTime dateTime)
+```
+
+
+Converti la data e ora in valore double.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| dateTime | [DateTime](../../com.aspose.diagram/datetime) | La data e ora. |
+
+**Returns:**
+java.lang.String -
+### getTimePeriodFinish() {#getTimePeriodFinish--}
+```
+public DateTime getTimePeriodFinish()
+```
+
+
+Periodo di tempo per il termine della forma timeline
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### getTimePeriodStart() {#getTimePeriodStart--}
+```
+public DateTime getTimePeriodStart()
+```
+
+
+Periodo di tempo per l'inizio della forma timeline
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### getTimeScale() {#getTimeScale--}
+```
+public int getTimeScale()
+```
+
+
+scala della forma timeline
+
+**Returns:**
+int
+### getWeekEnd(DateTime startDate, int weekStart) {#getWeekEnd-com.aspose.diagram.DateTime-int-}
+```
+public static DateTime getWeekEnd(DateTime startDate, int weekStart)
+```
+
+
+getweekstart
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| startDate | [DateTime](../../com.aspose.diagram/datetime) |  |
+| weekStart | int | (0domenica 1lunedì 2 3 4 5 6) |
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - 
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### refreshTimeLine() {#refreshTimeLine--}
+```
+public void refreshTimeLine()
+```
+
+
+Aggiorna il tempo delle forme timeline
+
+### setArrowHead(int value) {#setArrowHead-int-}
+```
+public void setArrowHead(int value)
+```
+
+
+Testa della freccia della forma timeline
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setAutoUpdate(boolean value) {#setAutoUpdate-boolean-}
+```
+public void setAutoUpdate(boolean value)
+```
+
+
+se aggiornare i dati per i marcatori (milestones, intervals) mentre vengono spostati sulla timeline
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setBeginWeek(int value) {#setBeginWeek-int-}
+```
+public void setBeginWeek(int value)
+```
+
+
+Settimana di inizio della forma timeline
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setDateFormatForBE(int value) {#setDateFormatForBE-int-}
+```
+public void setDateFormatForBE(int value)
+```
+
+
+DateFormat per l'inizio e la fine della forma timeline ///
+
+| ----------------------- | ------------------------------- |
+| **Value**\u9286\u20ac | **Format String**\u9286\u20ac |
+| 0                       | dddd, yyyy-M-d                  |
+| 1                       | yyyy-MM-dd                      |
+| 2                       | yy-MMM-d                        |
+| 3                       | yyyy/M/d                        |
+| 4                       | yy-MMM.-d                       |
+| 5                       | d MMMM yyyy                     |
+| 6                       | yy-M                            |
+| 7                       | MMM-yy                          |
+| 8                       | MMMM d, yyyy                    |
+| 9                       | MMM d, yyyy                     |
+| 10                      | M-d-yy                          |
+| 11                      | M-d                             |
+| 12                      | d MMMM, yyyy                    |
+| 13                      | d MMM, yyyy                     |
+| 14                      | d-M-yy                          |
+| 15                      | d-M                             |
+| 16                      | yy-M-d                          |
+| 17                      | yyyy-M-d                        |
+| 18                      | M-yy                            |
+| 19                      | M-yyyy                          |
+| 20                      | MMMM yyyy                       |
+| 21                      | MMMM yy                         |
+| 22                      | MMM yyyy                        |
+| 23                      | MMM yy                          |
+| 24                      | yy                              |
+| 25                      | yyyy                            |
+| 26                      | d                               |
+| 27                      | MMMM                            |
+| 28                      | MMM                             |
+| 29                      | M                               |
+| 30                      | MM/dd/yyyy                      |
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setDateFormatForIntm(int value) {#setDateFormatForIntm-int-}
+```
+public void setDateFormatForIntm(int value)
+```
+
+
+DateFormat per Intm della forma timeline ///
+
+| ----------------------- | ------------------------------- |
+| **Value**\u9286\u20ac | **Format String**\u9286\u20ac |
+| 0                       | dddd, yyyy-M-d                  |
+| 1                       | yyyy-MM-dd                      |
+| 2                       | yy-MMM-d                        |
+| 3                       | yyyy/M/d                        |
+| 4                       | yy-MMM.-d                       |
+| 5                       | d MMMM yyyy                     |
+| 6                       | yy-M                            |
+| 7                       | MMM-yy                          |
+| 8                       | MMMM d, yyyy                    |
+| 9                       | MMM d, yyyy                     |
+| 10                      | M-d-yy                          |
+| 11                      | M-d                             |
+| 12                      | d MMMM, yyyy                    |
+| 13                      | d MMM, yyyy                     |
+| 14                      | d-M-yy                          |
+| 15                      | d-M                             |
+| 16                      | yy-M-d                          |
+| 17                      | yyyy-M-d                        |
+| 18                      | M-yy                            |
+| 19                      | M-yyyy                          |
+| 20                      | MMMM yyyy                       |
+| 21                      | MMMM yy                         |
+| 22                      | MMM yyyy                        |
+| 23                      | MMM yy                          |
+| 24                      | yy                              |
+| 25                      | yyyy                            |
+| 26                      | d                               |
+| 27                      | MMMM                            |
+| 28                      | MMM                             |
+| 29                      | M                               |
+| 30                      | MM/dd/yyyy                      |
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setDateFormatStringForBE(String value) {#setDateFormatStringForBE-java.lang.String-}
+```
+public void setDateFormatStringForBE(String value)
+```
+
+
+Stringa DateFormat per l'inizio e la fine della forma timeline
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setDateFormatStringForIntm(String value) {#setDateFormatStringForIntm-java.lang.String-}
+```
+public void setDateFormatStringForIntm(String value)
+```
+
+
+Stringa DateFormat per Intm della forma timeline
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setDisplayBE(boolean value) {#setDisplayBE-boolean-}
+```
+public void setDisplayBE(boolean value)
+```
+
+
+se visualizzare le date Begin e End sulla timeline
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setDisplayIntm(boolean value) {#setDisplayIntm-boolean-}
+```
+public void setDisplayIntm(boolean value)
+```
+
+
+se visualizzare i tick interim di data/ora sulla timeline
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setDisplayIntmDates(boolean value) {#setDisplayIntmDates-boolean-}
+```
+public void setDisplayIntmDates(boolean value)
+```
+
+
+se visualizzare le date interim sui tick interim
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setFiscalStart(DateTime value) {#setFiscalStart-com.aspose.diagram.DateTime-}
+```
+public void setFiscalStart(DateTime value)
+```
+
+
+Primo giorno dell'anno fiscale
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setTimeLineType(int value) {#setTimeLineType-int-}
+```
+public void setTimeLineType(int value)
+```
+
+
+Settimana di inizio della forma timeline
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setTimePeriodFinish(DateTime value) {#setTimePeriodFinish-com.aspose.diagram.DateTime-}
+```
+public void setTimePeriodFinish(DateTime value)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setTimePeriodStart(DateTime value) {#setTimePeriodStart-com.aspose.diagram.DateTime-}
+```
+public void setTimePeriodStart(DateTime value)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setTimeScale(int value) {#setTimeScale-int-}
+```
+public void setTimeScale(int value)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/togglebuttonactivexcontrol/_index.md
+++ b/italian/java/com.aspose.diagram/togglebuttonactivexcontrol/_index.md
@@ -1,0 +1,604 @@
+---
+title: ToggleButtonActiveXControl
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta un controllo ActiveX ToggleButton.
+type: docs
+weight: 410
+url: /it/java/com.aspose.diagram/togglebuttonactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class ToggleButtonActiveXControl extends ActiveXControl
+```
+
+Rappresenta un controllo ActiveX ToggleButton.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAccelerator()](#getAccelerator--) | il tasto di accelerazione per il controllo. |
+| [getBackOleColor()](#getBackOleColor--) | il colore OLE dello sfondo. |
+| [getCaption()](#getCaption--) | il testo descrittivo che appare su un controllo. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | i dati binari del controllo. |
+| [getForeOleColor()](#getForeOleColor--) | il colore OLE del primo piano. |
+| [getHeight()](#getHeight--) | l'altezza del controllo in unità di punti. |
+| [getIMEMode()](#getIMEMode--) | la modalità di esecuzione predefinita dell'Input Method Editor per il controllo quando riceve il fuoco. |
+| [getMouseIcon()](#getMouseIcon--) | un'icona personalizzata da visualizzare come puntatore del mouse per il controllo. |
+| [getMousePointer()](#getMousePointer--) | il tipo di icona visualizzata come puntatore del mouse per il controllo. |
+| [getPicture()](#getPicture--) | i dati dell'immagine. |
+| [getPicturePosition()](#getPicturePosition--) | la posizione dell'immagine del controllo rispetto alla sua didascalia. |
+| [getSpecialEffect()](#getSpecialEffect--) | l'effetto speciale del controllo. |
+| [getType()](#getType--) | Ottiene il tipo del controllo ActiveX. |
+| [getValue()](#getValue--) | Indica se il controllo è selezionato o meno. |
+| [getWidth()](#getWidth--) | la larghezza del controllo in unità di punti. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | Indica se il controllo ridimensionerà automaticamente per visualizzare tutto il contenuto. |
+| [isEnabled()](#isEnabled--) | Indica se il controllo può ricevere il focus e rispondere agli eventi generati dall'utente. |
+| [isLocked()](#isLocked--) | Indica se i dati nel controllo sono bloccati per la modifica. |
+| [isTransparent()](#isTransparent--) | Indica se il controllo è trasparente. |
+| [isTripleState()](#isTripleState--) | Indica come il controllo specificato visualizzerà i valori Null. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAccelerator(char value)](#setAccelerator-char-) | Per la descrizione di questa proprietà, vedere [getAccelerator()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getAccelerator--) |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | Per la descrizione di questa proprietà, vedere [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | Per la descrizione di questa proprietà, vedere [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setCaption(String value)](#setCaption-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getCaption()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getCaption--) |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | Per la descrizione di questa proprietà, vedere [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | Per la descrizione di questa proprietà, vedere [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setHeight(double value)](#setHeight-double-) | Per la descrizione di questa proprietà, vedere [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setIMEMode(int value)](#setIMEMode-int-) | Per la descrizione di questa proprietà, vedere [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) |
+| [setLocked(boolean value)](#setLocked-boolean-) | Per la descrizione di questa proprietà, vedere [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | Per la descrizione di questa proprietà, vedere [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | Per la descrizione di questa proprietà, vedere [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setPicture(byte[] value)](#setPicture-byte---) | Per la descrizione di questa proprietà, vedere [getPicture()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getPicture--) |
+| [setPicturePosition(int value)](#setPicturePosition-int-) | Per la descrizione di questa proprietà, vedere [getPicturePosition()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getPicturePosition--) |
+| [setSpecialEffect(int value)](#setSpecialEffect-int-) | Per la descrizione di questa proprietà, vedere [getSpecialEffect()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getSpecialEffect--) |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | Per la descrizione di questa proprietà, vedere [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) |
+| [setTripleState(boolean value)](#setTripleState-boolean-) | Per la descrizione di questa proprietà, vedere [isTripleState()](../../com.aspose.diagram/togglebuttonactivexcontrol\#isTripleState--) |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getValue--) |
+| [setWidth(double value)](#setWidth-double-) | Per la descrizione di questa proprietà, vedere [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAccelerator() {#getAccelerator--}
+```
+public char getAccelerator()
+```
+
+
+il tasto di accelerazione per il controllo.
+
+**Returns:**
+char
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+il colore OLE dello sfondo.
+
+**Returns:**
+int
+### getCaption() {#getCaption--}
+```
+public String getCaption()
+```
+
+
+il testo descrittivo che appare su un controllo.
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+i dati binari del controllo.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+Il colore OLE del primo piano. Non si applica al controllo Image.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+l'altezza del controllo in unità di punti.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+la modalità di esecuzione predefinita dell'Input Method Editor per il controllo quando riceve il fuoco.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+un'icona personalizzata da visualizzare come puntatore del mouse per il controllo.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+il tipo di icona visualizzata come puntatore del mouse per il controllo.
+
+**Returns:**
+int
+### getPicture() {#getPicture--}
+```
+public byte[] getPicture()
+```
+
+
+i dati dell'immagine.
+
+**Returns:**
+byte[]
+### getPicturePosition() {#getPicturePosition--}
+```
+public int getPicturePosition()
+```
+
+
+la posizione dell'immagine del controllo rispetto alla sua didascalia.
+
+**Returns:**
+int
+### getSpecialEffect() {#getSpecialEffect--}
+```
+public int getSpecialEffect()
+```
+
+
+l'effetto speciale del controllo.
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Ottiene il tipo del controllo ActiveX.
+
+**Returns:**
+int
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Indica se il controllo è selezionato o meno.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+la larghezza del controllo in unità di punti.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+Indica se il controllo ridimensionerà automaticamente per visualizzare tutto il contenuto.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+Indica se il controllo può ricevere il focus e rispondere agli eventi generati dall'utente.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+Indica se i dati nel controllo sono bloccati per la modifica.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+Indica se il controllo è trasparente.
+
+**Returns:**
+boolean
+### isTripleState() {#isTripleState--}
+```
+public boolean isTripleState()
+```
+
+
+Indica come il controllo specificato visualizzerà i valori Null.
+
+| ------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| Impostazione | Descrizione |
+| True    | Il controllo ciclerà attraverso gli stati per i valori Sì, No e Null. Il controllo appare attenuato (grigio) quando la sua proprietà Value è impostata su Null. |
+| False   | (Predefinito) Il controllo ciclerà attraverso gli stati per i valori Sì e No. I valori Null vengono visualizzati come se fossero valori No. |
+
+|
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAccelerator(char value) {#setAccelerator-char-}
+```
+public void setAccelerator(char value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getAccelerator()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getAccelerator--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | char |  |
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setCaption(String value) {#setCaption-java.lang.String-}
+```
+public void setCaption(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getCaption()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getCaption--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setPicture(byte[] value) {#setPicture-byte---}
+```
+public void setPicture(byte[] value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getPicture()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getPicture--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | byte[] |  |
+
+### setPicturePosition(int value) {#setPicturePosition-int-}
+```
+public void setPicturePosition(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getPicturePosition()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getPicturePosition--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setSpecialEffect(int value) {#setSpecialEffect-int-}
+```
+public void setSpecialEffect(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getSpecialEffect()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getSpecialEffect--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setTripleState(boolean value) {#setTripleState-boolean-}
+```
+public void setTripleState(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isTripleState()](../../com.aspose.diagram/togglebuttonactivexcontrol\#isTripleState--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/topartvalue/_index.md
+++ b/italian/java/com.aspose.diagram/topartvalue/_index.md
@@ -1,0 +1,201 @@
+---
+title: ToPartValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: La parte di una forma a cui viene effettuata una connessione.
+type: docs
+weight: 409
+url: /it/java/com.aspose.diagram/topartvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ToPartValue
+```
+
+La parte di una forma a cui viene effettuata una connessione.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [CONNECTION_POINT](#CONNECTION-POINT) | Punto di connessione. |
+| [GUIDE_INTERSECTION](#GUIDE-INTERSECTION) | Intersezione della guida. |
+| [GUIDE_X](#GUIDE-X) | GuidaX. |
+| [GUIDE_Y](#GUIDE-Y) | GuidaY. |
+| [NONE](#NONE) | None. |
+| [TO_ANGLE](#TO-ANGLE) | All'angolo. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+| [WHOLE_SHAPE](#WHOLE-SHAPE) | Forma intera. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CONNECTION_POINT {#CONNECTION-POINT}
+```
+public static final int CONNECTION_POINT
+```
+
+
+Punto di connessione.
+
+### GUIDE_INTERSECTION {#GUIDE-INTERSECTION}
+```
+public static final int GUIDE_INTERSECTION
+```
+
+
+Intersezione della guida.
+
+### GUIDE_X {#GUIDE-X}
+```
+public static final int GUIDE_X
+```
+
+
+GuidaX.
+
+### GUIDE_Y {#GUIDE-Y}
+```
+public static final int GUIDE_Y
+```
+
+
+GuidaY.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+None.
+
+### TO_ANGLE {#TO-ANGLE}
+```
+public static final int TO_ANGLE
+```
+
+
+All'angolo.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### WHOLE_SHAPE {#WHOLE-SHAPE}
+```
+public static final int WHOLE_SHAPE
+```
+
+
+Forma intera.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/tp/_index.md
+++ b/italian/java/com.aspose.diagram/tp/_index.md
@@ -1,0 +1,154 @@
+---
+title: Tp
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica l'inizio di una sequenza di proprietà delle tabulazioni.
+type: docs
+weight: 411
+url: /it/java/com.aspose.diagram/tp/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.FormatTxt](../../com.aspose.diagram/formattxt)
+```
+public class Tp extends FormatTxt
+```
+
+Specifica l'inizio di una sequenza di proprietà di tabulazione. La sequenza è definita fino alla fine del testo o fino al prossimo
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [Tp(int IX)](#Tp-int-) | Costruttore |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getValue()](#getValue--) | Valore |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Tp(int IX) {#Tp-int-}
+```
+public Tp(int IX)
+```
+
+
+Costruttore
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| IX | int | L'indice basato su zero dell'elemento all'interno del suo elemento genitore. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+Valore
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/txt/_index.md
+++ b/italian/java/com.aspose.diagram/txt/_index.md
@@ -1,0 +1,179 @@
+---
+title: Txt
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Testo della forma
+type: docs
+weight: 412
+url: /it/java/com.aspose.diagram/txt/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.FormatTxt](../../com.aspose.diagram/formattxt)
+```
+public class Txt extends FormatTxt
+```
+
+Testo della forma
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [Txt(String value)](#Txt-java.lang.String-) | Costruttore |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getText()](#getText--) | Contiene il testo di una forma. |
+| [getValue()](#getValue--) | Valore |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setText(String value)](#setText-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getText()](../../com.aspose.diagram/txt\#getText--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Txt(String value) {#Txt-java.lang.String-}
+```
+public Txt(String value)
+```
+
+
+Costruttore
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String | Testo della forma. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getText() {#getText--}
+```
+public String getText()
+```
+
+
+Contiene il testo di una forma.
+
+**Returns:**
+java.lang.String
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+Valore
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setText(String value) {#setText-java.lang.String-}
+```
+public void setText(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getText()](../../com.aspose.diagram/txt\#getText--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/typeconnection/_index.md
+++ b/italian/java/com.aspose.diagram/typeconnection/_index.md
@@ -1,0 +1,190 @@
+---
+title: TypeConnection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica vari tipi in base all'elemento in cui è contenuto.
+type: docs
+weight: 413
+url: /it/java/com.aspose.diagram/typeconnection/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class TypeConnection
+```
+
+Specifica vari tipi, in base all'elemento in cui è contenuto.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [TypeConnection(int value)](#TypeConnection-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Specifica vari tipi, in base all'elemento in cui è contenuto. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/typeconnection\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### TypeConnection(int value) {#TypeConnection-int-}
+```
+public TypeConnection(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specifica vari tipi, in base all'elemento in cui è contenuto.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/typeconnection\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/typeconnectionvalue/_index.md
+++ b/italian/java/com.aspose.diagram/typeconnectionvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: TypeConnectionValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica vari tipi in base all'elemento in cui è contenuto.
+type: docs
+weight: 414
+url: /it/java/com.aspose.diagram/typeconnectionvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class TypeConnectionValue
+```
+
+Specifica vari tipi, in base all'elemento in cui è contenuto.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [INWARD](#INWARD) | Inward. |
+| [INWARD_OUTWARD](#INWARD-OUTWARD) | Inward and outward. |
+| [OUTWARD](#OUTWARD) | Outward. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### INWARD {#INWARD}
+```
+public static final int INWARD
+```
+
+
+Inward.
+
+### INWARD_OUTWARD {#INWARD-OUTWARD}
+```
+public static final int INWARD_OUTWARD
+```
+
+
+Inward and outward.
+
+### OUTWARD {#OUTWARD}
+```
+public static final int OUTWARD
+```
+
+
+Outward.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/typefield/_index.md
+++ b/italian/java/com.aspose.diagram/typefield/_index.md
@@ -1,0 +1,190 @@
+---
+title: TypeField
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Tipo specifica un tipo di dati per il valore del campo di testo.
+type: docs
+weight: 415
+url: /it/java/com.aspose.diagram/typefield/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class TypeField
+```
+
+Tipo specifica un tipo di dati per il valore del campo di testo.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [TypeField(int value)](#TypeField-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Tipo specifica un tipo di dati per il valore del campo di testo. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/typefield\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### TypeField(int value) {#TypeField-int-}
+```
+public TypeField(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Tipo specifica un tipo di dati per il valore del campo di testo.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/typefield\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/typefieldvalue/_index.md
+++ b/italian/java/com.aspose.diagram/typefieldvalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: TypeFieldValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Tipo specifica un tipo di dati per il valore del campo di testo.
+type: docs
+weight: 416
+url: /it/java/com.aspose.diagram/typefieldvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class TypeFieldValue
+```
+
+Tipo specifica un tipo di dati per il valore del campo di testo.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [CURRENCY](#CURRENCY) | Currency value. |
+| [DATE_TIME](#DATE-TIME) | Date or time value. |
+| [DURATION](#DURATION) | Duration value. |
+| [NUMBER](#NUMBER) | Number. |
+| [STRING](#STRING) | Stringa. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CURRENCY {#CURRENCY}
+```
+public static final int CURRENCY
+```
+
+
+Valore di valuta. Utilizza le impostazioni regionali correnti del sistema.
+
+### DATE_TIME {#DATE-TIME}
+```
+public static final int DATE_TIME
+```
+
+
+Valore di data o ora. Visualizza giorni, mesi e anni, oppure secondi, minuti e ore, oppure un valore combinato di data e ora.
+
+### DURATION {#DURATION}
+```
+public static final int DURATION
+```
+
+
+Valore di durata. Visualizza il tempo trascorso.
+
+### NUMBER {#NUMBER}
+```
+public static final int NUMBER
+```
+
+
+Numero. Include valori di data, ora, durata e valuta, nonché scalari, dimensioni e angoli.
+
+### STRING {#STRING}
+```
+public static final int STRING
+```
+
+
+Stringa.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/typeprop/_index.md
+++ b/italian/java/com.aspose.diagram/typeprop/_index.md
@@ -1,0 +1,193 @@
+---
+title: TypeProp
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Tipo specifica un tipo di dati per il valore della proprietà personalizzata.
+type: docs
+weight: 417
+url: /it/java/com.aspose.diagram/typeprop/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class TypeProp
+```
+
+Tipo specifica un tipo di dati per il valore della proprietà personalizzata.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [TypeProp(int value)](#TypeProp-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Tipo specifica un tipo di dati per il valore della proprietà personalizzata. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | Per la descrizione di questa proprietà, vedere [getUfe()](../../com.aspose.diagram/typeprop\#getUfe--) |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/typeprop\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### TypeProp(int value) {#TypeProp-int-}
+```
+public TypeProp(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Tipo specifica un tipo di dati per il valore della proprietà personalizzata.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getUfe()](../../com.aspose.diagram/typeprop\#getUfe--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/typeprop\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/typepropvalue/_index.md
+++ b/italian/java/com.aspose.diagram/typepropvalue/_index.md
@@ -1,0 +1,210 @@
+---
+title: TypePropValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Tipo specifica un tipo di dati per il valore della proprietà personalizzata.
+type: docs
+weight: 418
+url: /it/java/com.aspose.diagram/typepropvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class TypePropValue
+```
+
+Tipo specifica un tipo di dati per il valore della proprietà personalizzata.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [BOOLEAN](#BOOLEAN) | Booleano. |
+| [CURRENCY](#CURRENCY) | Currency value. |
+| [DATE_TIME](#DATE-TIME) | Date or time value. |
+| [DURATION](#DURATION) | Duration value. |
+| [FIXED_LIST](#FIXED-LIST) | Fixed list. |
+| [NUMBER](#NUMBER) | Number. |
+| [STRING](#STRING) | Stringa. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+| [VARIABLE_LIST](#VARIABLE-LIST) | Elenco variabile. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOOLEAN {#BOOLEAN}
+```
+public static final int BOOLEAN
+```
+
+
+Booleano. Visualizza FALSE e TRUE come elementi che gli utenti possono selezionare da una casella a discesa nella finestra di dialogo Proprietà personalizzate nell'applicazione Visio.
+
+### CURRENCY {#CURRENCY}
+```
+public static final int CURRENCY
+```
+
+
+Valore di valuta. Utilizza le impostazioni regionali correnti del sistema.
+
+### DATE_TIME {#DATE-TIME}
+```
+public static final int DATE_TIME
+```
+
+
+Valore di data o ora. Visualizza giorni, mesi e anni, oppure secondi, minuti e ore, oppure un valore combinato di data e ora.
+
+### DURATION {#DURATION}
+```
+public static final int DURATION
+```
+
+
+Valore di durata. Visualizza il tempo trascorso.
+
+### FIXED_LIST {#FIXED-LIST}
+```
+public static final int FIXED_LIST
+```
+
+
+Elenco fisso. Visualizza gli elementi dell'elenco in una casella combinata a discesa nella finestra di dialogo Proprietà personalizzate.
+
+### NUMBER {#NUMBER}
+```
+public static final int NUMBER
+```
+
+
+Numero. Include valori di data, ora, durata e valuta, nonché scalari, dimensioni e angoli.
+
+### STRING {#STRING}
+```
+public static final int STRING
+```
+
+
+Stringa. Questo è il valore predefinito.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### VARIABLE_LIST {#VARIABLE-LIST}
+```
+public static final int VARIABLE_LIST
+```
+
+
+Elenco variabile. Visualizza gli elementi dell'elenco in una casella combinata a discesa nella finestra di dialogo Proprietà personalizzate in Visio. Gli utenti possono selezionare un elemento dell'elenco o inserire un nuovo elemento che viene aggiunto all'elenco corrente nell'elemento Format.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/typevalue/_index.md
+++ b/italian/java/com.aspose.diagram/typevalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: TypeValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Enumerazione opzionale.
+type: docs
+weight: 419
+url: /it/java/com.aspose.diagram/typevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class TypeValue
+```
+
+Enumerazione facoltativa. Il tipo di una forma.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [FOREIGN](#FOREIGN) | Estero. |
+| [GROUP](#GROUP) | Gruppo. |
+| [GUIDE](#GUIDE) | Guida. |
+| [SHAPE](#SHAPE) | Forma. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FOREIGN {#FOREIGN}
+```
+public static final int FOREIGN
+```
+
+
+Estero.
+
+### GROUP {#GROUP}
+```
+public static final int GROUP
+```
+
+
+Gruppo.
+
+### GUIDE {#GUIDE}
+```
+public static final int GUIDE
+```
+
+
+Guida.
+
+### SHAPE {#SHAPE}
+```
+public static final int SHAPE
+```
+
+
+Forma.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/uivisibility/_index.md
+++ b/italian/java/com.aspose.diagram/uivisibility/_index.md
@@ -1,0 +1,179 @@
+---
+title: UIVisibility
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica l'allineamento della scheda.
+type: docs
+weight: 420
+url: /it/java/com.aspose.diagram/uivisibility/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class UIVisibility
+```
+
+Specifica l'allineamento della scheda.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [UIVisibility(int value)](#UIVisibility-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Specifica la uivisibility. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/uivisibility\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### UIVisibility(int value) {#UIVisibility-int-}
+```
+public UIVisibility(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specifica la uivisibility.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/uivisibility\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/uivisibilityvalue/_index.md
+++ b/italian/java/com.aspose.diagram/uivisibilityvalue/_index.md
@@ -1,0 +1,156 @@
+---
+title: UIVisibilityValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica l'allineamento della scheda.
+type: docs
+weight: 421
+url: /it/java/com.aspose.diagram/uivisibilityvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class UIVisibilityValue
+```
+
+Specifica l'allineamento della scheda.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [HIDDEN](#HIDDEN) | Nascosto. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+| [VISIBLE](#VISIBLE) | Visibile . |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### HIDDEN {#HIDDEN}
+```
+public static final int HIDDEN
+```
+
+
+Nascosto.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### VISIBLE {#VISIBLE}
+```
+public static final int VISIBLE
+```
+
+
+Visibile .
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/unitformulaerr/_index.md
+++ b/italian/java/com.aspose.diagram/unitformulaerr/_index.md
@@ -1,0 +1,240 @@
+---
+title: UnitFormulaErr
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica gli attributi di un elemento.
+type: docs
+weight: 422
+url: /it/java/com.aspose.diagram/unitformulaerr/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class UnitFormulaErr
+```
+
+Specifica gli attributi di un elemento.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [UnitFormulaErr(int unit, String f, String err)](#UnitFormulaErr-int-java.lang.String-java.lang.String-) | Costruttore. |
+| [UnitFormulaErr()](#UnitFormulaErr--) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getErr()](#getErr--) | Indica che la formula restituisce un errore. |
+| [getF()](#getF--) | Rappresenta la formula dell'elemento. |
+| [getUnit()](#getUnit--) | Unità di misura. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setErr(String value)](#setErr-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getErr()](../../com.aspose.diagram/unitformulaerr\#getErr--) |
+| [setF(String value)](#setF-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getF()](../../com.aspose.diagram/unitformulaerr\#getF--) |
+| [setUnit(int value)](#setUnit-int-) | Per la descrizione di questa proprietà, vedere [getUnit()](../../com.aspose.diagram/unitformulaerr\#getUnit--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### UnitFormulaErr(int unit, String f, String err) {#UnitFormulaErr-int-java.lang.String-java.lang.String-}
+```
+public UnitFormulaErr(int unit, String f, String err)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| unità | int |  |
+| f | java.lang.String |  |
+| err | java.lang.String |  |
+
+### UnitFormulaErr() {#UnitFormulaErr--}
+```
+public UnitFormulaErr()
+```
+
+
+Costruttore.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getErr() {#getErr--}
+```
+public String getErr()
+```
+
+
+Indica che la formula restituisce un errore.
+
+**Returns:**
+java.lang.String
+### getF() {#getF--}
+```
+public String getF()
+```
+
+
+Rappresenta la formula dell'elemento.
+
+**Returns:**
+java.lang.String
+### getUnit() {#getUnit--}
+```
+public int getUnit()
+```
+
+
+Unità di misura.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setErr(String value) {#setErr-java.lang.String-}
+```
+public void setErr(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getErr()](../../com.aspose.diagram/unitformulaerr\#getErr--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setF(String value) {#setF-java.lang.String-}
+```
+public void setF(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getF()](../../com.aspose.diagram/unitformulaerr\#getF--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setUnit(int value) {#setUnit-int-}
+```
+public void setUnit(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getUnit()](../../com.aspose.diagram/unitformulaerr\#getUnit--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/unitformulaerrv/_index.md
+++ b/italian/java/com.aspose.diagram/unitformulaerrv/_index.md
@@ -1,0 +1,257 @@
+---
+title: UnitFormulaErrV
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Attributi specificati di un elemento.
+type: docs
+weight: 423
+url: /it/java/com.aspose.diagram/unitformulaerrv/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+```
+public class UnitFormulaErrV extends UnitFormulaErr
+```
+
+Attributi specificati di un elemento.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [UnitFormulaErrV(int unit, String f, String err, String v)](#UnitFormulaErrV-int-java.lang.String-java.lang.String-java.lang.String-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getErr()](#getErr--) | Indica che la formula restituisce un errore. |
+| [getF()](#getF--) | Rappresenta la formula dell'elemento. |
+| [getUnit()](#getUnit--) | Unità di misura. |
+| [getV()](#getV--) | Rappresenta la condizione di stringa nulla per il valore di una cella stringa. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setErr(String value)](#setErr-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getErr()](../../com.aspose.diagram/unitformulaerr\#getErr--) |
+| [setF(String value)](#setF-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getF()](../../com.aspose.diagram/unitformulaerr\#getF--) |
+| [setUnit(int value)](#setUnit-int-) | Per la descrizione di questa proprietà, vedere [getUnit()](../../com.aspose.diagram/unitformulaerr\#getUnit--) |
+| [setV(String value)](#setV-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getV()](../../com.aspose.diagram/unitformulaerrv\#getV--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### UnitFormulaErrV(int unit, String f, String err, String v) {#UnitFormulaErrV-int-java.lang.String-java.lang.String-java.lang.String-}
+```
+public UnitFormulaErrV(int unit, String f, String err, String v)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| unità | int |  |
+| f | java.lang.String |  |
+| err | java.lang.String |  |
+| v | java.lang.String |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getErr() {#getErr--}
+```
+public String getErr()
+```
+
+
+Indica che la formula restituisce un errore.
+
+**Returns:**
+java.lang.String
+### getF() {#getF--}
+```
+public String getF()
+```
+
+
+Rappresenta la formula dell'elemento.
+
+**Returns:**
+java.lang.String
+### getUnit() {#getUnit--}
+```
+public int getUnit()
+```
+
+
+Unità di misura.
+
+**Returns:**
+int
+### getV() {#getV--}
+```
+public String getV()
+```
+
+
+Rappresenta la condizione di stringa nulla per il valore di una cella stringa. In alcuni casi è utile distinguere tra una cella stringa vuota nulla e un valore di cella stringa nullo. Questo attributo è usato per distinguere tra queste forme di valore vuoto.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setErr(String value) {#setErr-java.lang.String-}
+```
+public void setErr(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getErr()](../../com.aspose.diagram/unitformulaerr\#getErr--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setF(String value) {#setF-java.lang.String-}
+```
+public void setF(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getF()](../../com.aspose.diagram/unitformulaerr\#getF--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setUnit(int value) {#setUnit-int-}
+```
+public void setUnit(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getUnit()](../../com.aspose.diagram/unitformulaerr\#getUnit--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setV(String value) {#setV-java.lang.String-}
+```
+public void setV(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getV()](../../com.aspose.diagram/unitformulaerrv\#getV--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/unknowncontrol/_index.md
+++ b/italian/java/com.aspose.diagram/unknowncontrol/_index.md
@@ -1,0 +1,449 @@
+---
+title: UnknownControl
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Controllo sconosciuto.
+type: docs
+weight: 424
+url: /it/java/com.aspose.diagram/unknowncontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class UnknownControl extends ActiveXControl
+```
+
+Controllo sconosciuto.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBackOleColor()](#getBackOleColor--) | il colore OLE dello sfondo. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | i dati binari del controllo. |
+| [getForeOleColor()](#getForeOleColor--) | il colore OLE del primo piano. |
+| [getHeight()](#getHeight--) | l'altezza del controllo in unità di punti. |
+| [getIMEMode()](#getIMEMode--) | la modalità di esecuzione predefinita dell'Input Method Editor per il controllo quando riceve il fuoco. |
+| [getMouseIcon()](#getMouseIcon--) | un'icona personalizzata da visualizzare come puntatore del mouse per il controllo. |
+| [getMousePointer()](#getMousePointer--) | il tipo di icona visualizzata come puntatore del mouse per il controllo. |
+| [getPersistenceType()](#getPersistenceType--) | Ottiene il metodo di persistenza per mantenere un controllo ActiveX. |
+| [getRelationshipData(String relId)](#getRelationshipData-java.lang.String-) | Ottiene i dati della relazione. |
+| [getType()](#getType--) | Ottiene il tipo del controllo ActiveX. |
+| [getWidth()](#getWidth--) | la larghezza del controllo in unità di punti. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | Indica se il controllo ridimensionerà automaticamente per visualizzare tutto il contenuto. |
+| [isEnabled()](#isEnabled--) | Indica se il controllo può ricevere il focus e rispondere agli eventi generati dall'utente. |
+| [isLocked()](#isLocked--) | Indica se i dati nel controllo sono bloccati per la modifica. |
+| [isTransparent()](#isTransparent--) | Indica se il controllo è trasparente. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | Per la descrizione di questa proprietà, vedere [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | Per la descrizione di questa proprietà, vedere [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | Per la descrizione di questa proprietà, vedere [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | Per la descrizione di questa proprietà, vedere [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setHeight(double value)](#setHeight-double-) | Per la descrizione di questa proprietà, vedere [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setIMEMode(int value)](#setIMEMode-int-) | Per la descrizione di questa proprietà, vedere [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) |
+| [setLocked(boolean value)](#setLocked-boolean-) | Per la descrizione di questa proprietà, vedere [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | Per la descrizione di questa proprietà, vedere [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | Per la descrizione di questa proprietà, vedere [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | Per la descrizione di questa proprietà, vedere [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) |
+| [setWidth(double value)](#setWidth-double-) | Per la descrizione di questa proprietà, vedere [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+il colore OLE dello sfondo.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+i dati binari del controllo.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+Il colore OLE del primo piano. Non si applica al controllo Image.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+l'altezza del controllo in unità di punti.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+la modalità di esecuzione predefinita dell'Input Method Editor per il controllo quando riceve il fuoco.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+un'icona personalizzata da visualizzare come puntatore del mouse per il controllo.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+il tipo di icona visualizzata come puntatore del mouse per il controllo.
+
+**Returns:**
+int
+### getPersistenceType() {#getPersistenceType--}
+```
+public int getPersistenceType()
+```
+
+
+Ottiene il metodo di persistenza per mantenere un controllo ActiveX.
+
+**Returns:**
+int
+### getRelationshipData(String relId) {#getRelationshipData-java.lang.String-}
+```
+public byte[] getRelationshipData(String relId)
+```
+
+
+Ottiene i dati della relazione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| relId | java.lang.String | L'ID della relazione. |
+
+**Returns:**
+byte[] - restituisce i dati della relazione.
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Ottiene il tipo del controllo ActiveX.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+la larghezza del controllo in unità di punti.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+Indica se il controllo ridimensionerà automaticamente per visualizzare tutto il contenuto.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+Indica se il controllo può ricevere il focus e rispondere agli eventi generati dall'utente.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+Indica se i dati nel controllo sono bloccati per la modifica.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+Indica se il controllo è trasparente.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/user/_index.md
+++ b/italian/java/com.aspose.diagram/user/_index.md
@@ -1,0 +1,299 @@
+---
+title: Utente
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene un'area di lavoro per l'inserimento di formule in elementi specifici dell'utente a cui fanno riferimento altri elementi e strumenti aggiuntivi.
+type: docs
+weight: 425
+url: /it/java/com.aspose.diagram/user/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class User
+```
+
+Contiene un'area di lavoro per l'inserimento di formule in elementi specifici dell'utente a cui fanno riferimento altri elementi e strumenti aggiuntivi.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [User()](#User--) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getID()](#getID--) | L'ID univoco dell'elemento all'interno del suo elemento genitore. |
+| [getName()](#getName--) | Il nome dell'elemento. |
+| [getNameU()](#getNameU--) | Il nome universale dell'elemento. |
+| [getPrompt()](#getPrompt--) | Specifica un prompt descrittivo o un commento per l'elemento definito dall'utente. |
+| [getValue()](#getValue--) | Contiene dati XML ben formati specifici della soluzione, con prefisso in uno spazio dei nomi esplicito e memorizzati con un documento. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, consultare [getDel()](../../com.aspose.diagram/user\#getDel--) |
+| [setID(int value)](#setID-int-) | Per la descrizione di questa proprietà, consultare [getID()](../../com.aspose.diagram/user\#getID--) |
+| [setName(String value)](#setName-java.lang.String-) | Per la descrizione di questa proprietà, consultare [getName()](../../com.aspose.diagram/user\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | Per la descrizione di questa proprietà, consultare [getNameU()](../../com.aspose.diagram/user\#getNameU--) |
+| [setPrompt(Str2Value value)](#setPrompt-com.aspose.diagram.Str2Value-) | Per la descrizione di questa proprietà, consultare [getPrompt()](../../com.aspose.diagram/user\#getPrompt--) |
+| [setValue(Value value)](#setValue-com.aspose.diagram.Value-) | Per la descrizione di questa proprietà, consultare [getValue()](../../com.aspose.diagram/user\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### User() {#User--}
+```
+public User()
+```
+
+
+Costruttore.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+L'ID univoco dell'elemento all'interno del suo elemento genitore.
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Il nome dell'elemento.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+Il nome universale dell'elemento.
+
+**Returns:**
+java.lang.String
+### getPrompt() {#getPrompt--}
+```
+public Str2Value getPrompt()
+```
+
+
+Specifica un prompt descrittivo o un commento per l'elemento definito dall'utente.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getValue() {#getValue--}
+```
+public Value getValue()
+```
+
+
+Contiene dati XML ben formati specifici della soluzione, con prefisso in uno spazio dei nomi esplicito e memorizzati con un documento.
+
+**Returns:**
+[Value](../../com.aspose.diagram/value)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getDel()](../../com.aspose.diagram/user\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getID()](../../com.aspose.diagram/user\#getID--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getName()](../../com.aspose.diagram/user\#getName--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getNameU()](../../com.aspose.diagram/user\#getNameU--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setPrompt(Str2Value value) {#setPrompt-com.aspose.diagram.Str2Value-}
+```
+public void setPrompt(Str2Value value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getPrompt()](../../com.aspose.diagram/user\#getPrompt--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [Str2Value](../../com.aspose.diagram/str2value) |  |
+
+### setValue(Value value) {#setValue-com.aspose.diagram.Value-}
+```
+public void setValue(Value value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getValue()](../../com.aspose.diagram/user\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [Value](../../com.aspose.diagram/value) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/usercollection/_index.md
+++ b/italian/java/com.aspose.diagram/usercollection/_index.md
@@ -1,0 +1,250 @@
+---
+title: UserCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Raccolta utenti.
+type: docs
+weight: 426
+url: /it/java/com.aspose.diagram/usercollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class UserCollection extends Collection
+```
+
+Raccolta utenti.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [add(User item)](#add-com.aspose.diagram.User-) | Aggiungi l'oggetto User nella collezione. |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [getUser(int ID)](#getUser-int-) | Restituisce l'elemento con l'ID specificato. |
+| [getUser(String name)](#getUser-java.lang.String-) | Restituisce l'elemento con l'ID specificato. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(User item)](#remove-com.aspose.diagram.User-) | Rimuovi l'oggetto User dalla collezione. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(User item) {#add-com.aspose.diagram.User-}
+```
+public int add(User item)
+```
+
+
+Aggiungi l'oggetto User nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [User](../../com.aspose.diagram/user) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public User get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[User](../../com.aspose.diagram/user) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### getUser(int ID) {#getUser-int-}
+```
+public User getUser(int ID)
+```
+
+
+Restituisce l'elemento con l'ID specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| ID | int |  |
+
+**Returns:**
+[User](../../com.aspose.diagram/user) - 
+### getUser(String name) {#getUser-java.lang.String-}
+```
+public User getUser(String name)
+```
+
+
+Restituisce l'elemento con l'ID specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| nome | java.lang.String |  |
+
+**Returns:**
+[User](../../com.aspose.diagram/user) - 
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(User item) {#remove-com.aspose.diagram.User-}
+```
+public void remove(User item)
+```
+
+
+Rimuovi l'oggetto User dalla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| item | [User](../../com.aspose.diagram/user) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/validation/_index.md
+++ b/italian/java/com.aspose.diagram/validation/_index.md
@@ -1,0 +1,158 @@
+---
+title: Validazione
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Memorizza informazioni sulla convalida del diagramma per il documento.
+type: docs
+weight: 427
+url: /it/java/com.aspose.diagram/validation/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Validation
+```
+
+Memorizza informazioni sulla convalida del diagramma per il documento.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getIssues()](#getIssues--) | Contiene tutti gli elementi Issue per il documento. |
+| [getRuleSets()](#getRuleSets--) | Include un elemento RuleSet per ogni set di regole di validazione nel documento. |
+| [getValidationProperties()](#getValidationProperties--) | Incapsula le proprietà relative alla convalida per il documento. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getIssues() {#getIssues--}
+```
+public IssueCollection getIssues()
+```
+
+
+Contiene tutti gli elementi Issue per il documento.
+
+**Returns:**
+[IssueCollection](../../com.aspose.diagram/issuecollection)
+### getRuleSets() {#getRuleSets--}
+```
+public RuleSetCollection getRuleSets()
+```
+
+
+Include un elemento RuleSet per ogni set di regole di validazione nel documento.
+
+**Returns:**
+[RuleSetCollection](../../com.aspose.diagram/rulesetcollection)
+### getValidationProperties() {#getValidationProperties--}
+```
+public ValidationProperties getValidationProperties()
+```
+
+
+Incapsula le proprietà relative alla convalida per il documento.
+
+**Returns:**
+[ValidationProperties](../../com.aspose.diagram/validationproperties)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/validationproperties/_index.md
+++ b/italian/java/com.aspose.diagram/validationproperties/_index.md
@@ -1,0 +1,194 @@
+---
+title: ValidationProperties
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Incapsula le proprietà relative alla convalida per il documento.
+type: docs
+weight: 428
+url: /it/java/com.aspose.diagram/validationproperties/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ValidationProperties
+```
+
+Incapsula le proprietà relative alla convalida per il documento.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [ValidationProperties(DateTime lastValidated, int showIgnored)](#ValidationProperties-com.aspose.diagram.DateTime-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getLastValidated()](#getLastValidated--) | La data e l'ora in cui il documento è stato convalidato l'ultima volta |
+| [getShowIgnored()](#getShowIgnored--) | Indica se mostrare i problemi di convalida ignorati nella finestra Problemi. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setLastValidated(DateTime value)](#setLastValidated-com.aspose.diagram.DateTime-) | Per la descrizione di questa proprietà, vedere [getLastValidated()](../../com.aspose.diagram/validationproperties\#getLastValidated--) |
+| [setShowIgnored(int value)](#setShowIgnored-int-) | Per la descrizione di questa proprietà, vedere [getShowIgnored()](../../com.aspose.diagram/validationproperties\#getShowIgnored--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ValidationProperties(DateTime lastValidated, int showIgnored) {#ValidationProperties-com.aspose.diagram.DateTime-int-}
+```
+public ValidationProperties(DateTime lastValidated, int showIgnored)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| lastValidated | [DateTime](../../com.aspose.diagram/datetime) |  |
+| showIgnored | int |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLastValidated() {#getLastValidated--}
+```
+public DateTime getLastValidated()
+```
+
+
+La data e l'ora in cui il documento è stato convalidato l'ultima volta
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### getShowIgnored() {#getShowIgnored--}
+```
+public int getShowIgnored()
+```
+
+
+Indica se mostrare i problemi di convalida ignorati nella finestra Problemi.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setLastValidated(DateTime value) {#setLastValidated-com.aspose.diagram.DateTime-}
+```
+public void setLastValidated(DateTime value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getLastValidated()](../../com.aspose.diagram/validationproperties\#getLastValidated--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setShowIgnored(int value) {#setShowIgnored-int-}
+```
+public void setShowIgnored(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getShowIgnored()](../../com.aspose.diagram/validationproperties\#getShowIgnored--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/value/_index.md
+++ b/italian/java/com.aspose.diagram/value/_index.md
@@ -1,0 +1,211 @@
+---
+title: Valore
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Valore.
+type: docs
+weight: 429
+url: /it/java/com.aspose.diagram/value/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Value
+```
+
+Valore.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object obj)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getSolutionXML()](#getSolutionXML--) | Contiene dati XML ben formati specifici della soluzione, con prefisso in uno spazio dei nomi esplicito e memorizzati con un documento. |
+| [getUfev()](#getUfev--) | Attributi specificati di un elemento. |
+| [getVal()](#getVal--) | Valore di testo |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setSolutionXML(SolutionXML value)](#setSolutionXML-com.aspose.diagram.SolutionXML-) | Per la descrizione di questa proprietà, vedere [getSolutionXML()](../../com.aspose.diagram/value\#getSolutionXML--) |
+| [setUfev(UnitFormulaErrV value)](#setUfev-com.aspose.diagram.UnitFormulaErrV-) | Per la descrizione di questa proprietà, vedere [getUfev()](../../com.aspose.diagram/value\#getUfev--) |
+| [setVal(String value)](#setVal-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getVal()](../../com.aspose.diagram/value\#getVal--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| obj | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getSolutionXML() {#getSolutionXML--}
+```
+public SolutionXML getSolutionXML()
+```
+
+
+Contiene dati XML ben formati specifici della soluzione, con prefisso in uno spazio dei nomi esplicito e memorizzati con un documento.
+
+**Returns:**
+[SolutionXML](../../com.aspose.diagram/solutionxml)
+### getUfev() {#getUfev--}
+```
+public UnitFormulaErrV getUfev()
+```
+
+
+Attributi specificati di un elemento.
+
+**Returns:**
+[UnitFormulaErrV](../../com.aspose.diagram/unitformulaerrv)
+### getVal() {#getVal--}
+```
+public String getVal()
+```
+
+
+Valore di testo
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setSolutionXML(SolutionXML value) {#setSolutionXML-com.aspose.diagram.SolutionXML-}
+```
+public void setSolutionXML(SolutionXML value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getSolutionXML()](../../com.aspose.diagram/value\#getSolutionXML--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [SolutionXML](../../com.aspose.diagram/solutionxml) |  |
+
+### setUfev(UnitFormulaErrV value) {#setUfev-com.aspose.diagram.UnitFormulaErrV-}
+```
+public void setUfev(UnitFormulaErrV value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getUfev()](../../com.aspose.diagram/value\#getUfev--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [UnitFormulaErrV](../../com.aspose.diagram/unitformulaerrv) |  |
+
+### setVal(String value) {#setVal-java.lang.String-}
+```
+public void setVal(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getVal()](../../com.aspose.diagram/value\#getVal--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/vbamodule/_index.md
+++ b/italian/java/com.aspose.diagram/vbamodule/_index.md
@@ -1,0 +1,186 @@
+---
+title: VbaModule
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta il modulo contenuto nel progetto VBA.
+type: docs
+weight: 430
+url: /it/java/com.aspose.diagram/vbamodule/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class VbaModule
+```
+
+Rappresenta il modulo contenuto nel progetto VBA.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCodes()](#getCodes--) | i codici del modulo. |
+| [getName()](#getName--) | il nome del modulo. |
+| [getType()](#getType--) | Ottiene il tipo di modulo. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCodes(String value)](#setCodes-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getCodes()](../../com.aspose.diagram/vbamodule\#getCodes--) |
+| [setName(String value)](#setName-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getName()](../../com.aspose.diagram/vbamodule\#getName--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCodes() {#getCodes--}
+```
+public String getCodes()
+```
+
+
+i codici del modulo.
+
+**Returns:**
+java.lang.String
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+il nome del modulo.
+
+**Returns:**
+java.lang.String
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Ottiene il tipo di modulo.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCodes(String value) {#setCodes-java.lang.String-}
+```
+public void setCodes(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getCodes()](../../com.aspose.diagram/vbamodule\#getCodes--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getName()](../../com.aspose.diagram/vbamodule\#getName--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/vbamodulecollection/_index.md
+++ b/italian/java/com.aspose.diagram/vbamodulecollection/_index.md
@@ -1,0 +1,311 @@
+---
+title: VbaModuleCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta l'elenco di
+type: docs
+weight: 431
+url: /it/java/com.aspose.diagram/vbamodulecollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.CollectionBase](../../com.aspose.diagram/collectionbase)
+```
+public class VbaModuleCollection extends CollectionBase
+```
+
+Rappresenta l'elenco di [VbaModule](../../com.aspose.diagram/vbamodule)
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [add(Page page)](#add-com.aspose.diagram.Page-) | Aggiunge un modulo per una pagina. |
+| [add(int type, String name)](#add-int-java.lang.String-) | Aggiunge un modulo. |
+| [add(Object o)](#add-java.lang.Object-) | Aggiunge un elemento all'istanza di CollectionBase. |
+| [clear()](#clear--) | Rimuove tutti gli oggetti dall'istanza di CollectionBase. |
+| [contains(Object o)](#contains-java.lang.Object-) | Restituisce se l'istanza contiene questo oggetto |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene [VbaModule](../../com.aspose.diagram/vbamodule) nell'elenco per indice. |
+| [get(String name)](#get-java.lang.String-) | Ottiene [VbaModule](../../com.aspose.diagram/vbamodule) nell'elenco per nome. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi contenuti nell'istanza di CollectionBase. |
+| [hashCode()](#hashCode--) |  |
+| [indexOf(Object o)](#indexOf-java.lang.Object-) | Determina l'indice di un elemento specifico nell'istanza di CollectionBase. |
+| [iterator()](#iterator--) | Restituisce un enumeratore che itera attraverso l'istanza di CollectionBase. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Page page)](#remove-com.aspose.diagram.Page-) | Rimuove il modulo per una pagina. |
+| [remove(String name)](#remove-java.lang.String-) | Rimuovi il modulo per nome |
+| [removeAt(int index)](#removeAt-int-) | Rimuove l'elemento all'indice specificato. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Page page) {#add-com.aspose.diagram.Page-}
+```
+public int add(Page page)
+```
+
+
+Aggiunge un modulo per una pagina.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| page | [Page](../../com.aspose.diagram/page) | La Pagina |
+
+**Returns:**
+int -
+### add(int type, String name) {#add-int-java.lang.String-}
+```
+public int add(int type, String name)
+```
+
+
+Aggiunge un modulo.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| tipo | int | Il tipo di modulo. |
+| nome | java.lang.String | Il nome del modulo. |
+
+**Returns:**
+int -
+### add(Object o) {#add-java.lang.Object-}
+```
+public int add(Object o)
+```
+
+
+Aggiunge un elemento all'istanza di CollectionBase.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| o | java.lang.Object | L'oggetto da aggiungere all'istanza di CollectionBase. |
+
+**Returns:**
+int - La posizione in cui è stato inserito il nuovo elemento.
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli oggetti dall'istanza di CollectionBase.
+
+### contains(Object o) {#contains-java.lang.Object-}
+```
+public boolean contains(Object o)
+```
+
+
+Restituisce se l'istanza contiene questo oggetto
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| o | java.lang.Object | oggetto di test |
+
+**Returns:**
+boolean - Indica se l'istanza contiene questo oggetto
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public VbaModule get(int index)
+```
+
+
+Ottiene [VbaModule](../../com.aspose.diagram/vbamodule) nell'elenco per indice.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | The index. |
+
+**Returns:**
+[VbaModule](../../com.aspose.diagram/vbamodule) - 
+### get(String name) {#get-java.lang.String-}
+```
+public VbaModule get(String name)
+```
+
+
+Ottiene [VbaModule](../../com.aspose.diagram/vbamodule) nell'elenco per nome.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| nome | java.lang.String | Il nome del modulo. |
+
+**Returns:**
+[VbaModule](../../com.aspose.diagram/vbamodule) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi contenuti nell'istanza di CollectionBase.
+
+**Returns:**
+int - Il numero di elementi contenuti nell'istanza di CollectionBase.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### indexOf(Object o) {#indexOf-java.lang.Object-}
+```
+public int indexOf(Object o)
+```
+
+
+Determina l'indice di un elemento specifico nell'istanza di CollectionBase.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| o | java.lang.Object | Determina l'indice di un elemento specifico nell'istanza di CollectionBase. |
+
+**Returns:**
+int - L'indice del valore se trovato nella lista; altrimenti, -1.
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Restituisce un enumeratore che itera attraverso l'istanza di CollectionBase.
+
+**Returns:**
+java.util.Iterator - Un iteratore per l'istanza di CollectionBase.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Page page) {#remove-com.aspose.diagram.Page-}
+```
+public void remove(Page page)
+```
+
+
+Rimuove il modulo per una pagina.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| page | [Page](../../com.aspose.diagram/page) | La pagina |
+
+### remove(String name) {#remove-java.lang.String-}
+```
+public void remove(String name)
+```
+
+
+Rimuovi il modulo per nome
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| nome | java.lang.String |  |
+
+### removeAt(int index) {#removeAt-int-}
+```
+public void removeAt(int index)
+```
+
+
+Rimuove l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | L'indice basato su zero dell'elemento da rimuovere. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/vbamoduletype/_index.md
+++ b/italian/java/com.aspose.diagram/vbamoduletype/_index.md
@@ -1,0 +1,165 @@
+---
+title: VbaModuleType
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta il tipo di modulo VBA.
+type: docs
+weight: 432
+url: /it/java/com.aspose.diagram/vbamoduletype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class VbaModuleType
+```
+
+Rappresenta il tipo di modulo VBA.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [CLASS](#CLASS) | Rappresenta un modulo di classe. |
+| [DESIGNER](#DESIGNER) | Rappresenta un modulo di progettazione. |
+| [DOCUMENT](#DOCUMENT) | Rappresenta un modulo di documento. |
+| [PROCEDURAL](#PROCEDURAL) | Rappresenta un modulo procedurale. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CLASS {#CLASS}
+```
+public static final int CLASS
+```
+
+
+Rappresenta un modulo di classe.
+
+### DESIGNER {#DESIGNER}
+```
+public static final int DESIGNER
+```
+
+
+Rappresenta un modulo di progettazione.
+
+### DOCUMENT {#DOCUMENT}
+```
+public static final int DOCUMENT
+```
+
+
+Rappresenta un modulo di documento.
+
+### PROCEDURAL {#PROCEDURAL}
+```
+public static final int PROCEDURAL
+```
+
+
+Rappresenta un modulo procedurale.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/vbaproject/_index.md
+++ b/italian/java/com.aspose.diagram/vbaproject/_index.md
@@ -1,0 +1,183 @@
+---
+title: VbaProject
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta il progetto VBA.
+type: docs
+weight: 433
+url: /it/java/com.aspose.diagram/vbaproject/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class VbaProject
+```
+
+Rappresenta il progetto VBA.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getModules()](#getModules--) | Ottiene tutti gli oggetti [VbaModule](../../com.aspose.diagram/vbamodule). |
+| [getName()](#getName--) | il nome del progetto VBA. |
+| [getReferences()](#getReferences--) | Ottiene tutti i riferimenti del progetto VBA. |
+| [hashCode()](#hashCode--) |  |
+| [isSigned()](#isSigned--) | Indica se VBAcode è firmato o meno. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setName(String value)](#setName-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getName()](../../com.aspose.diagram/vbaproject\#getName--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getModules() {#getModules--}
+```
+public VbaModuleCollection getModules()
+```
+
+
+Ottiene tutti gli oggetti [VbaModule](../../com.aspose.diagram/vbamodule).
+
+**Returns:**
+[VbaModuleCollection](../../com.aspose.diagram/vbamodulecollection)
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+il nome del progetto VBA.
+
+**Returns:**
+java.lang.String
+### getReferences() {#getReferences--}
+```
+public VbaProjectReferenceCollection getReferences()
+```
+
+
+Ottiene tutti i riferimenti del progetto VBA.
+
+**Returns:**
+[VbaProjectReferenceCollection](../../com.aspose.diagram/vbaprojectreferencecollection)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isSigned() {#isSigned--}
+```
+public boolean isSigned()
+```
+
+
+Indica se VBAcode è firmato o meno.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getName()](../../com.aspose.diagram/vbaproject\#getName--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/vbaprojectreference/_index.md
+++ b/italian/java/com.aspose.diagram/vbaprojectreference/_index.md
@@ -1,0 +1,261 @@
+---
+title: VbaProjectReference
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta il riferimento del progetto VBA.
+type: docs
+weight: 434
+url: /it/java/com.aspose.diagram/vbaprojectreference/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class VbaProjectReference
+```
+
+Rappresenta il riferimento del progetto VBA.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getExtendedLibid()](#getExtendedLibid--) | l'extended Libid del riferimento. |
+| [getLibid()](#getLibid--) | il Libid del riferimento. |
+| [getName()](#getName--) | il nome del riferimento. |
+| [getRelativeLibid()](#getRelativeLibid--) | l'identificatore del progetto VBA referenziato\u9225\u6a9a con un percorso relativo. |
+| [getTwiddledlibid()](#getTwiddledlibid--) | il twiddled Libid del riferimento. |
+| [getType()](#getType--) | Ottiene il tipo di questo riferimento. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setExtendedLibid(String value)](#setExtendedLibid-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getExtendedLibid()](../../com.aspose.diagram/vbaprojectreference\#getExtendedLibid--) |
+| [setLibid(String value)](#setLibid-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getLibid()](../../com.aspose.diagram/vbaprojectreference\#getLibid--) |
+| [setName(String value)](#setName-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getName()](../../com.aspose.diagram/vbaprojectreference\#getName--) |
+| [setRelativeLibid(String value)](#setRelativeLibid-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getRelativeLibid()](../../com.aspose.diagram/vbaprojectreference\#getRelativeLibid--) |
+| [setTwiddledlibid(String value)](#setTwiddledlibid-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getTwiddledlibid()](../../com.aspose.diagram/vbaprojectreference\#getTwiddledlibid--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getExtendedLibid() {#getExtendedLibid--}
+```
+public String getExtendedLibid()
+```
+
+
+l'extended Libid del riferimento. Solo per riferimento di controllo.
+
+**Returns:**
+java.lang.String
+### getLibid() {#getLibid--}
+```
+public String getLibid()
+```
+
+
+il Libid del riferimento.
+
+**Returns:**
+java.lang.String
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+il nome del riferimento.
+
+**Returns:**
+java.lang.String
+### getRelativeLibid() {#getRelativeLibid--}
+```
+public String getRelativeLibid()
+```
+
+
+l'identificatore del progetto VBA referenziato\u9225\u6a9a con un percorso relativo. Solo per riferimento di progetto.
+
+**Returns:**
+java.lang.String
+### getTwiddledlibid() {#getTwiddledlibid--}
+```
+public String getTwiddledlibid()
+```
+
+
+il twiddled Libid del riferimento. Solo per riferimento di controllo.
+
+**Returns:**
+java.lang.String
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Ottiene il tipo di questo riferimento.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setExtendedLibid(String value) {#setExtendedLibid-java.lang.String-}
+```
+public void setExtendedLibid(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getExtendedLibid()](../../com.aspose.diagram/vbaprojectreference\#getExtendedLibid--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setLibid(String value) {#setLibid-java.lang.String-}
+```
+public void setLibid(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getLibid()](../../com.aspose.diagram/vbaprojectreference\#getLibid--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getName()](../../com.aspose.diagram/vbaprojectreference\#getName--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setRelativeLibid(String value) {#setRelativeLibid-java.lang.String-}
+```
+public void setRelativeLibid(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getRelativeLibid()](../../com.aspose.diagram/vbaprojectreference\#getRelativeLibid--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setTwiddledlibid(String value) {#setTwiddledlibid-java.lang.String-}
+```
+public void setTwiddledlibid(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getTwiddledlibid()](../../com.aspose.diagram/vbaprojectreference\#getTwiddledlibid--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/vbaprojectreferencecollection/_index.md
+++ b/italian/java/com.aspose.diagram/vbaprojectreferencecollection/_index.md
@@ -1,0 +1,288 @@
+---
+title: VbaProjectReferenceCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta tutti i riferimenti del progetto VBA.
+type: docs
+weight: 435
+url: /it/java/com.aspose.diagram/vbaprojectreferencecollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.CollectionBase](../../com.aspose.diagram/collectionbase)
+```
+public class VbaProjectReferenceCollection extends CollectionBase
+```
+
+Rappresenta tutti i riferimenti del progetto VBA.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [add(Object o)](#add-java.lang.Object-) | Aggiunge un elemento all'istanza di CollectionBase. |
+| [addControlRefrernce(String name, String libid, String twiddledlibid, String extendedLibid)](#addControlRefrernce-java.lang.String-java.lang.String-java.lang.String-java.lang.String-) | Add a reference to a twiddled type library and its extended type library. |
+| [addProjectRefrernce(String name, String absoluteLibid, String relativeLibid)](#addProjectRefrernce-java.lang.String-java.lang.String-java.lang.String-) | Add a reference to an external VBA project. |
+| [addRegisteredReference(String name, String libid)](#addRegisteredReference-java.lang.String-java.lang.String-) | Add a reference to an Automation type library. |
+| [clear()](#clear--) | Rimuove tutti gli oggetti dall'istanza di CollectionBase. |
+| [contains(Object o)](#contains-java.lang.Object-) | Restituisce se l'istanza contiene questo oggetto |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int i)](#get-int-) | Get the reference in the list by the index. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Ottiene il numero di elementi contenuti nell'istanza di CollectionBase. |
+| [hashCode()](#hashCode--) |  |
+| [indexOf(Object o)](#indexOf-java.lang.Object-) | Determina l'indice di un elemento specifico nell'istanza di CollectionBase. |
+| [iterator()](#iterator--) | Restituisce un enumeratore che itera attraverso l'istanza di CollectionBase. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [removeAt(int index)](#removeAt-int-) | Rimuove l'elemento all'indice specificato. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Object o) {#add-java.lang.Object-}
+```
+public int add(Object o)
+```
+
+
+Aggiunge un elemento all'istanza di CollectionBase.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| o | java.lang.Object | L'oggetto da aggiungere all'istanza di CollectionBase. |
+
+**Returns:**
+int - La posizione in cui è stato inserito il nuovo elemento.
+### addControlRefrernce(String name, String libid, String twiddledlibid, String extendedLibid) {#addControlRefrernce-java.lang.String-java.lang.String-java.lang.String-java.lang.String-}
+```
+public int addControlRefrernce(String name, String libid, String twiddledlibid, String extendedLibid)
+```
+
+
+Add a reference to a twiddled type library and its extended type library.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| nome | java.lang.String | The name of reference. |
+| libid | java.lang.String | The identifier of an Automation type library. |
+| twiddledlibid | java.lang.String | The identifier of a twiddled type library |
+| extendedLibid | java.lang.String | L'identificatore di una libreria di tipi estesa |
+
+**Returns:**
+int -
+### addProjectRefrernce(String name, String absoluteLibid, String relativeLibid) {#addProjectRefrernce-java.lang.String-java.lang.String-java.lang.String-}
+```
+public int addProjectRefrernce(String name, String absoluteLibid, String relativeLibid)
+```
+
+
+Add a reference to an external VBA project.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| nome | java.lang.String | The name of reference. |
+| absoluteLibid | java.lang.String | L'identificatore del progetto VBA\u9225\u6a9a di riferimento con un percorso assoluto. |
+| relativeLibid | java.lang.String | L'identificatore del progetto VBA\u9225\u6a9a di riferimento con un percorso relativo. |
+
+**Returns:**
+int -
+### addRegisteredReference(String name, String libid) {#addRegisteredReference-java.lang.String-java.lang.String-}
+```
+public int addRegisteredReference(String name, String libid)
+```
+
+
+Add a reference to an Automation type library.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| nome | java.lang.String | The name of reference. |
+| libid | java.lang.String | The identifier of an Automation type library. |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli oggetti dall'istanza di CollectionBase.
+
+### contains(Object o) {#contains-java.lang.Object-}
+```
+public boolean contains(Object o)
+```
+
+
+Restituisce se l'istanza contiene questo oggetto
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| o | java.lang.Object | oggetto di test |
+
+**Returns:**
+boolean - Indica se l'istanza contiene questo oggetto
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int i) {#get-int-}
+```
+public VbaProjectReference get(int i)
+```
+
+
+Get the reference in the list by the index.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| i | int | The index. |
+
+**Returns:**
+[VbaProjectReference](../../com.aspose.diagram/vbaprojectreference) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi contenuti nell'istanza di CollectionBase.
+
+**Returns:**
+int - Il numero di elementi contenuti nell'istanza di CollectionBase.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### indexOf(Object o) {#indexOf-java.lang.Object-}
+```
+public int indexOf(Object o)
+```
+
+
+Determina l'indice di un elemento specifico nell'istanza di CollectionBase.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| o | java.lang.Object | Determina l'indice di un elemento specifico nell'istanza di CollectionBase. |
+
+**Returns:**
+int - L'indice del valore se trovato nella lista; altrimenti, -1.
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Restituisce un enumeratore che itera attraverso l'istanza di CollectionBase.
+
+**Returns:**
+java.util.Iterator - Un iteratore per l'istanza di CollectionBase.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### removeAt(int index) {#removeAt-int-}
+```
+public void removeAt(int index)
+```
+
+
+Rimuove l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | L'indice basato su zero dell'elemento da rimuovere. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/vbaprojectreferencetype/_index.md
+++ b/italian/java/com.aspose.diagram/vbaprojectreferencetype/_index.md
@@ -1,0 +1,156 @@
+---
+title: VbaProjectReferenceType
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta il tipo di riferimento del progetto VBA.
+type: docs
+weight: 436
+url: /it/java/com.aspose.diagram/vbaprojectreferencetype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class VbaProjectReferenceType
+```
+
+Rappresenta il tipo di riferimento del progetto VBA.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [CONTROL](#CONTROL) | Specifica un riferimento a una libreria di tipo modificata e alla sua libreria di tipo estesa. |
+| [PROJECT](#PROJECT) | Specifica un riferimento a un progetto VBA esterno. |
+| [REGISTERED](#REGISTERED) | Specifica un riferimento a una libreria di tipo Automation. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CONTROL {#CONTROL}
+```
+public static final int CONTROL
+```
+
+
+Specifica un riferimento a una libreria di tipo modificata e alla sua libreria di tipo estesa.
+
+### PROJECT {#PROJECT}
+```
+public static final int PROJECT
+```
+
+
+Specifica un riferimento a un progetto VBA esterno.
+
+### REGISTERED {#REGISTERED}
+```
+public static final int REGISTERED
+```
+
+
+Specifica un riferimento a una libreria di tipo Automation.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/verticalalign/_index.md
+++ b/italian/java/com.aspose.diagram/verticalalign/_index.md
@@ -1,0 +1,204 @@
+---
+title: VerticalAlign
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica l'allineamento verticale del testo all'interno del blocco di testo.
+type: docs
+weight: 437
+url: /it/java/com.aspose.diagram/verticalalign/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class VerticalAlign
+```
+
+Specifica l'allineamento verticale del testo all'interno del blocco di testo.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [VerticalAlign(int value)](#VerticalAlign-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Specifica l'allineamento verticale del testo all'interno del blocco di testo. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | Per la descrizione di questa proprietà, vedere [getUfe()](../../com.aspose.diagram/verticalalign\#getUfe--) |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/verticalalign\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### VerticalAlign(int value) {#VerticalAlign-int-}
+```
+public VerticalAlign(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specifica l'allineamento verticale del testo all'interno del blocco di testo.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getUfe()](../../com.aspose.diagram/verticalalign\#getUfe--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/verticalalign\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/verticalalignvalue/_index.md
+++ b/italian/java/com.aspose.diagram/verticalalignvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: VerticalAlignValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica l'allineamento verticale del testo all'interno del blocco di testo.
+type: docs
+weight: 438
+url: /it/java/com.aspose.diagram/verticalalignvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class VerticalAlignValue
+```
+
+Specifica l'allineamento verticale del testo all'interno del blocco di testo.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [BOTTOM](#BOTTOM) | In basso. |
+| [MIDDLE](#MIDDLE) | Al centro. |
+| [TOP](#TOP) | Superiore. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOTTOM {#BOTTOM}
+```
+public static final int BOTTOM
+```
+
+
+In basso.
+
+### MIDDLE {#MIDDLE}
+```
+public static final int MIDDLE
+```
+
+
+Al centro.
+
+### TOP {#TOP}
+```
+public static final int TOP
+```
+
+
+Superiore.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/visruletargetsvalue/_index.md
+++ b/italian/java/com.aspose.diagram/visruletargetsvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: VisRuleTargetsValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica i contenuti che definiscono l'obiettivo della regola di convalida passata a e restituita dalla proprietà ValidationRule.TargetType.
+type: docs
+weight: 439
+url: /it/java/com.aspose.diagram/visruletargetsvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class VisRuleTargetsValue
+```
+
+Specifica i contenuti che definiscono l'obiettivo della regola di convalida; passati a e restituiti dalla proprietà ValidationRule.TargetType.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+| [VIS_RULE_TARGET_DOCUMENT](#VIS-RULE-TARGET-DOCUMENT) | La regola si applica alle forme nel documento. |
+| [VIS_RULE_TARGET_PAGE](#VIS-RULE-TARGET-PAGE) | La regola si applica alle pagine nel documento. |
+| [VIS_RULE_TARGET_SHAPE](#VIS-RULE-TARGET-SHAPE) | La regola si applica al documento stesso. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### VIS_RULE_TARGET_DOCUMENT {#VIS-RULE-TARGET-DOCUMENT}
+```
+public static final int VIS_RULE_TARGET_DOCUMENT
+```
+
+
+La regola si applica alle forme nel documento.
+
+### VIS_RULE_TARGET_PAGE {#VIS-RULE-TARGET-PAGE}
+```
+public static final int VIS_RULE_TARGET_PAGE
+```
+
+
+La regola si applica alle pagine nel documento.
+
+### VIS_RULE_TARGET_SHAPE {#VIS-RULE-TARGET-SHAPE}
+```
+public static final int VIS_RULE_TARGET_SHAPE
+```
+
+
+La regola si applica al documento stesso.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/walkpreference/_index.md
+++ b/italian/java/com.aspose.diagram/walkpreference/_index.md
@@ -1,0 +1,179 @@
+---
+title: WalkPreference
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica se un'estremità di una forma 1-D si sposta verso un punto di connessione orizzontale o verticale sulla forma a cui è incollata usando colla dinamica quando la forma viene spostata in una posizione ambigua.
+type: docs
+weight: 440
+url: /it/java/com.aspose.diagram/walkpreference/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class WalkPreference
+```
+
+Specifica se un'estremità di una forma 1-D si sposta verso un punto di connessione orizzontale o verticale sulla forma a cui è incollata, utilizzando la colla dinamica, quando la forma viene spostata in una posizione ambigua.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [WalkPreference(int value)](#WalkPreference-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Specifica se un'estremità di una forma 1-D si sposta verso un punto di connessione orizzontale o verticale sulla forma a cui è incollata, utilizzando la colla dinamica, quando la forma viene spostata in una posizione ambigua. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/walkpreference\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### WalkPreference(int value) {#WalkPreference-int-}
+```
+public WalkPreference(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specifica se un'estremità di una forma 1-D si sposta verso un punto di connessione orizzontale o verticale sulla forma a cui è incollata, utilizzando la colla dinamica, quando la forma viene spostata in una posizione ambigua.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/walkpreference\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/walkpreferencevalue/_index.md
+++ b/italian/java/com.aspose.diagram/walkpreferencevalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: WalkPreferenceValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica se un'estremità di una forma 1-D si sposta verso un punto di connessione orizzontale o verticale sulla forma a cui è incollata usando colla dinamica quando la forma viene spostata in una posizione ambigua.
+type: docs
+weight: 441
+url: /it/java/com.aspose.diagram/walkpreferencevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class WalkPreferenceValue
+```
+
+Specifica se un'estremità di una forma 1-D si sposta verso un punto di connessione orizzontale o verticale sulla forma a cui è incollata, utilizzando la colla dinamica, quando la forma viene spostata in una posizione ambigua.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [SIDE_TO_SIDE_CONNECTIONS](#SIDE-TO-SIDE-CONNECTIONS) | Il valore predefinito. |
+| [SIDE_TO_TOP_OR_SIDE_TO_BOTTOM_CONNECTIONS](#SIDE-TO-TOP-OR-SIDE-TO-BOTTOM-CONNECTIONS) | Il punto iniziale della forma 1-D si sposta verso un punto di connessione orizzontale, e il punto finale si sposta verso un punto di connessione verticale (connessioni lato‑alto o lato‑basso). |
+| [TOP_TO_BOTTOM_CONNECTIONS](#TOP-TO-BOTTOM-CONNECTIONS) | Entrambi gli estremi della forma 1-D si spostano verso punti di connessione verticali (connessioni alto‑basso). |
+| [TOP_TO_SIDE_OR_BOTTOM_TO_SIDE_CONNECTIONS](#TOP-TO-SIDE-OR-BOTTOM-TO-SIDE-CONNECTIONS) | Il punto iniziale della forma 1-D si sposta verso un punto di connessione verticale, e il punto finale si sposta verso un punto di connessione orizzontale (connessioni alto‑lato o basso‑lato). |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SIDE_TO_SIDE_CONNECTIONS {#SIDE-TO-SIDE-CONNECTIONS}
+```
+public static final int SIDE_TO_SIDE_CONNECTIONS
+```
+
+
+Il valore predefinito. Entrambi gli estremi della forma 1-D si spostano verso punti di connessione orizzontali (connessioni lato‑lato).
+
+### SIDE_TO_TOP_OR_SIDE_TO_BOTTOM_CONNECTIONS {#SIDE-TO-TOP-OR-SIDE-TO-BOTTOM-CONNECTIONS}
+```
+public static final int SIDE_TO_TOP_OR_SIDE_TO_BOTTOM_CONNECTIONS
+```
+
+
+Il punto iniziale della forma 1-D si sposta verso un punto di connessione orizzontale, e il punto finale si sposta verso un punto di connessione verticale (connessioni lato‑alto o lato‑basso).
+
+### TOP_TO_BOTTOM_CONNECTIONS {#TOP-TO-BOTTOM-CONNECTIONS}
+```
+public static final int TOP_TO_BOTTOM_CONNECTIONS
+```
+
+
+Entrambi gli estremi della forma 1-D si spostano verso punti di connessione verticali (connessioni alto‑basso).
+
+### TOP_TO_SIDE_OR_BOTTOM_TO_SIDE_CONNECTIONS {#TOP-TO-SIDE-OR-BOTTOM-TO-SIDE-CONNECTIONS}
+```
+public static final int TOP_TO_SIDE_OR_BOTTOM_TO_SIDE_CONNECTIONS
+```
+
+
+Il punto iniziale della forma 1-D si sposta verso un punto di connessione verticale, e il punto finale si sposta verso un punto di connessione orizzontale (connessioni alto‑lato o basso‑lato).
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/warninginfo/_index.md
+++ b/italian/java/com.aspose.diagram/warninginfo/_index.md
@@ -1,0 +1,166 @@
+---
+title: WarningInfo
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Informazioni di avviso
+type: docs
+weight: 442
+url: /it/java/com.aspose.diagram/warninginfo/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class WarningInfo
+```
+
+Informazioni di avviso
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [WarningInfo(int warningType, String description)](#WarningInfo-int-java.lang.String-) | Create warning info. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDescription()](#getDescription--) | Get description of warning info. |
+| [getWarningType()](#getWarningType--) | Get warning type. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### WarningInfo(int warningType, String description) {#WarningInfo-int-java.lang.String-}
+```
+public WarningInfo(int warningType, String description)
+```
+
+
+Create warning info.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| warningType | int | warning type |
+| description | java.lang.String | warning description |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDescription() {#getDescription--}
+```
+public String getDescription()
+```
+
+
+Get description of warning info.
+
+**Returns:**
+java.lang.String
+### getWarningType() {#getWarningType--}
+```
+public int getWarningType()
+```
+
+
+Get warning type.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/warningtype/_index.md
+++ b/italian/java/com.aspose.diagram/warningtype/_index.md
@@ -1,0 +1,138 @@
+---
+title: WarningType
+second_title: Riferimento API di Aspose.Diagram per Java
+description: WarningType
+type: docs
+weight: 443
+url: /it/java/com.aspose.diagram/warningtype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class WarningType
+```
+
+WarningType
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [FONT_SUBSTITUTION](#FONT-SUBSTITUTION) | Tipo di avviso di sostituzione del carattere quando un font non è stato trovato; questo tipo di avviso può essere ottenuto. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FONT_SUBSTITUTION {#FONT-SUBSTITUTION}
+```
+public static final int FONT_SUBSTITUTION
+```
+
+
+Tipo di avviso di sostituzione del carattere quando un font non è stato trovato; questo tipo di avviso può essere ottenuto.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/window/_index.md
+++ b/italian/java/com.aspose.diagram/window/_index.md
@@ -1,0 +1,899 @@
+---
+title: Window
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Rappresenta una finestra aperta in un'istanza di Microsoft Visio.
+type: docs
+weight: 444
+url: /it/java/com.aspose.diagram/window/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Window
+```
+
+Rappresenta una finestra aperta in un'istanza di Microsoft Visio. Questo elemento contiene le informazioni necessarie per ricreare esattamente una finestra dell'interfaccia utente nello spazio di lavoro dell'applicazione quando il file DatadiagramML viene aperto inizialmente da Visio.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [Window()](#Window--) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getContainer()](#getContainer--) | ID del contenitore: Pagina, Foglio o Master. |
+| [getContainerType()](#getContainerType--) | Può essere uno dei seguenti valori: Document, Page o Master. |
+| [getDocument()](#getDocument--) | Percorso file del documento visualizzato in questa finestra. |
+| [getDynamicGridEnabled()](#getDynamicGridEnabled--) | Specifica se la funzionalità griglia dinamica è abilitata per un documento o una finestra. |
+| [getGlueSettings()](#getGlueSettings--) | Specifica gli oggetti a cui le forme si incollano quando la colla è abilitata nel documento. |
+| [getID()](#getID--) | L'ID univoco dell'elemento all'interno del suo elemento genitore. |
+| [getMaster()](#getMaster--) | ID del master se questa finestra sta visualizzando un master. |
+| [getPage()](#getPage--) | ID della pagina se questa finestra sta visualizzando una pagina. |
+| [getParentWindow()](#getParentWindow--) | ID della finestra in cui è contenuta questa finestra stencil. |
+| [getReadOnly()](#getReadOnly--) | Flag di sola lettura se questo stencil non è uno stencil di documento. |
+| [getSheet()](#getSheet--) | ID del foglio nel contenitore. |
+| [getShowConnectionPoints()](#getShowConnectionPoints--) | Specifica se i punti di connessione sono mostrati in una finestra. |
+| [getShowGrid()](#getShowGrid--) | Specifica se una griglia è mostrata nella finestra di disegno. |
+| [getShowGuides()](#getShowGuides--) | Specifica se le guide sono mostrate nella finestra di disegno. |
+| [getShowPageBreaks()](#getShowPageBreaks--) | Specifica se le interruzioni di pagina sono mostrate in una finestra. |
+| [getShowRulers()](#getShowRulers--) | Specifica se i righelli sono mostrati nella finestra di disegno. |
+| [getSnapAngles()](#getSnapAngles--) | Contiene una raccolta di elementi SnapAngle. |
+| [getSnapExtensions()](#getSnapExtensions--) | Specifica se un'impostazione specifica di estensione snap è abilitata o disabilitata per la finestra attiva. |
+| [getSnapSettings()](#getSnapSettings--) | Specifica gli oggetti a cui le forme si agganciano quando lo snap è attivo nella finestra. |
+| [getStencilGroup()](#getStencilGroup--) | Specifica il gruppo di finestre stencil unite di cui la finestra è membro. |
+| [getStencilGroupPos()](#getStencilGroupPos--) | Contiene un intero che specifica la posizione relativa di uno stencil all'interno di un gruppo in una finestra. |
+| [getTabSplitterPos()](#getTabSplitterPos--) | Specifica la larghezza del controllo della scheda pagina di una finestra di disegno (come frazione della larghezza totale della finestra di disegno). |
+| [getViewCenterX()](#getViewCenterX--) | Double opzionale. |
+| [getViewCenterY()](#getViewCenterY--) | Double opzionale. |
+| [getViewScale()](#getViewScale--) | Double opzionale. |
+| [getWindowHeight()](#getWindowHeight--) | Altezza del rettangolo della finestra. |
+| [getWindowLeft()](#getWindowLeft--) | Coordinata sinistra del rettangolo della finestra. |
+| [getWindowState()](#getWindowState--) | Questo attributo può essere una somma dei seguenti valori. |
+| [getWindowTop()](#getWindowTop--) | Coordinata superiore del rettangolo della finestra. |
+| [getWindowType()](#getWindowType--) | Un valore enumerato che può essere uno dei seguenti: Drawing, Sheet, Stencil o Icon. Un elemento Window con WindowType='Stencil' deve apparire dopo la sua finestra di disegno padre (WindowType='Drawing') e prima di qualsiasi altro elemento di finestra di disegno. |
+| [getWindowWidth()](#getWindowWidth--) | Larghezza del rettangolo della finestra. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setContainer(int value)](#setContainer-int-) | Per la descrizione di questa proprietà, vedere [getContainer()](../../com.aspose.diagram/window\#getContainer--) |
+| [setContainerType(int value)](#setContainerType-int-) | Per la descrizione di questa proprietà, vedere [getContainerType()](../../com.aspose.diagram/window\#getContainerType--) |
+| [setDocument(String value)](#setDocument-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getDocument()](../../com.aspose.diagram/window\#getDocument--) |
+| [setDynamicGridEnabled(int value)](#setDynamicGridEnabled-int-) | Per la descrizione di questa proprietà, vedere [getDynamicGridEnabled()](../../com.aspose.diagram/window\#getDynamicGridEnabled--) |
+| [setGlueSettings(int value)](#setGlueSettings-int-) | Per la descrizione di questa proprietà, vedere [getGlueSettings()](../../com.aspose.diagram/window\#getGlueSettings--) |
+| [setID(int value)](#setID-int-) | Per la descrizione di questa proprietà, vedere [getID()](../../com.aspose.diagram/window\#getID--) |
+| [setMaster(Master value)](#setMaster-com.aspose.diagram.Master-) | Per la descrizione di questa proprietà, vedere [getMaster()](../../com.aspose.diagram/window\#getMaster--) |
+| [setPage(Page value)](#setPage-com.aspose.diagram.Page-) | Per la descrizione di questa proprietà, vedere [getPage()](../../com.aspose.diagram/window\#getPage--) |
+| [setParentWindow(int value)](#setParentWindow-int-) | Per la descrizione di questa proprietà, vedere [getParentWindow()](../../com.aspose.diagram/window\#getParentWindow--) |
+| [setReadOnly(int value)](#setReadOnly-int-) | Per la descrizione di questa proprietà, vedere [getReadOnly()](../../com.aspose.diagram/window\#getReadOnly--) |
+| [setSheet(int value)](#setSheet-int-) | Per la descrizione di questa proprietà, vedere [getSheet()](../../com.aspose.diagram/window\#getSheet--) |
+| [setShowConnectionPoints(int value)](#setShowConnectionPoints-int-) | Per la descrizione di questa proprietà, vedere [getShowConnectionPoints()](../../com.aspose.diagram/window\#getShowConnectionPoints--) |
+| [setShowGrid(int value)](#setShowGrid-int-) | Per la descrizione di questa proprietà, vedere [getShowGrid()](../../com.aspose.diagram/window\#getShowGrid--) |
+| [setShowGuides(int value)](#setShowGuides-int-) | Per la descrizione di questa proprietà, vedere [getShowGuides()](../../com.aspose.diagram/window\#getShowGuides--) |
+| [setShowPageBreaks(int value)](#setShowPageBreaks-int-) | Per la descrizione di questa proprietà, vedere [getShowPageBreaks()](../../com.aspose.diagram/window\#getShowPageBreaks--) |
+| [setShowRulers(int value)](#setShowRulers-int-) | Per la descrizione di questa proprietà, vedere [getShowRulers()](../../com.aspose.diagram/window\#getShowRulers--) |
+| [setSnapExtensions(int value)](#setSnapExtensions-int-) | Per la descrizione di questa proprietà, vedere [getSnapExtensions()](../../com.aspose.diagram/window\#getSnapExtensions--) |
+| [setSnapSettings(int value)](#setSnapSettings-int-) | Per la descrizione di questa proprietà, vedere [getSnapSettings()](../../com.aspose.diagram/window\#getSnapSettings--) |
+| [setStencilGroup(String value)](#setStencilGroup-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getStencilGroup()](../../com.aspose.diagram/window\#getStencilGroup--) |
+| [setStencilGroupPos(int value)](#setStencilGroupPos-int-) | Per la descrizione di questa proprietà, vedere [getStencilGroupPos()](../../com.aspose.diagram/window\#getStencilGroupPos--) |
+| [setTabSplitterPos(double value)](#setTabSplitterPos-double-) | Per la descrizione di questa proprietà, vedere [getTabSplitterPos()](../../com.aspose.diagram/window\#getTabSplitterPos--) |
+| [setViewCenterX(double value)](#setViewCenterX-double-) | Per la descrizione di questa proprietà, vedere [getViewCenterX()](../../com.aspose.diagram/window\#getViewCenterX--) |
+| [setViewCenterY(double value)](#setViewCenterY-double-) | Per la descrizione di questa proprietà, vedere [getViewCenterY()](../../com.aspose.diagram/window\#getViewCenterY--) |
+| [setViewScale(double value)](#setViewScale-double-) | Per la descrizione di questa proprietà, vedere [getViewScale()](../../com.aspose.diagram/window\#getViewScale--) |
+| [setWindowHeight(long value)](#setWindowHeight-long-) | Per la descrizione di questa proprietà, vedere [getWindowHeight()](../../com.aspose.diagram/window\#getWindowHeight--) |
+| [setWindowLeft(int value)](#setWindowLeft-int-) | Per la descrizione di questa proprietà, vedere [getWindowLeft()](../../com.aspose.diagram/window\#getWindowLeft--) |
+| [setWindowState(int value)](#setWindowState-int-) | Per la descrizione di questa proprietà, vedere [getWindowState()](../../com.aspose.diagram/window\#getWindowState--) |
+| [setWindowTop(int value)](#setWindowTop-int-) | Per la descrizione di questa proprietà, vedere [getWindowTop()](../../com.aspose.diagram/window\#getWindowTop--) |
+| [setWindowType(int value)](#setWindowType-int-) | Per la descrizione di questa proprietà, vedere [getWindowType()](../../com.aspose.diagram/window\#getWindowType--) |
+| [setWindowWidth(long value)](#setWindowWidth-long-) | Per la descrizione di questa proprietà, vedere [getWindowWidth()](../../com.aspose.diagram/window\#getWindowWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Window() {#Window--}
+```
+public Window()
+```
+
+
+Costruttore.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getContainer() {#getContainer--}
+```
+public int getContainer()
+```
+
+
+ID del contenitore: Page, Sheet o Master. Rilevante e necessario solo se è specificato ContainerType.
+
+**Returns:**
+int
+### getContainerType() {#getContainerType--}
+```
+public int getContainerType()
+```
+
+
+May be one of the following values: Document, Page, or Master. Only relevant when WindowType is specified as Drawing or Sheet.
+
+**Returns:**
+int
+### getDocument() {#getDocument--}
+```
+public String getDocument()
+```
+
+
+Percorso file del documento visualizzato in questa finestra. Questo attributo è rilevante per le finestre il cui WindowType è specificato come Stencil.
+
+**Returns:**
+java.lang.String
+### getDynamicGridEnabled() {#getDynamicGridEnabled--}
+```
+public int getDynamicGridEnabled()
+```
+
+
+Specifica se la funzionalità griglia dinamica è abilitata per un documento o una finestra.
+
+**Returns:**
+int
+### getGlueSettings() {#getGlueSettings--}
+```
+public int getGlueSettings()
+```
+
+
+Specifica gli oggetti a cui le forme si incollano quando la colla è abilitata nel documento.
+
+**Returns:**
+int
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+L'ID univoco dell'elemento all'interno del suo elemento genitore.
+
+**Returns:**
+int
+### getMaster() {#getMaster--}
+```
+public Master getMaster()
+```
+
+
+ID del master se questa finestra sta visualizzando un master.
+
+**Returns:**
+[Master](../../com.aspose.diagram/master)
+### getPage() {#getPage--}
+```
+public Page getPage()
+```
+
+
+ID della pagina se questa finestra visualizza una pagina. Rilevante solo quando WindowType è specificato come Drawing e ContainerType è specificato come Page.
+
+**Returns:**
+[Page](../../com.aspose.diagram/page)
+### getParentWindow() {#getParentWindow--}
+```
+public int getParentWindow()
+```
+
+
+ID della finestra in cui è contenuta questa finestra stencil. Rilevante solo quando WindowType è specificato come Stencil.
+
+**Returns:**
+int
+### getReadOnly() {#getReadOnly--}
+```
+public int getReadOnly()
+```
+
+
+Flag di sola lettura se questo stencil non è uno stencil di documento.
+
+**Returns:**
+int
+### getSheet() {#getSheet--}
+```
+public int getSheet()
+```
+
+
+ID del foglio nel contenitore. Rilevante solo quando Container è specificato come Sheet.
+
+**Returns:**
+int
+### getShowConnectionPoints() {#getShowConnectionPoints--}
+```
+public int getShowConnectionPoints()
+```
+
+
+Specifica se i punti di connessione sono mostrati in una finestra.
+
+**Returns:**
+int
+### getShowGrid() {#getShowGrid--}
+```
+public int getShowGrid()
+```
+
+
+Specifica se una griglia è mostrata nella finestra di disegno.
+
+**Returns:**
+int
+### getShowGuides() {#getShowGuides--}
+```
+public int getShowGuides()
+```
+
+
+Specifica se le guide sono mostrate nella finestra di disegno.
+
+**Returns:**
+int
+### getShowPageBreaks() {#getShowPageBreaks--}
+```
+public int getShowPageBreaks()
+```
+
+
+Specifica se le interruzioni di pagina sono mostrate in una finestra.
+
+**Returns:**
+int
+### getShowRulers() {#getShowRulers--}
+```
+public int getShowRulers()
+```
+
+
+Specifica se i righelli sono mostrati nella finestra di disegno.
+
+**Returns:**
+int
+### getSnapAngles() {#getSnapAngles--}
+```
+public FloatPointNumCollection getSnapAngles()
+```
+
+
+Contiene una raccolta di elementi SnapAngle.
+
+**Returns:**
+[FloatPointNumCollection](../../com.aspose.diagram/floatpointnumcollection)
+### getSnapExtensions() {#getSnapExtensions--}
+```
+public int getSnapExtensions()
+```
+
+
+Specifica se un'impostazione di estensione di aggancio specifica è abilitata o disabilitata per la finestra attiva. Il valore può essere la somma dei valori nella tabella seguente.
+
+**Returns:**
+int
+### getSnapSettings() {#getSnapSettings--}
+```
+public int getSnapSettings()
+```
+
+
+Specifica gli oggetti a cui le forme si agganciano quando l'aggancio è attivo nella finestra. Il valore può essere la somma dei valori nella tabella seguente.
+
+**Returns:**
+int
+### getStencilGroup() {#getStencilGroup--}
+```
+public String getStencilGroup()
+```
+
+
+Specifica il gruppo di finestre stencil unite di cui la finestra è membro. Questo attributo è rilevante solo per gli elementi Window il cui attributo WindowType è Stencil, e solo se la finestra stencil fa parte di un gruppo unito di finestre stencil. Tutte le finestre stencil che fanno parte dello stesso gruppo unito hanno lo stesso valore dell'elemento StencilGroup.
+
+**Returns:**
+java.lang.String
+### getStencilGroupPos() {#getStencilGroupPos--}
+```
+public int getStencilGroupPos()
+```
+
+
+Contiene un intero che specifica la posizione relativa di uno stencil all'interno di un gruppo in una finestra.
+
+**Returns:**
+int
+### getTabSplitterPos() {#getTabSplitterPos--}
+```
+public double getTabSplitterPos()
+```
+
+
+Specifica la larghezza del controllo della scheda pagina di una finestra di disegno (come frazione della larghezza totale della finestra di disegno).
+
+**Returns:**
+double
+### getViewCenterX() {#getViewCenterX--}
+```
+public double getViewCenterX()
+```
+
+
+Double opzionale.
+
+**Returns:**
+double
+### getViewCenterY() {#getViewCenterY--}
+```
+public double getViewCenterY()
+```
+
+
+Double opzionale.
+
+**Returns:**
+double
+### getViewScale() {#getViewScale--}
+```
+public double getViewScale()
+```
+
+
+Double opzionale.
+
+**Returns:**
+double
+### getWindowHeight() {#getWindowHeight--}
+```
+public long getWindowHeight()
+```
+
+
+Altezza del rettangolo della finestra.
+
+**Returns:**
+long
+### getWindowLeft() {#getWindowLeft--}
+```
+public int getWindowLeft()
+```
+
+
+Coordinata sinistra del rettangolo della finestra.
+
+**Returns:**
+int
+### getWindowState() {#getWindowState--}
+```
+public int getWindowState()
+```
+
+
+Questo attributo può essere una somma dei seguenti valori.
+
+**Returns:**
+int
+### getWindowTop() {#getWindowTop--}
+```
+public int getWindowTop()
+```
+
+
+Coordinata superiore del rettangolo della finestra.
+
+**Returns:**
+int
+### getWindowType() {#getWindowType--}
+```
+public int getWindowType()
+```
+
+
+Un valore enumerato che può essere uno dei seguenti: Drawing, Sheet, Stencil o Icon. Un elemento Window con WindowType='Stencil' deve apparire dopo la sua finestra di disegno padre (WindowType='Drawing') e prima di qualsiasi altro elemento di finestra di disegno.
+
+**Returns:**
+int
+### getWindowWidth() {#getWindowWidth--}
+```
+public long getWindowWidth()
+```
+
+
+Larghezza del rettangolo della finestra.
+
+**Returns:**
+long
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setContainer(int value) {#setContainer-int-}
+```
+public void setContainer(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getContainer()](../../com.aspose.diagram/window\#getContainer--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setContainerType(int value) {#setContainerType-int-}
+```
+public void setContainerType(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getContainerType()](../../com.aspose.diagram/window\#getContainerType--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setDocument(String value) {#setDocument-java.lang.String-}
+```
+public void setDocument(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDocument()](../../com.aspose.diagram/window\#getDocument--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setDynamicGridEnabled(int value) {#setDynamicGridEnabled-int-}
+```
+public void setDynamicGridEnabled(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDynamicGridEnabled()](../../com.aspose.diagram/window\#getDynamicGridEnabled--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setGlueSettings(int value) {#setGlueSettings-int-}
+```
+public void setGlueSettings(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getGlueSettings()](../../com.aspose.diagram/window\#getGlueSettings--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getID()](../../com.aspose.diagram/window\#getID--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setMaster(Master value) {#setMaster-com.aspose.diagram.Master-}
+```
+public void setMaster(Master value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getMaster()](../../com.aspose.diagram/window\#getMaster--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [Master](../../com.aspose.diagram/master) |  |
+
+### setPage(Page value) {#setPage-com.aspose.diagram.Page-}
+```
+public void setPage(Page value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getPage()](../../com.aspose.diagram/window\#getPage--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [Page](../../com.aspose.diagram/page) |  |
+
+### setParentWindow(int value) {#setParentWindow-int-}
+```
+public void setParentWindow(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getParentWindow()](../../com.aspose.diagram/window\#getParentWindow--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setReadOnly(int value) {#setReadOnly-int-}
+```
+public void setReadOnly(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getReadOnly()](../../com.aspose.diagram/window\#getReadOnly--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setSheet(int value) {#setSheet-int-}
+```
+public void setSheet(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getSheet()](../../com.aspose.diagram/window\#getSheet--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setShowConnectionPoints(int value) {#setShowConnectionPoints-int-}
+```
+public void setShowConnectionPoints(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getShowConnectionPoints()](../../com.aspose.diagram/window\#getShowConnectionPoints--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setShowGrid(int value) {#setShowGrid-int-}
+```
+public void setShowGrid(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getShowGrid()](../../com.aspose.diagram/window\#getShowGrid--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setShowGuides(int value) {#setShowGuides-int-}
+```
+public void setShowGuides(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getShowGuides()](../../com.aspose.diagram/window\#getShowGuides--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setShowPageBreaks(int value) {#setShowPageBreaks-int-}
+```
+public void setShowPageBreaks(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getShowPageBreaks()](../../com.aspose.diagram/window\#getShowPageBreaks--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setShowRulers(int value) {#setShowRulers-int-}
+```
+public void setShowRulers(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getShowRulers()](../../com.aspose.diagram/window\#getShowRulers--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setSnapExtensions(int value) {#setSnapExtensions-int-}
+```
+public void setSnapExtensions(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getSnapExtensions()](../../com.aspose.diagram/window\#getSnapExtensions--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setSnapSettings(int value) {#setSnapSettings-int-}
+```
+public void setSnapSettings(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getSnapSettings()](../../com.aspose.diagram/window\#getSnapSettings--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setStencilGroup(String value) {#setStencilGroup-java.lang.String-}
+```
+public void setStencilGroup(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getStencilGroup()](../../com.aspose.diagram/window\#getStencilGroup--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setStencilGroupPos(int value) {#setStencilGroupPos-int-}
+```
+public void setStencilGroupPos(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getStencilGroupPos()](../../com.aspose.diagram/window\#getStencilGroupPos--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setTabSplitterPos(double value) {#setTabSplitterPos-double-}
+```
+public void setTabSplitterPos(double value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getTabSplitterPos()](../../com.aspose.diagram/window\#getTabSplitterPos--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double |  |
+
+### setViewCenterX(double value) {#setViewCenterX-double-}
+```
+public void setViewCenterX(double value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getViewCenterX()](../../com.aspose.diagram/window\#getViewCenterX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double |  |
+
+### setViewCenterY(double value) {#setViewCenterY-double-}
+```
+public void setViewCenterY(double value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getViewCenterY()](../../com.aspose.diagram/window\#getViewCenterY--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double |  |
+
+### setViewScale(double value) {#setViewScale-double-}
+```
+public void setViewScale(double value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getViewScale()](../../com.aspose.diagram/window\#getViewScale--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | double |  |
+
+### setWindowHeight(long value) {#setWindowHeight-long-}
+```
+public void setWindowHeight(long value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getWindowHeight()](../../com.aspose.diagram/window\#getWindowHeight--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | long |  |
+
+### setWindowLeft(int value) {#setWindowLeft-int-}
+```
+public void setWindowLeft(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getWindowLeft()](../../com.aspose.diagram/window\#getWindowLeft--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setWindowState(int value) {#setWindowState-int-}
+```
+public void setWindowState(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getWindowState()](../../com.aspose.diagram/window\#getWindowState--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setWindowTop(int value) {#setWindowTop-int-}
+```
+public void setWindowTop(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getWindowTop()](../../com.aspose.diagram/window\#getWindowTop--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setWindowType(int value) {#setWindowType-int-}
+```
+public void setWindowType(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getWindowType()](../../com.aspose.diagram/window\#getWindowType--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setWindowWidth(long value) {#setWindowWidth-long-}
+```
+public void setWindowWidth(long value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getWindowWidth()](../../com.aspose.diagram/window\#getWindowWidth--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | long |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/windowcollection/_index.md
+++ b/italian/java/com.aspose.diagram/windowcollection/_index.md
@@ -1,0 +1,268 @@
+---
+title: WindowCollection
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Raccolta finestre.
+type: docs
+weight: 445
+url: /it/java/com.aspose.diagram/windowcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class WindowCollection extends Collection
+```
+
+Raccolta finestre.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [add(Window window)](#add-com.aspose.diagram.Window-) | Aggiungi la finestra nella collezione. |
+| [clear()](#clear--) | Rimuove tutti gli elementi dalla collezione. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Ottiene l'elemento all'indice specificato. |
+| [getClass()](#getClass--) |  |
+| [getClientHeight()](#getClientHeight--) | int opzionale. |
+| [getClientWidth()](#getClientWidth--) | int opzionale. |
+| [getCount()](#getCount--) | Ottiene il numero di elementi effettivamente contenuti nella collezione. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Esiste un elemento nella collezione. |
+| [iterator()](#iterator--) | Supporta un'iterazione semplice su una collezione non generica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Window window)](#remove-com.aspose.diagram.Window-) | Rimuovi la finestra dalla collezione. |
+| [setClientHeight(int value)](#setClientHeight-int-) | Per la descrizione di questa proprietà, vedere [getClientHeight()](../../com.aspose.diagram/windowcollection\#getClientHeight--) |
+| [setClientWidth(int value)](#setClientWidth-int-) | Per la descrizione di questa proprietà, vedere [getClientWidth()](../../com.aspose.diagram/windowcollection\#getClientWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Window window) {#add-com.aspose.diagram.Window-}
+```
+public int add(Window window)
+```
+
+
+Aggiungi la finestra nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| window | [Window](../../com.aspose.diagram/window) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Rimuove tutti gli elementi dalla collezione.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Window get(int index)
+```
+
+
+Ottiene l'elemento all'indice specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int |  |
+
+**Returns:**
+[Window](../../com.aspose.diagram/window) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getClientHeight() {#getClientHeight--}
+```
+public int getClientHeight()
+```
+
+
+int opzionale.
+
+**Returns:**
+int
+### getClientWidth() {#getClientWidth--}
+```
+public int getClientWidth()
+```
+
+
+int opzionale.
+
+**Returns:**
+int
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Ottiene il numero di elementi effettivamente contenuti nella collezione.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Esiste un elemento nella collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| indice | int | indice dell'elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Supporta un'iterazione semplice su una collezione non generica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Window window) {#remove-com.aspose.diagram.Window-}
+```
+public void remove(Window window)
+```
+
+
+Rimuovi la finestra dalla collezione.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| window | [Window](../../com.aspose.diagram/window) |  |
+
+### setClientHeight(int value) {#setClientHeight-int-}
+```
+public void setClientHeight(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getClientHeight()](../../com.aspose.diagram/windowcollection\#getClientHeight--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setClientWidth(int value) {#setClientWidth-int-}
+```
+public void setClientWidth(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getClientWidth()](../../com.aspose.diagram/windowcollection\#getClientWidth--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/windowstatevalue/_index.md
+++ b/italian/java/com.aspose.diagram/windowstatevalue/_index.md
@@ -1,0 +1,264 @@
+---
+title: WindowStateValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Un intero che specifica i flag di bit.
+type: docs
+weight: 446
+url: /it/java/com.aspose.diagram/windowstatevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class WindowStateValue
+```
+
+Un intero che specifica i flag bit. Questo attributo può essere la somma dei seguenti valori.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [ACTIVE](#ACTIVE) | Attivo. |
+| [ANCHOR_BOTTOM](#ANCHOR-BOTTOM) | Ancora in basso. |
+| [ANCHOR_LEFT](#ANCHOR-LEFT) | Ancora a sinistra. |
+| [ANCHOR_MERGED](#ANCHOR-MERGED) | Ancora unita. |
+| [ANCHOR_RIGHT](#ANCHOR-RIGHT) | Ancora a destra. |
+| [ANCHOR_TOP](#ANCHOR-TOP) | Ancora in alto. |
+| [DOCKED_BOTTOM](#DOCKED-BOTTOM) | Agganciato in basso. |
+| [DOCKED_LEFT](#DOCKED-LEFT) | Agganciato a sinistra. |
+| [DOCKED_RIGHT](#DOCKED-RIGHT) | Agganciato a destra. |
+| [DOCKED_TOP](#DOCKED-TOP) | Agganciato in alto. |
+| [DOUBLEING](#DOUBLEING) | Doppio. |
+| [MAXIMIZED](#MAXIMIZED) | Massimizzato. |
+| [MINIMIZED](#MINIMIZED) | Minimizzato. |
+| [RESTORED](#RESTORED) | Ripristinato. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ACTIVE {#ACTIVE}
+```
+public static final int ACTIVE
+```
+
+
+Attivo.
+
+### ANCHOR_BOTTOM {#ANCHOR-BOTTOM}
+```
+public static final int ANCHOR_BOTTOM
+```
+
+
+Ancora in basso.
+
+### ANCHOR_LEFT {#ANCHOR-LEFT}
+```
+public static final int ANCHOR_LEFT
+```
+
+
+Ancora a sinistra.
+
+### ANCHOR_MERGED {#ANCHOR-MERGED}
+```
+public static final int ANCHOR_MERGED
+```
+
+
+Ancora unita.
+
+### ANCHOR_RIGHT {#ANCHOR-RIGHT}
+```
+public static final int ANCHOR_RIGHT
+```
+
+
+Ancora a destra.
+
+### ANCHOR_TOP {#ANCHOR-TOP}
+```
+public static final int ANCHOR_TOP
+```
+
+
+Ancora in alto.
+
+### DOCKED_BOTTOM {#DOCKED-BOTTOM}
+```
+public static final int DOCKED_BOTTOM
+```
+
+
+Agganciato in basso.
+
+### DOCKED_LEFT {#DOCKED-LEFT}
+```
+public static final int DOCKED_LEFT
+```
+
+
+Agganciato a sinistra.
+
+### DOCKED_RIGHT {#DOCKED-RIGHT}
+```
+public static final int DOCKED_RIGHT
+```
+
+
+Agganciato a destra.
+
+### DOCKED_TOP {#DOCKED-TOP}
+```
+public static final int DOCKED_TOP
+```
+
+
+Agganciato in alto.
+
+### DOUBLEING {#DOUBLEING}
+```
+public static final int DOUBLEING
+```
+
+
+Doppio.
+
+### MAXIMIZED {#MAXIMIZED}
+```
+public static final int MAXIMIZED
+```
+
+
+Massimizzato.
+
+### MINIMIZED {#MINIMIZED}
+```
+public static final int MINIMIZED
+```
+
+
+Minimizzato.
+
+### RESTORED {#RESTORED}
+```
+public static final int RESTORED
+```
+
+
+Ripristinato.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/windowtypevalue/_index.md
+++ b/italian/java/com.aspose.diagram/windowtypevalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: WindowTypeValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Un valore enumerato che può essere uno dei seguenti: Drawing, Sheet, Stencil o Icon.
+type: docs
+weight: 447
+url: /it/java/com.aspose.diagram/windowtypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class WindowTypeValue
+```
+
+Un valore enumerato che può essere uno dei seguenti: Drawing, Sheet, Stencil o Icon. Un elemento Window con WindowType='Stencil' deve apparire dopo la sua finestra di disegno padre (WindowType='Drawing') e prima di qualsiasi altro elemento di finestra di disegno.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [DRAWING](#DRAWING) | Drawing |
+| [ICON](#ICON) | Icon. |
+| [SHEET](#SHEET) | Sheet |
+| [STENCIL](#STENCIL) | Stencil. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DRAWING {#DRAWING}
+```
+public static final int DRAWING
+```
+
+
+Drawing
+
+### ICON {#ICON}
+```
+public static final int ICON
+```
+
+
+Icon.
+
+### SHEET {#SHEET}
+```
+public static final int SHEET
+```
+
+
+Sheet
+
+### STENCIL {#STENCIL}
+```
+public static final int STENCIL
+```
+
+
+Stencil.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/xamlsaveoptions/_index.md
+++ b/italian/java/com.aspose.diagram/xamlsaveoptions/_index.md
@@ -1,0 +1,329 @@
+---
+title: XAMLSaveOptions
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Consente di specificare opzioni aggiuntive durante il rendering delle pagine del diagramma in XAML.
+type: docs
+weight: 448
+url: /it/java/com.aspose.diagram/xamlsaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.SaveOptions](../../com.aspose.diagram/saveoptions)
+```
+public class XAMLSaveOptions extends SaveOptions
+```
+
+Consente di specificare opzioni aggiuntive durante il rendering delle pagine del diagramma in XAML.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [XAMLSaveOptions()](#XAMLSaveOptions--) | Inizializza una nuova istanza di questa classe che può essere utilizzata per salvare un documento nel formato Aspose.Diagram.SaveFileFormat. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | Crea un oggetto di opzioni di salvataggio di una classe adatta al formato di salvataggio specificato. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDefaultFont()](#getDefaultFont--) | Quando i caratteri nel diagramma sono Unicode e non vengono impostati con il valore di carattere corretto o il carattere non è installato localmente, possono apparire come blocchi in PDF, immagine o XPS. |
+| [getPageCount()](#getPageCount--) | il numero di pagine da renderizzare in XAML. |
+| [getPageIndex()](#getPageIndex--) | l'indice basato su zero della prima pagina da renderizzare. |
+| [getSaveForegroundPagesOnly()](#getSaveForegroundPagesOnly--) | Specifica se tutte le pagine saranno salvate come immagine o solo il primo piano. |
+| [getSaveFormat()](#getSaveFormat--) | Specifica il formato in cui le pagine del diagramma renderizzate saranno salvate se viene utilizzato questo oggetto di opzioni di salvataggio. |
+| [getStreamProvider()](#getStreamProvider--) | l'IStreamProvider per l'esportazione degli oggetti. |
+| [getWarningCallback()](#getWarningCallback--) | callback di avviso. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--) |
+| [setPageCount(int value)](#setPageCount-int-) | Per la descrizione di questa proprietà, vedere [getPageCount()](../../com.aspose.diagram/xamlsaveoptions\#getPageCount--) |
+| [setPageIndex(int value)](#setPageIndex-int-) | Per la descrizione di questa proprietà, vedere [getPageIndex()](../../com.aspose.diagram/xamlsaveoptions\#getPageIndex--) |
+| [setSaveForegroundPagesOnly(boolean value)](#setSaveForegroundPagesOnly-boolean-) | Per la descrizione di questa proprietà, vedere [getSaveForegroundPagesOnly()](../../com.aspose.diagram/xamlsaveoptions\#getSaveForegroundPagesOnly--) |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | Per la descrizione di questa proprietà, vedere [getSaveFormat()](../../com.aspose.diagram/xamlsaveoptions\#getSaveFormat--) |
+| [setStreamProvider(IStreamProvider value)](#setStreamProvider-com.aspose.diagram.IStreamProvider-) | Per la descrizione di questa proprietà, vedere [getStreamProvider()](../../com.aspose.diagram/xamlsaveoptions\#getStreamProvider--) |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### XAMLSaveOptions() {#XAMLSaveOptions--}
+```
+public XAMLSaveOptions()
+```
+
+
+Inizializza una nuova istanza di questa classe che può essere utilizzata per salvare un documento nel formato Aspose.Diagram.SaveFileFormat.
+
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+Crea un oggetto di opzioni di salvataggio di una classe adatta al formato di salvataggio specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| saveFormat | int | Il Aspose.Diagram.SaveFileFormat per il quale creare un oggetto di opzioni di salvataggio. |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+Quando i caratteri nel diagramma sono Unicode e non sono impostati con il valore di font corretto o il font non è installato localmente, possono apparire come blocchi in PDF, immagine o XPS. Impostare il DefaultFont, ad esempio MingLiu o MS Gothic, per visualizzare questi caratteri.
+
+**Returns:**
+java.lang.String
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+Il numero di pagine da renderizzare in XAML. Il valore predefinito è MaxValue, il che significa che tutte le pagine del diagramma verranno renderizzate.
+
+**Returns:**
+int
+### getPageIndex() {#getPageIndex--}
+```
+public int getPageIndex()
+```
+
+
+L'indice basato su zero della prima pagina da renderizzare. Il valore predefinito è 0.
+
+**Returns:**
+int
+### getSaveForegroundPagesOnly() {#getSaveForegroundPagesOnly--}
+```
+public boolean getSaveForegroundPagesOnly()
+```
+
+
+Specifica se tutte le pagine saranno salvate in immagine o solo il primo piano. Se true - vengono renderizzate solo le pagine di primo piano (con lo sfondo se presente). Se false - vengono renderizzate le pagine di primo piano (con lo sfondo se presente) seguite da pagine di sfondo vuote. Può restituire true solo quando PageCount > 1. Il valore predefinito è false.
+
+**Returns:**
+boolean
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+Specifica il formato in cui le pagine del diagramma renderizzate saranno salvate se viene utilizzato questo oggetto di opzioni di salvataggio. Può essere solo Aspose.Diagram.SaveFileFormat.
+
+**Returns:**
+int
+### getStreamProvider() {#getStreamProvider--}
+```
+public IStreamProvider getStreamProvider()
+```
+
+
+l'IStreamProvider per l'esportazione degli oggetti.
+
+**Returns:**
+[IStreamProvider](../../com.aspose.diagram/istreamprovider)
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+callback di avviso.
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setPageCount(int value) {#setPageCount-int-}
+```
+public void setPageCount(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getPageCount()](../../com.aspose.diagram/xamlsaveoptions\#getPageCount--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setPageIndex(int value) {#setPageIndex-int-}
+```
+public void setPageIndex(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getPageIndex()](../../com.aspose.diagram/xamlsaveoptions\#getPageIndex--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setSaveForegroundPagesOnly(boolean value) {#setSaveForegroundPagesOnly-boolean-}
+```
+public void setSaveForegroundPagesOnly(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getSaveForegroundPagesOnly()](../../com.aspose.diagram/xamlsaveoptions\#getSaveForegroundPagesOnly--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getSaveFormat()](../../com.aspose.diagram/xamlsaveoptions\#getSaveFormat--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setStreamProvider(IStreamProvider value) {#setStreamProvider-com.aspose.diagram.IStreamProvider-}
+```
+public void setStreamProvider(IStreamProvider value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getStreamProvider()](../../com.aspose.diagram/xamlsaveoptions\#getStreamProvider--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [IStreamProvider](../../com.aspose.diagram/istreamprovider) |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/xform/_index.md
+++ b/italian/java/com.aspose.diagram/xform/_index.md
@@ -1,0 +1,436 @@
+---
+title: XForm
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene elementi che controllano gli attributi di linea per una forma, come lo spessore del tratto e il colore.
+type: docs
+weight: 449
+url: /it/java/com.aspose.diagram/xform/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class XForm
+```
+
+Contiene elementi che controllano gli attributi della linea per una forma, come modello, spessore e colore. Questi elementi determinano se le estremità della linea sono formattate (ad esempio, con una punta di freccia), la dimensione dei formati delle estremità della linea, il raggio del cerchio di arrotondamento applicato alla linea e lo stile del cappuccio della linea (rotondo o quadrato).
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAngle()](#getAngle--) | Rappresenta l'angolo di rotazione corrente della forma rispetto al suo genitore. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getFlipX()](#getFlipX--) | Indica se la forma è stata capovolta orizzontalmente |
+| [getFlipY()](#getFlipY--) | Indica se la forma è stata capovolta verticalmente. |
+| [getHeight()](#getHeight--) | Specifica l'altezza della forma in unità di disegno. |
+| [getLocPinX()](#getLocPinX--) | Specifica la coordinata x del perno della forma (centro di rotazione) rispetto all'origine della forma. |
+| [getLocPinY()](#getLocPinY--) | Specifica la coordinata y del perno della forma (centro di rotazione) rispetto all'origine della forma. |
+| [getPinPos()](#getPinPos--) | Specifica la posizione del perno della forma |
+| [getPinX()](#getPinX--) | Specifica la coordinata x del perno della forma (centro di rotazione) rispetto all'origine del suo genitore. |
+| [getPinY()](#getPinY--) | Specifica la coordinata y del perno della forma (centro di rotazione) rispetto all'origine del suo genitore. |
+| [getResizeMode()](#getResizeMode--) | Specifica l'impostazione corrente del comportamento di ridimensionamento per la forma quando è contenuta in un gruppo. |
+| [getWidth()](#getWidth--) | Contiene la larghezza della forma associata in unità di disegno. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAngle(DoubleValue value)](#setAngle-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getAngle()](../../com.aspose.diagram/xform\#getAngle--) |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/xform\#getDel--) |
+| [setFlipX(BoolValue value)](#setFlipX-com.aspose.diagram.BoolValue-) | Per la descrizione di questa proprietà, vedere [getFlipX()](../../com.aspose.diagram/xform\#getFlipX--) |
+| [setFlipY(BoolValue value)](#setFlipY-com.aspose.diagram.BoolValue-) | Per la descrizione di questa proprietà, vedere [getFlipY()](../../com.aspose.diagram/xform\#getFlipY--) |
+| [setHeight(DoubleValue value)](#setHeight-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getHeight()](../../com.aspose.diagram/xform\#getHeight--) |
+| [setLocPinX(DoubleValue value)](#setLocPinX-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getLocPinX()](../../com.aspose.diagram/xform\#getLocPinX--) |
+| [setLocPinY(DoubleValue value)](#setLocPinY-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getLocPinY()](../../com.aspose.diagram/xform\#getLocPinY--) |
+| [setPinPos(int value)](#setPinPos-int-) | Per la descrizione di questa proprietà, vedere [getPinPos()](../../com.aspose.diagram/xform\#getPinPos--) |
+| [setPinX(DoubleValue value)](#setPinX-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getPinX()](../../com.aspose.diagram/xform\#getPinX--) |
+| [setPinY(DoubleValue value)](#setPinY-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getPinY()](../../com.aspose.diagram/xform\#getPinY--) |
+| [setResizeMode(ResizeMode value)](#setResizeMode-com.aspose.diagram.ResizeMode-) | Per la descrizione di questa proprietà, vedere [getResizeMode()](../../com.aspose.diagram/xform\#getResizeMode--) |
+| [setWidth(DoubleValue value)](#setWidth-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, vedere [getWidth()](../../com.aspose.diagram/xform\#getWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAngle() {#getAngle--}
+```
+public DoubleValue getAngle()
+```
+
+
+Rappresenta l'angolo di rotazione corrente della forma rispetto al suo genitore.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getFlipX() {#getFlipX--}
+```
+public BoolValue getFlipX()
+```
+
+
+Indica se la forma è stata capovolta orizzontalmente
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getFlipY() {#getFlipY--}
+```
+public BoolValue getFlipY()
+```
+
+
+Indica se la forma è stata capovolta verticalmente.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getHeight() {#getHeight--}
+```
+public DoubleValue getHeight()
+```
+
+
+Specifica l'altezza della forma in unità di disegno.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLocPinX() {#getLocPinX--}
+```
+public DoubleValue getLocPinX()
+```
+
+
+Specifica la coordinata x del perno della forma (centro di rotazione) rispetto all'origine della forma. La formula predefinita per determinare LocPinX è: F='Width\* 0.5'.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLocPinY() {#getLocPinY--}
+```
+public DoubleValue getLocPinY()
+```
+
+
+Specifica la coordinata y del perno della forma (centro di rotazione) rispetto all'origine della forma. La formula predefinita per determinare LocPinY è: F='Height \* 0.5'.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getPinPos() {#getPinPos--}
+```
+public int getPinPos()
+```
+
+
+Specifica la posizione del perno della forma
+
+**Returns:**
+int
+### getPinX() {#getPinX--}
+```
+public DoubleValue getPinX()
+```
+
+
+Specifica la coordinata x del perno della forma (centro di rotazione) rispetto all'origine del suo genitore.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getPinY() {#getPinY--}
+```
+public DoubleValue getPinY()
+```
+
+
+Specifica la coordinata y del perno della forma (centro di rotazione) rispetto all'origine del suo genitore.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getResizeMode() {#getResizeMode--}
+```
+public ResizeMode getResizeMode()
+```
+
+
+Specifica l'impostazione corrente del comportamento di ridimensionamento per la forma quando è contenuta in un gruppo.
+
+**Returns:**
+[ResizeMode](../../com.aspose.diagram/resizemode)
+### getWidth() {#getWidth--}
+```
+public DoubleValue getWidth()
+```
+
+
+Contiene la larghezza della forma associata in unità di disegno.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAngle(DoubleValue value) {#setAngle-com.aspose.diagram.DoubleValue-}
+```
+public void setAngle(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getAngle()](../../com.aspose.diagram/xform\#getAngle--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDel()](../../com.aspose.diagram/xform\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setFlipX(BoolValue value) {#setFlipX-com.aspose.diagram.BoolValue-}
+```
+public void setFlipX(BoolValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getFlipX()](../../com.aspose.diagram/xform\#getFlipX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setFlipY(BoolValue value) {#setFlipY-com.aspose.diagram.BoolValue-}
+```
+public void setFlipY(BoolValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getFlipY()](../../com.aspose.diagram/xform\#getFlipY--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setHeight(DoubleValue value) {#setHeight-com.aspose.diagram.DoubleValue-}
+```
+public void setHeight(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getHeight()](../../com.aspose.diagram/xform\#getHeight--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setLocPinX(DoubleValue value) {#setLocPinX-com.aspose.diagram.DoubleValue-}
+```
+public void setLocPinX(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getLocPinX()](../../com.aspose.diagram/xform\#getLocPinX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setLocPinY(DoubleValue value) {#setLocPinY-com.aspose.diagram.DoubleValue-}
+```
+public void setLocPinY(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getLocPinY()](../../com.aspose.diagram/xform\#getLocPinY--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setPinPos(int value) {#setPinPos-int-}
+```
+public void setPinPos(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getPinPos()](../../com.aspose.diagram/xform\#getPinPos--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setPinX(DoubleValue value) {#setPinX-com.aspose.diagram.DoubleValue-}
+```
+public void setPinX(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getPinX()](../../com.aspose.diagram/xform\#getPinX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setPinY(DoubleValue value) {#setPinY-com.aspose.diagram.DoubleValue-}
+```
+public void setPinY(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getPinY()](../../com.aspose.diagram/xform\#getPinY--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setResizeMode(ResizeMode value) {#setResizeMode-com.aspose.diagram.ResizeMode-}
+```
+public void setResizeMode(ResizeMode value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getResizeMode()](../../com.aspose.diagram/xform\#getResizeMode--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [ResizeMode](../../com.aspose.diagram/resizemode) |  |
+
+### setWidth(DoubleValue value) {#setWidth-com.aspose.diagram.DoubleValue-}
+```
+public void setWidth(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getWidth()](../../com.aspose.diagram/xform\#getWidth--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/xform1d/_index.md
+++ b/italian/java/com.aspose.diagram/xform1d/_index.md
@@ -1,0 +1,261 @@
+---
+title: XForm1D
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Contiene le coordinate x e y del punto iniziale e del punto finale di una forma 1-D.
+type: docs
+weight: 450
+url: /it/java/com.aspose.diagram/xform1d/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class XForm1D
+```
+
+Contiene le coordinate x e y del punto iniziale e del punto finale di una forma 1-D. Questo elemento appare solo per forme 1-D.
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profonda di questa istanza. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBeginX()](#getBeginX--) | Rappresenta la coordinata x del punto iniziale della forma 1-D, in relazione all'origine del suo genitore. |
+| [getBeginY()](#getBeginY--) | Rappresenta la coordinata y del punto iniziale della forma 1-D, in relazione all'origine del suo genitore. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Un flag che indica se l'elemento è stato eliminato localmente. |
+| [getEndX()](#getEndX--) | Rappresenta la coordinata x del punto finale di una forma 1-D in relazione all'origine del suo genitore. |
+| [getEndY()](#getEndY--) | Rappresenta la coordinata y del punto finale di una forma 1-D in relazione all'origine del suo genitore. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setBeginX(DoubleValue value)](#setBeginX-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, consultare [getBeginX()](../../com.aspose.diagram/xform1d\#getBeginX--) |
+| [setBeginY(DoubleValue value)](#setBeginY-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, consultare [getBeginY()](../../com.aspose.diagram/xform1d\#getBeginY--) |
+| [setDel(int value)](#setDel-int-) | Per la descrizione di questa proprietà, consultare [getDel()](../../com.aspose.diagram/xform1d\#getDel--) |
+| [setEndX(DoubleValue value)](#setEndX-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, consultare [getEndX()](../../com.aspose.diagram/xform1d\#getEndX--) |
+| [setEndY(DoubleValue value)](#setEndY-com.aspose.diagram.DoubleValue-) | Per la descrizione di questa proprietà, consultare [getEndY()](../../com.aspose.diagram/xform1d\#getEndY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profonda di questa istanza.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBeginX() {#getBeginX--}
+```
+public DoubleValue getBeginX()
+```
+
+
+Rappresenta la coordinata x del punto iniziale della forma 1-D, in relazione all'origine del suo genitore.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBeginY() {#getBeginY--}
+```
+public DoubleValue getBeginY()
+```
+
+
+Rappresenta la coordinata y del punto iniziale della forma 1-D, in relazione all'origine del suo genitore.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Un flag che indica se l'elemento è stato eliminato localmente. Un valore di 1 indica che l'elemento è stato eliminato localmente.
+
+**Returns:**
+int
+### getEndX() {#getEndX--}
+```
+public DoubleValue getEndX()
+```
+
+
+Rappresenta la coordinata x del punto finale di una forma 1-D in relazione all'origine del suo genitore.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getEndY() {#getEndY--}
+```
+public DoubleValue getEndY()
+```
+
+
+Rappresenta la coordinata y del punto finale di una forma 1-D in relazione all'origine del suo genitore.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setBeginX(DoubleValue value) {#setBeginX-com.aspose.diagram.DoubleValue-}
+```
+public void setBeginX(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getBeginX()](../../com.aspose.diagram/xform1d\#getBeginX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setBeginY(DoubleValue value) {#setBeginY-com.aspose.diagram.DoubleValue-}
+```
+public void setBeginY(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getBeginY()](../../com.aspose.diagram/xform1d\#getBeginY--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getDel()](../../com.aspose.diagram/xform1d\#getDel--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setEndX(DoubleValue value) {#setEndX-com.aspose.diagram.DoubleValue-}
+```
+public void setEndX(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getEndX()](../../com.aspose.diagram/xform1d\#getEndX--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setEndY(DoubleValue value) {#setEndY-com.aspose.diagram.DoubleValue-}
+```
+public void setEndY(DoubleValue value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getEndY()](../../com.aspose.diagram/xform1d\#getEndY--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/xjustify/_index.md
+++ b/italian/java/com.aspose.diagram/xjustify/_index.md
@@ -1,0 +1,179 @@
+---
+title: XJustify
+second_title: Riferimento API di Aspose.Diagram per Java
+description: L'offset x del pulsante smart tag rispetto al punto definito dagli elementi X e Y.
+type: docs
+weight: 451
+url: /it/java/com.aspose.diagram/xjustify/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class XJustify
+```
+
+L'offset x del pulsante smart tag rispetto al punto definito dagli elementi X e Y.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [XJustify(int value)](#XJustify-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | L'offset x del pulsante smart tag rispetto al punto definito dagli elementi X e Y. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/xjustify\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### XJustify(int value) {#XJustify-int-}
+```
+public XJustify(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+L'offset x del pulsante smart tag rispetto al punto definito dagli elementi X e Y.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getValue()](../../com.aspose.diagram/xjustify\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/xjustifyvalue/_index.md
+++ b/italian/java/com.aspose.diagram/xjustifyvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: XJustifyValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: L'offset x del pulsante smart tag rispetto al punto definito dagli elementi X e Y.
+type: docs
+weight: 452
+url: /it/java/com.aspose.diagram/xjustifyvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class XJustifyValue
+```
+
+L'offset x del pulsante smart tag rispetto al punto definito dagli elementi X e Y.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [CENTERED](#CENTERED) | Centrato. |
+| [LEFT_JUSTIFIED](#LEFT-JUSTIFIED) | Allineato a sinistra (predefinito). |
+| [RIGHT_JUSTIFIED](#RIGHT-JUSTIFIED) | Allineato a destra. |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CENTERED {#CENTERED}
+```
+public static final int CENTERED
+```
+
+
+Centrato.
+
+### LEFT_JUSTIFIED {#LEFT-JUSTIFIED}
+```
+public static final int LEFT_JUSTIFIED
+```
+
+
+Allineato a sinistra (predefinito).
+
+### RIGHT_JUSTIFIED {#RIGHT-JUSTIFIED}
+```
+public static final int RIGHT_JUSTIFIED
+```
+
+
+Allineato a destra.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/xpssaveoptions/_index.md
+++ b/italian/java/com.aspose.diagram/xpssaveoptions/_index.md
@@ -1,0 +1,329 @@
+---
+title: XPSSaveOptions
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Consente di specificare opzioni aggiuntive durante il rendering delle pagine del diagramma in XPS.
+type: docs
+weight: 453
+url: /it/java/com.aspose.diagram/xpssaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.SaveOptions](../../com.aspose.diagram/saveoptions)
+```
+public class XPSSaveOptions extends SaveOptions
+```
+
+Consente di specificare opzioni aggiuntive durante il rendering delle pagine del diagramma in XPS.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [XPSSaveOptions()](#XPSSaveOptions--) | Inizializza una nuova istanza di questa classe che può essere utilizzata per salvare un documento nel formato Aspose.Diagram.SaveFileFormat. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | Crea un oggetto di opzioni di salvataggio di una classe adatta al formato di salvataggio specificato. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDefaultFont()](#getDefaultFont--) | Quando i caratteri nel diagramma sono Unicode e non vengono impostati con il valore di carattere corretto o il carattere non è installato localmente, possono apparire come blocchi in PDF, immagine o XPS. |
+| [getExportHiddenPage()](#getExportHiddenPage--) | Definisce se è necessario esportare la pagina nascosta o meno. |
+| [getPageCount()](#getPageCount--) | il numero di pagine da renderizzare in XPS. |
+| [getPageIndex()](#getPageIndex--) | l'indice basato su zero della prima pagina da renderizzare. |
+| [getSaveForegroundPagesOnly()](#getSaveForegroundPagesOnly--) | Specifica se tutte le pagine saranno salvate come immagine o solo il primo piano. |
+| [getSaveFormat()](#getSaveFormat--) | Specifica il formato in cui le pagine del diagramma renderizzate saranno salvate se viene utilizzato questo oggetto di opzioni di salvataggio. |
+| [getWarningCallback()](#getWarningCallback--) | callback di avviso. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | Per la descrizione di questa proprietà, vedere [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--) |
+| [setExportHiddenPage(boolean value)](#setExportHiddenPage-boolean-) | Per la descrizione di questa proprietà, vedere [getExportHiddenPage()](../../com.aspose.diagram/xpssaveoptions\#getExportHiddenPage--) |
+| [setPageCount(int value)](#setPageCount-int-) | Per la descrizione di questa proprietà, vedere [getPageCount()](../../com.aspose.diagram/xpssaveoptions\#getPageCount--) |
+| [setPageIndex(int value)](#setPageIndex-int-) | Per la descrizione di questa proprietà, vedere [getPageIndex()](../../com.aspose.diagram/xpssaveoptions\#getPageIndex--) |
+| [setSaveForegroundPagesOnly(boolean value)](#setSaveForegroundPagesOnly-boolean-) | Per la descrizione di questa proprietà, vedere [getSaveForegroundPagesOnly()](../../com.aspose.diagram/xpssaveoptions\#getSaveForegroundPagesOnly--) |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | Per la descrizione di questa proprietà, vedere [getSaveFormat()](../../com.aspose.diagram/xpssaveoptions\#getSaveFormat--) |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### XPSSaveOptions() {#XPSSaveOptions--}
+```
+public XPSSaveOptions()
+```
+
+
+Inizializza una nuova istanza di questa classe che può essere utilizzata per salvare un documento nel formato Aspose.Diagram.SaveFileFormat.
+
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+Crea un oggetto di opzioni di salvataggio di una classe adatta al formato di salvataggio specificato.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| saveFormat | int | Il Aspose.Diagram.SaveFileFormat per il quale creare un oggetto di opzioni di salvataggio. |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+Quando i caratteri nel diagramma sono Unicode e non sono impostati con il valore di font corretto o il font non è installato localmente, possono apparire come blocchi in PDF, immagine o XPS. Impostare il DefaultFont, ad esempio MingLiu o MS Gothic, per visualizzare questi caratteri.
+
+**Returns:**
+java.lang.String
+### getExportHiddenPage() {#getExportHiddenPage--}
+```
+public boolean getExportHiddenPage()
+```
+
+
+Definisce se è necessario esportare la pagina nascosta o meno. Il valore predefinito è true.
+
+**Returns:**
+boolean
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+il numero di pagine da renderizzare in XPS. Il valore predefinito è MaxValue, il che significa che verranno renderizzate tutte le pagine del diagramma.
+
+**Returns:**
+int
+### getPageIndex() {#getPageIndex--}
+```
+public int getPageIndex()
+```
+
+
+L'indice basato su zero della prima pagina da renderizzare. Il valore predefinito è 0.
+
+**Returns:**
+int
+### getSaveForegroundPagesOnly() {#getSaveForegroundPagesOnly--}
+```
+public boolean getSaveForegroundPagesOnly()
+```
+
+
+Specifica se tutte le pagine saranno salvate in immagine o solo il primo piano. Se true - vengono renderizzate solo le pagine di primo piano (con lo sfondo se presente). Se false - vengono renderizzate le pagine di primo piano (con lo sfondo se presente) seguite da pagine di sfondo vuote. Può restituire true solo quando PageCount > 1. Il valore predefinito è false.
+
+**Returns:**
+boolean
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+Specifica il formato in cui le pagine del diagramma renderizzate saranno salvate se viene utilizzato questo oggetto di opzioni di salvataggio. Può essere solo Aspose.Diagram.SaveFileFormat.
+
+**Returns:**
+int
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+callback di avviso.
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.String |  |
+
+### setExportHiddenPage(boolean value) {#setExportHiddenPage-boolean-}
+```
+public void setExportHiddenPage(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getExportHiddenPage()](../../com.aspose.diagram/xpssaveoptions\#getExportHiddenPage--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setPageCount(int value) {#setPageCount-int-}
+```
+public void setPageCount(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getPageCount()](../../com.aspose.diagram/xpssaveoptions\#getPageCount--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setPageIndex(int value) {#setPageIndex-int-}
+```
+public void setPageIndex(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getPageIndex()](../../com.aspose.diagram/xpssaveoptions\#getPageIndex--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setSaveForegroundPagesOnly(boolean value) {#setSaveForegroundPagesOnly-boolean-}
+```
+public void setSaveForegroundPagesOnly(boolean value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getSaveForegroundPagesOnly()](../../com.aspose.diagram/xpssaveoptions\#getSaveForegroundPagesOnly--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | boolean |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+Per la descrizione di questa proprietà, vedere [getSaveFormat()](../../com.aspose.diagram/xpssaveoptions\#getSaveFormat--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/yjustify/_index.md
+++ b/italian/java/com.aspose.diagram/yjustify/_index.md
@@ -1,0 +1,179 @@
+---
+title: YJustify
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica l'offset y del pulsante smart tag rispetto al punto definito dagli elementi X e Y.
+type: docs
+weight: 454
+url: /it/java/com.aspose.diagram/yjustify/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class YJustify
+```
+
+Specifica l'offset y del pulsante smart tag rispetto al punto definito dagli elementi X e Y.
+## Costruttori
+
+| Costruttore | Descrizione |
+| --- | --- |
+| [YJustify(int value)](#YJustify-int-) | Costruttore. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Gli oggetti sono uguali. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Specifica gli attributi di un elemento. |
+| [getValue()](#getValue--) | Specifica l'offset y del pulsante smart tag rispetto al punto definito dagli elementi X e Y. |
+| [hashCode()](#hashCode--) | Funziona come funzione hash per un tipo particolare. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Per la descrizione di questa proprietà, consultare [getValue()](../../com.aspose.diagram/yjustify\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### YJustify(int value) {#YJustify-int-}
+```
+public YJustify(int value)
+```
+
+
+Costruttore.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Gli oggetti sono uguali.
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Specifica gli attributi di un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specifica l'offset y del pulsante smart tag rispetto al punto definito dagli elementi X e Y.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Funziona come funzione hash per un tipo particolare.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Per la descrizione di questa proprietà, consultare [getValue()](../../com.aspose.diagram/yjustify\#getValue--)
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/italian/java/com.aspose.diagram/yjustifyvalue/_index.md
+++ b/italian/java/com.aspose.diagram/yjustifyvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: YJustifyValue
+second_title: Riferimento API di Aspose.Diagram per Java
+description: Specifica l'offset y del pulsante smart tag rispetto al punto definito dagli elementi X e Y.
+type: docs
+weight: 455
+url: /it/java/com.aspose.diagram/yjustifyvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class YJustifyValue
+```
+
+Specifica l'offset y del pulsante smart tag rispetto al punto definito dagli elementi X e Y.
+## Campi
+
+| Campo | Descrizione |
+| --- | --- |
+| [BOTTOM_JUSTIFIED](#BOTTOM-JUSTIFIED) | Allineato in basso. |
+| [CENTERED](#CENTERED) | Centrato. |
+| [TOP_JUSTIFIED](#TOP-JUSTIFIED) | Allineato in alto (predefinito). |
+| [UNDEFINED](#UNDEFINED) | Non definito. |
+## Metodi
+
+| Metodo | Descrizione |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOTTOM_JUSTIFIED {#BOTTOM-JUSTIFIED}
+```
+public static final int BOTTOM_JUSTIFIED
+```
+
+
+Allineato in basso.
+
+### CENTERED {#CENTERED}
+```
+public static final int CENTERED
+```
+
+
+Centrato.
+
+### TOP_JUSTIFIED {#TOP-JUSTIFIED}
+```
+public static final int TOP_JUSTIFIED
+```
+
+
+Allineato in alto (predefinito).
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Non definito.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+


### PR DESCRIPTION
Automated translation of the JAVA API Reference to **Italian** (`it`) generated by RDA.

- Pages translated: 451/451
- Errors: 0
- Source: `english/java`
- Output: `italian/java`

🤖 Generated by RDA