### PR TITLE
[auto] Translate JAVA API Reference to Japanese

### DIFF
--- a/japanese/java/_index.md
+++ b/japanese/java/_index.md
@@ -1,0 +1,13 @@
+---
+title: Aspose.Diagram for Java
+type: docs
+weight: 11
+url: /ja/java/
+description: Aspose.Diagram for Java API リファレンスには、サンプル、コードスニペット、および API ドキュメントが含まれています。パッケージ、クラス、インターフェイス、その他の API 詳細を提供します。
+is_root: true
+---
+
+## Packages
+| パッケージ | 説明 |
+| --- | --- |
+| [com.aspose.diagram](./com.aspose.diagram) | com.aspose.diagram パッケージは、Microsoft Visio を使用せずに Microsoft Visio ドキュメントを生成、変換、変更、レンダリング、印刷するためのクラスを提供します。 |

--- a/japanese/java/com.aspose.diagram/_index.md
+++ b/japanese/java/com.aspose.diagram/_index.md
@@ -1,0 +1,471 @@
+---
+title: com.aspose.diagram
+second_title: Aspose.Diagram for Java API リファレンス
+description: com.aspose.diagram パッケージは、Microsoft Visio を使用せずに Microsoft Visio ドキュメントを生成、変換、変更、レンダリング、印刷するためのクラスを提供します。
+type: docs
+weight: 10
+url: /ja/java/com.aspose.diagram/
+---
+
+
+com.aspose.diagram パッケージは、Microsoft Visio を使用せずに Microsoft Visio ドキュメントを生成、変換、変更、レンダリング、印刷するためのクラスを提供します。
+
+
+## クラス
+
+| クラス | 説明 |
+| --- | --- |
+| [AbstractInterruptMonitor](../com.aspose.diagram/abstractinterruptmonitor) | 時間のかかるすべての操作における割り込み要求を監視します。 |
+| [Act](../com.aspose.diagram/act) | オブジェクトのショートカットメニューに表示されるカスタムコマンド名を定義し、コマンドが実行するアクションを指定します。 |
+| [ActCollection](../com.aspose.diagram/actcollection) | Act コレクション。 |
+| [ActiveXControl](../com.aspose.diagram/activexcontrol) | ActiveX コントロールを表します。 |
+| [ActiveXControlBase](../com.aspose.diagram/activexcontrolbase) | ActiveX コントロールを表します。 |
+| [ActiveXPersistenceType](../com.aspose.diagram/activexpersistencetype) | ActiveX コントロールを永続化するための永続化方法を表します。 |
+| [Align](../com.aspose.diagram/align) | シェイプが貼り付けられているガイドまたはガイドポイントに対するシェイプの配置を示します。 |
+| [AlignNameValue](../com.aspose.diagram/alignnamevalue) | オプションの int。 |
+| [Alignment](../com.aspose.diagram/alignment) | タブの配置を指定します。 |
+| [AlignmentValue](../com.aspose.diagram/alignmentvalue) | タブの配置を指定します。 |
+| [Annotation](../com.aspose.diagram/annotation) | ドキュメントページに挿入されたコメントに関する情報を含む要素が含まれています。 |
+| [AnnotationCollection](../com.aspose.diagram/annotationcollection) | Annotation コレクション。 |
+| [ArcTo](../com.aspose.diagram/arcto) | 円弧の X、Y、A 要素でそれぞれ表される x 座標、y 座標、そして弧度を含みます。 |
+| [ArcToCollection](../com.aspose.diagram/arctocollection) | ArcTo コレクション。 |
+| [ArrowSize](../com.aspose.diagram/arrowsize) | 線の矢じりのサイズを指定します。 |
+| [ArrowSizeValue](../com.aspose.diagram/arrowsizevalue) | 線の矢じりのサイズを指定します。 |
+| [AsposeDiagramPrintDocument](../com.aspose.diagram/asposediagramprintdocument) | .NET PrintDocument クラスの独自バージョンで、PrintPreviewDialog フォームに渡して図面の印刷とプレビューができます。 |
+| [AutoLinkComparison](../com.aspose.diagram/autolinkcomparison) | 親 DataRecordset 要素の列と、ユーザーインターフェイスで最後に成功した自動リンク操作から取得されたシェイプ データ項目を比較するルールを定義します。 |
+| [AutoSpaceOptions](../com.aspose.diagram/autospaceoptions) | 自動スペースオプションを表します。 |
+| [BOOL](../com.aspose.diagram/bool) | ブール値。 |
+| [Bevel](../com.aspose.diagram/bevel) | シェイプのベベルを表します。 |
+| [BevelLightingType](../com.aspose.diagram/bevellightingtype) | シェイプの影のタイプを指定します。 |
+| [BevelLightingTypeValue](../com.aspose.diagram/bevellightingtypevalue) | シェイプに適用できる右側のプリセットライトを表します。 |
+| [BevelMaterialType](../com.aspose.diagram/bevelmaterialtype) | シェイプの影のタイプを指定します。 |
+| [BevelMaterialTypeValue](../com.aspose.diagram/bevelmaterialtypevalue) | シェイプの表面外観を記述します。 |
+| [BevelPresetType](../com.aspose.diagram/bevelpresettype) | 3D でシェイプに適用できるベベルタイプのプリセットを表します。 |
+| [BevelType](../com.aspose.diagram/beveltype) | シェイプの影のタイプを指定します。 |
+| [BevelTypeValue](../com.aspose.diagram/beveltypevalue) | 3D でシェイプに適用できるベベルタイプのプリセットを表します。 |
+| [BoolValue](../com.aspose.diagram/boolvalue) | ブール値。 |
+| [Bullet](../com.aspose.diagram/bullet) | 箇条書きのスタイルを決定します。 |
+| [BulletValue](../com.aspose.diagram/bulletvalue) | 箇条書きのスタイルを決定します。 |
+| [Calendar](../com.aspose.diagram/calendar) | カスタム プロパティ、テキスト フィールド、要素の数式に使用されるカレンダーを決定します。 |
+| [CalendarValue](../com.aspose.diagram/calendarvalue) | カスタム プロパティ、テキスト フィールド、要素の数式に使用されるカレンダーを決定します。 |
+| [Case](../com.aspose.diagram/case) | シェイプのテキストの大文字小文字を決定します。 |
+| [CaseValue](../com.aspose.diagram/casevalue) | シェイプのテキストの大文字小文字を決定します。 |
+| [Char](../com.aspose.diagram/char) | シェイプのテキストの書式属性（フォント、色、テキストスタイル、大文字小文字、ベースラインに対する位置、ポイントサイズなど）を含みます。 |
+| [CharCollection](../com.aspose.diagram/charcollection) | 文字コレクション。 |
+| [CheckBoxActiveXControl](../com.aspose.diagram/checkboxactivexcontrol) | CheckBox ActiveX コントロールを表します。 |
+| [CheckValueType](../com.aspose.diagram/checkvaluetype) | チェックボックスのチェック値タイプを表します。 |
+| [Collection](../com.aspose.diagram/collection) | コレクションの基底クラスです。 |
+| [CollectionBase](../com.aspose.diagram/collectionbase) | 強く型付けされたコレクションの抽象基底クラスを提供します。 |
+| [Color](../com.aspose.diagram/color) | ARGB（アルファ、赤、緑、青）カラーを表します。 |
+| [ColorEntry](../com.aspose.diagram/colorentry) | カラーテーブルエントリを含みます。 |
+| [ColorEntryCollection](../com.aspose.diagram/colorentrycollection) | ドキュメントのカラーテーブルを含みます。 |
+| [ColorValue](../com.aspose.diagram/colorvalue) | カラー値を表します |
+| [ComboBoxActiveXControl](../com.aspose.diagram/comboboxactivexcontrol) | ComboBox ActiveX コントロールを表します。 |
+| [CommandButtonActiveXControl](../com.aspose.diagram/commandbuttonactivexcontrol) | コマンドボタンを表します。 |
+| [CompositingQuality](../com.aspose.diagram/compositingquality) | 合成時に使用する品質レベルを指定します。 |
+| [CompoundType](../com.aspose.diagram/compoundtype) | 線の矢じりのサイズを指定します。 |
+| [CompoundTypeValue](../com.aspose.diagram/compoundtypevalue) | 線を描画するスタイルを表します。 |
+| [CompressionType](../com.aspose.diagram/compressiontype) | この属性は、外部データが DIB、JPG、PNG、TIFF、または GIF ファイルなどのラスタベースの外部オブジェクトである場合にのみ意味があります。 |
+| [ConFixedCode](../com.aspose.diagram/confixedcode) | コネクタが再ルーティングするタイミングを決定します。 |
+| [ConFixedCodeValue](../com.aspose.diagram/confixedcodevalue) | コネクタが再ルーティングするタイミングを決定します。 |
+| [ConLineJumpCode](../com.aspose.diagram/conlinejumpcode) | 2 本のコネクタが交差したときにコネクタがジャンプするかどうかを決定します。 |
+| [ConLineJumpCodeValue](../com.aspose.diagram/conlinejumpcodevalue) | 2 本のコネクタが交差したときにコネクタがジャンプするかどうかを決定します。 |
+| [ConLineJumpDirX](../com.aspose.diagram/conlinejumpdirx) | 動的コネクタの水平セグメントで発生するラインジャンプの方向を決定します。 |
+| [ConLineJumpDirXValue](../com.aspose.diagram/conlinejumpdirxvalue) | 動的コネクタの水平セグメントで発生するラインジャンプの方向を決定します。 |
+| [ConLineJumpDirY](../com.aspose.diagram/conlinejumpdiry) | 動的コネクタの垂直セグメントで発生するラインジャンプの方向を決定します。 |
+| [ConLineJumpDirYValue](../com.aspose.diagram/conlinejumpdiryvalue) | 動的コネクタの垂直セグメントで発生するラインジャンプの方向を決定します。 |
+| [ConLineJumpStyle](../com.aspose.diagram/conlinejumpstyle) | 動的コネクタ上のラインジャンプのスタイルを決定します。 |
+| [ConLineJumpStyleValue](../com.aspose.diagram/conlinejumpstylevalue) | 動的コネクタ上のラインジャンプのスタイルを決定します。 |
+| [ConLineRouteExt](../com.aspose.diagram/conlinerouteext) | コネクタの外観を決定します。 |
+| [ConLineRouteExtValue](../com.aspose.diagram/conlinerouteextvalue) | コネクタの外観を決定します。 |
+| [ConType](../com.aspose.diagram/contype) | ハンドルが移動した後にコントロールハンドルの x または y 座標が示す動作の種類を指定します。 |
+| [ConValue](../com.aspose.diagram/convalue) | ハンドルが移動した後にコントロールハンドルの x または y 座標が示す動作の種類を指定します。 |
+| [Connect](../com.aspose.diagram/connect) | 組織図などの図面で、線とボックスのように 2 つの図形間の接続を表します。 |
+| [ConnectCollection](../com.aspose.diagram/connectcollection) | Connect コレクション。 |
+| [ConnectedShapesFlags](../com.aspose.diagram/connectedshapesflags) | コネクタの方向性に基づいて返されるシェイプ ID の配列をフィルタリングします。 |
+| [Connection](../com.aspose.diagram/connection) | シェイプに定義された 1 つの接続点の要素を含みます。 |
+| [ConnectionABCD](../com.aspose.diagram/connectionabcd) | ConnectionABCD 要素は Connection 要素の廃止されたバージョンで、下位互換性のためだけに存在します。 |
+| [ConnectionABCDCollection](../com.aspose.diagram/connectionabcdcollection) | ConnectionABCD コレクション。 |
+| [ConnectionCollection](../com.aspose.diagram/connectioncollection) | Connection コレクション。 |
+| [ConnectionPointPlace](../com.aspose.diagram/connectionpointplace) | コネクタが接続されるシェイプ上の位置を指定します。 |
+| [ConnectorRule](../com.aspose.diagram/connectorrule) | コネクタを持つ 2 つのシェイプ間のコネクタルールを表し、開始シェイプのどの接続点から始まるか、終了シェイプとその接続点を含みます。 |
+| [ConnectorsTypeValue](../com.aspose.diagram/connectorstypevalue) | 次のいずれかの値を取ります: RightAngle、StraightLines、または CurvedLines。 |
+| [ContainerTypeValue](../com.aspose.diagram/containertypevalue) | 次のいずれかの値を取ります: Document、Page、または Master。 |
+| [ContextTypeValue](../com.aspose.diagram/contexttypevalue) | 比較に使用するグループまたはシェイプのプロパティを指定します。 |
+| [Control](../com.aspose.diagram/control) | シェイプに定義された各コントロールハンドルの x および y 座標の要素と、コントロールハンドルの動作方法を指定する要素を含みます。 |
+| [ControlBorderType](../com.aspose.diagram/controlbordertype) | ActiveX コントロールの境界タイプを表します。 |
+| [ControlCaptionAlignmentType](../com.aspose.diagram/controlcaptionalignmenttype) | コントロールに対する Caption の位置を表します。 |
+| [ControlCollection](../com.aspose.diagram/controlcollection) | Control コレクション。 |
+| [ControlListStyle](../com.aspose.diagram/controlliststyle) | ListBox または ComboBox のリストの視覚的外観を表します。 |
+| [ControlMatchEntryType](../com.aspose.diagram/controlmatchentrytype) | ユーザーが入力する際に、ListBox または ComboBox がリストを検索する方法を表します。 |
+| [ControlMousePointerType](../com.aspose.diagram/controlmousepointertype) | コントロールのマウスポインタとして表示されるアイコンの種類を表します。 |
+| [ControlPictureAlignmentType](../com.aspose.diagram/controlpicturealignmenttype) | Form または Image 内の画像の配置を表します。 |
+| [ControlPicturePositionType](../com.aspose.diagram/controlpicturepositiontype) | コントロールの画像がキャプションに対してどの位置にあるかを表します。 |
+| [ControlPictureSizeMode](../com.aspose.diagram/controlpicturesizemode) | 画像の表示方法を表します。 |
+| [ControlScrollBarType](../com.aspose.diagram/controlscrollbartype) | スクロールバーの種類を表します。 |
+| [ControlScrollOrientation](../com.aspose.diagram/controlscrollorientation) | スクロールの向きの種類を表します。 |
+| [ControlSpecialEffectType](../com.aspose.diagram/controlspecialeffecttype) | 特殊効果の種類を表します。 |
+| [ControlType](../com.aspose.diagram/controltype) | すべての ActiveX コントロールの種類を表します。 |
+| [Coordinate](../com.aspose.diagram/coordinate) | x および y 座標の抽象クラスです。 |
+| [CoordinateCollection](../com.aspose.diagram/coordinatecollection) | 座標コレクション。 |
+| [CountryCode](../com.aspose.diagram/countrycode) | Diagram の国識別子を表します。 |
+| [Cp](../com.aspose.diagram/cp) | 対応する Char 要素に従って書式設定された文字プロパティのランの開始を示します。 |
+| [CustomProp](../com.aspose.diagram/customprop) | CustomProp 構造体。 |
+| [CustomPropCollection](../com.aspose.diagram/custompropcollection) | CustomProps コレクション。 |
+| [CustomValue](../com.aspose.diagram/customvalue) | プロパティの値。 |
+| [DataColumn](../com.aspose.diagram/datacolumn) | Visio ユーザーインターフェイスの外部データウィンドウでデータ列がどのように表示されるかを定義し、データ型と書式設定を定義することで列のデータを限定します。 |
+| [DataColumnCollection](../com.aspose.diagram/datacolumncollection) | DataColumn コレクション。 |
+| [DataConnection](../com.aspose.diagram/dataconnection) | 1 つまたは複数の DataRecordset 要素と非 XML データ ソース間の通信を抽象化します。 |
+| [DataConnectionCollection](../com.aspose.diagram/dataconnectioncollection) | DataConnection コレクション。 |
+| [DataConnectionType](../com.aspose.diagram/dataconnectiontype) | データベースへの接続オプションを構成できるようにします。 |
+| [DataRecordSet](../com.aspose.diagram/datarecordset) | Microsoft Visio でデータベースから取得したデータを保存、書式設定、更新、公開します。 |
+| [DataRecordSetCollection](../com.aspose.diagram/datarecordsetcollection) | DataRecordSet コレクション。 |
+| [DateTime](../com.aspose.diagram/datetime) | 通常、日付と時刻として表される特定の時点を表します。 |
+| [DateValue](../com.aspose.diagram/datevalue) | 日付と時刻の値。 |
+| [Diagram](../com.aspose.diagram/diagram) | Visio オブジェクト階層のルート要素です。 |
+| [DiagramException](../com.aspose.diagram/diagramexception) | すべての Aspose.Diagram 例外の基底クラスです。 |
+| [DiagramSaveOptions](../com.aspose.diagram/diagramsaveoptions) | Visio (VDX\\VSX) 形式で図を保存する際に、追加オプションを指定するために使用できます。 |
+| [DisplayMode](../com.aspose.diagram/displaymode) | Group 要素に含まれる場合、DisplayMode 要素はグループ シェイプとそのメンバーの表示方法を指定します。 |
+| [DisplayModeSmartTagDef](../com.aspose.diagram/displaymodesmarttagdef) | DisplayMode 要素は、ユーザーがタグ上でマウスを止めたとき、シェイプが選択されたとき、または常にスマート タグを表示するかどうかを決定します。 |
+| [DisplayModeSmartTagDefValue](../com.aspose.diagram/displaymodesmarttagdefvalue) | DisplayMode 要素は、ユーザーがタグ上でマウスを止めたとき、シェイプが選択されたとき、または常にスマート タグを表示するかどうかを決定します。 |
+| [DisplayModeValue](../com.aspose.diagram/displaymodevalue) | Group 要素に含まれる場合、DisplayMode 要素はグループ シェイプとそのメンバーの表示方法を指定します。 |
+| [DocProps](../com.aspose.diagram/docprops) | ドキュメントのプレビュー品質、範囲、出力形式を制御する要素を含みます。 |
+| [DocumentProperties](../com.aspose.diagram/documentproperties) | ドキュメントのタイトル、作成者などのプロパティ要素を含みます。 |
+| [DocumentSettings](../com.aspose.diagram/documentsettings) | ドキュメント設定を指定する要素を含みます。 |
+| [DocumentSheet](../com.aspose.diagram/documentsheet) | ドキュメントの ShapeSheet 構造を指定します。 |
+| [DoubleValue](../com.aspose.diagram/doublevalue) | Double 値 |
+| [DrawingResizeType](../com.aspose.diagram/drawingresizetype) | 図に合わせて描画ページが自動的にサイズ変更されるかどうかを決定します。 |
+| [DrawingResizeTypeValue](../com.aspose.diagram/drawingresizetypevalue) | 図に合わせて描画ページが自動的にサイズ変更されるかどうかを決定します。 |
+| [DrawingScaleType](../com.aspose.diagram/drawingscaletype) | ページに使用する描画スケールのタイプを指定します。 |
+| [DrawingScaleTypeValue](../com.aspose.diagram/drawingscaletypevalue) | ページに使用する描画スケールのタイプを指定します。 |
+| [DrawingSizeType](../com.aspose.diagram/drawingsizetype) | ページの描画サイズを指定します。 |
+| [DrawingSizeTypeValue](../com.aspose.diagram/drawingsizetypevalue) | ページの描画サイズを指定します。 |
+| [DropButtonStyle](../com.aspose.diagram/dropbuttonstyle) | ドロップ ボタンに表示されるシンボルを表します。 |
+| [DynFeedback](../com.aspose.diagram/dynfeedback) | コネクタをドラッグするときにユーザーに提供される視覚的フィードバックのタイプを指定します。 |
+| [DynFeedbackValue](../com.aspose.diagram/dynfeedbackvalue) | コネクタをドラッグするときにユーザーに提供される視覚的フィードバックのタイプを指定します。 |
+| [Ellipse](../com.aspose.diagram/ellipse) | 楕円の中心点および楕円上の 2 点の x 座標と y 座標を指定する要素を含みます。 |
+| [EllipseCollection](../com.aspose.diagram/ellipsecollection) | 楕円コレクションです。 |
+| [EllipticalArcTo](../com.aspose.diagram/ellipticalarcto) | 楕円弧に関する情報を指定する要素を含みます。 |
+| [EllipticalArcToCollection](../com.aspose.diagram/ellipticalarctocollection) | EllipticalArcTo コレクションです。 |
+| [EmfRenderSetting](../com.aspose.diagram/emfrendersetting) | Emf メタファイルのレンダリング設定です。 |
+| [Encoding](../com.aspose.diagram/encoding) | 文字エンコーディングを表します。 |
+| [Event](../com.aspose.diagram/event) | シェイプ イベントを制御する数式を指定する要素を含みます。 |
+| [EventItem](../com.aspose.diagram/eventitem) | イベント コードをカプセル化します。 |
+| [EventItemCollection](../com.aspose.diagram/eventitemcollection) | EventItem コレクションです。 |
+| [Field](../com.aspose.diagram/field) | シェイプのテキストに挿入された関数と数式を指定する要素を含みます。 |
+| [FieldCollection](../com.aspose.diagram/fieldcollection) | フィールド コレクション。 |
+| [FileFontSource](../com.aspose.diagram/filefontsource) | ファイルシステムに保存されている単一の TrueType フォント ファイルを表します。 |
+| [FileFormatInfo](../com.aspose.diagram/fileformatinfo) | [FileFormatUtil](../com.aspose.diagram/fileformatutil) のファイル形式検出メソッドによって返されるデータを含みます。 |
+| [FileFormatType](../com.aspose.diagram/fileformattype) | スプレッドシートのファイル形式タイプを列挙します。 |
+| [FileFormatUtil](../com.aspose.diagram/fileformatutil) | ファイル形式列挙体を文字列またはファイル拡張子に変換し、逆変換するユーティリティ メソッドを提供します。 |
+| [Fill](../com.aspose.diagram/fill) | シェイプとシェイプのドロップシャドウの現在の塗りつぶし書式設定値を含み、パターン、前景色、背景色が含まれます。 |
+| [FillType](../com.aspose.diagram/filltype) | 塗りつぶし形式タイプ。 |
+| [Fld](../com.aspose.diagram/fld) | 対応する Field 要素のテキスト フィールド挿入ポイントを示します。 |
+| [FloatPointNumCollection](../com.aspose.diagram/floatpointnumcollection) | 倍精度ポイント数のコレクションを含みます。 |
+| [FolderFontSource](../com.aspose.diagram/folderfontsource) | TrueType フォント ファイルを含むフォルダーを表します。 |
+| [Font](../com.aspose.diagram/font) | フォントに関する情報を含みます。 |
+| [FontCollection](../com.aspose.diagram/fontcollection) | Font 要素のコレクションを含みます。 |
+| [FontConfigs](../com.aspose.diagram/fontconfigs) | フォント設定を指定します。 |
+| [FontSourceBase](../com.aspose.diagram/fontsourcebase) | これは、ユーザーがさまざまなフォント ソースを指定できるクラスの抽象基底クラスです。 |
+| [FontSourceType](../com.aspose.diagram/fontsourcetype) | フォント ソースのタイプを指定します。 |
+| [Foreign](../com.aspose.diagram/foreign) | Microsoft Visio ドキュメントで使用される別のプログラムからのオブジェクトの幅と高さを指定する要素を含みます。 |
+| [ForeignData](../com.aspose.diagram/foreigndata) | Windows メタファイル、ビットマップ、または OLE データなどの画像データの MIME (Multipurpose Internet Mail Extensions) エンコード BLOB を含みます。 |
+| [ForeignType](../com.aspose.diagram/foreigntype) | データ型。 |
+| [FormatTxt](../com.aspose.diagram/formattxt) | テキストの書式設定のための抽象クラス。 |
+| [FormatTxtCollection](../com.aspose.diagram/formattxtcollection) | シェイプのテキストを含む FormatTxt コレクション。 |
+| [FromPartValue](../com.aspose.diagram/frompartvalue) | 接続が開始されるシェイプの部分。 |
+| [Geom](../com.aspose.diagram/geom) | シェイプを構成する線と円弧の頂点座標を指定する要素を含みます。 |
+| [GeomCollection](../com.aspose.diagram/geomcollection) | Geom コレクション。 |
+| [GlowEffect](../com.aspose.diagram/gloweffect) | このクラスは、オブジェクトのエッジの外側にカラーのぼかし輪郭が追加されるグロー効果を指定します。 |
+| [GlueSettings](../com.aspose.diagram/gluesettings) | ビット値は、特定の接着設定がオンかオフかを示します。 |
+| [GlueSettingsValue](../com.aspose.diagram/gluesettingsvalue) | ドキュメントで接着が有効な場合に、シェイプが接着するオブジェクトを指定します。 |
+| [GlueType](../com.aspose.diagram/gluetype) | シェイプに接続する際に、動的（シェイプ間）接着が許可されるかどうかを指定します。 |
+| [GlueTypeValue](../com.aspose.diagram/gluetypevalue) | シェイプに接続する際に、動的（シェイプ間）接着が許可されるかどうかを指定します。 |
+| [GluedShapesFlags](../com.aspose.diagram/gluedshapesflags) | 特定のシェイプに接着された接続ポイントの次元性と方向性に基づいて、返すシェイプを識別する定数を指定します。これらは Shape.GluedShapes メソッドに渡されます。 |
+| [GradientDirectionType](../com.aspose.diagram/gradientdirectiontype) | すべての方向タイプのグラデーションを表します。 |
+| [GradientFill](../com.aspose.diagram/gradientfill) | グラデーション塗りつぶしを表します。 |
+| [GradientFillDir](../com.aspose.diagram/gradientfilldir) | シェイプの塗りつぶしカラーグラデーションのタイプを指定します。 |
+| [GradientFillType](../com.aspose.diagram/gradientfilltype) | すべてのグラデーション塗りつぶしタイプを表します。 |
+| [GradientStop](../com.aspose.diagram/gradientstop) | グラデーションストップを表します。 |
+| [GradientStopCollection](../com.aspose.diagram/gradientstopcollection) | グラデーションストップのコレクションを表します。 |
+| [GradientStyleType](../com.aspose.diagram/gradientstyletype) | グラデーションシェーディングスタイルを表します。 |
+| [GridDensity](../com.aspose.diagram/griddensity) | ページで使用する水平/垂直グリッドのタイプを指定します。 |
+| [GridDensityValue](../com.aspose.diagram/griddensityvalue) | ページで使用する水平/垂直グリッドのタイプを指定します。 |
+| [Group](../com.aspose.diagram/group) | グループにシェイプを追加する方法、グループのメンバーを移動する方法、グループを選択する方法を制御する要素を含みます。 |
+| [HTMLSaveOptions](../com.aspose.diagram/htmlsaveoptions) | ダイアグラムページを HTML にレンダリングする際に、追加オプションを指定できます。 |
+| [HeaderFooter](../com.aspose.diagram/headerfooter) | ドキュメントのヘッダーとフッターの要素を含みます。 |
+| [HeaderFooterFont](../com.aspose.diagram/headerfooterfont) | ヘッダーとフッターのテキストに使用されるフォントを指定します。 |
+| [Help](../com.aspose.diagram/help) | Shape 要素のヘルプファイルトピックと著作権情報を指定する要素を含みます。 |
+| [HorzAlign](../com.aspose.diagram/horzalign) | シェイプのテキストブロック内のテキストの水平揃えを指定します。 |
+| [HorzAlignValue](../com.aspose.diagram/horzalignvalue) | シェイプのテキストブロック内のテキストの水平揃えを指定します。 |
+| [Hyperlink](../com.aspose.diagram/hyperlink) | シェイプまたは描画ページと別の描画ページ、別のファイル、または Web サイト間で複数のジャンプを作成するための要素を含みます。 |
+| [HyperlinkCollection](../com.aspose.diagram/hyperlinkcollection) | ハイパーリンク コレクション。 |
+| [IconSizeValue](../com.aspose.diagram/iconsizevalue) | オプションの int。 |
+| [Image](../com.aspose.diagram/image) | ビットマップのガンマ、明るさ、コントラスト、ぼかし、シャープ、ノイズ除去、透明度の値を含みます。 |
+| [ImageActiveXControl](../com.aspose.diagram/imageactivexcontrol) | 画像コントロールを表します。 |
+| [ImageColorMode](../com.aspose.diagram/imagecolormode) | ドキュメントページの生成画像のカラーモードを指定します。 |
+| [ImageFormat](../com.aspose.diagram/imageformat) | 画像のファイル形式を指定します。 |
+| [ImageSaveOptions](../com.aspose.diagram/imagesaveoptions) | ダイアグラムページを画像にレンダリングする際に、追加オプションを指定できます。 |
+| [IndividualFontConfigs](../com.aspose.diagram/individualfontconfigs) | 各 [Diagram](../com.aspose.diagram/diagram) オブジェクトのフォント設定。 |
+| [InfiniteLine](../com.aspose.diagram/infiniteline) | 無限直線上の2点の x および y 座標を指定する要素を含みます。 |
+| [InfiniteLineCollection](../com.aspose.diagram/infinitelinecollection) | InfiniteLine コレクション。 |
+| [InputMethodEditorMode](../com.aspose.diagram/inputmethodeditormode) | Input Method Editor のデフォルト実行時モードを表します。 |
+| [IntValue](../com.aspose.diagram/intvalue) | 整数値 |
+| [InterpolationMode](../com.aspose.diagram/interpolationmode) | InterpolationMode 列挙体は、画像が拡大縮小または回転される際に使用されるアルゴリズムを指定します。 |
+| [InterruptMonitor](../com.aspose.diagram/interruptmonitor) | 割り込みに関するすべての演算子を表します。 |
+| [Issue](../com.aspose.diagram/issue) | ドキュメント内の単一の検証問題を表します。 |
+| [IssueCollection](../com.aspose.diagram/issuecollection) | Issue コレクション。 |
+| [IssueTarget](../com.aspose.diagram/issuetarget) | 親検証問題の対象に応じて、親検証問題が関連付けられるページ、またはページとシェイプの両方を指定します。 |
+| [LabelActiveXControl](../com.aspose.diagram/labelactivexcontrol) | ラベル ActiveX コントロールを表します。 |
+| [Layer](../com.aspose.diagram/layer) | ページ用の単一レイヤーとそのプロパティを定義する要素を含みます。 |
+| [LayerCollection](../com.aspose.diagram/layercollection) | Layer コレクション。 |
+| [LayerMem](../com.aspose.diagram/layermem) | LayerMember 要素を含み、シェイプが割り当てられる各レイヤーを指定します。 |
+| [Layout](../com.aspose.diagram/layout) | シェイプの配置とコネクタのルーティング設定を制御する要素を含みます。 |
+| [LayoutDirection](../com.aspose.diagram/layoutdirection) | レイアウトの方向を設定するために使用されます。 |
+| [LayoutOptions](../com.aspose.diagram/layoutoptions) | ページ（複数ページ）の再レイアウトを実行するために、シェイプのレイアウトのスタイルと追加オプションを指定するために使用されます。 |
+| [LayoutStyle](../com.aspose.diagram/layoutstyle) | レイアウトのスタイルを指定するために使用されます。 |
+| [License](../com.aspose.diagram/license) | コンポーネントのライセンスを取得するためのメソッドを提供します。 |
+| [LightRigDirectionType](../com.aspose.diagram/lightrigdirectiontype) | ライトリグ方向タイプを表します。 |
+| [Line](../com.aspose.diagram/line) | シェイプに関する一般的な位置情報を指定する要素を含みます。 |
+| [LineAdjustFrom](../com.aspose.diagram/lineadjustfrom) | 動的コネクタが互いに重なる場合に、どのコネクタを間隔を空けるかを指定します。 |
+| [LineAdjustFromValue](../com.aspose.diagram/lineadjustfromvalue) | 動的コネクタが互いに重なる場合に、どのコネクタを間隔を空けるかを指定します。 |
+| [LineAdjustTo](../com.aspose.diagram/lineadjustto) | 動的コネクタが互いに重なる場合に、どのコネクタを重ねて配置するかを指定します。 |
+| [LineAdjustToValue](../com.aspose.diagram/lineadjusttovalue) | 動的コネクタが互いに重なる場合に、どのコネクタを重ねて配置するかを指定します。 |
+| [LineJumpCode](../com.aspose.diagram/linejumpcode) | ジャンプを追加したい動的コネクタを決定します。 |
+| [LineJumpCodeValue](../com.aspose.diagram/linejumpcodevalue) | ジャンプを追加したい動的コネクタを決定します。 |
+| [LineJumpStyle](../com.aspose.diagram/linejumpstyle) | ローカルのラインジャンプスタイルが設定されていない描画ページ上のすべてのコネクタのラインジャンプスタイルを指定します。 |
+| [LineJumpStyleValue](../com.aspose.diagram/linejumpstylevalue) | ローカルのラインジャンプスタイルが設定されていない描画ページ上のすべてのコネクタのラインジャンプスタイルを指定します。 |
+| [LineRouteExt](../com.aspose.diagram/linerouteext) | ページ上のすべてのコネクタのデフォルト外観を指定します。 |
+| [LineRouteExtValue](../com.aspose.diagram/linerouteextvalue) | ページ上のすべてのコネクタのデフォルト外観を指定します。 |
+| [LineTo](../com.aspose.diagram/lineto) | 直線セグメントの終点頂点の x および y 座標を含みます。 |
+| [LineToCollection](../com.aspose.diagram/linetocollection) | LineTo コレクション。 |
+| [ListBoxActiveXControl](../com.aspose.diagram/listboxactivexcontrol) | ListBox ActiveX コントロールを表します。 |
+| [LoadFileFormat](../com.aspose.diagram/loadfileformat) | 図面形式選択の読み込み用列挙体。 |
+| [LoadOptions](../com.aspose.diagram/loadoptions) | Diagram オブジェクトに図面を読み込む際に追加オプションを指定できます。 |
+| [LocalizeFont](../com.aspose.diagram/localizefont) | シェイプテキストをローカライズ（別の言語に翻訳）するかどうかを指定します。 |
+| [LocalizeFontValue](../com.aspose.diagram/localizefontvalue) | シェイプテキストをローカライズ（別の言語に翻訳）するかどうかを指定します。 |
+| [Margin](../com.aspose.diagram/margin) | 余白を指定します。 |
+| [Master](../com.aspose.diagram/master) | ドキュメントのマスターを定義する要素を含みます。 |
+| [MasterCollection](../com.aspose.diagram/mastercollection) | マスター コレクション。 |
+| [MasterShortcut](../com.aspose.diagram/mastershortcut) | ドキュメントで定義されたマスターショートカットを指定します。 |
+| [MasterShortcutCollection](../com.aspose.diagram/mastershortcutcollection) | MasterShortcut コレクション。 |
+| [MeasureConst](../com.aspose.diagram/measureconst) | 測定単位。 |
+| [MemoryFontSource](../com.aspose.diagram/memoryfontsource) | メモリに格納された単一の TrueType フォントファイルを表します。 |
+| [MilestoneHelper](../com.aspose.diagram/milestonehelper) | マイルストーン シェイプのプロパティを設定する MilestoneHelper。 |
+| [Misc](../com.aspose.diagram/misc) | 選択ハイライトや表示を制御する要素など、シェイプやグループのさまざまな要素を含みます。 |
+| [MoveTo](../com.aspose.diagram/moveto) | シェイプの最初の頂点の x および y 座標、またはパスの途中で切れた後の最初の頂点の x および y 座標を含みます。 |
+| [MoveToCollection](../com.aspose.diagram/movetocollection) | MoveTo コレクション。 |
+| [NURBSTo](../com.aspose.diagram/nurbsto) | x および y 座標、2 番目から最後のノットの位置、最後のウェイトの位置、最初のノットの位置、最初のウェイトの位置、そして非一様有理 B スプライン (NURBS) の式を含みます。 |
+| [NURBSToCollection](../com.aspose.diagram/nurbstocollection) | NURBSTo コレクション。 |
+| [ObjType](../com.aspose.diagram/objtype) | Microsoft Visio を使用して描画ページ上にシェイプを配置する際、オブジェクトが配置可能かルーティング可能かを指定します。 |
+| [ObjTypeValue](../com.aspose.diagram/objtypevalue) | Microsoft Visio を使用して描画ページ上にシェイプを配置する際、オブジェクトが配置可能かルーティング可能かを指定します。 |
+| [ObjectKind](../com.aspose.diagram/objectkind) | テキスト フィールドのタイプを示します。 |
+| [ObjectKindValue](../com.aspose.diagram/objectkindvalue) | テキスト フィールドのタイプを示します。 |
+| [ObjectType](../com.aspose.diagram/objecttype) | If the ForeignType attribute is "Object", the ForeignData element must also have an ObjectType attribute. |
+| [OptionsValue](../com.aspose.diagram/optionsvalue) | オプションの符号なし整数。 |
+| [OutputFormat](../com.aspose.diagram/outputformat) | 図面の出力形式を指定します。 |
+| [OutputFormatValue](../com.aspose.diagram/outputformatvalue) | 図面の出力形式を指定します。 |
+| [Page](../com.aspose.diagram/page) | ドキュメント内のページを定義する要素を含みます。 |
+| [PageCollection](../com.aspose.diagram/pagecollection) | ページコレクション。 |
+| [PageEndSavingArgs](../com.aspose.diagram/pageendsavingargs) | ページの情報が保存プロセスを終了します。 |
+| [PageLayout](../com.aspose.diagram/pagelayout) | ページ上の図形やコネクタのレイアウト設定を制御するセルを含みます。例えば、ページ上のすべての図形間の間隔、すべてのコネクタ間の間隔、そしてすべてのコネクタのルーティングスタイルなどです。 |
+| [PageLineJumpDirX](../com.aspose.diagram/pagelinejumpdirx) | 描画ページ上の動的コネクタの水平セグメントにおいて、ローカルなジャンプ方向が設定されていない場合のラインジャンプの方向を指定します。 |
+| [PageLineJumpDirXValue](../com.aspose.diagram/pagelinejumpdirxvalue) | 描画ページ上の動的コネクタの水平セグメントにおいて、ローカルなジャンプ方向が設定されていない場合のラインジャンプの方向を指定します。 |
+| [PageLineJumpDirY](../com.aspose.diagram/pagelinejumpdiry) | 描画ページ上の垂直動的コネクタにおいて、ローカルなジャンプ方向が設定されていない場合のラインジャンプの方向を指定します。 |
+| [PageLineJumpDirYValue](../com.aspose.diagram/pagelinejumpdiryvalue) | 描画ページ上の垂直動的コネクタにおいて、ローカルなジャンプ方向が設定されていない場合のラインジャンプの方向を指定します。 |
+| [PageProps](../com.aspose.diagram/pageprops) | ページ幅、ページ高さ、スケールなど、ページ属性を制御するセルを含みます。 |
+| [PageSavingArgs](../com.aspose.diagram/pagesavingargs) | ページの保存プロセスに関する情報です。 |
+| [PageSheet](../com.aspose.diagram/pagesheet) | ページまたはマスター要素のページシートを定義する要素を含みます。 |
+| [PageSize](../com.aspose.diagram/pagesize) | 生成された画像のページサイズに関する情報を含みます。 |
+| [PageStartSavingArgs](../com.aspose.diagram/pagestartsavingargs) | ページの保存プロセス開始に関する情報です。 |
+| [PaperSizeFormat](../com.aspose.diagram/papersizeformat) | 用紙サイズ形式の選択を保存する列挙型です。 |
+| [Para](../com.aspose.diagram/para) | 図形のテキストに対する段落書式設定要素を含みます。インデント、行間、箇条書き、段落の水平揃えなどです。 |
+| [ParaCollection](../com.aspose.diagram/paracollection) | 段落コレクション。 |
+| [PdfCompliance](../com.aspose.diagram/pdfcompliance) | 出力ファイルの PDF 準拠レベルを指定します。 |
+| [PdfDigitalSignatureHashAlgorithm](../com.aspose.diagram/pdfdigitalsignaturehashalgorithm) | デジタル署名で使用されるデジタルハッシュアルゴリズムを指定します。 |
+| [PdfEncryptionAlgorithm](../com.aspose.diagram/pdfencryptionalgorithm) | PDF ドキュメントを暗号化する際に使用する暗号化アルゴリズムを指定します。 |
+| [PdfEncryptionDetails](../com.aspose.diagram/pdfencryptiondetails) | PDF 暗号化に関する詳細を含みます。 |
+| [PdfPermissions](../com.aspose.diagram/pdfpermissions) | PDF ドキュメントのユーザー権限を指定します。 |
+| [PdfSaveOptions](../com.aspose.diagram/pdfsaveoptions) | ダイアグラムページを PDF にレンダリングする際に追加オプションを指定できます。 |
+| [PdfTextCompression](../com.aspose.diagram/pdftextcompression) | 画像を除く PDF ファイル内のすべてのコンテンツに適用される圧縮タイプを指定します。 |
+| [PinPosValue](../com.aspose.diagram/pinposvalue) | 図形のピン位置を指定します。 |
+| [PixelOffsetMode](../com.aspose.diagram/pixeloffsetmode) | レンダリング時のピクセルのオフセット方法を指定します。 |
+| [PlaceDepth](../com.aspose.diagram/placedepth) | 自動的にレイアウトされる図面について、レイアウト作成前に図面を解析する方法とレイアウトのタイプを決定する方法を指定します。 |
+| [PlaceDepthValue](../com.aspose.diagram/placedepthvalue) | 自動的にレイアウトされる図面について、レイアウト作成前に図面を解析する方法とレイアウトのタイプを決定する方法を指定します。 |
+| [PlaceFlip](../com.aspose.diagram/placeflip) | Microsoft Visio の「図形の配置」コマンドを使用して図形を配置する際、ページ上の配置可能な図形が反転または回転する方法を指定します。 |
+| [PlaceFlipValue](../com.aspose.diagram/placeflipvalue) | Microsoft Visio の「図形の配置」コマンドを使用して図形を配置する際、ページ上の配置可能な図形が反転または回転する方法を指定します。 |
+| [PlaceStyle](../com.aspose.diagram/placestyle) | ユーザーが「図形の配置」（図形メニュー）を選択して図形を配置する際、図形がページ上に配置される方法を指定します。 |
+| [PlaceStyleValue](../com.aspose.diagram/placestylevalue) | ユーザーが「図形の配置」（図形メニュー）を選択して図形を配置する際、図形がページ上に配置される方法を指定します。 |
+| [PolylineTo](../com.aspose.diagram/polylineto) | ポリラインの最後の点の x および y 座標とポリラインの式を含みます。 |
+| [PolylineToCollection](../com.aspose.diagram/polylinetocollection) | PolylineTo コレクション。 |
+| [Pos](../com.aspose.diagram/pos) | シェイプのテキストの位置をベースラインに対して指定します。 |
+| [PosValue](../com.aspose.diagram/posvalue) | シェイプのテキストの位置をベースラインに対して指定します。 |
+| [Pp](../com.aspose.diagram/pp) | 段落プロパティ ランの開始を指定します。 |
+| [PresetCameraType](../com.aspose.diagram/presetcameratype) | 位置を含むすべてのカメラ プロパティを設定するさまざまなアルゴリズム手法を表します。 |
+| [PresetColorMatricsValue](../com.aspose.diagram/presetcolormatricsvalue) | Shape のテーマ スタイルの色プロパティを設定するために使用されます。 |
+| [PresetQuickStyleValue](../com.aspose.diagram/presetquickstylevalue) | テーマのクイック スタイル値を指定します。 |
+| [PresetShadowType](../com.aspose.diagram/presetshadowtype) | プリセットの影タイプを表します。 |
+| [PresetStyleMatricsValue](../com.aspose.diagram/presetstylematricsvalue) | Shape のテーマ スタイル プロパティを設定するために使用されます。 |
+| [PresetThemeValue](../com.aspose.diagram/presetthemevalue) | テーマの値を指定します。 |
+| [PresetThemeVariantValue](../com.aspose.diagram/presetthemevariantvalue) | テーマのバリアント値を指定します。 |
+| [PreviewScope](../com.aspose.diagram/previewscope) | ドキュメントにプレビューが含まれるかどうか、含まれる場合はプレビューが最初のページのみを表示するか、ドキュメント全体のページを表示するかを指定します。 |
+| [PreviewScopeValue](../com.aspose.diagram/previewscopevalue) | ドキュメントにプレビューが含まれるかどうか、含まれる場合はプレビューが最初のページのみを表示するか、ドキュメント全体のページを表示するかを指定します。 |
+| [PrintPageOrientation](../com.aspose.diagram/printpageorientation) | ページが縦向きで印刷されるか横向きで印刷されるかを決定します。 |
+| [PrintPageOrientationValue](../com.aspose.diagram/printpageorientationvalue) | ページが縦向きで印刷されるか横向きで印刷されるかを決定します。 |
+| [PrintProps](../com.aspose.diagram/printprops) | 描画ページがプリンタページ上でどのようにフォーマット（表示）されるかを制御する要素を含みます。 |
+| [PrintSaveOptions](../com.aspose.diagram/printsaveoptions) | 図を印刷する際に追加オプションを指定できるようにします。 |
+| [Prop](../com.aspose.diagram/prop) | カスタム プロパティを定義する要素と、データをシェイプに関連付ける要素を含みます。 |
+| [PropCollection](../com.aspose.diagram/propcollection) | Prop コレクション。 |
+| [PropType](../com.aspose.diagram/proptype) | プロパティのタイプ。 |
+| [Protection](../com.aspose.diagram/protection) | ロックはシェイプへの偶発的な変更を防止するのに役立ちますが、他の状況で Microsoft Visio が値をリセットすることは防げません。 |
+| [RadioButtonActiveXControl](../com.aspose.diagram/radiobuttonactivexcontrol) | RadioButton ActiveX コントロールを表します。 |
+| [RectangleAlignmentType](../com.aspose.diagram/rectanglealignmenttype) | 2 つの矩形を相互に配置する方法を表します。 |
+| [ReflectionEffectType](../com.aspose.diagram/reflectioneffecttype) |  |
+| [RelCubBezTo](../com.aspose.diagram/relcubbezto) | RelCubBezTo の点の x および y 座標を含みます。 |
+| [RelCubBezToCollection](../com.aspose.diagram/relcubbeztocollection) | RelCubBezTo コレクション。 |
+| [RelEllipticalArcTo](../com.aspose.diagram/relellipticalarcto) | 楕円弧に関する情報を指定する要素を含みます。座標は相対座標として指定されます。 |
+| [RelEllipticalArcToCollection](../com.aspose.diagram/relellipticalarctocollection) | RelEllipticalArcTo コレクション。 |
+| [RelLineTo](../com.aspose.diagram/rellineto) | 直線セグメントの終点頂点の x および y 座標を含みます。 |
+| [RelLineToCollection](../com.aspose.diagram/rellinetocollection) | RelLineTo コレクション。 |
+| [RelMoveTo](../com.aspose.diagram/relmoveto) | 形状の最初の頂点の x および y 座標、またはパスの途中で切れ目が入った後の最初の頂点の x および y 座標を含みます。座標は相対座標として指定されます。 |
+| [RelMoveToCollection](../com.aspose.diagram/relmovetocollection) | RelMoveTo コレクション。 |
+| [RelQuadBezTo](../com.aspose.diagram/relquadbezto) | RelQuadBezTo のポイントの x および y 座標を含みます。 |
+| [RelQuadBezToCollection](../com.aspose.diagram/relquadbeztocollection) | RelQuadBezTo コレクション。 |
+| [RemoveHiddenInfoItem](../com.aspose.diagram/removehiddeninfoitem) | 図の非表示情報を削除することを指定します。 |
+| [RenderingSaveOptions](../com.aspose.diagram/renderingsaveoptions) | これは、ユーザーが図を特定の形式で保存する際に追加オプションを指定できるクラスのための抽象基底クラスです。 |
+| [ResizeMode](../com.aspose.diagram/resizemode) | グループ内に含まれる形状の現在のリサイズ動作設定を指定します。 |
+| [ResizeModeValue](../com.aspose.diagram/resizemodevalue) | グループ内に含まれる形状の現在のリサイズ動作設定を指定します。 |
+| [Reviewer](../com.aspose.diagram/reviewer) | 文書レビュアーに関する識別情報を含む要素を含みます。 |
+| [ReviewerCollection](../com.aspose.diagram/reviewercollection) | Reviewer コレクション。 |
+| [RotationType](../com.aspose.diagram/rotationtype) | シェイプの影のタイプを指定します。 |
+| [RotationTypeValue](../com.aspose.diagram/rotationtypevalue) | 形状の効果プロパティの投影タイプを指定します。 |
+| [RouteStyle](../com.aspose.diagram/routestyle) | ローカルのルーティングスタイルが設定されていない描画ページ上のすべての動的コネクタのルーティングスタイルと方向を指定します。 |
+| [RouteStyleValue](../com.aspose.diagram/routestylevalue) | ローカルのルーティングスタイルが設定されていない描画ページ上のすべての動的コネクタのルーティングスタイルと方向を指定します。 |
+| [Row](../com.aspose.diagram/row) | データレコードセットの行を示します。 |
+| [RowCollection](../com.aspose.diagram/rowcollection) | Row コレクション。 |
+| [Rule](../com.aspose.diagram/rule) | 図の検証ルールセット内の単一の検証ルールを表します。 |
+| [RuleCollection](../com.aspose.diagram/rulecollection) | ルール コレクション。 |
+| [RuleInfo](../com.aspose.diagram/ruleinfo) | 親の検証問題が関連する検証ルールに関する情報を指定します。 |
+| [RuleSet](../com.aspose.diagram/ruleset) | 図の検証ルールのセットを表します。 |
+| [RuleSetCollection](../com.aspose.diagram/rulesetcollection) | RuleSet コレクション。 |
+| [RuleValue](../com.aspose.diagram/rulevalue) | ルール 値。 |
+| [RulerDensity](../com.aspose.diagram/rulerdensity) | ページの定規上の水平分割を指定します。 |
+| [RulerDensityValue](../com.aspose.diagram/rulerdensityvalue) | ページの定規上の水平分割を指定します。 |
+| [RulerGrid](../com.aspose.diagram/rulergrid) | ページの定規とグリッドの設定を指定する要素を含みます。 |
+| [SVGSaveOptions](../com.aspose.diagram/svgsaveoptions) | 図ページを SVG にレンダリングする際に追加オプションを指定できます。 |
+| [SaveFileFormat](../com.aspose.diagram/savefileformat) | 図の形式選択を保存するための列挙体です。 |
+| [SaveOptions](../com.aspose.diagram/saveoptions) | これは、ユーザーが図を特定の形式で保存する際に追加オプションを指定できるクラスのための抽象基底クラスです。 |
+| [Scratch](../com.aspose.diagram/scratch) | 他の要素から参照される数式を入力およびテストするための作業領域を含みます。 |
+| [ScratchCollection](../com.aspose.diagram/scratchcollection) | スクラッチ コレクション。 |
+| [ScrollBarActiveXControl](../com.aspose.diagram/scrollbaractivexcontrol) | ScrollBar コントロールを表します。 |
+| [SelectMode](../com.aspose.diagram/selectmode) | ユーザーがグループ シェイプとそのメンバーを選択する方法を指定します。 |
+| [SelectModeValue](../com.aspose.diagram/selectmodevalue) | ユーザーがグループ シェイプとそのメンバーを選択する方法を指定します。 |
+| [Shape](../com.aspose.diagram/shape) | マスター、ページ、またはグループ シェイプ要素内でシェイプを定義する要素を含みます。 |
+| [ShapeCollection](../com.aspose.diagram/shapecollection) | シェイプのコレクション。 |
+| [ShapeFixedCode](../com.aspose.diagram/shapefixedcode) | 配置可能なシェイプの配置動作を指定します。 |
+| [ShapeFixedCodeValue](../com.aspose.diagram/shapefixedcodevalue) | 配置可能なシェイプの配置動作を指定します。 |
+| [ShapePlaceFlip](../com.aspose.diagram/shapeplaceflip) | ユーザーが「Lay Out Shapes」（シェイプ メニュー）を選択したときに、配置可能なシェイプがページ上で反転または回転する方法を指定します。 |
+| [ShapePlaceFlipValue](../com.aspose.diagram/shapeplaceflipvalue) | ユーザーが「Lay Out Shapes」（シェイプ メニュー）を選択したときに、配置可能なシェイプがページ上で反転または回転する方法を指定します。 |
+| [ShapePlaceStyle](../com.aspose.diagram/shapeplacestyle) | 子要素の配置スタイルを決定します。 |
+| [ShapePlaceStyleValue](../com.aspose.diagram/shapeplacestylevalue) | 子要素の配置スタイルを決定します。 |
+| [ShapePlowCode](../com.aspose.diagram/shapeplowcode) | 描画ページ上で別の配置可能なシェイプを対象シェイプの近くにドラッグしたときに、対象シェイプが離れるかどうかを指定します。 |
+| [ShapePlowCodeValue](../com.aspose.diagram/shapeplowcodevalue) | 描画ページ上で別の配置可能なシェイプを対象シェイプの近くにドラッグしたときに、対象シェイプが離れるかどうかを指定します。 |
+| [ShapeRouteStyle](../com.aspose.diagram/shaperoutestyle) | 描画ページ上のコネクタのルーティング スタイルと方向を指定します。 |
+| [ShapeRouteStyleValue](../com.aspose.diagram/shaperoutestylevalue) | 描画ページ上のコネクタのルーティング スタイルと方向を指定します。 |
+| [ShapeShdwShow](../com.aspose.diagram/shapeshdwshow) | シェイプの影のタイプを指定します。 |
+| [ShapeShdwShowValue](../com.aspose.diagram/shapeshdwshowvalue) | シェイプの影のタイプを指定します。 |
+| [ShapeShdwType](../com.aspose.diagram/shapeshdwtype) | シェイプの影のタイプを指定します。 |
+| [ShapeShdwTypeValue](../com.aspose.diagram/shapeshdwtypevalue) | シェイプの影のタイプを指定します。 |
+| [ShdwType](../com.aspose.diagram/shdwtype) | ページのデフォルトの影タイプを示します。 |
+| [ShdwTypeValue](../com.aspose.diagram/shdwtypevalue) | ページのデフォルトの影タイプを示します。 |
+| [ShowDropButtonType](../com.aspose.diagram/showdropbuttontype) | ドロップ ボタンを表示するタイミングを指定します |
+| [SmartTagDef](../com.aspose.diagram/smarttagdef) | シェイプまたはページに定義された各スマート タグの情報を含む要素を含みます。 |
+| [SmartTagDefCollection](../com.aspose.diagram/smarttagdefcollection) | SmartTagDef コレクション。 |
+| [SmoothingMode](../com.aspose.diagram/smoothingmode) | 線や曲線、塗りつぶし領域のエッジに平滑化（アンチエイリアス）が適用されるかどうかを指定します。 |
+| [SnapExtensions](../com.aspose.diagram/snapextensions) | アクティブ ウィンドウに対して特定のスナップ拡張設定が有効か無効かを指定します。 |
+| [SnapExtensionsValue](../com.aspose.diagram/snapextensionsvalue) | アクティブ ウィンドウに対して特定のスナップ拡張設定が有効か無効かを指定します。 |
+| [SnapSettings](../com.aspose.diagram/snapsettings) | ウィンドウでスナップが有効なときにシェイプがスナップするオブジェクトを指定します。 |
+| [SnapSettingsValue](../com.aspose.diagram/snapsettingsvalue) | ウィンドウでスナップが有効なときにシェイプがスナップするオブジェクトを指定します |
+| [SolutionXML](../com.aspose.diagram/solutionxml) | 明示的な名前空間でプレフィックスが付けられ、ドキュメントに保存される、ソリューション固有の整形式 XML データを含みます。 |
+| [SolutionXMLCollection](../com.aspose.diagram/solutionxmlcollection) | SolutionXML コレクション。 |
+| [SpinButtonActiveXControl](../com.aspose.diagram/spinbuttonactivexcontrol) | SpinButton コントロールを表します。 |
+| [SplineKnot](../com.aspose.diagram/splineknot) | スプラインの制御点およびスプラインのノットの x および y 座標を含み、これらはそれぞれ X、Y、A 要素で表されます。 |
+| [SplineKnotCollection](../com.aspose.diagram/splineknotcollection) | SplineKnot コレクション。 |
+| [SplineStart](../com.aspose.diagram/splinestart) | スプラインの第2制御点、その第2ノット、第1ノット、最後のノット、およびスプラインの次数の x と y 座標を含みます。 |
+| [SplineStartCollection](../com.aspose.diagram/splinestartcollection) | SplineStart コレクション。 |
+| [Str2Value](../com.aspose.diagram/str2value) | 文字列の値。 |
+| [StrValue](../com.aspose.diagram/strvalue) | 文字列の値 |
+| [StreamProviderOptions](../com.aspose.diagram/streamprovideroptions) | ストリーム オプションを表します。 |
+| [Style](../com.aspose.diagram/style) | シェイプのテキスト ブロック内のテキスト範囲に適用される文字書式設定を指定します。 |
+| [StyleProp](../com.aspose.diagram/styleprop) | スタイルがテキスト、ライン、塗りつぶし属性を含むかどうかなど、スタイルの動作を制御する要素を含みます。 |
+| [StyleSheet](../com.aspose.diagram/stylesheet) | ドキュメントで定義されたスタイルを表します。 |
+| [StyleSheetCollection](../com.aspose.diagram/stylesheetcollection) | StyleSheets のコレクション。 |
+| [StyleValue](../com.aspose.diagram/stylevalue) | シェイプのテキスト ブロック内のテキスト範囲に適用される文字書式設定を指定します。 |
+| [Tab](../com.aspose.diagram/tab) | Tab 要素のコレクションを含みます。 |
+| [TabCollection](../com.aspose.diagram/tabcollection) | Tab 要素のコレクションを含みます |
+| [TabsCollection](../com.aspose.diagram/tabscollection) | TabCollection 要素のコレクションを含みます |
+| [Text](../com.aspose.diagram/text) | シェイプのテキストを含みます。 |
+| [TextBlock](../com.aspose.diagram/textblock) | シェイプのテキスト ブロック内のテキストの配置、余白、デフォルトのタブ位置を指定する要素を含みます。 |
+| [TextBoxActiveXControl](../com.aspose.diagram/textboxactivexcontrol) | テキスト ボックス ActiveX コントロールを表します。 |
+| [TextCollection](../com.aspose.diagram/textcollection) | シェイプのテキストを含みます。 |
+| [TextDirection](../com.aspose.diagram/textdirection) | テキスト ブロック内の文字の方向を指定します。 |
+| [TextDirectionValue](../com.aspose.diagram/textdirectionvalue) | テキスト ブロック内の文字の方向を指定します。 |
+| [TextXForm](../com.aspose.diagram/textxform) | シェイプのテキスト ブロックに関する位置情報を指定する要素を含みます。 |
+| [ThreeDFormat](../com.aspose.diagram/threedformat) | シェイプの三次元書式設定を表します。 |
+| [TiffCompression](../com.aspose.diagram/tiffcompression) | ページを TIFF 形式で保存する際に適用する圧縮タイプを指定します。 |
+| [TimeLineHelper](../com.aspose.diagram/timelinehelper) | タイムライン シェイプのプロパティを設定するための TimeLineHelper。 |
+| [ToPartValue](../com.aspose.diagram/topartvalue) | 接続が行われるシェイプの部分。 |
+| [ToggleButtonActiveXControl](../com.aspose.diagram/togglebuttonactivexcontrol) | ToggleButton ActiveX コントロールを表します。 |
+| [Tp](../com.aspose.diagram/tp) | タブ プロパティ ランの開始位置を指定します。 |
+| [Txt](../com.aspose.diagram/txt) | シェイプのテキスト |
+| [TypeConnection](../com.aspose.diagram/typeconnection) | 含まれる要素に基づいてさまざまなタイプを指定します。 |
+| [TypeConnectionValue](../com.aspose.diagram/typeconnectionvalue) | 含まれる要素に基づいてさまざまなタイプを指定します。 |
+| [TypeField](../com.aspose.diagram/typefield) | Type はテキスト フィールドの値のデータ型を指定します。 |
+| [TypeFieldValue](../com.aspose.diagram/typefieldvalue) | Type はテキスト フィールドの値のデータ型を指定します。 |
+| [TypeProp](../com.aspose.diagram/typeprop) | Type はカスタム プロパティの値のデータ型を指定します。 |
+| [TypePropValue](../com.aspose.diagram/typepropvalue) | Type はカスタム プロパティの値のデータ型を指定します。 |
+| [TypeValue](../com.aspose.diagram/typevalue) | オプション列挙。 |
+| [UIVisibility](../com.aspose.diagram/uivisibility) | タブの配置を指定します。 |
+| [UIVisibilityValue](../com.aspose.diagram/uivisibilityvalue) | タブの配置を指定します。 |
+| [UnitFormulaErr](../com.aspose.diagram/unitformulaerr) | 要素の属性を指定します。 |
+| [UnitFormulaErrV](../com.aspose.diagram/unitformulaerrv) | 要素の指定された属性。 |
+| [UnknownControl](../com.aspose.diagram/unknowncontrol) | 不明なコントロール。 |
+| [User](../com.aspose.diagram/user) | 他の要素やアドオンツールから参照されるユーザー固有の要素で数式を入力する作業領域を含みます。 |
+| [UserCollection](../com.aspose.diagram/usercollection) | ユーザーコレクション。 |
+| [Validation](../com.aspose.diagram/validation) | ドキュメントの図表検証に関する情報を格納します。 |
+| [ValidationProperties](../com.aspose.diagram/validationproperties) | ドキュメントの検証に関連するプロパティをカプセル化します。 |
+| [Value](../com.aspose.diagram/value) | 値。 |
+| [VbaModule](../com.aspose.diagram/vbamodule) | VBA プロジェクトに含まれるモジュールを表します。 |
+| [VbaModuleCollection](../com.aspose.diagram/vbamodulecollection) | [VbaModule](../com.aspose.diagram/vbamodule) のリストを表します。 |
+| [VbaModuleType](../com.aspose.diagram/vbamoduletype) | VBA モジュールのタイプを表します。 |
+| [VbaProject](../com.aspose.diagram/vbaproject) | VBA プロジェクトを表します。 |
+| [VbaProjectReference](../com.aspose.diagram/vbaprojectreference) | VBA プロジェクトの参照を表します。 |
+| [VbaProjectReferenceCollection](../com.aspose.diagram/vbaprojectreferencecollection) | VBA プロジェクトのすべての参照を表します。 |
+| [VbaProjectReferenceType](../com.aspose.diagram/vbaprojectreferencetype) | VBA プロジェクト参照のタイプを表します。 |
+| [VerticalAlign](../com.aspose.diagram/verticalalign) | テキストブロック内のテキストの垂直配置を指定します。 |
+| [VerticalAlignValue](../com.aspose.diagram/verticalalignvalue) | テキストブロック内のテキストの垂直配置を指定します。 |
+| [VisRuleTargetsValue](../com.aspose.diagram/visruletargetsvalue) | 検証ルールの対象を定義する内容を指定します。ValidationRule.TargetType プロパティに渡され、返されます。 |
+| [WalkPreference](../com.aspose.diagram/walkpreference) | 形状が曖昧な位置に移動したとき、動的接着を使用して、1 次元形状の端点が接着された形状上の水平または垂直の接続点に移動するかどうかを指定します。 |
+| [WalkPreferenceValue](../com.aspose.diagram/walkpreferencevalue) | 形状が曖昧な位置に移動したとき、動的接着を使用して、1 次元形状の端点が接着された形状上の水平または垂直の接続点に移動するかどうかを指定します。 |
+| [WarningInfo](../com.aspose.diagram/warninginfo) | 警告情報 |
+| [WarningType](../com.aspose.diagram/warningtype) | WarningType |
+| [Window](../com.aspose.diagram/window) | Microsoft Visio インスタンス内の開いているウィンドウを表します。 |
+| [WindowCollection](../com.aspose.diagram/windowcollection) | ウィンドウコレクション。 |
+| [WindowStateValue](../com.aspose.diagram/windowstatevalue) | ビットフラグを指定する整数。 |
+| [WindowTypeValue](../com.aspose.diagram/windowtypevalue) | 次のいずれかになる列挙値です：Drawing、Sheet、Stencil、または Icon。 |
+| [XAMLSaveOptions](../com.aspose.diagram/xamlsaveoptions) | ダイアグラムページを XAML にレンダリングする際に、追加オプションを指定できます。 |
+| [XForm](../com.aspose.diagram/xform) | パターン、太さ、色など、シェイプの線属性を制御する要素を含みます。 |
+| [XForm1D](../com.aspose.diagram/xform1d) | 1 次元シェイプの開始点と終了点の x 座標と y 座標を含みます。 |
+| [XJustify](../com.aspose.diagram/xjustify) | X および Y 要素で定義された点に対するスマートタグボタンの x オフセットです。 |
+| [XJustifyValue](../com.aspose.diagram/xjustifyvalue) | X および Y 要素で定義された点に対するスマートタグボタンの x オフセットです。 |
+| [XPSSaveOptions](../com.aspose.diagram/xpssaveoptions) | ダイアグラムページを XPS にレンダリングする際に、追加オプションを指定できます。 |
+| [YJustify](../com.aspose.diagram/yjustify) | X および Y 要素で定義された点に対するスマートタグボタンの y オフセットを指定します。 |
+| [YJustifyValue](../com.aspose.diagram/yjustifyvalue) | X および Y 要素で定義された点に対するスマートタグボタンの y オフセットを指定します。 |
+
+## インターフェイス
+
+| インターフェイス | 説明 |
+| --- | --- |
+| [IPageSavingCallback](../com.aspose.diagram/ipagesavingcallback) | ページ保存プロセスの進行状況を制御/表示します。 |
+| [IStreamProvider](../com.aspose.diagram/istreamprovider) | エクスポートされたストリームプロバイダーを表します。 |
+| [IWarningCallback](../com.aspose.diagram/iwarningcallback) | 警告のコールバックインターフェイスです。 |

--- a/japanese/java/com.aspose.diagram/abstractinterruptmonitor/_index.md
+++ b/japanese/java/com.aspose.diagram/abstractinterruptmonitor/_index.md
@@ -1,0 +1,147 @@
+---
+title: AbstractInterruptMonitor
+second_title: Aspose.Diagram for Java API リファレンス
+description: 時間のかかるすべての操作における割り込み要求を監視します。
+type: docs
+weight: 10
+url: /ja/java/com.aspose.diagram/abstractinterruptmonitor/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public abstract class AbstractInterruptMonitor
+```
+
+時間のかかるすべての操作における割り込み要求を監視します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [AbstractInterruptMonitor()](#AbstractInterruptMonitor--) |  |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [isInterruptionRequested()](#isInterruptionRequested--) | 現在の操作に対して割り込みが要求されているかどうかを示します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AbstractInterruptMonitor() {#AbstractInterruptMonitor--}
+```
+public AbstractInterruptMonitor()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isInterruptionRequested() {#isInterruptionRequested--}
+```
+public abstract boolean isInterruptionRequested()
+```
+
+
+現在の操作に対して割り込みが要求されているかどうかを示します。true の場合、現在の操作は割り込まれます。
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/act/_index.md
+++ b/japanese/java/com.aspose.diagram/act/_index.md
@@ -1,0 +1,395 @@
+---
+title: Act
+second_title: Aspose.Diagram for Java API リファレンス
+description: オブジェクトのショートカットメニューに表示されるカスタムコマンド名を定義し、コマンドが実行するアクションを指定します。
+type: docs
+weight: 11
+url: /ja/java/com.aspose.diagram/act/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Act
+```
+
+オブジェクトのショートカットメニューに表示されるカスタムコマンド名を定義し、コマンドが実行するアクションを指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Act()](#Act--) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAction()](#getAction--) | 対応する Menu 要素で定義されたコマンド名がユーザーによってクリックされたときに実行される数式を含みます。 |
+| [getBeginGroup()](#getBeginGroup--) | このアクションの上のメニューに区切り線が挿入されるかどうかを示します。 |
+| [getButtonFace()](#getButtonFace--) | ショートカットメニューの項目の横に表示されるアイコンを識別します。 |
+| [getChecked()](#getChecked--) | シェイプのショートカットメニューでコマンド名の横にチェックマークが表示されるかどうかを決定します。 |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getDisabled()](#getDisabled--) | 無効化された要素は、ショートカットメニューにコマンド名が表示されるかどうかを決定します。 |
+| [getFlyoutChild()](#getFlyoutChild--) | アクション行が、上方の最後の行でフライアウト子ではない行の子フライアウトメニューであるかどうかを決定します。 |
+| [getID()](#getID--) | 要素の親要素内における一意の ID。 |
+| [getIX()](#getIX--) | 親要素内の要素のゼロベースインデックスです。 |
+| [getInvisible()](#getInvisible--) | 不可視要素は、スマートタグまたはショートカットメニュー上でアクションが表示されるかどうかを示します。 |
+| [getMenu()](#getMenu--) | シェイプまたはページのショートカットメニューに表示されるコマンド名を指定します。 |
+| [getName()](#getName--) | 要素の名前。 |
+| [getNameU()](#getNameU--) | 要素のユニバーサル名。 |
+| [getReadOnly()](#getReadOnly--) | スマートタグまたはショートカットメニュー上のアクションが読み取り専用かどうかを決定します。 |
+| [getSortKey()](#getSortKey--) | ショートカットまたはスマートタグメニューに表示されるアクションの順序を決定する番号を指定します。 |
+| [getTagName()](#getTagName--) | このアクションに関連付けられたスマートタグの名前が含まれています。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | このプロパティの説明については、[getDel()](../../com.aspose.diagram/act\#getDel--) を参照してください。 |
+| [setID(int value)](#setID-int-) | このプロパティの説明については、[getID()](../../com.aspose.diagram/act\#getID--) を参照してください。 |
+| [setIX(int value)](#setIX-int-) | このプロパティの説明については、[getIX()](../../com.aspose.diagram/act\#getIX--) を参照してください。 |
+| [setName(String value)](#setName-java.lang.String-) | このプロパティの説明については、[getName()](../../com.aspose.diagram/act\#getName--) を参照してください。 |
+| [setNameU(String value)](#setNameU-java.lang.String-) | このプロパティの説明については、[getNameU()](../../com.aspose.diagram/act\#getNameU--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Act() {#Act--}
+```
+public Act()
+```
+
+
+コンストラクタ。
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAction() {#getAction--}
+```
+public DoubleValue getAction()
+```
+
+
+対応する Menu 要素で定義されたコマンド名がユーザーによってクリックされたときに実行される数式を含みます。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBeginGroup() {#getBeginGroup--}
+```
+public BoolValue getBeginGroup()
+```
+
+
+このアクションの上のメニューに区切り線が挿入されるかどうかを示します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getButtonFace() {#getButtonFace--}
+```
+public Str2Value getButtonFace()
+```
+
+
+ショートカットメニューの項目の横に表示されるアイコンを識別します。
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getChecked() {#getChecked--}
+```
+public BoolValue getChecked()
+```
+
+
+シェイプのショートカットメニューでコマンド名の横にチェックマークが表示されるかどうかを決定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getDisabled() {#getDisabled--}
+```
+public BoolValue getDisabled()
+```
+
+
+無効化された要素は、ショートカットメニューにコマンド名が表示されるかどうかを決定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getFlyoutChild() {#getFlyoutChild--}
+```
+public BoolValue getFlyoutChild()
+```
+
+
+アクション行が、上方の最後の行でフライアウト子ではない行の子フライアウトメニューであるかどうかを決定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+要素の親要素内における一意の ID。
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+親要素内の要素のゼロベースインデックスです。
+
+**Returns:**
+int
+### getInvisible() {#getInvisible--}
+```
+public BoolValue getInvisible()
+```
+
+
+不可視要素は、スマートタグまたはショートカットメニュー上でアクションが表示されるかどうかを示します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getMenu() {#getMenu--}
+```
+public Str2Value getMenu()
+```
+
+
+シェイプまたはページのショートカットメニューに表示されるコマンド名を指定します。
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素の名前。
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+要素のユニバーサル名。
+
+**Returns:**
+java.lang.String
+### getReadOnly() {#getReadOnly--}
+```
+public BoolValue getReadOnly()
+```
+
+
+スマートタグまたはショートカットメニュー上のアクションが読み取り専用かどうかを決定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getSortKey() {#getSortKey--}
+```
+public Str2Value getSortKey()
+```
+
+
+ショートカットまたはスマートタグメニューに表示されるアクションの順序を決定する番号を指定します。
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getTagName() {#getTagName--}
+```
+public Str2Value getTagName()
+```
+
+
+このアクションに関連付けられたスマートタグの名前が含まれています。
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+このプロパティの説明については、[getDel()](../../com.aspose.diagram/act\#getDel--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+このプロパティの説明については、[getID()](../../com.aspose.diagram/act\#getID--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+このプロパティの説明については、[getIX()](../../com.aspose.diagram/act\#getIX--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+このプロパティの説明については、[getName()](../../com.aspose.diagram/act\#getName--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+このプロパティの説明については、[getNameU()](../../com.aspose.diagram/act\#getNameU--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/actcollection/_index.md
+++ b/japanese/java/com.aspose.diagram/actcollection/_index.md
@@ -1,0 +1,234 @@
+---
+title: ActCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: Act コレクション。
+type: docs
+weight: 12
+url: /ja/java/com.aspose.diagram/actcollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ActCollection extends Collection
+```
+
+Act コレクション。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(Act item)](#add-com.aspose.diagram.Act-) | コレクションに Act オブジェクトを追加します。 |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getAct(int ID)](#getAct-int-) | 指定された ID の要素を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Act item)](#remove-com.aspose.diagram.Act-) | コレクションから Act オブジェクトを削除します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Act item) {#add-com.aspose.diagram.Act-}
+```
+public int add(Act item)
+```
+
+
+コレクションに Act オブジェクトを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [Act](../../com.aspose.diagram/act) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Act get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[Act](../../com.aspose.diagram/act) - 
+### getAct(int ID) {#getAct-int-}
+```
+public Act getAct(int ID)
+```
+
+
+指定された ID の要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ID | int |  |
+
+**Returns:**
+[Act](../../com.aspose.diagram/act) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Act item) {#remove-com.aspose.diagram.Act-}
+```
+public void remove(Act item)
+```
+
+
+コレクションから Act オブジェクトを削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [Act](../../com.aspose.diagram/act) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/activexcontrol/_index.md
+++ b/japanese/java/com.aspose.diagram/activexcontrol/_index.md
@@ -1,0 +1,422 @@
+---
+title: ActiveXControl
+second_title: Aspose.Diagram for Java API リファレンス
+description: ActiveX コントロールを表します。
+type: docs
+weight: 13
+url: /ja/java/com.aspose.diagram/activexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase)
+```
+public abstract class ActiveXControl extends ActiveXControlBase
+```
+
+ActiveX コントロールを表します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBackOleColor()](#getBackOleColor--) | 背景の OLE カラー。 |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | コントロールのバイナリ データ。 |
+| [getForeOleColor()](#getForeOleColor--) | 前景の OLE カラー。 |
+| [getHeight()](#getHeight--) | ポイント単位のコントロールの高さ。 |
+| [getIMEMode()](#getIMEMode--) | コントロールがフォーカスを受け取る際の Input Method Editor のデフォルト実行時モード。 |
+| [getMouseIcon()](#getMouseIcon--) | コントロールのマウスポインタとして表示するカスタムアイコンです。 |
+| [getMousePointer()](#getMousePointer--) | コントロールのマウスポインタとして表示されるアイコンの種類です。 |
+| [getType()](#getType--) | ActiveX コントロールのタイプを取得します。 |
+| [getWidth()](#getWidth--) | ポイント単位のコントロールの幅です。 |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | コントロールが全内容を表示するために自動的にサイズ変更されるかどうかを示します。 |
+| [isEnabled()](#isEnabled--) | コントロールがフォーカスを受け取り、ユーザー生成イベントに応答できるかどうかを示します。 |
+| [isLocked()](#isLocked--) | コントロール内のデータが編集ロックされているかどうかを示します。 |
+| [isTransparent()](#isTransparent--) | コントロールが透明かどうかを示します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | このプロパティの説明については、[isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) を参照してください |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | このプロパティの説明については、[getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) を参照してください |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | このプロパティの説明については、[isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) を参照してください |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | このプロパティの説明については、[getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) を参照してください |
+| [setHeight(double value)](#setHeight-double-) | このプロパティの説明については、[getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) を参照してください |
+| [setIMEMode(int value)](#setIMEMode-int-) | このプロパティの説明については、[getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) を参照してください |
+| [setLocked(boolean value)](#setLocked-boolean-) | このプロパティの説明については、[isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) を参照してください |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | このプロパティの説明については、[getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) を参照してください |
+| [setMousePointer(int value)](#setMousePointer-int-) | このプロパティの説明については、[getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) を参照してください |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | このプロパティの説明については、[isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) を参照してください |
+| [setWidth(double value)](#setWidth-double-) | このプロパティの説明については、[getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) を参照してください |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+背景の OLE カラー。
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+コントロールのバイナリ データ。
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+前景の OLE カラーです。Image コントロールには適用されません。
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+ポイント単位のコントロールの高さ。
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+コントロールがフォーカスを受け取る際の Input Method Editor のデフォルト実行時モード。
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+コントロールのマウスポインタとして表示するカスタムアイコンです。
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+コントロールのマウスポインタとして表示されるアイコンの種類です。
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public abstract int getType()
+```
+
+
+ActiveX コントロールのタイプを取得します。
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+ポイント単位のコントロールの幅です。
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+コントロールが全内容を表示するために自動的にサイズ変更されるかどうかを示します。
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+コントロールがフォーカスを受け取り、ユーザー生成イベントに応答できるかどうかを示します。
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+コントロール内のデータが編集ロックされているかどうかを示します。
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+コントロールが透明かどうかを示します。
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+このプロパティの説明については、[isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+このプロパティの説明については、[getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+このプロパティの説明については、[isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+このプロパティの説明については、[getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+このプロパティの説明については、[getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+このプロパティの説明については、[getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+このプロパティの説明については、[isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+このプロパティの説明については、[getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+このプロパティの説明については、[getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+このプロパティの説明については、[isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+このプロパティの説明については、[getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/activexcontrolbase/_index.md
+++ b/japanese/java/com.aspose.diagram/activexcontrolbase/_index.md
@@ -1,0 +1,297 @@
+---
+title: ActiveXControlBase
+second_title: Aspose.Diagram for Java API リファレンス
+description: ActiveX コントロールを表します。
+type: docs
+weight: 14
+url: /ja/java/com.aspose.diagram/activexcontrolbase/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public abstract class ActiveXControlBase
+```
+
+ActiveX コントロールを表します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBackOleColor()](#getBackOleColor--) | 背景の OLE カラー。 |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | コントロールのバイナリ データ。 |
+| [getForeOleColor()](#getForeOleColor--) | 前景の OLE カラー。 |
+| [getHeight()](#getHeight--) | ポイント単位のコントロールの高さ。 |
+| [getMouseIcon()](#getMouseIcon--) | コントロールのマウスポインタとして表示するカスタムアイコンです。 |
+| [getMousePointer()](#getMousePointer--) | コントロールのマウスポインタとして表示されるアイコンの種類です。 |
+| [getType()](#getType--) | ActiveX コントロールのタイプを取得します。 |
+| [getWidth()](#getWidth--) | ポイント単位のコントロールの幅です。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | このプロパティの説明については、[getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) を参照してください |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | このプロパティの説明については、[getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) を参照してください |
+| [setHeight(double value)](#setHeight-double-) | このプロパティの説明については、[getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) を参照してください |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | このプロパティの説明については、[getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) を参照してください |
+| [setMousePointer(int value)](#setMousePointer-int-) | このプロパティの説明については、[getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) を参照してください |
+| [setWidth(double value)](#setWidth-double-) | このプロパティの説明については、[getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) を参照してください |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+背景の OLE カラー。
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+コントロールのバイナリ データ。
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+前景の OLE カラーです。Image コントロールには適用されません。
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+ポイント単位のコントロールの高さ。
+
+**Returns:**
+double
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+コントロールのマウスポインタとして表示するカスタムアイコンです。
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+コントロールのマウスポインタとして表示されるアイコンの種類です。
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public abstract int getType()
+```
+
+
+ActiveX コントロールのタイプを取得します。
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+ポイント単位のコントロールの幅です。
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+このプロパティの説明については、[getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+このプロパティの説明については、[getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+このプロパティの説明については、[getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+このプロパティの説明については、[getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+このプロパティの説明については、[getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+このプロパティの説明については、[getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/activexpersistencetype/_index.md
+++ b/japanese/java/com.aspose.diagram/activexpersistencetype/_index.md
@@ -1,0 +1,165 @@
+---
+title: ActiveXPersistenceType
+second_title: Aspose.Diagram for Java API リファレンス
+description: ActiveX コントロールを永続化するための永続化方法を表します。
+type: docs
+weight: 15
+url: /ja/java/com.aspose.diagram/activexpersistencetype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ActiveXPersistenceType
+```
+
+ActiveX コントロールを永続化するための永続化方法を表します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [PROPERTY_BAG](#PROPERTY-BAG) | データは XML データとして保存されます。 |
+| [STORAGE](#STORAGE) | データはストレージバイナリデータとして保存されます。 |
+| [STREAM](#STREAM) | データはストリームバイナリデータとして保存されます。 |
+| [STREAM_INIT](#STREAM-INIT) | データは streaminit バイナリデータとして保存されます。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PROPERTY_BAG {#PROPERTY-BAG}
+```
+public static final int PROPERTY_BAG
+```
+
+
+データは XML データとして保存されます。
+
+### STORAGE {#STORAGE}
+```
+public static final int STORAGE
+```
+
+
+データはストレージバイナリデータとして保存されます。
+
+### STREAM {#STREAM}
+```
+public static final int STREAM
+```
+
+
+データはストリームバイナリデータとして保存されます。
+
+### STREAM_INIT {#STREAM-INIT}
+```
+public static final int STREAM_INIT
+```
+
+
+データは streaminit バイナリデータとして保存されます。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/align/_index.md
+++ b/japanese/java/com.aspose.diagram/align/_index.md
@@ -1,0 +1,227 @@
+---
+title: Align
+second_title: Aspose.Diagram for Java API リファレンス
+description: シェイプが貼り付けられているガイドまたはガイドポイントに対するシェイプの配置を示します。
+type: docs
+weight: 16
+url: /ja/java/com.aspose.diagram/align/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Align
+```
+
+形状が接着されているガイドまたはガイドポイントに対する形状の配置を示します。Align 要素は、ガイドまたはガイドポイントに接着された形状に対してのみ表示されます。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAlignBottom()](#getAlignBottom--) | 親の原点に対する相対位置として、形状の下端が合わせられる水平ガイドまたはガイドポイントの垂直位置を決定します。 |
+| [getAlignCenter()](#getAlignCenter--) | 親の原点に対する相対位置として、形状の水平中心が合わせられる垂直ガイドまたはガイドポイントの水平位置を決定します。 |
+| [getAlignLeft()](#getAlignLeft--) | 親の原点に対する相対位置として、形状の左端が合わせられる垂直ガイドまたはガイドポイントの水平位置を決定します。 |
+| [getAlignMiddle()](#getAlignMiddle--) | 親の原点に対して相対的な、シェイプの垂直中心が合わせられる水平ガイドまたはガイドポイントの垂直位置を決定します。 |
+| [getAlignRight()](#getAlignRight--) | 親の原点に対して相対的な、シェイプの右端が合わせられる垂直ガイドまたはガイドポイントの水平位置を決定します。 |
+| [getAlignTop()](#getAlignTop--) | 親の原点に対して相対的な、シェイプの上端が合わせられる水平ガイドまたはガイドポイントの垂直位置を決定します。 |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | このプロパティの説明については、[getDel()](../../com.aspose.diagram/align\#getDel--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAlignBottom() {#getAlignBottom--}
+```
+public DoubleValue getAlignBottom()
+```
+
+
+親の原点に対する相対位置として、形状の下端が合わせられる水平ガイドまたはガイドポイントの垂直位置を決定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getAlignCenter() {#getAlignCenter--}
+```
+public DoubleValue getAlignCenter()
+```
+
+
+親の原点に対する相対位置として、形状の水平中心が合わせられる垂直ガイドまたはガイドポイントの水平位置を決定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getAlignLeft() {#getAlignLeft--}
+```
+public DoubleValue getAlignLeft()
+```
+
+
+親の原点に対する相対位置として、形状の左端が合わせられる垂直ガイドまたはガイドポイントの水平位置を決定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getAlignMiddle() {#getAlignMiddle--}
+```
+public DoubleValue getAlignMiddle()
+```
+
+
+親の原点に対して相対的な、シェイプの垂直中心が合わせられる水平ガイドまたはガイドポイントの垂直位置を決定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getAlignRight() {#getAlignRight--}
+```
+public DoubleValue getAlignRight()
+```
+
+
+親の原点に対して相対的な、シェイプの右端が合わせられる垂直ガイドまたはガイドポイントの水平位置を決定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getAlignTop() {#getAlignTop--}
+```
+public DoubleValue getAlignTop()
+```
+
+
+親の原点に対して相対的な、シェイプの上端が合わせられる水平ガイドまたはガイドポイントの垂直位置を決定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+このプロパティの説明については、[getDel()](../../com.aspose.diagram/align\#getDel--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/alignment/_index.md
+++ b/japanese/java/com.aspose.diagram/alignment/_index.md
@@ -1,0 +1,179 @@
+---
+title: Alignment
+second_title: Aspose.Diagram for Java API リファレンス
+description: タブの配置を指定します。
+type: docs
+weight: 18
+url: /ja/java/com.aspose.diagram/alignment/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Alignment
+```
+
+タブの配置を指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Alignment(int value)](#Alignment-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | タブの配置を指定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/alignment\#getValue--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Alignment(int value) {#Alignment-int-}
+```
+public Alignment(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+タブの配置を指定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/alignment\#getValue--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/alignmentvalue/_index.md
+++ b/japanese/java/com.aspose.diagram/alignmentvalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: AlignmentValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: タブの配置を指定します。
+type: docs
+weight: 19
+url: /ja/java/com.aspose.diagram/alignmentvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class AlignmentValue
+```
+
+タブの配置を指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [CENTER](#CENTER) | 中央。 |
+| [DECIMAL](#DECIMAL) | 小数。 |
+| [LEFT](#LEFT) | 左。 |
+| [RIGHT](#RIGHT) | 右。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CENTER {#CENTER}
+```
+public static final int CENTER
+```
+
+
+中央。
+
+### DECIMAL {#DECIMAL}
+```
+public static final int DECIMAL
+```
+
+
+小数。
+
+### LEFT {#LEFT}
+```
+public static final int LEFT
+```
+
+
+左。
+
+### RIGHT {#RIGHT}
+```
+public static final int RIGHT
+```
+
+
+右。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/alignnamevalue/_index.md
+++ b/japanese/java/com.aspose.diagram/alignnamevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: AlignNameValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: オプションの int。
+type: docs
+weight: 17
+url: /ja/java/com.aspose.diagram/alignnamevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class AlignNameValue
+```
+
+オプションの int。ステンシル ウィンドウ内のマスター テキストが左、右、または中央に揃えてあるかを指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [ALIGN_TEXT_CENTER](#ALIGN-TEXT-CENTER) | テキストを中央揃えにします。 |
+| [ALIGN_TEXT_LEFT](#ALIGN-TEXT-LEFT) | テキストを左揃えにします。 |
+| [ALIGN_TEXT_RIGHT](#ALIGN-TEXT-RIGHT) | テキストを右揃えにします。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALIGN_TEXT_CENTER {#ALIGN-TEXT-CENTER}
+```
+public static final int ALIGN_TEXT_CENTER
+```
+
+
+テキストを中央揃えにします。
+
+### ALIGN_TEXT_LEFT {#ALIGN-TEXT-LEFT}
+```
+public static final int ALIGN_TEXT_LEFT
+```
+
+
+テキストを左揃えにします。
+
+### ALIGN_TEXT_RIGHT {#ALIGN-TEXT-RIGHT}
+```
+public static final int ALIGN_TEXT_RIGHT
+```
+
+
+テキストを右揃えにします。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/annotation/_index.md
+++ b/japanese/java/com.aspose.diagram/annotation/_index.md
@@ -1,0 +1,288 @@
+---
+title: アノテーション
+second_title: Aspose.Diagram for Java API リファレンス
+description: ドキュメントページに挿入されたコメントに関する情報を含む要素が含まれています。
+type: docs
+weight: 20
+url: /ja/java/com.aspose.diagram/annotation/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Annotation
+```
+
+ドキュメントページに挿入されたコメントに関する情報を含む要素が含まれています。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getComment()](#getComment--) | シェイプのコメントテキストを文字列形式で含みます。 |
+| [getDate()](#getDate--) | コメントが作成された時期を指定します |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getEditDate()](#getEditDate--) | コメントが最後に変更された時期を指定します |
+| [getIX()](#getIX--) | 親要素内の要素のゼロベースインデックスです。 |
+| [getLangID()](#getLangID--) | セルの数式、テキスト、カスタムプロパティ、またはコメントが入力された言語のロケール ID (LCID) を示します。 |
+| [getMarkerIndex()](#getMarkerIndex--) | コメントマーカーに割り当てられたインデックス番号を指定します。 |
+| [getReviewerID()](#getReviewerID--) | ドキュメントにマークアップを追加したレビュアーの ID 番号を含みます。 |
+| [getShapeID()](#getShapeID--) | コメントのシェイプ ID です。 |
+| [getX()](#getX--) | ページ座標系でのコメントマーカーの X 座標です。 |
+| [getY()](#getY--) | ページ座標系でのコメントマーカーの Y 座標です。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | このプロパティの説明については、[getDel()](../../com.aspose.diagram/annotation\#getDel--) を参照してください |
+| [setIX(int value)](#setIX-int-) | このプロパティの説明については、[getIX()](../../com.aspose.diagram/annotation\#getIX--) を参照してください |
+| [setShapeID(int value)](#setShapeID-int-) | このプロパティの説明については、[getShapeID()](../../com.aspose.diagram/annotation\#getShapeID--) を参照してください |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getComment() {#getComment--}
+```
+public Str2Value getComment()
+```
+
+
+シェイプのコメントテキストを文字列形式で含みます。
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getDate() {#getDate--}
+```
+public DateValue getDate()
+```
+
+
+コメントが作成された時期を指定します
+
+**Returns:**
+[DateValue](../../com.aspose.diagram/datevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getEditDate() {#getEditDate--}
+```
+public DateValue getEditDate()
+```
+
+
+コメントが最後に変更された時期を指定します
+
+**Returns:**
+[DateValue](../../com.aspose.diagram/datevalue)
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+親要素内の要素のゼロベースインデックスです。
+
+**Returns:**
+int
+### getLangID() {#getLangID--}
+```
+public IntValue getLangID()
+```
+
+
+セルの数式、テキスト、カスタムプロパティ、またはコメントが入力された言語のロケール ID (LCID) を示します。
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getMarkerIndex() {#getMarkerIndex--}
+```
+public IntValue getMarkerIndex()
+```
+
+
+コメントマーカーに割り当てられたインデックス番号を指定します。
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getReviewerID() {#getReviewerID--}
+```
+public IntValue getReviewerID()
+```
+
+
+ドキュメントにマークアップを追加したレビュアーの ID 番号を含みます。
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getShapeID() {#getShapeID--}
+```
+public int getShapeID()
+```
+
+
+コメントのシェイプ ID です。
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+ページ座標系でのコメントマーカーの X 座標です。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+ページ座標系でのコメントマーカーの Y 座標です。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+このプロパティの説明については、[getDel()](../../com.aspose.diagram/annotation\#getDel--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+このプロパティの説明については、[getIX()](../../com.aspose.diagram/annotation\#getIX--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setShapeID(int value) {#setShapeID-int-}
+```
+public void setShapeID(int value)
+```
+
+
+このプロパティの説明については、[getShapeID()](../../com.aspose.diagram/annotation\#getShapeID--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/annotationcollection/_index.md
+++ b/japanese/java/com.aspose.diagram/annotationcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: AnnotationCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: Annotation コレクション。
+type: docs
+weight: 21
+url: /ja/java/com.aspose.diagram/annotationcollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class AnnotationCollection extends Collection
+```
+
+Annotation コレクション。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(Annotation item)](#add-com.aspose.diagram.Annotation-) | コレクションに Annotation オブジェクトを追加します。 |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Annotation item)](#remove-com.aspose.diagram.Annotation-) | コレクションから Annotation オブジェクトを削除します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Annotation item) {#add-com.aspose.diagram.Annotation-}
+```
+public int add(Annotation item)
+```
+
+
+コレクションに Annotation オブジェクトを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [Annotation](../../com.aspose.diagram/annotation) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Annotation get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[Annotation](../../com.aspose.diagram/annotation) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Annotation item) {#remove-com.aspose.diagram.Annotation-}
+```
+public void remove(Annotation item)
+```
+
+
+コレクションから Annotation オブジェクトを削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [Annotation](../../com.aspose.diagram/annotation) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/arcto/_index.md
+++ b/japanese/java/com.aspose.diagram/arcto/_index.md
@@ -1,0 +1,274 @@
+---
+title: ArcTo
+second_title: Aspose.Diagram for Java API リファレンス
+description: 円弧の x 座標と y 座標、および弓（bow）をそれぞれ X、Y、A 要素で表したものを含みます。
+type: docs
+weight: 22
+url: /ja/java/com.aspose.diagram/arcto/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class ArcTo extends Coordinate
+```
+
+円弧の X、Y、A 要素でそれぞれ表される x 座標、y 座標、そして弧度を含みます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [ArcTo()](#ArcTo--) | [ArcTo](../../com.aspose.diagram/arcto) クラスのインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | 円弧の中点から弦の中点までの距離です。 |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getIX()](#getIX--) | 親要素内の要素のゼロベースインデックスです。 |
+| [getX()](#getX--) | 円弧の終点の x 座標です。 |
+| [getY()](#getY--) | 円弧の終点の y 座標です。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getA()](../../com.aspose.diagram/arcto\#getA--) を参照してください。 |
+| [setDel(int value)](#setDel-int-) | このプロパティの説明については、[getDel()](../../com.aspose.diagram/arcto\#getDel--) を参照してください。 |
+| [setIX(int value)](#setIX-int-) | このプロパティの説明については、[getIX()](../../com.aspose.diagram/arcto\#getIX--) を参照してください。 |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getX()](../../com.aspose.diagram/arcto\#getX--) を参照してください。 |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getY()](../../com.aspose.diagram/arcto\#getY--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ArcTo() {#ArcTo--}
+```
+public ArcTo()
+```
+
+
+[ArcTo](../../com.aspose.diagram/arcto) クラスのインスタンスを作成します。
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+円弧の中点から弦の中点までの距離です。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+親要素内の要素のゼロベースインデックスです。
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+円弧の終点の x 座標です。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+円弧の終点の y 座標です。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getA()](../../com.aspose.diagram/arcto\#getA--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+このプロパティの説明については、[getDel()](../../com.aspose.diagram/arcto\#getDel--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+このプロパティの説明については、[getIX()](../../com.aspose.diagram/arcto\#getIX--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getX()](../../com.aspose.diagram/arcto\#getX--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getY()](../../com.aspose.diagram/arcto\#getY--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/arctocollection/_index.md
+++ b/japanese/java/com.aspose.diagram/arctocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: ArcToCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: ArcTo コレクション。
+type: docs
+weight: 23
+url: /ja/java/com.aspose.diagram/arctocollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ArcToCollection extends Collection
+```
+
+ArcTo コレクション。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public ArcTo get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[ArcTo](../../com.aspose.diagram/arcto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/arrowsize/_index.md
+++ b/japanese/java/com.aspose.diagram/arrowsize/_index.md
@@ -1,0 +1,204 @@
+---
+title: ArrowSize
+second_title: Aspose.Diagram for Java API リファレンス
+description: 線の矢じりのサイズを指定します。
+type: docs
+weight: 24
+url: /ja/java/com.aspose.diagram/arrowsize/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ArrowSize
+```
+
+線の矢じりのサイズを指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [ArrowSize(int value)](#ArrowSize-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | 線の矢じりのサイズを指定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [isThemed()](#isThemed--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setThemed(boolean value)](#setThemed-boolean-) | このプロパティの説明については、[isThemed()](../../com.aspose.diagram/arrowsize\#isThemed--)をご覧ください |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/arrowsize\#getValue--)をご覧ください |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ArrowSize(int value) {#ArrowSize-int-}
+```
+public ArrowSize(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+線の矢じりのサイズを指定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### isThemed() {#isThemed--}
+```
+public boolean isThemed()
+```
+
+
+
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setThemed(boolean value) {#setThemed-boolean-}
+```
+public void setThemed(boolean value)
+```
+
+
+このプロパティの説明については、[isThemed()](../../com.aspose.diagram/arrowsize\#isThemed--)をご覧ください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/arrowsize\#getValue--)をご覧ください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/arrowsizevalue/_index.md
+++ b/japanese/java/com.aspose.diagram/arrowsizevalue/_index.md
@@ -1,0 +1,201 @@
+---
+title: ArrowSizeValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: 線の矢じりのサイズを指定します。
+type: docs
+weight: 25
+url: /ja/java/com.aspose.diagram/arrowsizevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ArrowSizeValue
+```
+
+線の矢じりのサイズを指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [COLOSSAL](#COLOSSAL) | 巨大。 |
+| [EXTRA_LARGE](#EXTRA-LARGE) | 特大。 |
+| [JUMBO](#JUMBO) | ジャンボ。 |
+| [LARGE](#LARGE) | 大きい。 |
+| [MEDIUM](#MEDIUM) | 中程度。 |
+| [SMALL](#SMALL) | 小さい。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+| [VERY_SMALL](#VERY-SMALL) | とても小さい。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### COLOSSAL {#COLOSSAL}
+```
+public static final int COLOSSAL
+```
+
+
+巨大。
+
+### EXTRA_LARGE {#EXTRA-LARGE}
+```
+public static final int EXTRA_LARGE
+```
+
+
+特大。
+
+### JUMBO {#JUMBO}
+```
+public static final int JUMBO
+```
+
+
+ジャンボ。
+
+### LARGE {#LARGE}
+```
+public static final int LARGE
+```
+
+
+大きい。
+
+### MEDIUM {#MEDIUM}
+```
+public static final int MEDIUM
+```
+
+
+中程度。
+
+### SMALL {#SMALL}
+```
+public static final int SMALL
+```
+
+
+小さい。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### VERY_SMALL {#VERY-SMALL}
+```
+public static final int VERY_SMALL
+```
+
+
+とても小さい。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/asposediagramprintdocument/_index.md
+++ b/japanese/java/com.aspose.diagram/asposediagramprintdocument/_index.md
@@ -1,0 +1,143 @@
+---
+title: AsposeDiagramPrintDocument
+second_title: Aspose.Diagram for Java API リファレンス
+description: .NET の PrintDocument クラスの独自バージョンで、PrintPreviewDialog フォームに渡して図面を印刷およびプレビューできます。
+type: docs
+weight: 26
+url: /ja/java/com.aspose.diagram/asposediagramprintdocument/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class AsposeDiagramPrintDocument
+```
+
+.NET PrintDocument クラスの独自バージョンで、PrintPreviewDialog フォームに渡して図面の印刷とプレビューができます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [AsposeDiagramPrintDocument(Diagram diagram)](#AsposeDiagramPrintDocument-com.aspose.diagram.Diagram-) | このクラスの新しいインスタンスを初期化し、PrintPreviewDialog フォームに渡して図面を印刷およびプレビューできます。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AsposeDiagramPrintDocument(Diagram diagram) {#AsposeDiagramPrintDocument-com.aspose.diagram.Diagram-}
+```
+public AsposeDiagramPrintDocument(Diagram diagram)
+```
+
+
+このクラスの新しいインスタンスを初期化し、PrintPreviewDialog フォームに渡して図面を印刷およびプレビューできます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| diagram | [Diagram](../../com.aspose.diagram/diagram) |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/autolinkcomparison/_index.md
+++ b/japanese/java/com.aspose.diagram/autolinkcomparison/_index.md
@@ -1,0 +1,200 @@
+---
+title: AutoLinkComparison
+second_title: Aspose.Diagram for Java API リファレンス
+description: 親 DataRecordset 要素の列と、ユーザーインターフェイスで最後に成功した自動リンク操作から取得されたシェイプ データ項目を比較するルールを定義します。
+type: docs
+weight: 27
+url: /ja/java/com.aspose.diagram/autolinkcomparison/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class AutoLinkComparison
+```
+
+親 DataRecordset 要素の列と、ユーザーインターフェイスで最後に成功した自動リンク操作から取得されたシェイプ データ項目を比較するルールを定義します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getColumnName()](#getColumnName--) | ADO レコードセットの列名に対応します。 |
+| [getContextType()](#getContextType--) | 比較に使用するグループまたはシェイプのプロパティを指定します。 |
+| [getContextTypeLabel()](#getContextTypeLabel--) | ContextType の値が 2 または 3 の場合、この属性は比較を定義するために必須です。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setColumnName(String value)](#setColumnName-java.lang.String-) | このプロパティの説明については、[getColumnName()](../../com.aspose.diagram/autolinkcomparison\#getColumnName--) を参照してください。 |
+| [setContextType(int value)](#setContextType-int-) | このプロパティの説明については、[getContextType()](../../com.aspose.diagram/autolinkcomparison\#getContextType--) を参照してください。 |
+| [setContextTypeLabel(String value)](#setContextTypeLabel-java.lang.String-) | このプロパティの説明については、[getContextTypeLabel()](../../com.aspose.diagram/autolinkcomparison\#getContextTypeLabel--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColumnName() {#getColumnName--}
+```
+public String getColumnName()
+```
+
+
+ADO レコードセットの列名に対応します。
+
+**Returns:**
+java.lang.String
+### getContextType() {#getContextType--}
+```
+public int getContextType()
+```
+
+
+比較に使用するグループまたはシェイプのプロパティを指定します。可能な値は以下の表に示されています。
+
+**Returns:**
+int
+### getContextTypeLabel() {#getContextTypeLabel--}
+```
+public String getContextTypeLabel()
+```
+
+
+ContextType の値が 2 または 3 の場合、この属性は比較を定義するために必須です。ContextType = 2 の場合、ContextTypeLabel はシェイプ データ アイテムのラベルでなければならず、ContextType = 3 の場合、ContextTypeLabel はローカル行名でなければなりません。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setColumnName(String value) {#setColumnName-java.lang.String-}
+```
+public void setColumnName(String value)
+```
+
+
+このプロパティの説明については、[getColumnName()](../../com.aspose.diagram/autolinkcomparison\#getColumnName--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setContextType(int value) {#setContextType-int-}
+```
+public void setContextType(int value)
+```
+
+
+このプロパティの説明については、[getContextType()](../../com.aspose.diagram/autolinkcomparison\#getContextType--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setContextTypeLabel(String value) {#setContextTypeLabel-java.lang.String-}
+```
+public void setContextTypeLabel(String value)
+```
+
+
+このプロパティの説明については、[getContextTypeLabel()](../../com.aspose.diagram/autolinkcomparison\#getContextTypeLabel--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/autospaceoptions/_index.md
+++ b/japanese/java/com.aspose.diagram/autospaceoptions/_index.md
@@ -1,0 +1,186 @@
+---
+title: AutoSpaceOptions
+second_title: Aspose.Diagram for Java API リファレンス
+description: 自動スペースオプションを表します。
+type: docs
+weight: 28
+url: /ja/java/com.aspose.diagram/autospaceoptions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class AutoSpaceOptions
+```
+
+自動スペースオプションを表します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [AutoSpaceOptions()](#AutoSpaceOptions--) |  |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDistanceInHorizontal()](#getDistanceInHorizontal--) | 形状間の水平方向の距離（インチ）を定義します。 |
+| [getDistanceInVertical()](#getDistanceInVertical--) | 形状間の垂直方向の距離（インチ）を定義します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDistanceInHorizontal(double value)](#setDistanceInHorizontal-double-) | このプロパティの説明については、[getDistanceInHorizontal()](../../com.aspose.diagram/autospaceoptions\#getDistanceInHorizontal--) を参照してください。 |
+| [setDistanceInVertical(double value)](#setDistanceInVertical-double-) | このプロパティの説明については、[getDistanceInVertical()](../../com.aspose.diagram/autospaceoptions\#getDistanceInVertical--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AutoSpaceOptions() {#AutoSpaceOptions--}
+```
+public AutoSpaceOptions()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDistanceInHorizontal() {#getDistanceInHorizontal--}
+```
+public double getDistanceInHorizontal()
+```
+
+
+形状間の水平方向の距離（インチ）を定義します。デフォルト値は 0.375 インチです。
+
+**Returns:**
+double
+### getDistanceInVertical() {#getDistanceInVertical--}
+```
+public double getDistanceInVertical()
+```
+
+
+形状間の垂直方向の距離（インチ）を定義します。デフォルト値は 0.375 インチです。
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDistanceInHorizontal(double value) {#setDistanceInHorizontal-double-}
+```
+public void setDistanceInHorizontal(double value)
+```
+
+
+このプロパティの説明については、[getDistanceInHorizontal()](../../com.aspose.diagram/autospaceoptions\#getDistanceInHorizontal--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double |  |
+
+### setDistanceInVertical(double value) {#setDistanceInVertical-double-}
+```
+public void setDistanceInVertical(double value)
+```
+
+
+このプロパティの説明については、[getDistanceInVertical()](../../com.aspose.diagram/autospaceoptions\#getDistanceInVertical--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/bevel/_index.md
+++ b/japanese/java/com.aspose.diagram/bevel/_index.md
@@ -1,0 +1,175 @@
+---
+title: Bevel
+second_title: Aspose.Diagram for Java API リファレンス
+description: シェイプのベベルを表します。
+type: docs
+weight: 30
+url: /ja/java/com.aspose.diagram/bevel/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Bevel
+```
+
+シェイプのベベルを表します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getHeight()](#getHeight--) | ベベルの高さ、またはシェイプの上方にどれだけ適用されるかです。 |
+| [getWidth()](#getWidth--) | ベベルの幅、またはシェイプの内部にどれだけ適用されるかです。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setHeight(DoubleValue value)](#setHeight-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getHeight()](../../com.aspose.diagram/bevel\#getHeight--) を参照してください。 |
+| [setWidth(DoubleValue value)](#setWidth-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getWidth()](../../com.aspose.diagram/bevel\#getWidth--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getHeight() {#getHeight--}
+```
+public DoubleValue getHeight()
+```
+
+
+ベベルの高さ、またはシェイプの上方にどれだけ適用されるかです。単位はポイントです。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getWidth() {#getWidth--}
+```
+public DoubleValue getWidth()
+```
+
+
+ベベルの幅、またはシェイプの内部にどれだけ適用されるかです。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setHeight(DoubleValue value) {#setHeight-com.aspose.diagram.DoubleValue-}
+```
+public void setHeight(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getHeight()](../../com.aspose.diagram/bevel\#getHeight--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setWidth(DoubleValue value) {#setWidth-com.aspose.diagram.DoubleValue-}
+```
+public void setWidth(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getWidth()](../../com.aspose.diagram/bevel\#getWidth--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/bevellightingtype/_index.md
+++ b/japanese/java/com.aspose.diagram/bevellightingtype/_index.md
@@ -1,0 +1,179 @@
+---
+title: BevelLightingType
+second_title: Aspose.Diagram for Java API リファレンス
+description: シェイプの影のタイプを指定します。
+type: docs
+weight: 31
+url: /ja/java/com.aspose.diagram/bevellightingtype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class BevelLightingType
+```
+
+シェイプの影のタイプを指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [BevelLightingType(int value)](#BevelLightingType-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | ベベルのタイプを指定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/bevellightingtype\#getValue--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BevelLightingType(int value) {#BevelLightingType-int-}
+```
+public BevelLightingType(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+ベベルのタイプを指定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/bevellightingtype\#getValue--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/bevellightingtypevalue/_index.md
+++ b/japanese/java/com.aspose.diagram/bevellightingtypevalue/_index.md
@@ -1,0 +1,381 @@
+---
+title: BevelLightingTypeValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: シェイプに適用できる右側のプリセットライトを表します。
+type: docs
+weight: 32
+url: /ja/java/com.aspose.diagram/bevellightingtypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class BevelLightingTypeValue
+```
+
+シェイプに適用できる右側のプリセットライトを表します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [BALANCED](#BALANCED) | Balanced |
+| [BRIGHT_ROOM](#BRIGHT-ROOM) | Bright room |
+| [CHILLY](#CHILLY) | Chilly |
+| [CONTRASTING](#CONTRASTING) | Contrasting |
+| [FLAT](#FLAT) | Flat |
+| [FLOOD](#FLOOD) | Flood |
+| [FREEZING](#FREEZING) | Freezing |
+| [GLOW](#GLOW) | Glow |
+| [HARSH](#HARSH) | Harsh |
+| [LEGACY_FLAT_1](#LEGACY-FLAT-1) | LegacyFlat1 |
+| [LEGACY_FLAT_2](#LEGACY-FLAT-2) | LegacyFlat2 |
+| [LEGACY_FLAT_3](#LEGACY-FLAT-3) | LegacyFlat3 |
+| [LEGACY_FLAT_4](#LEGACY-FLAT-4) | LegacyFlat4 |
+| [LEGACY_HARSH_1](#LEGACY-HARSH-1) | LegacyHarsh1 |
+| [LEGACY_HARSH_2](#LEGACY-HARSH-2) | LegacyHarsh2 |
+| [LEGACY_HARSH_3](#LEGACY-HARSH-3) | LegacyHarsh3 |
+| [LEGACY_HARSH_4](#LEGACY-HARSH-4) | LegacyHarsh4 |
+| [LEGACY_NORMAL_1](#LEGACY-NORMAL-1) | LegacyNormal1 |
+| [LEGACY_NORMAL_2](#LEGACY-NORMAL-2) | LegacyNormal2 |
+| [LEGACY_NORMAL_3](#LEGACY-NORMAL-3) | LegacyNormal3 |
+| [LEGACY_NORMAL_4](#LEGACY-NORMAL-4) | LegacyNormal4 |
+| [MORNING](#MORNING) | Morning |
+| [SOFT](#SOFT) | ソフト |
+| [SUNRISE](#SUNRISE) | 日の出 |
+| [SUNSET](#SUNSET) | 日の入り |
+| [THREE_POINT](#THREE-POINT) | 3点 |
+| [TWO_POINT](#TWO-POINT) | 2点 |
+| [UNDEFINED](#UNDEFINED) | ライトリグなし。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BALANCED {#BALANCED}
+```
+public static final int BALANCED
+```
+
+
+Balanced
+
+### BRIGHT_ROOM {#BRIGHT-ROOM}
+```
+public static final int BRIGHT_ROOM
+```
+
+
+Bright room
+
+### CHILLY {#CHILLY}
+```
+public static final int CHILLY
+```
+
+
+Chilly
+
+### CONTRASTING {#CONTRASTING}
+```
+public static final int CONTRASTING
+```
+
+
+Contrasting
+
+### FLAT {#FLAT}
+```
+public static final int FLAT
+```
+
+
+Flat
+
+### FLOOD {#FLOOD}
+```
+public static final int FLOOD
+```
+
+
+Flood
+
+### FREEZING {#FREEZING}
+```
+public static final int FREEZING
+```
+
+
+Freezing
+
+### GLOW {#GLOW}
+```
+public static final int GLOW
+```
+
+
+Glow
+
+### HARSH {#HARSH}
+```
+public static final int HARSH
+```
+
+
+Harsh
+
+### LEGACY_FLAT_1 {#LEGACY-FLAT-1}
+```
+public static final int LEGACY_FLAT_1
+```
+
+
+LegacyFlat1
+
+### LEGACY_FLAT_2 {#LEGACY-FLAT-2}
+```
+public static final int LEGACY_FLAT_2
+```
+
+
+LegacyFlat2
+
+### LEGACY_FLAT_3 {#LEGACY-FLAT-3}
+```
+public static final int LEGACY_FLAT_3
+```
+
+
+LegacyFlat3
+
+### LEGACY_FLAT_4 {#LEGACY-FLAT-4}
+```
+public static final int LEGACY_FLAT_4
+```
+
+
+LegacyFlat4
+
+### LEGACY_HARSH_1 {#LEGACY-HARSH-1}
+```
+public static final int LEGACY_HARSH_1
+```
+
+
+LegacyHarsh1
+
+### LEGACY_HARSH_2 {#LEGACY-HARSH-2}
+```
+public static final int LEGACY_HARSH_2
+```
+
+
+LegacyHarsh2
+
+### LEGACY_HARSH_3 {#LEGACY-HARSH-3}
+```
+public static final int LEGACY_HARSH_3
+```
+
+
+LegacyHarsh3
+
+### LEGACY_HARSH_4 {#LEGACY-HARSH-4}
+```
+public static final int LEGACY_HARSH_4
+```
+
+
+LegacyHarsh4
+
+### LEGACY_NORMAL_1 {#LEGACY-NORMAL-1}
+```
+public static final int LEGACY_NORMAL_1
+```
+
+
+LegacyNormal1
+
+### LEGACY_NORMAL_2 {#LEGACY-NORMAL-2}
+```
+public static final int LEGACY_NORMAL_2
+```
+
+
+LegacyNormal2
+
+### LEGACY_NORMAL_3 {#LEGACY-NORMAL-3}
+```
+public static final int LEGACY_NORMAL_3
+```
+
+
+LegacyNormal3
+
+### LEGACY_NORMAL_4 {#LEGACY-NORMAL-4}
+```
+public static final int LEGACY_NORMAL_4
+```
+
+
+LegacyNormal4
+
+### MORNING {#MORNING}
+```
+public static final int MORNING
+```
+
+
+Morning
+
+### SOFT {#SOFT}
+```
+public static final int SOFT
+```
+
+
+ソフト
+
+### SUNRISE {#SUNRISE}
+```
+public static final int SUNRISE
+```
+
+
+日の出
+
+### SUNSET {#SUNSET}
+```
+public static final int SUNSET
+```
+
+
+日の入り
+
+### THREE_POINT {#THREE-POINT}
+```
+public static final int THREE_POINT
+```
+
+
+3点
+
+### TWO_POINT {#TWO-POINT}
+```
+public static final int TWO_POINT
+```
+
+
+2点
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+ライトリグなし。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/bevelmaterialtype/_index.md
+++ b/japanese/java/com.aspose.diagram/bevelmaterialtype/_index.md
@@ -1,0 +1,179 @@
+---
+title: BevelMaterialType
+second_title: Aspose.Diagram for Java API リファレンス
+description: シェイプの影のタイプを指定します。
+type: docs
+weight: 33
+url: /ja/java/com.aspose.diagram/bevelmaterialtype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class BevelMaterialType
+```
+
+シェイプの影のタイプを指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [BevelMaterialType(int value)](#BevelMaterialType-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | ベベルのタイプを指定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/bevelmaterialtype\#getValue--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BevelMaterialType(int value) {#BevelMaterialType-int-}
+```
+public BevelMaterialType(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+ベベルのタイプを指定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/bevelmaterialtype\#getValue--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/bevelmaterialtypevalue/_index.md
+++ b/japanese/java/com.aspose.diagram/bevelmaterialtypevalue/_index.md
@@ -1,0 +1,271 @@
+---
+title: BevelMaterialTypeValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: シェイプの表面外観を記述します。
+type: docs
+weight: 34
+url: /ja/java/com.aspose.diagram/bevelmaterialtypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class BevelMaterialTypeValue
+```
+
+シェイプの表面外観を記述します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [CLEAR](#CLEAR) | クリア |
+| [DARK_EDGE](#DARK-EDGE) | 暗いエッジ |
+| [FLAT](#FLAT) | Flat |
+| [LEGACY_MATTE](#LEGACY-MATTE) | レガシー マット |
+| [LEGACY_METAL](#LEGACY-METAL) | レガシー メタル |
+| [LEGACY_PLASTIC](#LEGACY-PLASTIC) | レガシー プラスチック |
+| [LEGACY_WIREFRAME](#LEGACY-WIREFRAME) | レガシー ワイヤーフレーム |
+| [MATTE](#MATTE) | マット |
+| [METAL](#METAL) | メタル |
+| [PLASTIC](#PLASTIC) | プラスチック |
+| [POWDER](#POWDER) | Powder |
+| [SOFT_EDGE](#SOFT-EDGE) | Soft edge |
+| [SOFT_METAL](#SOFT-METAL) | Soft metal |
+| [TRANSLUCENT_POWDER](#TRANSLUCENT-POWDER) | Translucent powder |
+| [UNDEFINED](#UNDEFINED) |  |
+| [WARM_MATTE](#WARM-MATTE) | Warm matte |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CLEAR {#CLEAR}
+```
+public static final int CLEAR
+```
+
+
+クリア
+
+### DARK_EDGE {#DARK-EDGE}
+```
+public static final int DARK_EDGE
+```
+
+
+暗いエッジ
+
+### FLAT {#FLAT}
+```
+public static final int FLAT
+```
+
+
+Flat
+
+### LEGACY_MATTE {#LEGACY-MATTE}
+```
+public static final int LEGACY_MATTE
+```
+
+
+レガシー マット
+
+### LEGACY_METAL {#LEGACY-METAL}
+```
+public static final int LEGACY_METAL
+```
+
+
+レガシー メタル
+
+### LEGACY_PLASTIC {#LEGACY-PLASTIC}
+```
+public static final int LEGACY_PLASTIC
+```
+
+
+レガシー プラスチック
+
+### LEGACY_WIREFRAME {#LEGACY-WIREFRAME}
+```
+public static final int LEGACY_WIREFRAME
+```
+
+
+レガシー ワイヤーフレーム
+
+### MATTE {#MATTE}
+```
+public static final int MATTE
+```
+
+
+マット
+
+### METAL {#METAL}
+```
+public static final int METAL
+```
+
+
+メタル
+
+### PLASTIC {#PLASTIC}
+```
+public static final int PLASTIC
+```
+
+
+プラスチック
+
+### POWDER {#POWDER}
+```
+public static final int POWDER
+```
+
+
+Powder
+
+### SOFT_EDGE {#SOFT-EDGE}
+```
+public static final int SOFT_EDGE
+```
+
+
+Soft edge
+
+### SOFT_METAL {#SOFT-METAL}
+```
+public static final int SOFT_METAL
+```
+
+
+Soft metal
+
+### TRANSLUCENT_POWDER {#TRANSLUCENT-POWDER}
+```
+public static final int TRANSLUCENT_POWDER
+```
+
+
+Translucent powder
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+### WARM_MATTE {#WARM-MATTE}
+```
+public static final int WARM_MATTE
+```
+
+
+Warm matte
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/bevelpresettype/_index.md
+++ b/japanese/java/com.aspose.diagram/bevelpresettype/_index.md
@@ -1,0 +1,246 @@
+---
+title: BevelPresetType
+second_title: Aspose.Diagram for Java API リファレンス
+description: 3D でシェイプに適用できるベベルタイプのプリセットを表します。
+type: docs
+weight: 35
+url: /ja/java/com.aspose.diagram/bevelpresettype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class BevelPresetType
+```
+
+3D でシェイプに適用できるベベルタイプのプリセットを表します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [ANGLE](#ANGLE) | 角度 |
+| [ART_DECO](#ART-DECO) | アールデコ |
+| [CIRCLE](#CIRCLE) | 円 |
+| [CONVEX](#CONVEX) | 凸 |
+| [COOL_SLANT](#COOL-SLANT) | クールな斜め |
+| [CROSS](#CROSS) | クロス |
+| [DIVOT](#DIVOT) | ディボット |
+| [HARD_EDGE](#HARD-EDGE) | ハードエッジ |
+| [NONE](#NONE) | ベベルなし |
+| [RELAXED_INSET](#RELAXED-INSET) | リラックスしたインセット |
+| [RIBLET](#RIBLET) | リブレット |
+| [SLOPE](#SLOPE) | スロープ |
+| [SOFT_ROUND](#SOFT-ROUND) | ソフトラウンド |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ANGLE {#ANGLE}
+```
+public static final int ANGLE
+```
+
+
+角度
+
+### ART_DECO {#ART-DECO}
+```
+public static final int ART_DECO
+```
+
+
+アールデコ
+
+### CIRCLE {#CIRCLE}
+```
+public static final int CIRCLE
+```
+
+
+円
+
+### CONVEX {#CONVEX}
+```
+public static final int CONVEX
+```
+
+
+凸
+
+### COOL_SLANT {#COOL-SLANT}
+```
+public static final int COOL_SLANT
+```
+
+
+クールな斜め
+
+### CROSS {#CROSS}
+```
+public static final int CROSS
+```
+
+
+クロス
+
+### DIVOT {#DIVOT}
+```
+public static final int DIVOT
+```
+
+
+ディボット
+
+### HARD_EDGE {#HARD-EDGE}
+```
+public static final int HARD_EDGE
+```
+
+
+ハードエッジ
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+ベベルなし
+
+### RELAXED_INSET {#RELAXED-INSET}
+```
+public static final int RELAXED_INSET
+```
+
+
+リラックスしたインセット
+
+### RIBLET {#RIBLET}
+```
+public static final int RIBLET
+```
+
+
+リブレット
+
+### SLOPE {#SLOPE}
+```
+public static final int SLOPE
+```
+
+
+スロープ
+
+### SOFT_ROUND {#SOFT-ROUND}
+```
+public static final int SOFT_ROUND
+```
+
+
+ソフトラウンド
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/beveltype/_index.md
+++ b/japanese/java/com.aspose.diagram/beveltype/_index.md
@@ -1,0 +1,179 @@
+---
+title: BevelType
+second_title: Aspose.Diagram for Java API リファレンス
+description: シェイプの影のタイプを指定します。
+type: docs
+weight: 36
+url: /ja/java/com.aspose.diagram/beveltype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class BevelType
+```
+
+シェイプの影のタイプを指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [BevelType(int value)](#BevelType-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | ベベルのタイプを指定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/beveltype\#getValue--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BevelType(int value) {#BevelType-int-}
+```
+public BevelType(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+ベベルのタイプを指定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/beveltype\#getValue--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/beveltypevalue/_index.md
+++ b/japanese/java/com.aspose.diagram/beveltypevalue/_index.md
@@ -1,0 +1,255 @@
+---
+title: BevelTypeValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: 3D でシェイプに適用できるベベルタイプのプリセットを表します。
+type: docs
+weight: 37
+url: /ja/java/com.aspose.diagram/beveltypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class BevelTypeValue
+```
+
+3D でシェイプに適用できるベベルタイプのプリセットを表します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [ANGLE](#ANGLE) | 角度 |
+| [ART_DECO](#ART-DECO) | アールデコ |
+| [CIRCLE](#CIRCLE) | 円 |
+| [CONVEX](#CONVEX) | 凸 |
+| [COOL_SLANT](#COOL-SLANT) | クールな斜め |
+| [CROSS](#CROSS) | クロス |
+| [DIVOT](#DIVOT) | ディボット |
+| [HARD_EDGE](#HARD-EDGE) | ハードエッジ |
+| [NONE](#NONE) | ベベルなし |
+| [RELAXED_INSET](#RELAXED-INSET) | リラックスしたインセット |
+| [RIBLET](#RIBLET) | リブレット |
+| [SLOPE](#SLOPE) | スロープ |
+| [SOFT_ROUND](#SOFT-ROUND) | ソフトラウンド |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ANGLE {#ANGLE}
+```
+public static final int ANGLE
+```
+
+
+角度
+
+### ART_DECO {#ART-DECO}
+```
+public static final int ART_DECO
+```
+
+
+アールデコ
+
+### CIRCLE {#CIRCLE}
+```
+public static final int CIRCLE
+```
+
+
+円
+
+### CONVEX {#CONVEX}
+```
+public static final int CONVEX
+```
+
+
+凸
+
+### COOL_SLANT {#COOL-SLANT}
+```
+public static final int COOL_SLANT
+```
+
+
+クールな斜め
+
+### CROSS {#CROSS}
+```
+public static final int CROSS
+```
+
+
+クロス
+
+### DIVOT {#DIVOT}
+```
+public static final int DIVOT
+```
+
+
+ディボット
+
+### HARD_EDGE {#HARD-EDGE}
+```
+public static final int HARD_EDGE
+```
+
+
+ハードエッジ
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+ベベルなし
+
+### RELAXED_INSET {#RELAXED-INSET}
+```
+public static final int RELAXED_INSET
+```
+
+
+リラックスしたインセット
+
+### RIBLET {#RIBLET}
+```
+public static final int RIBLET
+```
+
+
+リブレット
+
+### SLOPE {#SLOPE}
+```
+public static final int SLOPE
+```
+
+
+スロープ
+
+### SOFT_ROUND {#SOFT-ROUND}
+```
+public static final int SOFT_ROUND
+```
+
+
+ソフトラウンド
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/bool/_index.md
+++ b/japanese/java/com.aspose.diagram/bool/_index.md
@@ -1,0 +1,156 @@
+---
+title: BOOL
+second_title: Aspose.Diagram for Java API リファレンス
+description: ブール値。
+type: docs
+weight: 29
+url: /ja/java/com.aspose.diagram/bool/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class BOOL
+```
+
+ブール値。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [FALSE](#FALSE) | False. |
+| [TRUE](#TRUE) | True. |
+| [UNDEFINED](#UNDEFINED) | 未定義の状態です。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FALSE {#FALSE}
+```
+public static final int FALSE
+```
+
+
+False.
+
+### TRUE {#TRUE}
+```
+public static final int TRUE
+```
+
+
+True.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+未定義の状態です。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/boolvalue/_index.md
+++ b/japanese/java/com.aspose.diagram/boolvalue/_index.md
@@ -1,0 +1,230 @@
+---
+title: BoolValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: ブール値。
+type: docs
+weight: 38
+url: /ja/java/com.aspose.diagram/boolvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class BoolValue
+```
+
+ブール値。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [BoolValue(int value, int unit)](#BoolValue-int-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性。 |
+| [getValue()](#getValue--) | ブール値 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [isThemed()](#isThemed--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setThemed(boolean value)](#setThemed-boolean-) | このプロパティの説明については、[isThemed()](../../com.aspose.diagram/boolvalue\#isThemed--) をご覧ください。 |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | このプロパティの説明については、[getUfe()](../../com.aspose.diagram/boolvalue\#getUfe--) を参照してください。 |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/boolvalue\#getValue--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BoolValue(int value, int unit) {#BoolValue-int-int-}
+```
+public BoolValue(int value, int unit)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+| 単位 | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+ブール値
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### isThemed() {#isThemed--}
+```
+public boolean isThemed()
+```
+
+
+
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setThemed(boolean value) {#setThemed-boolean-}
+```
+public void setThemed(boolean value)
+```
+
+
+このプロパティの説明については、[isThemed()](../../com.aspose.diagram/boolvalue\#isThemed--) をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+このプロパティの説明については、[getUfe()](../../com.aspose.diagram/boolvalue\#getUfe--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/boolvalue\#getValue--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/bullet/_index.md
+++ b/japanese/java/com.aspose.diagram/bullet/_index.md
@@ -1,0 +1,179 @@
+---
+title: Bullet
+second_title: Aspose.Diagram for Java API リファレンス
+description: 箇条書きのスタイルを決定します。
+type: docs
+weight: 39
+url: /ja/java/com.aspose.diagram/bullet/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Bullet
+```
+
+箇条書きのスタイルを決定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Bullet(int value)](#Bullet-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | 箇条書きのスタイルを決定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/bullet\#getValue--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Bullet(int value) {#Bullet-int-}
+```
+public Bullet(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+箇条書きのスタイルを決定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/bullet\#getValue--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/bulletvalue/_index.md
+++ b/japanese/java/com.aspose.diagram/bulletvalue/_index.md
@@ -1,0 +1,210 @@
+---
+title: BulletValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: 箇条書きのスタイルを決定します。
+type: docs
+weight: 40
+url: /ja/java/com.aspose.diagram/bulletvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class BulletValue
+```
+
+箇条書きのスタイルを決定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [NONE](#NONE) | None. |
+| [STYLE_1](#STYLE-1) | ポイント。 |
+| [STYLE_2](#STYLE-2) | ひし形。 |
+| [STYLE_3](#STYLE-3) | 正方形。 |
+| [STYLE_4](#STYLE-4) | 大きな正方形。 |
+| [STYLE_5](#STYLE-5) | ひし形（複数）。 |
+| [STYLE_6](#STYLE-6) | Arrow. |
+| [STYLE_7](#STYLE-7) | チェック。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+None.
+
+### STYLE_1 {#STYLE-1}
+```
+public static final int STYLE_1
+```
+
+
+ポイント。
+
+### STYLE_2 {#STYLE-2}
+```
+public static final int STYLE_2
+```
+
+
+ひし形。
+
+### STYLE_3 {#STYLE-3}
+```
+public static final int STYLE_3
+```
+
+
+正方形。
+
+### STYLE_4 {#STYLE-4}
+```
+public static final int STYLE_4
+```
+
+
+大きな正方形。
+
+### STYLE_5 {#STYLE-5}
+```
+public static final int STYLE_5
+```
+
+
+ひし形（複数）。
+
+### STYLE_6 {#STYLE-6}
+```
+public static final int STYLE_6
+```
+
+
+Arrow.
+
+### STYLE_7 {#STYLE-7}
+```
+public static final int STYLE_7
+```
+
+
+チェック。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/calendar/_index.md
+++ b/japanese/java/com.aspose.diagram/calendar/_index.md
@@ -1,0 +1,204 @@
+---
+title: Calendar
+second_title: Aspose.Diagram for Java API リファレンス
+description: カスタムプロパティのテキストフィールドと要素の数式に使用されるカレンダーを決定します。
+type: docs
+weight: 41
+url: /ja/java/com.aspose.diagram/calendar/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Calendar
+```
+
+カスタム プロパティ、テキスト フィールド、要素の数式に使用されるカレンダーを決定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Calendar(int value)](#Calendar-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | カスタム プロパティ、テキスト フィールド、要素の数式に使用されるカレンダーを決定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | このプロパティの説明については、[getUfe()](../../com.aspose.diagram/calendar\#getUfe--) を参照してください。 |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/calendar\#getValue--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Calendar(int value) {#Calendar-int-}
+```
+public Calendar(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+カスタム プロパティ、テキスト フィールド、要素の数式に使用されるカレンダーを決定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+このプロパティの説明については、[getUfe()](../../com.aspose.diagram/calendar\#getUfe--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/calendar\#getValue--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/calendarvalue/_index.md
+++ b/japanese/java/com.aspose.diagram/calendarvalue/_index.md
@@ -1,0 +1,228 @@
+---
+title: CalendarValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: カスタムプロパティのテキストフィールドと要素の数式に使用されるカレンダーを決定します。
+type: docs
+weight: 42
+url: /ja/java/com.aspose.diagram/calendarvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class CalendarValue
+```
+
+カスタム プロパティ、テキスト フィールド、要素の数式に使用されるカレンダーを決定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [ARABIC_HIJIRI](#ARABIC-HIJIRI) | Arabic hijiri. |
+| [ENGLISH_TRANSLITERATED](#ENGLISH-TRANSLITERATED) | English Transliterated. |
+| [FRENCH_TRANSLITERATED](#FRENCH-TRANSLITERATED) | French Transliterated. |
+| [HEBREW_LUNAR](#HEBREW-LUNAR) | Hebrew lunar. |
+| [JAPANESE_EMPEROR_REIGN](#JAPANESE-EMPEROR-REIGN) | Japanese Emperor Reign. |
+| [KOREAN_DANKI](#KOREAN-DANKI) | Korean Danki. |
+| [SAKA_ERA](#SAKA-ERA) | Saka Era. |
+| [TAIWAN_CALENDAR](#TAIWAN-CALENDAR) | Taiwan calendar. |
+| [THAI_BUDDHIST](#THAI-BUDDHIST) | Thai Buddhist. |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+| [WESTERN](#WESTERN) | Western. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ARABIC_HIJIRI {#ARABIC-HIJIRI}
+```
+public static final int ARABIC_HIJIRI
+```
+
+
+Arabic hijiri.
+
+### ENGLISH_TRANSLITERATED {#ENGLISH-TRANSLITERATED}
+```
+public static final int ENGLISH_TRANSLITERATED
+```
+
+
+English Transliterated.
+
+### FRENCH_TRANSLITERATED {#FRENCH-TRANSLITERATED}
+```
+public static final int FRENCH_TRANSLITERATED
+```
+
+
+French Transliterated.
+
+### HEBREW_LUNAR {#HEBREW-LUNAR}
+```
+public static final int HEBREW_LUNAR
+```
+
+
+Hebrew lunar.
+
+### JAPANESE_EMPEROR_REIGN {#JAPANESE-EMPEROR-REIGN}
+```
+public static final int JAPANESE_EMPEROR_REIGN
+```
+
+
+Japanese Emperor Reign.
+
+### KOREAN_DANKI {#KOREAN-DANKI}
+```
+public static final int KOREAN_DANKI
+```
+
+
+Korean Danki.
+
+### SAKA_ERA {#SAKA-ERA}
+```
+public static final int SAKA_ERA
+```
+
+
+Saka Era.
+
+### TAIWAN_CALENDAR {#TAIWAN-CALENDAR}
+```
+public static final int TAIWAN_CALENDAR
+```
+
+
+Taiwan calendar.
+
+### THAI_BUDDHIST {#THAI-BUDDHIST}
+```
+public static final int THAI_BUDDHIST
+```
+
+
+Thai Buddhist.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### WESTERN {#WESTERN}
+```
+public static final int WESTERN
+```
+
+
+Western.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/case/_index.md
+++ b/japanese/java/com.aspose.diagram/case/_index.md
@@ -1,0 +1,204 @@
+---
+title: Case
+second_title: Aspose.Diagram for Java API リファレンス
+description: シェイプのテキストの大文字小文字を決定します。
+type: docs
+weight: 43
+url: /ja/java/com.aspose.diagram/case/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Case
+```
+
+シェイプのテキストの大文字小文字を決定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Case(int value)](#Case-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | シェイプのテキストの大文字小文字を決定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | このプロパティの説明については、[getUfe()](../../com.aspose.diagram/case\#getUfe--) を参照してください。 |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/case\#getValue--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Case(int value) {#Case-int-}
+```
+public Case(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+シェイプのテキストの大文字小文字を決定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+このプロパティの説明については、[getUfe()](../../com.aspose.diagram/case\#getUfe--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/case\#getValue--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/casevalue/_index.md
+++ b/japanese/java/com.aspose.diagram/casevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: CaseValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: シェイプのテキストの大文字小文字を決定します。
+type: docs
+weight: 44
+url: /ja/java/com.aspose.diagram/casevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class CaseValue
+```
+
+シェイプのテキストの大文字小文字を決定します。すべて大文字（uppercase）文字（1）および先頭大文字（2）は、すべて大文字で入力されたテキストの外観を変更しません。これらのオプションが効果を示すには、テキストを小文字で入力する必要があります。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [ALL_CAPITAL_LETTERS](#ALL-CAPITAL-LETTERS) | すべて大文字（uppercase）の文字。 |
+| [INITIAL_CAPITAL_LETTERS_ONLY](#INITIAL-CAPITAL-LETTERS-ONLY) | 最初の文字だけが大文字。 |
+| [NORMAL_CASE](#NORMAL-CASE) | 通常のケース。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALL_CAPITAL_LETTERS {#ALL-CAPITAL-LETTERS}
+```
+public static final int ALL_CAPITAL_LETTERS
+```
+
+
+すべて大文字（uppercase）の文字。
+
+### INITIAL_CAPITAL_LETTERS_ONLY {#INITIAL-CAPITAL-LETTERS-ONLY}
+```
+public static final int INITIAL_CAPITAL_LETTERS_ONLY
+```
+
+
+最初の文字だけが大文字。
+
+### NORMAL_CASE {#NORMAL-CASE}
+```
+public static final int NORMAL_CASE
+```
+
+
+通常のケース。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/char/_index.md
+++ b/japanese/java/com.aspose.diagram/char/_index.md
@@ -1,0 +1,937 @@
+---
+title: Char
+second_title: Aspose.Diagram for Java API リファレンス
+description: 形状のテキストの書式属性（フォントカラー、テキストスタイル、ケース、ベースラインに対する位置、ポイントサイズなど）を含みます。
+type: docs
+weight: 45
+url: /ja/java/com.aspose.diagram/char/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Char
+```
+
+シェイプのテキストの書式属性（フォント、色、テキストスタイル、大文字小文字、ベースラインに対する位置、ポイントサイズなど）を含みます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Char()](#Char--) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAsianFont()](#getAsianFont--) | アジア文字を含むテキストの書式設定に使用されるフォントの ID 番号を指定します。 |
+| [getAsianFontName()](#getAsianFontName--) | テキストの書式設定に使用されるフォントのアジアフォント名を指定します。Visio 2013 用です。 |
+| [getCase()](#getCase--) | シェイプのテキストの大文字小文字を決定します。 |
+| [getClass()](#getClass--) |  |
+| [getColor()](#getColor--) | Char 要素に含まれる場合、Color 要素です。 |
+| [getColorTrans()](#getColorTrans--) | レイヤーまたはシェイプのテキストカラーの透明度を決定します。0（完全に不透明）から 1（完全に透明）までの範囲です。 |
+| [getComplexScriptFont()](#getComplexScriptFont--) | 複合スクリプト文字で構成されたテキストの書式設定に使用されるフォントの番号を含みます。 |
+| [getComplexScriptFontName()](#getComplexScriptFontName--) | テキストの書式設定に使用されるフォントの ComplexScript フォント名を指定します。Visio 2013 用です。 |
+| [getComplexScriptSize()](#getComplexScriptSize--) | 複合スクリプト文字で構成されたテキストの書式設定に使用されるフォントサイズです。 |
+| [getDblUnderline()](#getDblUnderline--) | テキスト範囲に二重下線が付いているかどうかを指定します。 |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getDoubleStrikethrough()](#getDoubleStrikethrough--) | テキストが二重取り消し線として書式設定されているかどうかを判断します。 |
+| [getFont()](#getFont--) | テキストの書式設定に使用されるフォントの ID 番号を指定します。 |
+| [getFontName()](#getFontName--) | テキストの書式設定に使用されるフォントの名前を指定します。Visio 2013 用です。 |
+| [getFontScale()](#getFontScale--) | フォントの幅を指定します。 |
+| [getHighlight()](#getHighlight--) | ハイライトを指定します。 |
+| [getIX()](#getIX--) | 親要素内の要素のゼロベースインデックスです。 |
+| [getLangID()](#getLangID--) | セルの数式、テキスト、カスタムプロパティ、またはコメントが入力された言語のロケール ID (LCID) を示します。 |
+| [getLetterspace()](#getLetterspace--) | 2 文字以上の文字間のスペース量を指定します。 |
+| [getLocale()](#getLocale--) | スペルチェック目的でテキスト ランのロケールを指定します。 |
+| [getLocalizeFont()](#getLocalizeFont--) | シェイプテキストをローカライズ（別の言語に翻訳）するかどうかを指定します。 |
+| [getOverline()](#getOverline--) | テキストの上に線があるかどうかを指定します。 |
+| [getPerpendicular()](#getPerpendicular--) | テキスト ブロック内の他のテキストに対してテキスト フィールドが垂直に表示されるかどうかを指定します。 |
+| [getPos()](#getPos--) | シェイプのテキストの位置をベースラインに対して指定します。 |
+| [getRTLText()](#getRTLText--) | 現在の文字ランのテキスト方向が左から右か右から左かを判断します。 |
+| [getSize()](#getSize--) | シェイプのテキスト ブロック内のテキストサイズを指定します。 |
+| [getStrikethru()](#getStrikethru--) | テキストが取り消し線として書式設定されているかどうかを指定します。 |
+| [getStyle()](#getStyle--) | シェイプのテキスト ブロック内のテキスト範囲に適用される文字書式設定を指定します。 |
+| [getUseVertical()](#getUseVertical--) | 文字ランが縦向きか横向きかを判断します。 |
+| [hashCode()](#hashCode--) |  |
+| [isBold()](#isBold--) | フォントが太字かどうかを示します。 |
+| [isDoubleStrikethrough()](#isDoubleStrikethrough--) | フォントが二重取り消し線かどうかを示します。 |
+| [isDoubleUnderline()](#isDoubleUnderline--) | フォントが二重下線かどうかを示します。 |
+| [isItalic()](#isItalic--) | フォントが斜体かどうかを示します。 |
+| [isStrikethrough()](#isStrikethrough--) | フォントが取り消し線かどうかを示します。 |
+| [isSubscript()](#isSubscript--) | フォントが下付き文字かどうかを示します。 |
+| [isSuperscript()](#isSuperscript--) | フォントが上付き文字かどうかを示します。 |
+| [isUnderline()](#isUnderline--) | フォントが下線かどうかを示します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAsianFont(IntValue value)](#setAsianFont-com.aspose.diagram.IntValue-) | このプロパティの説明については、[getAsianFont()](../../com.aspose.diagram/char\#getAsianFont--) を参照してください。 |
+| [setAsianFontName(StrValue value)](#setAsianFontName-com.aspose.diagram.StrValue-) | このプロパティの説明については、[getAsianFontName()](../../com.aspose.diagram/char\#getAsianFontName--) を参照してください。 |
+| [setCase(Case value)](#setCase-com.aspose.diagram.Case-) | このプロパティの説明については、[getCase()](../../com.aspose.diagram/char\#getCase--) を参照してください。 |
+| [setColor(ColorValue value)](#setColor-com.aspose.diagram.ColorValue-) | このプロパティの説明については、[getColor()](../../com.aspose.diagram/char\#getColor--) を参照してください。 |
+| [setColorTrans(DoubleValue value)](#setColorTrans-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getColorTrans](../../com.aspose.diagram/char\#getColorTrans--) を参照してください。 |
+| [setComplexScriptFont(IntValue value)](#setComplexScriptFont-com.aspose.diagram.IntValue-) | このプロパティの説明については、[getComplexScriptFont](../../com.aspose.diagram/char\#getComplexScriptFont--) を参照してください。 |
+| [setComplexScriptFontName(StrValue value)](#setComplexScriptFontName-com.aspose.diagram.StrValue-) | このプロパティの説明については、[getComplexScriptFontName](../../com.aspose.diagram/char\#getComplexScriptFontName--) を参照してください。 |
+| [setComplexScriptSize(DoubleValue value)](#setComplexScriptSize-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getComplexScriptSize](../../com.aspose.diagram/char\#getComplexScriptSize--) を参照してください。 |
+| [setDblUnderline(BoolValue value)](#setDblUnderline-com.aspose.diagram.BoolValue-) | このプロパティの説明については、[getDblUnderline](../../com.aspose.diagram/char\#getDblUnderline--) を参照してください。 |
+| [setDel(int value)](#setDel-int-) | このプロパティの説明については、[getDel](../../com.aspose.diagram/char\#getDel--) を参照してください。 |
+| [setDoubleStrikethrough(BoolValue value)](#setDoubleStrikethrough-com.aspose.diagram.BoolValue-) | このプロパティの説明については、[getDoubleStrikethrough](../../com.aspose.diagram/char\#getDoubleStrikethrough--) を参照してください。 |
+| [setFont(IntValue value)](#setFont-com.aspose.diagram.IntValue-) | このプロパティの説明については、[getFont](../../com.aspose.diagram/char\#getFont--) を参照してください。 |
+| [setFontName(StrValue value)](#setFontName-com.aspose.diagram.StrValue-) | このプロパティの説明については、[getFontName](../../com.aspose.diagram/char\#getFontName--) を参照してください。 |
+| [setFontScale(DoubleValue value)](#setFontScale-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getFontScale](../../com.aspose.diagram/char\#getFontScale--) を参照してください。 |
+| [setHighlight(BoolValue value)](#setHighlight-com.aspose.diagram.BoolValue-) | このプロパティの説明については、[getHighlight](../../com.aspose.diagram/char\#getHighlight--) を参照してください。 |
+| [setIX(int value)](#setIX-int-) | このプロパティの説明については、[getIX](../../com.aspose.diagram/char\#getIX--) を参照してください。 |
+| [setLangID(IntValue value)](#setLangID-com.aspose.diagram.IntValue-) | このプロパティの説明については、[getLangID](../../com.aspose.diagram/char\#getLangID--) を参照してください。 |
+| [setLetterspace(DoubleValue value)](#setLetterspace-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getLetterspace](../../com.aspose.diagram/char\#getLetterspace--) を参照してください。 |
+| [setLocale(StrValue value)](#setLocale-com.aspose.diagram.StrValue-) | このプロパティの説明については、[getLocale](../../com.aspose.diagram/char\#getLocale--) を参照してください。 |
+| [setLocalizeFont(LocalizeFont value)](#setLocalizeFont-com.aspose.diagram.LocalizeFont-) | このプロパティの説明については、[getLocalizeFont](../../com.aspose.diagram/char\#getLocalizeFont--) を参照してください。 |
+| [setOverline(BoolValue value)](#setOverline-com.aspose.diagram.BoolValue-) | このプロパティの説明については、[getOverline](../../com.aspose.diagram/char\#getOverline--) を参照してください。 |
+| [setPerpendicular(StrValue value)](#setPerpendicular-com.aspose.diagram.StrValue-) | このプロパティの説明については、[getPerpendicular](../../com.aspose.diagram/char\#getPerpendicular--) を参照してください。 |
+| [setPos(Pos value)](#setPos-com.aspose.diagram.Pos-) | このプロパティの説明については、[getPos](../../com.aspose.diagram/char\#getPos--) を参照してください。 |
+| [setRTLText(BoolValue value)](#setRTLText-com.aspose.diagram.BoolValue-) | このプロパティの説明については、[getRTLText](../../com.aspose.diagram/char\#getRTLText--) を参照してください。 |
+| [setSize(DoubleValue value)](#setSize-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getSize](../../com.aspose.diagram/char\#getSize--) を参照してください。 |
+| [setStrikethru(BoolValue value)](#setStrikethru-com.aspose.diagram.BoolValue-) | このプロパティの説明については、[getStrikethru](../../com.aspose.diagram/char\#getStrikethru--) を参照してください。 |
+| [setStyle(Style value)](#setStyle-com.aspose.diagram.Style-) | このプロパティの説明については、[getStyle](../../com.aspose.diagram/char\#getStyle--) を参照してください。 |
+| [setUseVertical(BoolValue value)](#setUseVertical-com.aspose.diagram.BoolValue-) | このプロパティの説明については、[getUseVertical](../../com.aspose.diagram/char\#getUseVertical--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Char() {#Char--}
+```
+public Char()
+```
+
+
+コンストラクタ。
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAsianFont() {#getAsianFont--}
+```
+public IntValue getAsianFont()
+```
+
+
+アジア文字を含むテキストの書式設定に使用されるフォントの ID 番号を指定します。
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getAsianFontName() {#getAsianFontName--}
+```
+public StrValue getAsianFontName()
+```
+
+
+テキストの書式設定に使用されるフォントのアジアフォント名を指定します。Visio 2013 用です。
+
+**Returns:**
+[StrValue](../../com.aspose.diagram/strvalue)
+### getCase() {#getCase--}
+```
+public Case getCase()
+```
+
+
+シェイプのテキストの大文字小文字を決定します。
+
+**Returns:**
+[Case](../../com.aspose.diagram/case)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColor() {#getColor--}
+```
+public ColorValue getColor()
+```
+
+
+Char 要素に含まれる場合、Color 要素です。
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getColorTrans() {#getColorTrans--}
+```
+public DoubleValue getColorTrans()
+```
+
+
+レイヤーまたはシェイプのテキストカラーの透明度を決定します。0（完全に不透明）から 1（完全に透明）までの範囲です。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getComplexScriptFont() {#getComplexScriptFont--}
+```
+public IntValue getComplexScriptFont()
+```
+
+
+複雑スクリプト文字で構成されたテキストの書式設定に使用されるフォントの番号が含まれます。複雑スクリプトとは、文字の結合や形状変化が必要な言語で、右から左へ書く言語（アラビア語、ペルシア語、ヘブライ語、ウルドゥー語）や南アジアのいくつかの言語が該当します。
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getComplexScriptFontName() {#getComplexScriptFontName--}
+```
+public StrValue getComplexScriptFontName()
+```
+
+
+テキストの書式設定に使用されるフォントの ComplexScript フォント名を指定します。Visio 2013 用です。
+
+**Returns:**
+[StrValue](../../com.aspose.diagram/strvalue)
+### getComplexScriptSize() {#getComplexScriptSize--}
+```
+public DoubleValue getComplexScriptSize()
+```
+
+
+複雑なスクリプト文字で構成されたテキストをフォーマットするために使用されるフォントのサイズ。複雑なスクリプトとは、文字の結合や形状変化が必要な言語で、右から左へ書く言語（アラビア語、ペルシア語、ヘブライ語、ウルドゥー語）やいくつかの南アジア言語が含まれます。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDblUnderline() {#getDblUnderline--}
+```
+public BoolValue getDblUnderline()
+```
+
+
+テキスト範囲に二重下線が付いているかどうかを指定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getDoubleStrikethrough() {#getDoubleStrikethrough--}
+```
+public BoolValue getDoubleStrikethrough()
+```
+
+
+テキストが二重取り消し線として書式設定されているかどうかを判断します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getFont() {#getFont--}
+```
+public IntValue getFont()
+```
+
+
+テキストの書式設定に使用されるフォントの ID 番号を指定します。
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getFontName() {#getFontName--}
+```
+public StrValue getFontName()
+```
+
+
+テキストの書式設定に使用されるフォントの名前を指定します。Visio 2013 用です。
+
+**Returns:**
+[StrValue](../../com.aspose.diagram/strvalue)
+### getFontScale() {#getFontScale--}
+```
+public DoubleValue getFontScale()
+```
+
+
+フォントの幅を指定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getHighlight() {#getHighlight--}
+```
+public BoolValue getHighlight()
+```
+
+
+ハイライトを指定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+親要素内の要素のゼロベースインデックスです。
+
+**Returns:**
+int
+### getLangID() {#getLangID--}
+```
+public IntValue getLangID()
+```
+
+
+セルの数式、テキスト、カスタム プロパティ、またはコメントが入力された言語のロケール ID（LCID）を示します。Microsoft Office アプリケーションでサポートされている言語とそれに対応する言語 ID の一覧については、DocLangID 要素を参照してください。
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getLetterspace() {#getLetterspace--}
+```
+public DoubleValue getLetterspace()
+```
+
+
+2 文字以上の間のスペース量を指定します。スペースは 1/20 ポイント単位で増減できます。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLocale() {#getLocale--}
+```
+public StrValue getLocale()
+```
+
+
+スペルチェック目的でテキスト ランのロケールを指定します。
+
+**Returns:**
+[StrValue](../../com.aspose.diagram/strvalue)
+### getLocalizeFont() {#getLocalizeFont--}
+```
+public LocalizeFont getLocalizeFont()
+```
+
+
+シェイプテキストをローカライズ（別の言語に翻訳）するかどうかを指定します。
+
+**Returns:**
+[LocalizeFont](../../com.aspose.diagram/localizefont)
+### getOverline() {#getOverline--}
+```
+public BoolValue getOverline()
+```
+
+
+テキストの上に線があるかどうかを指定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getPerpendicular() {#getPerpendicular--}
+```
+public StrValue getPerpendicular()
+```
+
+
+テキスト ブロック内の他のテキストに対してテキスト フィールドが垂直に表示されるかどうかを指定します。
+
+**Returns:**
+[StrValue](../../com.aspose.diagram/strvalue)
+### getPos() {#getPos--}
+```
+public Pos getPos()
+```
+
+
+シェイプのテキストの位置をベースラインに対して指定します。
+
+**Returns:**
+[Pos](../../com.aspose.diagram/pos)
+### getRTLText() {#getRTLText--}
+```
+public BoolValue getRTLText()
+```
+
+
+現在の文字ランのテキスト方向が左から右か右から左かを判断します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getSize() {#getSize--}
+```
+public DoubleValue getSize()
+```
+
+
+シェイプのテキスト ブロック内のテキストサイズを指定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getStrikethru() {#getStrikethru--}
+```
+public BoolValue getStrikethru()
+```
+
+
+テキストが取り消し線として書式設定されているかどうかを指定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getStyle() {#getStyle--}
+```
+public Style getStyle()
+```
+
+
+シェイプのテキスト ブロック内のテキスト範囲に適用される文字書式設定を指定します。
+
+**Returns:**
+[Style](../../com.aspose.diagram/style)
+### getUseVertical() {#getUseVertical--}
+```
+public BoolValue getUseVertical()
+```
+
+
+文字ランが縦向きか横向きかを判断します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isBold() {#isBold--}
+```
+public boolean isBold()
+```
+
+
+フォントが太字かどうかを示します。
+
+**Returns:**
+boolean
+### isDoubleStrikethrough() {#isDoubleStrikethrough--}
+```
+public boolean isDoubleStrikethrough()
+```
+
+
+フォントが二重取り消し線かどうかを示します。
+
+**Returns:**
+boolean
+### isDoubleUnderline() {#isDoubleUnderline--}
+```
+public boolean isDoubleUnderline()
+```
+
+
+フォントが二重下線かどうかを示します。
+
+**Returns:**
+boolean
+### isItalic() {#isItalic--}
+```
+public boolean isItalic()
+```
+
+
+フォントが斜体かどうかを示します。
+
+**Returns:**
+boolean
+### isStrikethrough() {#isStrikethrough--}
+```
+public boolean isStrikethrough()
+```
+
+
+フォントが取り消し線かどうかを示します。
+
+**Returns:**
+boolean
+### isSubscript() {#isSubscript--}
+```
+public boolean isSubscript()
+```
+
+
+フォントが下付き文字かどうかを示します。
+
+**Returns:**
+boolean
+### isSuperscript() {#isSuperscript--}
+```
+public boolean isSuperscript()
+```
+
+
+フォントが上付き文字かどうかを示します。
+
+**Returns:**
+boolean
+### isUnderline() {#isUnderline--}
+```
+public boolean isUnderline()
+```
+
+
+フォントが下線かどうかを示します。
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAsianFont(IntValue value) {#setAsianFont-com.aspose.diagram.IntValue-}
+```
+public void setAsianFont(IntValue value)
+```
+
+
+このプロパティの説明については、[getAsianFont()](../../com.aspose.diagram/char\#getAsianFont--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setAsianFontName(StrValue value) {#setAsianFontName-com.aspose.diagram.StrValue-}
+```
+public void setAsianFontName(StrValue value)
+```
+
+
+このプロパティの説明については、[getAsianFontName()](../../com.aspose.diagram/char\#getAsianFontName--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [StrValue](../../com.aspose.diagram/strvalue) |  |
+
+### setCase(Case value) {#setCase-com.aspose.diagram.Case-}
+```
+public void setCase(Case value)
+```
+
+
+このプロパティの説明については、[getCase()](../../com.aspose.diagram/char\#getCase--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [Case](../../com.aspose.diagram/case) |  |
+
+### setColor(ColorValue value) {#setColor-com.aspose.diagram.ColorValue-}
+```
+public void setColor(ColorValue value)
+```
+
+
+このプロパティの説明については、[getColor()](../../com.aspose.diagram/char\#getColor--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setColorTrans(DoubleValue value) {#setColorTrans-com.aspose.diagram.DoubleValue-}
+```
+public void setColorTrans(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getColorTrans](../../com.aspose.diagram/char\#getColorTrans--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setComplexScriptFont(IntValue value) {#setComplexScriptFont-com.aspose.diagram.IntValue-}
+```
+public void setComplexScriptFont(IntValue value)
+```
+
+
+このプロパティの説明については、[getComplexScriptFont](../../com.aspose.diagram/char\#getComplexScriptFont--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setComplexScriptFontName(StrValue value) {#setComplexScriptFontName-com.aspose.diagram.StrValue-}
+```
+public void setComplexScriptFontName(StrValue value)
+```
+
+
+このプロパティの説明については、[getComplexScriptFontName](../../com.aspose.diagram/char\#getComplexScriptFontName--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [StrValue](../../com.aspose.diagram/strvalue) |  |
+
+### setComplexScriptSize(DoubleValue value) {#setComplexScriptSize-com.aspose.diagram.DoubleValue-}
+```
+public void setComplexScriptSize(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getComplexScriptSize](../../com.aspose.diagram/char\#getComplexScriptSize--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDblUnderline(BoolValue value) {#setDblUnderline-com.aspose.diagram.BoolValue-}
+```
+public void setDblUnderline(BoolValue value)
+```
+
+
+このプロパティの説明については、[getDblUnderline](../../com.aspose.diagram/char\#getDblUnderline--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+このプロパティの説明については、[getDel](../../com.aspose.diagram/char\#getDel--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setDoubleStrikethrough(BoolValue value) {#setDoubleStrikethrough-com.aspose.diagram.BoolValue-}
+```
+public void setDoubleStrikethrough(BoolValue value)
+```
+
+
+このプロパティの説明については、[getDoubleStrikethrough](../../com.aspose.diagram/char\#getDoubleStrikethrough--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setFont(IntValue value) {#setFont-com.aspose.diagram.IntValue-}
+```
+public void setFont(IntValue value)
+```
+
+
+このプロパティの説明については、[getFont](../../com.aspose.diagram/char\#getFont--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setFontName(StrValue value) {#setFontName-com.aspose.diagram.StrValue-}
+```
+public void setFontName(StrValue value)
+```
+
+
+このプロパティの説明については、[getFontName](../../com.aspose.diagram/char\#getFontName--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [StrValue](../../com.aspose.diagram/strvalue) |  |
+
+### setFontScale(DoubleValue value) {#setFontScale-com.aspose.diagram.DoubleValue-}
+```
+public void setFontScale(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getFontScale](../../com.aspose.diagram/char\#getFontScale--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setHighlight(BoolValue value) {#setHighlight-com.aspose.diagram.BoolValue-}
+```
+public void setHighlight(BoolValue value)
+```
+
+
+このプロパティの説明については、[getHighlight](../../com.aspose.diagram/char\#getHighlight--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+このプロパティの説明については、[getIX](../../com.aspose.diagram/char\#getIX--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setLangID(IntValue value) {#setLangID-com.aspose.diagram.IntValue-}
+```
+public void setLangID(IntValue value)
+```
+
+
+このプロパティの説明については、[getLangID](../../com.aspose.diagram/char\#getLangID--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setLetterspace(DoubleValue value) {#setLetterspace-com.aspose.diagram.DoubleValue-}
+```
+public void setLetterspace(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getLetterspace](../../com.aspose.diagram/char\#getLetterspace--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setLocale(StrValue value) {#setLocale-com.aspose.diagram.StrValue-}
+```
+public void setLocale(StrValue value)
+```
+
+
+このプロパティの説明については、[getLocale](../../com.aspose.diagram/char\#getLocale--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [StrValue](../../com.aspose.diagram/strvalue) |  |
+
+### setLocalizeFont(LocalizeFont value) {#setLocalizeFont-com.aspose.diagram.LocalizeFont-}
+```
+public void setLocalizeFont(LocalizeFont value)
+```
+
+
+このプロパティの説明については、[getLocalizeFont](../../com.aspose.diagram/char\#getLocalizeFont--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [LocalizeFont](../../com.aspose.diagram/localizefont) |  |
+
+### setOverline(BoolValue value) {#setOverline-com.aspose.diagram.BoolValue-}
+```
+public void setOverline(BoolValue value)
+```
+
+
+このプロパティの説明については、[getOverline](../../com.aspose.diagram/char\#getOverline--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setPerpendicular(StrValue value) {#setPerpendicular-com.aspose.diagram.StrValue-}
+```
+public void setPerpendicular(StrValue value)
+```
+
+
+このプロパティの説明については、[getPerpendicular](../../com.aspose.diagram/char\#getPerpendicular--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [StrValue](../../com.aspose.diagram/strvalue) |  |
+
+### setPos(Pos value) {#setPos-com.aspose.diagram.Pos-}
+```
+public void setPos(Pos value)
+```
+
+
+このプロパティの説明については、[getPos](../../com.aspose.diagram/char\#getPos--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [Pos](../../com.aspose.diagram/pos) |  |
+
+### setRTLText(BoolValue value) {#setRTLText-com.aspose.diagram.BoolValue-}
+```
+public void setRTLText(BoolValue value)
+```
+
+
+このプロパティの説明については、[getRTLText](../../com.aspose.diagram/char\#getRTLText--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setSize(DoubleValue value) {#setSize-com.aspose.diagram.DoubleValue-}
+```
+public void setSize(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getSize](../../com.aspose.diagram/char\#getSize--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setStrikethru(BoolValue value) {#setStrikethru-com.aspose.diagram.BoolValue-}
+```
+public void setStrikethru(BoolValue value)
+```
+
+
+このプロパティの説明については、[getStrikethru](../../com.aspose.diagram/char\#getStrikethru--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setStyle(Style value) {#setStyle-com.aspose.diagram.Style-}
+```
+public void setStyle(Style value)
+```
+
+
+このプロパティの説明については、[getStyle](../../com.aspose.diagram/char\#getStyle--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [Style](../../com.aspose.diagram/style) |  |
+
+### setUseVertical(BoolValue value) {#setUseVertical-com.aspose.diagram.BoolValue-}
+```
+public void setUseVertical(BoolValue value)
+```
+
+
+このプロパティの説明については、[getUseVertical](../../com.aspose.diagram/char\#getUseVertical--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/charcollection/_index.md
+++ b/japanese/java/com.aspose.diagram/charcollection/_index.md
@@ -1,0 +1,234 @@
+---
+title: CharCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: 文字コレクション。
+type: docs
+weight: 46
+url: /ja/java/com.aspose.diagram/charcollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class CharCollection extends Collection
+```
+
+文字コレクション。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(Char item)](#add-com.aspose.diagram.Char-) | コレクションに Char オブジェクトを追加します。 |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getChar(int IX)](#getChar-int-) | 指定された IX の要素を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Char item)](#remove-com.aspose.diagram.Char-) | コレクションから Char オブジェクトを削除します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Char item) {#add-com.aspose.diagram.Char-}
+```
+public int add(Char item)
+```
+
+
+コレクションに Char オブジェクトを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [Char](../../com.aspose.diagram/char) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Char get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[Char](../../com.aspose.diagram/char) - 
+### getChar(int IX) {#getChar-int-}
+```
+public Char getChar(int IX)
+```
+
+
+指定された IX の要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| IX | int | int 要素の親要素内でのゼロベースインデックスです。 |
+
+**Returns:**
+[Char](../../com.aspose.diagram/char) - [Char](../../com.aspose.diagram/char)Char.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Char item) {#remove-com.aspose.diagram.Char-}
+```
+public void remove(Char item)
+```
+
+
+コレクションから Char オブジェクトを削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [Char](../../com.aspose.diagram/char) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/checkboxactivexcontrol/_index.md
+++ b/japanese/java/com.aspose.diagram/checkboxactivexcontrol/_index.md
@@ -1,0 +1,704 @@
+---
+title: CheckBoxActiveXControl
+second_title: Aspose.Diagram for Java API リファレンス
+description: CheckBox ActiveX コントロールを表します。
+type: docs
+weight: 47
+url: /ja/java/com.aspose.diagram/checkboxactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class CheckBoxActiveXControl extends ActiveXControl
+```
+
+CheckBox ActiveX コントロールを表します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAccelerator()](#getAccelerator--) | コントロールのアクセラレータキーです。 |
+| [getAlignment()](#getAlignment--) | コントロールに対する Caption の位置です。 |
+| [getBackOleColor()](#getBackOleColor--) | 背景の OLE カラー。 |
+| [getCaption()](#getCaption--) | コントロール上に表示される説明テキストです。 |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | コントロールのバイナリ データ。 |
+| [getForeOleColor()](#getForeOleColor--) | 前景の OLE カラー。 |
+| [getGroupName()](#getGroupName--) | グループの名前です。 |
+| [getHeight()](#getHeight--) | ポイント単位のコントロールの高さ。 |
+| [getIMEMode()](#getIMEMode--) | コントロールがフォーカスを受け取る際の Input Method Editor のデフォルト実行時モード。 |
+| [getMouseIcon()](#getMouseIcon--) | コントロールのマウスポインタとして表示するカスタムアイコンです。 |
+| [getMousePointer()](#getMousePointer--) | コントロールのマウスポインタとして表示されるアイコンの種類です。 |
+| [getPicture()](#getPicture--) | 画像のデータです。 |
+| [getPicturePosition()](#getPicturePosition--) | コントロールのキャプションに対する画像の位置。 |
+| [getSpecialEffect()](#getSpecialEffect--) | コントロールの特殊効果です。 |
+| [getType()](#getType--) | ActiveX コントロールのタイプを取得します。 |
+| [getValue()](#getValue--) | コントロールがチェックされているかどうかを示します。 |
+| [getWidth()](#getWidth--) | ポイント単位のコントロールの幅です。 |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | コントロールが全内容を表示するために自動的にサイズ変更されるかどうかを示します。 |
+| [isChecked()](#isChecked--) | ボックスがチェックされているかどうかを示します。 |
+| [isEnabled()](#isEnabled--) | コントロールがフォーカスを受け取り、ユーザー生成イベントに応答できるかどうかを示します。 |
+| [isLocked()](#isLocked--) | コントロール内のデータが編集ロックされているかどうかを示します。 |
+| [isTransparent()](#isTransparent--) | コントロールが透明かどうかを示します。 |
+| [isTripleState()](#isTripleState--) | 指定されたコントロールが Null 値をどのように表示するかを示します。 |
+| [isWordWrapped()](#isWordWrapped--) | コントロールの内容が行末で自動的に折り返されるかどうかを示します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAccelerator(char value)](#setAccelerator-char-) | このプロパティの説明については、[getAccelerator()](../../com.aspose.diagram/checkboxactivexcontrol\#getAccelerator--) を参照してください。 |
+| [setAlignment(int value)](#setAlignment-int-) | このプロパティの説明については、[getAlignment()](../../com.aspose.diagram/checkboxactivexcontrol\#getAlignment--) を参照してください。 |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | このプロパティの説明については、[isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) を参照してください |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | このプロパティの説明については、[getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) を参照してください |
+| [setCaption(String value)](#setCaption-java.lang.String-) | このプロパティの説明については、[getCaption()](../../com.aspose.diagram/checkboxactivexcontrol\#getCaption--) を参照してください。 |
+| [setChecked(boolean value)](#setChecked-boolean-) | このプロパティの説明については、[isChecked()](../../com.aspose.diagram/checkboxactivexcontrol\#isChecked--) を参照してください。 |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | このプロパティの説明については、[isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) を参照してください |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | このプロパティの説明については、[getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) を参照してください |
+| [setGroupName(String value)](#setGroupName-java.lang.String-) | このプロパティの説明については、[getGroupName()](../../com.aspose.diagram/checkboxactivexcontrol\#getGroupName--) を参照してください。 |
+| [setHeight(double value)](#setHeight-double-) | このプロパティの説明については、[getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) を参照してください |
+| [setIMEMode(int value)](#setIMEMode-int-) | このプロパティの説明については、[getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) を参照してください |
+| [setLocked(boolean value)](#setLocked-boolean-) | このプロパティの説明については、[isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) を参照してください |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | このプロパティの説明については、[getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) を参照してください |
+| [setMousePointer(int value)](#setMousePointer-int-) | このプロパティの説明については、[getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) を参照してください |
+| [setPicture(byte[] value)](#setPicture-byte---) | このプロパティの説明については、[getPicture()](../../com.aspose.diagram/checkboxactivexcontrol\#getPicture--) を参照してください。 |
+| [setPicturePosition(int value)](#setPicturePosition-int-) | このプロパティの説明については、[getPicturePosition()](../../com.aspose.diagram/checkboxactivexcontrol\#getPicturePosition--) を参照してください。 |
+| [setSpecialEffect(int value)](#setSpecialEffect-int-) | このプロパティの説明については、[getSpecialEffect()](../../com.aspose.diagram/checkboxactivexcontrol\#getSpecialEffect--) を参照してください。 |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | このプロパティの説明については、[isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) を参照してください |
+| [setTripleState(boolean value)](#setTripleState-boolean-) | このプロパティの説明については、[isTripleState()](../../com.aspose.diagram/checkboxactivexcontrol\#isTripleState--) を参照してください。 |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/checkboxactivexcontrol\#getValue--) を参照してください。 |
+| [setWidth(double value)](#setWidth-double-) | このプロパティの説明については、[getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) を参照してください |
+| [setWordWrapped(boolean value)](#setWordWrapped-boolean-) | このプロパティの説明については、[isWordWrapped()](../../com.aspose.diagram/checkboxactivexcontrol\#isWordWrapped--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAccelerator() {#getAccelerator--}
+```
+public char getAccelerator()
+```
+
+
+コントロールのアクセラレータキーです。
+
+**Returns:**
+char
+### getAlignment() {#getAlignment--}
+```
+public int getAlignment()
+```
+
+
+コントロールに対する Caption の位置です。
+
+**Returns:**
+int
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+背景の OLE カラー。
+
+**Returns:**
+int
+### getCaption() {#getCaption--}
+```
+public String getCaption()
+```
+
+
+コントロール上に表示される説明テキストです。
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+コントロールのバイナリ データ。
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+前景の OLE カラーです。Image コントロールには適用されません。
+
+**Returns:**
+int
+### getGroupName() {#getGroupName--}
+```
+public String getGroupName()
+```
+
+
+グループの名前です。
+
+**Returns:**
+java.lang.String
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+ポイント単位のコントロールの高さ。
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+コントロールがフォーカスを受け取る際の Input Method Editor のデフォルト実行時モード。
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+コントロールのマウスポインタとして表示するカスタムアイコンです。
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+コントロールのマウスポインタとして表示されるアイコンの種類です。
+
+**Returns:**
+int
+### getPicture() {#getPicture--}
+```
+public byte[] getPicture()
+```
+
+
+画像のデータです。
+
+**Returns:**
+byte[]
+### getPicturePosition() {#getPicturePosition--}
+```
+public int getPicturePosition()
+```
+
+
+コントロールのキャプションに対する画像の位置。
+
+**Returns:**
+int
+### getSpecialEffect() {#getSpecialEffect--}
+```
+public int getSpecialEffect()
+```
+
+
+コントロールの特殊効果です。
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+ActiveX コントロールのタイプを取得します。
+
+**Returns:**
+int
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+コントロールがチェックされているかどうかを示します。
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+ポイント単位のコントロールの幅です。
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+コントロールが全内容を表示するために自動的にサイズ変更されるかどうかを示します。
+
+**Returns:**
+boolean
+### isChecked() {#isChecked--}
+```
+public boolean isChecked()
+```
+
+
+ボックスがチェックされているかどうかを示します。
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+コントロールがフォーカスを受け取り、ユーザー生成イベントに応答できるかどうかを示します。
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+コントロール内のデータが編集ロックされているかどうかを示します。
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+コントロールが透明かどうかを示します。
+
+**Returns:**
+boolean
+### isTripleState() {#isTripleState--}
+```
+public boolean isTripleState()
+```
+
+
+指定されたコントロールが Null 値をどのように表示するかを示します。
+
+| ------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| 設定 | 説明 |
+| True    | コントロールは Yes、No、Null の状態を循環します。Value プロパティが Null に設定されている場合、コントロールは暗く（グレー表示）なります。 |
+| False   | (Default) コントロールは Yes と No の状態を循環します。Null 値は No 値として表示されます。 |
+
+|
+
+**Returns:**
+boolean
+### isWordWrapped() {#isWordWrapped--}
+```
+public boolean isWordWrapped()
+```
+
+
+コントロールの内容が行末で自動的に折り返されるかどうかを示します。
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAccelerator(char value) {#setAccelerator-char-}
+```
+public void setAccelerator(char value)
+```
+
+
+このプロパティの説明については、[getAccelerator()](../../com.aspose.diagram/checkboxactivexcontrol\#getAccelerator--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | char |  |
+
+### setAlignment(int value) {#setAlignment-int-}
+```
+public void setAlignment(int value)
+```
+
+
+このプロパティの説明については、[getAlignment()](../../com.aspose.diagram/checkboxactivexcontrol\#getAlignment--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+このプロパティの説明については、[isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+このプロパティの説明については、[getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setCaption(String value) {#setCaption-java.lang.String-}
+```
+public void setCaption(String value)
+```
+
+
+このプロパティの説明については、[getCaption()](../../com.aspose.diagram/checkboxactivexcontrol\#getCaption--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setChecked(boolean value) {#setChecked-boolean-}
+```
+public void setChecked(boolean value)
+```
+
+
+このプロパティの説明については、[isChecked()](../../com.aspose.diagram/checkboxactivexcontrol\#isChecked--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+このプロパティの説明については、[isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+このプロパティの説明については、[getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setGroupName(String value) {#setGroupName-java.lang.String-}
+```
+public void setGroupName(String value)
+```
+
+
+このプロパティの説明については、[getGroupName()](../../com.aspose.diagram/checkboxactivexcontrol\#getGroupName--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+このプロパティの説明については、[getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+このプロパティの説明については、[getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+このプロパティの説明については、[isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+このプロパティの説明については、[getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+このプロパティの説明については、[getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setPicture(byte[] value) {#setPicture-byte---}
+```
+public void setPicture(byte[] value)
+```
+
+
+このプロパティの説明については、[getPicture()](../../com.aspose.diagram/checkboxactivexcontrol\#getPicture--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | byte[] |  |
+
+### setPicturePosition(int value) {#setPicturePosition-int-}
+```
+public void setPicturePosition(int value)
+```
+
+
+このプロパティの説明については、[getPicturePosition()](../../com.aspose.diagram/checkboxactivexcontrol\#getPicturePosition--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setSpecialEffect(int value) {#setSpecialEffect-int-}
+```
+public void setSpecialEffect(int value)
+```
+
+
+このプロパティの説明については、[getSpecialEffect()](../../com.aspose.diagram/checkboxactivexcontrol\#getSpecialEffect--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+このプロパティの説明については、[isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setTripleState(boolean value) {#setTripleState-boolean-}
+```
+public void setTripleState(boolean value)
+```
+
+
+このプロパティの説明については、[isTripleState()](../../com.aspose.diagram/checkboxactivexcontrol\#isTripleState--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/checkboxactivexcontrol\#getValue--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+このプロパティの説明については、[getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double |  |
+
+### setWordWrapped(boolean value) {#setWordWrapped-boolean-}
+```
+public void setWordWrapped(boolean value)
+```
+
+
+このプロパティの説明については、[isWordWrapped()](../../com.aspose.diagram/checkboxactivexcontrol\#isWordWrapped--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/checkvaluetype/_index.md
+++ b/japanese/java/com.aspose.diagram/checkvaluetype/_index.md
@@ -1,0 +1,156 @@
+---
+title: CheckValueType
+second_title: Aspose.Diagram for Java API リファレンス
+description: チェックボックスのチェック値タイプを表します。
+type: docs
+weight: 48
+url: /ja/java/com.aspose.diagram/checkvaluetype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class CheckValueType
+```
+
+チェックボックスのチェック値タイプを表します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [CHECKED](#CHECKED) | チェック済み |
+| [MIXED](#MIXED) | 混在 |
+| [UN_CHECKED](#UN-CHECKED) | 未チェック |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CHECKED {#CHECKED}
+```
+public static final int CHECKED
+```
+
+
+チェック済み
+
+### MIXED {#MIXED}
+```
+public static final int MIXED
+```
+
+
+混在
+
+### UN_CHECKED {#UN-CHECKED}
+```
+public static final int UN_CHECKED
+```
+
+
+未チェック
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/collection/_index.md
+++ b/japanese/java/com.aspose.diagram/collection/_index.md
@@ -1,0 +1,188 @@
+---
+title: コレクション
+second_title: Aspose.Diagram for Java API リファレンス
+description: コレクションの基底クラスです。
+type: docs
+weight: 49
+url: /ja/java/com.aspose.diagram/collection/
+---
+
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+java.lang.Iterable
+```
+public abstract class Collection implements Iterable
+```
+
+コレクションの基底クラスです。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Collection()](#Collection--) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Collection() {#Collection--}
+```
+public Collection()
+```
+
+
+コンストラクタ。
+
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/collectionbase/_index.md
+++ b/japanese/java/com.aspose.diagram/collectionbase/_index.md
@@ -1,0 +1,264 @@
+---
+title: CollectionBase
+second_title: Aspose.Diagram for Java API リファレンス
+description: 強く型付けされたコレクションの抽象基底クラスを提供します。
+type: docs
+weight: 50
+url: /ja/java/com.aspose.diagram/collectionbase/
+---
+
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+java.lang.Iterable
+```
+public abstract class CollectionBase implements Iterable
+```
+
+強く型付けされたコレクションの抽象基底クラスを提供します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [CollectionBase()](#CollectionBase--) | Initializes a new instance of the CollectionBase class with the default initial capacity. |
+| [CollectionBase(int capacity)](#CollectionBase-int-) | Initializes a new instance of the CollectionBase class with the specified capacity. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(Object o)](#add-java.lang.Object-) | Adds an item to the CollectionBase instance. |
+| [clear()](#clear--) | Removes all objects from the CollectionBase instance. |
+| [contains(Object o)](#contains-java.lang.Object-) | Return whether instance contains this object |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Get an item at specified position. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gets the number of elements contained in the CollectionBase instance. |
+| [hashCode()](#hashCode--) |  |
+| [indexOf(Object o)](#indexOf-java.lang.Object-) | Determines the index of a specific item in the CollectionBase instance. |
+| [iterator()](#iterator--) | Returns an enumerator that iterates through the CollectionBase instance. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [removeAt(int index)](#removeAt-int-) | Removes the item at the specified index. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CollectionBase() {#CollectionBase--}
+```
+public CollectionBase()
+```
+
+
+Initializes a new instance of the CollectionBase class with the default initial capacity.
+
+### CollectionBase(int capacity) {#CollectionBase-int-}
+```
+public CollectionBase(int capacity)
+```
+
+
+Initializes a new instance of the CollectionBase class with the specified capacity.
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| capacity | int | The number of elements that the new list can initially store. |
+
+### add(Object o) {#add-java.lang.Object-}
+```
+public int add(Object o)
+```
+
+
+Adds an item to the CollectionBase instance.
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| o | java.lang.Object | The Object to add to the CollectionBase instance. |
+
+**Returns:**
+int - The position into which the new element was inserted.
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Removes all objects from the CollectionBase instance.
+
+### contains(Object o) {#contains-java.lang.Object-}
+```
+public boolean contains(Object o)
+```
+
+
+Return whether instance contains this object
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| o | java.lang.Object | テストオブジェクト |
+
+**Returns:**
+boolean - インスタンスがこのオブジェクトを含むかどうか
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Object get(int index)
+```
+
+
+Get an item at specified position.
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 指定された位置のインデックスです。 |
+
+**Returns:**
+java.lang.Object - 指定された位置の項目です。
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gets the number of elements contained in the CollectionBase instance.
+
+**Returns:**
+int - CollectionBase インスタンスに含まれる要素数です。
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### indexOf(Object o) {#indexOf-java.lang.Object-}
+```
+public int indexOf(Object o)
+```
+
+
+Determines the index of a specific item in the CollectionBase instance.
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| o | java.lang.Object | Determines the index of a specific item in the CollectionBase instance. |
+
+**Returns:**
+int - リスト内に値が見つかった場合のインデックス。見つからない場合は -1 です。
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Returns an enumerator that iterates through the CollectionBase instance.
+
+**Returns:**
+java.util.Iterator - CollectionBase インスタンス用のイテレータです。
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### removeAt(int index) {#removeAt-int-}
+```
+public void removeAt(int index)
+```
+
+
+Removes the item at the specified index.
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 削除する項目のゼロベースインデックスです。 |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/color/_index.md
+++ b/japanese/java/com.aspose.diagram/color/_index.md
@@ -1,0 +1,1819 @@
+---
+title: Color
+second_title: Aspose.Diagram for Java API リファレンス
+description: ARGB（アルファ、赤、緑、青）カラーを表します。
+type: docs
+weight: 51
+url: /ja/java/com.aspose.diagram/color/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Color
+```
+
+ARGB（アルファ、赤、緑、青）カラーを表します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Color()](#Color--) | 構築関数 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object obj)](#equals-java.lang.Object-) | 指定されたオブジェクトが Color オブジェクトであり、このオブジェクトと等価かどうかをテストします。 |
+| [fromArgb(int argb)](#fromArgb-int-) | 32 ビット ARGB 値から Color オブジェクトを作成します。 |
+| [fromArgb(int red, int green, int blue)](#fromArgb-int-int-int-) | 指定された 8 ビットカラー値（赤、緑、青）から Color オブジェクトを作成します。 |
+| [fromArgb(int alpha, int red, int green, int blue)](#fromArgb-int-int-int-int-) | 4 つの ARGB コンポーネント（アルファ、赤、緑、青）値から Color オブジェクトを作成します。 |
+| [getA()](#getA--) | この Color オブジェクトのアルファコンポーネント値を取得します。 |
+| [getAliceBlue()](#getAliceBlue--) | システム定義のカラーを取得します。 |
+| [getAntiqueWhite()](#getAntiqueWhite--) | システム定義のカラーを取得します。 |
+| [getAqua()](#getAqua--) | システム定義のカラーを取得します。 |
+| [getAquamarine()](#getAquamarine--) | システム定義のカラーを取得します。 |
+| [getAzure()](#getAzure--) | システム定義のカラーを取得します。 |
+| [getB()](#getB--) | この Color オブジェクトの青コンポーネント値を取得します。 |
+| [getBeige()](#getBeige--) | システム定義のカラーを取得します。 |
+| [getBisque()](#getBisque--) | システム定義のカラーを取得します。 |
+| [getBlack()](#getBlack--) | システム定義のカラーを取得します。 |
+| [getBlanchedAlmond()](#getBlanchedAlmond--) | システム定義のカラーを取得します。 |
+| [getBlue()](#getBlue--) | システム定義のカラーを取得します。 |
+| [getBlueViolet()](#getBlueViolet--) | システム定義のカラーを取得します。 |
+| [getBrown()](#getBrown--) | システム定義のカラーを取得します。 |
+| [getBurlyWood()](#getBurlyWood--) | システム定義のカラーを取得します。 |
+| [getCadetBlue()](#getCadetBlue--) | システム定義のカラーを取得します。 |
+| [getChartreuse()](#getChartreuse--) | システム定義のカラーを取得します。 |
+| [getChocolate()](#getChocolate--) | システム定義のカラーを取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCoral()](#getCoral--) | システム定義のカラーを取得します。 |
+| [getCornflowerBlue()](#getCornflowerBlue--) | システム定義のカラーを取得します。 |
+| [getCornsilk()](#getCornsilk--) | システム定義のカラーを取得します。 |
+| [getCrimson()](#getCrimson--) | システム定義のカラーを取得します。 |
+| [getCyan()](#getCyan--) | システム定義のカラーを取得します。 |
+| [getDarkBlue()](#getDarkBlue--) | システム定義のカラーを取得します。 |
+| [getDarkCyan()](#getDarkCyan--) | システム定義のカラーを取得します。 |
+| [getDarkGoldenrod()](#getDarkGoldenrod--) | システム定義のカラーを取得します。 |
+| [getDarkGray()](#getDarkGray--) | システム定義のカラーを取得します。 |
+| [getDarkGreen()](#getDarkGreen--) | システム定義のカラーを取得します。 |
+| [getDarkKhaki()](#getDarkKhaki--) | システム定義のカラーを取得します。 |
+| [getDarkMagenta()](#getDarkMagenta--) | システム定義のカラーを取得します。 |
+| [getDarkOliveGreen()](#getDarkOliveGreen--) | システム定義のカラーを取得します。 |
+| [getDarkOrange()](#getDarkOrange--) | システム定義のカラーを取得します。 |
+| [getDarkOrchid()](#getDarkOrchid--) | システム定義のカラーを取得します。 |
+| [getDarkRed()](#getDarkRed--) | システム定義のカラーを取得します。 |
+| [getDarkSalmon()](#getDarkSalmon--) | システム定義のカラーを取得します。 |
+| [getDarkSeaGreen()](#getDarkSeaGreen--) | システム定義のカラーを取得します。 |
+| [getDarkSlateBlue()](#getDarkSlateBlue--) | システム定義のカラーを取得します。 |
+| [getDarkSlateGray()](#getDarkSlateGray--) | システム定義のカラーを取得します。 |
+| [getDarkTurquoise()](#getDarkTurquoise--) | システム定義のカラーを取得します。 |
+| [getDarkViolet()](#getDarkViolet--) | システム定義のカラーを取得します。 |
+| [getDeepPink()](#getDeepPink--) | システム定義のカラーを取得します。 |
+| [getDeepSkyBlue()](#getDeepSkyBlue--) | システム定義のカラーを取得します。 |
+| [getDimGray()](#getDimGray--) | システム定義のカラーを取得します。 |
+| [getDodgerBlue()](#getDodgerBlue--) | システム定義のカラーを取得します。 |
+| [getEmpty()](#getEmpty--) | システム定義の空のカラーを取得します。 |
+| [getFirebrick()](#getFirebrick--) | システム定義のカラーを取得します。 |
+| [getFloralWhite()](#getFloralWhite--) | システム定義のカラーを取得します。 |
+| [getForestGreen()](#getForestGreen--) | システム定義のカラーを取得します。 |
+| [getFuchsia()](#getFuchsia--) | システム定義のカラーを取得します。 |
+| [getG()](#getG--) | この Color オブジェクトの緑コンポーネント値を取得します。 |
+| [getGainsboro()](#getGainsboro--) | システム定義のカラーを取得します。 |
+| [getGhostWhite()](#getGhostWhite--) | システム定義のカラーを取得します。 |
+| [getGold()](#getGold--) | システム定義のカラーを取得します。 |
+| [getGoldenrod()](#getGoldenrod--) | システム定義のカラーを取得します。 |
+| [getGray()](#getGray--) | システム定義のカラーを取得します。 |
+| [getGreen()](#getGreen--) | システム定義のカラーを取得します。 |
+| [getGreenYellow()](#getGreenYellow--) | システム定義のカラーを取得します。 |
+| [getHoneydew()](#getHoneydew--) | システム定義のカラーを取得します。 |
+| [getHotPink()](#getHotPink--) | システム定義のカラーを取得します。 |
+| [getIndianRed()](#getIndianRed--) | システム定義のカラーを取得します。 |
+| [getIndigo()](#getIndigo--) | システム定義のカラーを取得します。 |
+| [getIvory()](#getIvory--) | システム定義のカラーを取得します。 |
+| [getKhaki()](#getKhaki--) | システム定義のカラーを取得します。 |
+| [getLavender()](#getLavender--) | システム定義のカラーを取得します。 |
+| [getLavenderBlush()](#getLavenderBlush--) | システム定義のカラーを取得します。 |
+| [getLawnGreen()](#getLawnGreen--) | システム定義のカラーを取得します。 |
+| [getLemonChiffon()](#getLemonChiffon--) | システム定義のカラーを取得します。 |
+| [getLightBlue()](#getLightBlue--) | システム定義のカラーを取得します。 |
+| [getLightCoral()](#getLightCoral--) | システム定義のカラーを取得します。 |
+| [getLightCyan()](#getLightCyan--) | システム定義のカラーを取得します。 |
+| [getLightGoldenrodYellow()](#getLightGoldenrodYellow--) | システム定義のカラーを取得します。 |
+| [getLightGray()](#getLightGray--) | システム定義のカラーを取得します。 |
+| [getLightGreen()](#getLightGreen--) | システム定義のカラーを取得します。 |
+| [getLightPink()](#getLightPink--) | システム定義のカラーを取得します。 |
+| [getLightSalmon()](#getLightSalmon--) | システム定義のカラーを取得します。 |
+| [getLightSeaGreen()](#getLightSeaGreen--) | システム定義のカラーを取得します。 |
+| [getLightSkyBlue()](#getLightSkyBlue--) | システム定義のカラーを取得します。 |
+| [getLightSlateGray()](#getLightSlateGray--) | システム定義のカラーを取得します。 |
+| [getLightSteelBlue()](#getLightSteelBlue--) | システム定義のカラーを取得します。 |
+| [getLightYellow()](#getLightYellow--) | システム定義のカラーを取得します。 |
+| [getLime()](#getLime--) | システム定義のカラーを取得します。 |
+| [getLimeGreen()](#getLimeGreen--) | システム定義のカラーを取得します。 |
+| [getLinen()](#getLinen--) | システム定義のカラーを取得します。 |
+| [getMagenta()](#getMagenta--) | システム定義のカラーを取得します。 |
+| [getMaroon()](#getMaroon--) | システム定義のカラーを取得します。 |
+| [getMediumAquamarine()](#getMediumAquamarine--) | システム定義のカラーを取得します。 |
+| [getMediumBlue()](#getMediumBlue--) | システム定義のカラーを取得します。 |
+| [getMediumOrchid()](#getMediumOrchid--) | システム定義のカラーを取得します。 |
+| [getMediumPurple()](#getMediumPurple--) | システム定義のカラーを取得します。 |
+| [getMediumSeaGreen()](#getMediumSeaGreen--) | システム定義のカラーを取得します。 |
+| [getMediumSlateBlue()](#getMediumSlateBlue--) | システム定義のカラーを取得します。 |
+| [getMediumSpringGreen()](#getMediumSpringGreen--) | システム定義のカラーを取得します。 |
+| [getMediumTurquoise()](#getMediumTurquoise--) | システム定義のカラーを取得します。 |
+| [getMediumVioletRed()](#getMediumVioletRed--) | システム定義のカラーを取得します。 |
+| [getMidnightBlue()](#getMidnightBlue--) | システム定義のカラーを取得します。 |
+| [getMintCream()](#getMintCream--) | システム定義のカラーを取得します。 |
+| [getMistyRose()](#getMistyRose--) | システム定義のカラーを取得します。 |
+| [getMoccasin()](#getMoccasin--) | システム定義のカラーを取得します。 |
+| [getNavajoWhite()](#getNavajoWhite--) | システム定義のカラーを取得します。 |
+| [getNavy()](#getNavy--) | システム定義のカラーを取得します。 |
+| [getOldLace()](#getOldLace--) | システム定義のカラーを取得します。 |
+| [getOlive()](#getOlive--) | システム定義のカラーを取得します。 |
+| [getOliveDrab()](#getOliveDrab--) | システム定義のカラーを取得します。 |
+| [getOrange()](#getOrange--) | システム定義のカラーを取得します。 |
+| [getOrangeRed()](#getOrangeRed--) | システム定義のカラーを取得します。 |
+| [getOrchid()](#getOrchid--) | システム定義のカラーを取得します。 |
+| [getPaleGoldenrod()](#getPaleGoldenrod--) | システム定義のカラーを取得します。 |
+| [getPaleGreen()](#getPaleGreen--) | システム定義のカラーを取得します。 |
+| [getPaleTurquoise()](#getPaleTurquoise--) | システム定義のカラーを取得します。 |
+| [getPaleVioletRed()](#getPaleVioletRed--) | システム定義のカラーを取得します。 |
+| [getPapayaWhip()](#getPapayaWhip--) | システム定義のカラーを取得します。 |
+| [getPeachPuff()](#getPeachPuff--) | システム定義のカラーを取得します。 |
+| [getPeru()](#getPeru--) | システム定義のカラーを取得します。 |
+| [getPink()](#getPink--) | システム定義のカラーを取得します。 |
+| [getPlum()](#getPlum--) | システム定義のカラーを取得します。 |
+| [getPowderBlue()](#getPowderBlue--) | システム定義のカラーを取得します。 |
+| [getPurple()](#getPurple--) | システム定義のカラーを取得します。 |
+| [getR()](#getR--) | この Color オブジェクトの赤コンポーネント値を取得します。 |
+| [getRed()](#getRed--) | システム定義のカラーを取得します。 |
+| [getRosyBrown()](#getRosyBrown--) | システム定義のカラーを取得します。 |
+| [getRoyalBlue()](#getRoyalBlue--) | システム定義のカラーを取得します。 |
+| [getSaddleBrown()](#getSaddleBrown--) | システム定義のカラーを取得します。 |
+| [getSalmon()](#getSalmon--) | システム定義のカラーを取得します。 |
+| [getSandyBrown()](#getSandyBrown--) | システム定義のカラーを取得します。 |
+| [getSeaGreen()](#getSeaGreen--) | システム定義のカラーを取得します。 |
+| [getSeaShell()](#getSeaShell--) | システム定義のカラーを取得します。 |
+| [getSienna()](#getSienna--) | システム定義のカラーを取得します。 |
+| [getSilver()](#getSilver--) | システム定義のカラーを取得します。 |
+| [getSkyBlue()](#getSkyBlue--) | システム定義のカラーを取得します。 |
+| [getSlateBlue()](#getSlateBlue--) | システム定義のカラーを取得します。 |
+| [getSlateGray()](#getSlateGray--) | システム定義のカラーを取得します。 |
+| [getSnow()](#getSnow--) | システム定義のカラーを取得します。 |
+| [getSpringGreen()](#getSpringGreen--) | システム定義のカラーを取得します。 |
+| [getSteelBlue()](#getSteelBlue--) | システム定義のカラーを取得します。 |
+| [getTan()](#getTan--) | システム定義のカラーを取得します。 |
+| [getTeal()](#getTeal--) | システム定義のカラーを取得します。 |
+| [getThistle()](#getThistle--) | システム定義のカラーを取得します。 |
+| [getTomato()](#getTomato--) | システム定義のカラーを取得します。 |
+| [getTransparent()](#getTransparent--) | システム定義のカラーを取得します。 |
+| [getTurquoise()](#getTurquoise--) | システム定義のカラーを取得します。 |
+| [getViolet()](#getViolet--) | システム定義のカラーを取得します。 |
+| [getWheat()](#getWheat--) | システム定義のカラーを取得します。 |
+| [getWhite()](#getWhite--) | システム定義のカラーを取得します。 |
+| [getWhiteSmoke()](#getWhiteSmoke--) | システム定義のカラーを取得します。 |
+| [getYellow()](#getYellow--) | システム定義のカラーを取得します。 |
+| [getYellowGreen()](#getYellowGreen--) | システム定義のカラーを取得します。 |
+| [hashCode()](#hashCode--) | この Color オブジェクトのハッシュコードを返します。 |
+| [isEmpty()](#isEmpty--) | この Color オブジェクトが未初期化かどうかを指定します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toArgb()](#toArgb--) | この Color オブジェクトの 32 ビット ARGB 値を取得します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Color() {#Color--}
+```
+public Color()
+```
+
+
+構築関数
+
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+指定されたオブジェクトが Color オブジェクトであり、このオブジェクトと等価かどうかをテストします。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| obj | java.lang.Object | テスト対象のオブジェクト。 |
+
+**Returns:**
+boolean - obj が Color オブジェクトであり、この Color オブジェクトと等価な場合は true、そうでない場合は false。
+### fromArgb(int argb) {#fromArgb-int-}
+```
+public static Color fromArgb(int argb)
+```
+
+
+32 ビット ARGB 値から Color オブジェクトを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| argb | int | 32 ビット ARGB 値を指定する値。 |
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - The Color object that this method creates.
+### fromArgb(int red, int green, int blue) {#fromArgb-int-int-int-}
+```
+public static Color fromArgb(int red, int green, int blue)
+```
+
+
+指定された 8 ビットカラー値（赤、緑、青）から Color オブジェクトを作成します。アルファ値は暗黙的に 255（完全に不透明）です。このメソッドは各カラーコンポーネントに 32 ビット値を渡すことを許可しますが、各コンポーネントの値は 8 ビットに制限されます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| red | int | 新しい Color オブジェクトの赤コンポーネント値。有効な値は 0 から 255 です。 |
+| 緑 | int | 新しい Color オブジェクトの緑コンポーネントの値です。有効な値は 0 から 255 です。 |
+| 青 | int | 新しい Color オブジェクトの青コンポーネントの値です。有効な値は 0 から 255 です。 |
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - The Color object that this method creates.
+### fromArgb(int alpha, int red, int green, int blue) {#fromArgb-int-int-int-int-}
+```
+public static Color fromArgb(int alpha, int red, int green, int blue)
+```
+
+
+4 つの ARGB コンポーネント（アルファ、赤、緑、青）の値から Color オブジェクトを作成します。このメソッドは各コンポーネントに 32 ビットの値を渡すことを許可しますが、各コンポーネントの値は 8 ビットに制限されます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| アルファ | int | アルファコンポーネントです。有効な値は 0 から 255 です。 |
+| red | int | 赤コンポーネントです。有効な値は 0 から 255 です。 |
+| 緑 | int | 緑コンポーネントです。有効な値は 0 から 255 です。 |
+| 青 | int | 青コンポーネントです。有効な値は 0 から 255 です。 |
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - The Color object that this method creates.
+### getA() {#getA--}
+```
+public byte getA()
+```
+
+
+この Color オブジェクトのアルファコンポーネント値を取得します。
+
+**Returns:**
+byte - この Color オブジェクトのアルファコンポーネント値です。
+### getAliceBlue() {#getAliceBlue--}
+```
+public static Color getAliceBlue()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getAntiqueWhite() {#getAntiqueWhite--}
+```
+public static Color getAntiqueWhite()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getAqua() {#getAqua--}
+```
+public static Color getAqua()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getAquamarine() {#getAquamarine--}
+```
+public static Color getAquamarine()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getAzure() {#getAzure--}
+```
+public static Color getAzure()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getB() {#getB--}
+```
+public byte getB()
+```
+
+
+この Color オブジェクトの青コンポーネント値を取得します。
+
+**Returns:**
+byte - この Color オブジェクトの青コンポーネント値です。
+### getBeige() {#getBeige--}
+```
+public static Color getBeige()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getBisque() {#getBisque--}
+```
+public static Color getBisque()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getBlack() {#getBlack--}
+```
+public static Color getBlack()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getBlanchedAlmond() {#getBlanchedAlmond--}
+```
+public static Color getBlanchedAlmond()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getBlue() {#getBlue--}
+```
+public static Color getBlue()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getBlueViolet() {#getBlueViolet--}
+```
+public static Color getBlueViolet()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getBrown() {#getBrown--}
+```
+public static Color getBrown()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getBurlyWood() {#getBurlyWood--}
+```
+public static Color getBurlyWood()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getCadetBlue() {#getCadetBlue--}
+```
+public static Color getCadetBlue()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getChartreuse() {#getChartreuse--}
+```
+public static Color getChartreuse()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getChocolate() {#getChocolate--}
+```
+public static Color getChocolate()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCoral() {#getCoral--}
+```
+public static Color getCoral()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getCornflowerBlue() {#getCornflowerBlue--}
+```
+public static Color getCornflowerBlue()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getCornsilk() {#getCornsilk--}
+```
+public static Color getCornsilk()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getCrimson() {#getCrimson--}
+```
+public static Color getCrimson()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getCyan() {#getCyan--}
+```
+public static Color getCyan()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkBlue() {#getDarkBlue--}
+```
+public static Color getDarkBlue()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkCyan() {#getDarkCyan--}
+```
+public static Color getDarkCyan()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkGoldenrod() {#getDarkGoldenrod--}
+```
+public static Color getDarkGoldenrod()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkGray() {#getDarkGray--}
+```
+public static Color getDarkGray()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkGreen() {#getDarkGreen--}
+```
+public static Color getDarkGreen()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkKhaki() {#getDarkKhaki--}
+```
+public static Color getDarkKhaki()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkMagenta() {#getDarkMagenta--}
+```
+public static Color getDarkMagenta()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkOliveGreen() {#getDarkOliveGreen--}
+```
+public static Color getDarkOliveGreen()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkOrange() {#getDarkOrange--}
+```
+public static Color getDarkOrange()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkOrchid() {#getDarkOrchid--}
+```
+public static Color getDarkOrchid()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkRed() {#getDarkRed--}
+```
+public static Color getDarkRed()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkSalmon() {#getDarkSalmon--}
+```
+public static Color getDarkSalmon()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkSeaGreen() {#getDarkSeaGreen--}
+```
+public static Color getDarkSeaGreen()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkSlateBlue() {#getDarkSlateBlue--}
+```
+public static Color getDarkSlateBlue()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkSlateGray() {#getDarkSlateGray--}
+```
+public static Color getDarkSlateGray()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkTurquoise() {#getDarkTurquoise--}
+```
+public static Color getDarkTurquoise()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkViolet() {#getDarkViolet--}
+```
+public static Color getDarkViolet()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDeepPink() {#getDeepPink--}
+```
+public static Color getDeepPink()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDeepSkyBlue() {#getDeepSkyBlue--}
+```
+public static Color getDeepSkyBlue()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDimGray() {#getDimGray--}
+```
+public static Color getDimGray()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDodgerBlue() {#getDodgerBlue--}
+```
+public static Color getDodgerBlue()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getEmpty() {#getEmpty--}
+```
+public static Color getEmpty()
+```
+
+
+システム定義の空のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getFirebrick() {#getFirebrick--}
+```
+public static Color getFirebrick()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getFloralWhite() {#getFloralWhite--}
+```
+public static Color getFloralWhite()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getForestGreen() {#getForestGreen--}
+```
+public static Color getForestGreen()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getFuchsia() {#getFuchsia--}
+```
+public static Color getFuchsia()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getG() {#getG--}
+```
+public byte getG()
+```
+
+
+この Color オブジェクトの緑コンポーネント値を取得します。
+
+**Returns:**
+byte - この Color オブジェクトの緑コンポーネント値です。
+### getGainsboro() {#getGainsboro--}
+```
+public static Color getGainsboro()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getGhostWhite() {#getGhostWhite--}
+```
+public static Color getGhostWhite()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getGold() {#getGold--}
+```
+public static Color getGold()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getGoldenrod() {#getGoldenrod--}
+```
+public static Color getGoldenrod()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getGray() {#getGray--}
+```
+public static Color getGray()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getGreen() {#getGreen--}
+```
+public static Color getGreen()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getGreenYellow() {#getGreenYellow--}
+```
+public static Color getGreenYellow()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getHoneydew() {#getHoneydew--}
+```
+public static Color getHoneydew()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getHotPink() {#getHotPink--}
+```
+public static Color getHotPink()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getIndianRed() {#getIndianRed--}
+```
+public static Color getIndianRed()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getIndigo() {#getIndigo--}
+```
+public static Color getIndigo()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getIvory() {#getIvory--}
+```
+public static Color getIvory()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getKhaki() {#getKhaki--}
+```
+public static Color getKhaki()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLavender() {#getLavender--}
+```
+public static Color getLavender()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLavenderBlush() {#getLavenderBlush--}
+```
+public static Color getLavenderBlush()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLawnGreen() {#getLawnGreen--}
+```
+public static Color getLawnGreen()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLemonChiffon() {#getLemonChiffon--}
+```
+public static Color getLemonChiffon()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightBlue() {#getLightBlue--}
+```
+public static Color getLightBlue()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightCoral() {#getLightCoral--}
+```
+public static Color getLightCoral()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightCyan() {#getLightCyan--}
+```
+public static Color getLightCyan()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightGoldenrodYellow() {#getLightGoldenrodYellow--}
+```
+public static Color getLightGoldenrodYellow()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightGray() {#getLightGray--}
+```
+public static Color getLightGray()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightGreen() {#getLightGreen--}
+```
+public static Color getLightGreen()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightPink() {#getLightPink--}
+```
+public static Color getLightPink()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightSalmon() {#getLightSalmon--}
+```
+public static Color getLightSalmon()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightSeaGreen() {#getLightSeaGreen--}
+```
+public static Color getLightSeaGreen()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightSkyBlue() {#getLightSkyBlue--}
+```
+public static Color getLightSkyBlue()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightSlateGray() {#getLightSlateGray--}
+```
+public static Color getLightSlateGray()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightSteelBlue() {#getLightSteelBlue--}
+```
+public static Color getLightSteelBlue()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightYellow() {#getLightYellow--}
+```
+public static Color getLightYellow()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLime() {#getLime--}
+```
+public static Color getLime()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLimeGreen() {#getLimeGreen--}
+```
+public static Color getLimeGreen()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLinen() {#getLinen--}
+```
+public static Color getLinen()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMagenta() {#getMagenta--}
+```
+public static Color getMagenta()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMaroon() {#getMaroon--}
+```
+public static Color getMaroon()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMediumAquamarine() {#getMediumAquamarine--}
+```
+public static Color getMediumAquamarine()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMediumBlue() {#getMediumBlue--}
+```
+public static Color getMediumBlue()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMediumOrchid() {#getMediumOrchid--}
+```
+public static Color getMediumOrchid()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMediumPurple() {#getMediumPurple--}
+```
+public static Color getMediumPurple()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMediumSeaGreen() {#getMediumSeaGreen--}
+```
+public static Color getMediumSeaGreen()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMediumSlateBlue() {#getMediumSlateBlue--}
+```
+public static Color getMediumSlateBlue()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMediumSpringGreen() {#getMediumSpringGreen--}
+```
+public static Color getMediumSpringGreen()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMediumTurquoise() {#getMediumTurquoise--}
+```
+public static Color getMediumTurquoise()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMediumVioletRed() {#getMediumVioletRed--}
+```
+public static Color getMediumVioletRed()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMidnightBlue() {#getMidnightBlue--}
+```
+public static Color getMidnightBlue()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMintCream() {#getMintCream--}
+```
+public static Color getMintCream()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMistyRose() {#getMistyRose--}
+```
+public static Color getMistyRose()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMoccasin() {#getMoccasin--}
+```
+public static Color getMoccasin()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getNavajoWhite() {#getNavajoWhite--}
+```
+public static Color getNavajoWhite()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getNavy() {#getNavy--}
+```
+public static Color getNavy()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getOldLace() {#getOldLace--}
+```
+public static Color getOldLace()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getOlive() {#getOlive--}
+```
+public static Color getOlive()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getOliveDrab() {#getOliveDrab--}
+```
+public static Color getOliveDrab()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getOrange() {#getOrange--}
+```
+public static Color getOrange()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getOrangeRed() {#getOrangeRed--}
+```
+public static Color getOrangeRed()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getOrchid() {#getOrchid--}
+```
+public static Color getOrchid()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPaleGoldenrod() {#getPaleGoldenrod--}
+```
+public static Color getPaleGoldenrod()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPaleGreen() {#getPaleGreen--}
+```
+public static Color getPaleGreen()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPaleTurquoise() {#getPaleTurquoise--}
+```
+public static Color getPaleTurquoise()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPaleVioletRed() {#getPaleVioletRed--}
+```
+public static Color getPaleVioletRed()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPapayaWhip() {#getPapayaWhip--}
+```
+public static Color getPapayaWhip()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPeachPuff() {#getPeachPuff--}
+```
+public static Color getPeachPuff()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPeru() {#getPeru--}
+```
+public static Color getPeru()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPink() {#getPink--}
+```
+public static Color getPink()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPlum() {#getPlum--}
+```
+public static Color getPlum()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPowderBlue() {#getPowderBlue--}
+```
+public static Color getPowderBlue()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPurple() {#getPurple--}
+```
+public static Color getPurple()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getR() {#getR--}
+```
+public byte getR()
+```
+
+
+この Color オブジェクトの赤コンポーネント値を取得します。
+
+**Returns:**
+byte - この Color オブジェクトの赤コンポーネント値です。
+### getRed() {#getRed--}
+```
+public static Color getRed()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getRosyBrown() {#getRosyBrown--}
+```
+public static Color getRosyBrown()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getRoyalBlue() {#getRoyalBlue--}
+```
+public static Color getRoyalBlue()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSaddleBrown() {#getSaddleBrown--}
+```
+public static Color getSaddleBrown()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSalmon() {#getSalmon--}
+```
+public static Color getSalmon()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSandyBrown() {#getSandyBrown--}
+```
+public static Color getSandyBrown()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSeaGreen() {#getSeaGreen--}
+```
+public static Color getSeaGreen()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSeaShell() {#getSeaShell--}
+```
+public static Color getSeaShell()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSienna() {#getSienna--}
+```
+public static Color getSienna()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSilver() {#getSilver--}
+```
+public static Color getSilver()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSkyBlue() {#getSkyBlue--}
+```
+public static Color getSkyBlue()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSlateBlue() {#getSlateBlue--}
+```
+public static Color getSlateBlue()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSlateGray() {#getSlateGray--}
+```
+public static Color getSlateGray()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSnow() {#getSnow--}
+```
+public static Color getSnow()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSpringGreen() {#getSpringGreen--}
+```
+public static Color getSpringGreen()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSteelBlue() {#getSteelBlue--}
+```
+public static Color getSteelBlue()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getTan() {#getTan--}
+```
+public static Color getTan()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getTeal() {#getTeal--}
+```
+public static Color getTeal()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getThistle() {#getThistle--}
+```
+public static Color getThistle()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getTomato() {#getTomato--}
+```
+public static Color getTomato()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getTransparent() {#getTransparent--}
+```
+public static Color getTransparent()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getTurquoise() {#getTurquoise--}
+```
+public static Color getTurquoise()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getViolet() {#getViolet--}
+```
+public static Color getViolet()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getWheat() {#getWheat--}
+```
+public static Color getWheat()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getWhite() {#getWhite--}
+```
+public static Color getWhite()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getWhiteSmoke() {#getWhiteSmoke--}
+```
+public static Color getWhiteSmoke()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getYellow() {#getYellow--}
+```
+public static Color getYellow()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getYellowGreen() {#getYellowGreen--}
+```
+public static Color getYellowGreen()
+```
+
+
+システム定義のカラーを取得します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+この Color オブジェクトのハッシュコードを返します。
+
+**Returns:**
+int - この Color オブジェクトのハッシュコードを指定する整数値です。
+### isEmpty() {#isEmpty--}
+```
+public boolean isEmpty()
+```
+
+
+この Color オブジェクトが未初期化かどうかを指定します。
+
+**Returns:**
+boolean - このプロパティは、この色が未初期化の場合は true を、そうでない場合は false を返します。
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toArgb() {#toArgb--}
+```
+public int toArgb()
+```
+
+
+この Color オブジェクトの 32 ビット ARGB 値を取得します。
+
+**Returns:**
+int - この Color オブジェクトの 32 ビット ARGB 値です。
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/colorentry/_index.md
+++ b/japanese/java/com.aspose.diagram/colorentry/_index.md
@@ -1,0 +1,188 @@
+---
+title: ColorEntry
+second_title: Aspose.Diagram for Java API リファレンス
+description: カラーテーブルエントリを含みます。
+type: docs
+weight: 52
+url: /ja/java/com.aspose.diagram/colorentry/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ColorEntry
+```
+
+カラー テーブル エントリを含みます。各カラー テーブル エントリは、図形、テキスト、レイヤーなどのオブジェクトに適用できる標準色を指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [ColorEntry()](#ColorEntry--) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getColor()](#getColor--) | ARGB カラーを表します。 |
+| [getIX()](#getIX--) | 必須の int。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setColor(Color value)](#setColor-com.aspose.diagram.Color-) | このプロパティの説明については、[getColor()](../../com.aspose.diagram/colorentry\#getColor--) をご覧ください。 |
+| [setIX(int value)](#setIX-int-) | このプロパティの説明については、[getIX()](../../com.aspose.diagram/colorentry\#getIX--) をご覧ください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ColorEntry() {#ColorEntry--}
+```
+public ColorEntry()
+```
+
+
+コンストラクタ。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColor() {#getColor--}
+```
+public Color getColor()
+```
+
+
+ARGB カラーを表します。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color)
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+必須の int。要素が親要素内で持つゼロベースのインデックスです。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setColor(Color value) {#setColor-com.aspose.diagram.Color-}
+```
+public void setColor(Color value)
+```
+
+
+このプロパティの説明については、[getColor()](../../com.aspose.diagram/colorentry\#getColor--) をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [Color](../../com.aspose.diagram/color) |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+このプロパティの説明については、[getIX()](../../com.aspose.diagram/colorentry\#getIX--) をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/colorentrycollection/_index.md
+++ b/japanese/java/com.aspose.diagram/colorentrycollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: ColorEntryCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: ドキュメントのカラーテーブルを含みます。
+type: docs
+weight: 53
+url: /ja/java/com.aspose.diagram/colorentrycollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ColorEntryCollection extends Collection
+```
+
+ドキュメントのカラーテーブルを含みます。各ドキュメントは 1 つのカラーテーブルを持ち、シェイプ、テキスト、レイヤーなどのオブジェクトに適用できる 24 の標準色が一覧されています。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(ColorEntry color)](#add-com.aspose.diagram.ColorEntry-) | コレクションに Color オブジェクトを追加します。 |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(ColorEntry color)](#remove-com.aspose.diagram.ColorEntry-) | コレクションから Color オブジェクトを削除します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(ColorEntry color) {#add-com.aspose.diagram.ColorEntry-}
+```
+public int add(ColorEntry color)
+```
+
+
+コレクションに Color オブジェクトを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| color | [ColorEntry](../../com.aspose.diagram/colorentry) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public ColorEntry get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[ColorEntry](../../com.aspose.diagram/colorentry) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(ColorEntry color) {#remove-com.aspose.diagram.ColorEntry-}
+```
+public void remove(ColorEntry color)
+```
+
+
+コレクションから Color オブジェクトを削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| color | [ColorEntry](../../com.aspose.diagram/colorentry) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/colorvalue/_index.md
+++ b/japanese/java/com.aspose.diagram/colorvalue/_index.md
@@ -1,0 +1,205 @@
+---
+title: ColorValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: カラー値を表します
+type: docs
+weight: 54
+url: /ja/java/com.aspose.diagram/colorvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ColorValue
+```
+
+カラー値を表します
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [ColorValue(String value, int unit)](#ColorValue-java.lang.String-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性。 |
+| [getValue()](#getValue--) | カラー値。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | このプロパティの説明については、[getUfe()](../../com.aspose.diagram/colorvalue\#getUfe--)をご覧ください。 |
+| [setValue(String value)](#setValue-java.lang.String-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/colorvalue\#getValue--)をご覧ください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ColorValue(String value, int unit) {#ColorValue-java.lang.String-int-}
+```
+public ColorValue(String value, int unit)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+| 単位 | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+カラー値。色を設定するには、0から23までの数値、または16進表記のRGB値を入力してください。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+このプロパティの説明については、[getUfe()](../../com.aspose.diagram/colorvalue\#getUfe--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(String value) {#setValue-java.lang.String-}
+```
+public void setValue(String value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/colorvalue\#getValue--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/comboboxactivexcontrol/_index.md
+++ b/japanese/java/com.aspose.diagram/comboboxactivexcontrol/_index.md
@@ -1,0 +1,972 @@
+---
+title: ComboBoxActiveXControl
+second_title: Aspose.Diagram for Java API リファレンス
+description: ComboBox ActiveX コントロールを表します。
+type: docs
+weight: 55
+url: /ja/java/com.aspose.diagram/comboboxactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class ComboBoxActiveXControl extends ActiveXControl
+```
+
+ComboBox ActiveX コントロールを表します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBackOleColor()](#getBackOleColor--) | 背景の OLE カラー。 |
+| [getBorderOleColor()](#getBorderOleColor--) | 背景の OLE カラー。 |
+| [getBorderStyle()](#getBorderStyle--) | コントロールで使用される境界線の種類。 |
+| [getBoundColumn()](#getBoundColumn--) | ComboBox または ListBox の Value プロパティが MultiSelect プロパティの値 (fmMultiSelectSingle) のときにどのように決定されるかを表します。 |
+| [getClass()](#getClass--) |  |
+| [getColumnCount()](#getColumnCount--) | ComboBox または ListBox に表示する列数を表します。 |
+| [getColumnWidths()](#getColumnWidths--) | 列の幅。 |
+| [getData()](#getData--) | コントロールのバイナリ データ。 |
+| [getDropButtonStyle()](#getDropButtonStyle--) | ドロップボタンに表示されるシンボルを指定します。 |
+| [getEnterFieldBehavior()](#getEnterFieldBehavior--) | コントロールに入るときの選択動作を指定します。 |
+| [getForeOleColor()](#getForeOleColor--) | 前景の OLE カラー。 |
+| [getHeight()](#getHeight--) | ポイント単位のコントロールの高さ。 |
+| [getHideSelection()](#getHideSelection--) | コントロールがフォーカスを持っていないときに、コントロール内の選択されたテキストがハイライト表示されるかどうかを示します。 |
+| [getIMEMode()](#getIMEMode--) | コントロールがフォーカスを受け取る際の Input Method Editor のデフォルト実行時モード。 |
+| [getListRows()](#getListRows--) | リストに表示する最大行数を表します。 |
+| [getListStyle()](#getListStyle--) | 視覚的な外観です。 |
+| [getListWidth()](#getListWidth--) | ポイント単位の幅です。 |
+| [getMatchEntry()](#getMatchEntry--) | ユーザーが入力する際に ListBox または ComboBox がリストを検索する方法を示します。 |
+| [getMaxLength()](#getMaxLength--) | 最大文字数 |
+| [getMouseIcon()](#getMouseIcon--) | コントロールのマウスポインタとして表示するカスタムアイコンです。 |
+| [getMousePointer()](#getMousePointer--) | コントロールのマウスポインタとして表示されるアイコンの種類です。 |
+| [getSelectionMargin()](#getSelectionMargin--) | ユーザーがテキストの左側領域をクリックしてテキスト行を選択できるかどうかを示します。 |
+| [getShowColumnHeads()](#getShowColumnHeads--) | 列見出しが表示されるかどうかを示します。 |
+| [getShowDropButtonTypeWhen()](#getShowDropButtonTypeWhen--) | ドロップボタンに表示されるシンボルを指定します。 |
+| [getSpecialEffect()](#getSpecialEffect--) | コントロールの特殊効果です。 |
+| [getTextColumn()](#getTextColumn--) | ユーザーに表示する ComboBox または ListBox の列を表します。 |
+| [getType()](#getType--) | ActiveX コントロールのタイプを取得します。 |
+| [getValue()](#getValue--) | コントロールの値です。 |
+| [getWidth()](#getWidth--) | ポイント単位のコントロールの幅です。 |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | コントロールが全内容を表示するために自動的にサイズ変更されるかどうかを示します。 |
+| [isAutoWordSelected()](#isAutoWordSelected--) | 選択範囲を拡張する際に使用される基本単位を指定します。 |
+| [isDragBehaviorEnabled()](#isDragBehaviorEnabled--) | コントロールでドラッグ アンド ドロップが有効かどうかを示します。 |
+| [isEditable()](#isEditable--) | ユーザーがコントロールに入力できるかどうかを示します。 |
+| [isEnabled()](#isEnabled--) | コントロールがフォーカスを受け取り、ユーザー生成イベントに応答できるかどうかを示します。 |
+| [isLocked()](#isLocked--) | コントロール内のデータが編集ロックされているかどうかを示します。 |
+| [isTransparent()](#isTransparent--) | コントロールが透明かどうかを示します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | このプロパティの説明については、[isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) を参照してください |
+| [setAutoWordSelected(boolean value)](#setAutoWordSelected-boolean-) | このプロパティの説明については、[isAutoWordSelected()](../../com.aspose.diagram/comboboxactivexcontrol\#isAutoWordSelected--) を参照してください |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | このプロパティの説明については、[getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) を参照してください |
+| [setBorderOleColor(int value)](#setBorderOleColor-int-) | このプロパティの説明については、[getBorderOleColor()](../../com.aspose.diagram/comboboxactivexcontrol\#getBorderOleColor--) を参照してください |
+| [setBorderStyle(int value)](#setBorderStyle-int-) | このプロパティの説明については、[getBorderStyle()](../../com.aspose.diagram/comboboxactivexcontrol\#getBorderStyle--) を参照してください |
+| [setBoundColumn(int value)](#setBoundColumn-int-) | このプロパティの説明については、[getBoundColumn()](../../com.aspose.diagram/comboboxactivexcontrol\#getBoundColumn--) を参照してください |
+| [setColumnCount(int value)](#setColumnCount-int-) | このプロパティの説明については、[getColumnCount()](../../com.aspose.diagram/comboboxactivexcontrol\#getColumnCount--) を参照してください |
+| [setColumnWidths(double value)](#setColumnWidths-double-) | このプロパティの説明については、[getColumnWidths()](../../com.aspose.diagram/comboboxactivexcontrol\#getColumnWidths--) を参照してください |
+| [setDragBehaviorEnabled(boolean value)](#setDragBehaviorEnabled-boolean-) | このプロパティの説明については、[isDragBehaviorEnabled()](../../com.aspose.diagram/comboboxactivexcontrol\#isDragBehaviorEnabled--) を参照してください |
+| [setDropButtonStyle(int value)](#setDropButtonStyle-int-) | このプロパティの説明については、[getDropButtonStyle()](../../com.aspose.diagram/comboboxactivexcontrol\#getDropButtonStyle--) を参照してください |
+| [setEditable(boolean value)](#setEditable-boolean-) | このプロパティの説明については、[isEditable()](../../com.aspose.diagram/comboboxactivexcontrol\#isEditable--) を参照してください |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | このプロパティの説明については、[isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) を参照してください |
+| [setEnterFieldBehavior(boolean value)](#setEnterFieldBehavior-boolean-) | このプロパティの説明については、[getEnterFieldBehavior()](../../com.aspose.diagram/comboboxactivexcontrol\#getEnterFieldBehavior--) を参照してください |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | このプロパティの説明については、[getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) を参照してください |
+| [setHeight(double value)](#setHeight-double-) | このプロパティの説明については、[getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) を参照してください |
+| [setHideSelection(boolean value)](#setHideSelection-boolean-) | このプロパティの説明については、[getHideSelection()](../../com.aspose.diagram/comboboxactivexcontrol\#getHideSelection--) を参照してください |
+| [setIMEMode(int value)](#setIMEMode-int-) | このプロパティの説明については、[getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) を参照してください |
+| [setListRows(int value)](#setListRows-int-) | このプロパティの説明については、[getListRows()](../../com.aspose.diagram/comboboxactivexcontrol\#getListRows--) を参照してください |
+| [setListStyle(int value)](#setListStyle-int-) | このプロパティの説明については、[getListStyle()](../../com.aspose.diagram/comboboxactivexcontrol\#getListStyle--) を参照してください |
+| [setListWidth(double value)](#setListWidth-double-) | このプロパティの説明については、[getListWidth()](../../com.aspose.diagram/comboboxactivexcontrol\#getListWidth--) を参照してください |
+| [setLocked(boolean value)](#setLocked-boolean-) | このプロパティの説明については、[isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) を参照してください |
+| [setMatchEntry(int value)](#setMatchEntry-int-) | このプロパティの説明については、[getMatchEntry()](../../com.aspose.diagram/comboboxactivexcontrol\#getMatchEntry--) を参照してください |
+| [setMaxLength(int value)](#setMaxLength-int-) | このプロパティの説明については、[getMaxLength()](../../com.aspose.diagram/comboboxactivexcontrol\#getMaxLength--) を参照してください |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | このプロパティの説明については、[getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) を参照してください |
+| [setMousePointer(int value)](#setMousePointer-int-) | このプロパティの説明については、[getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) を参照してください |
+| [setSelectionMargin(boolean value)](#setSelectionMargin-boolean-) | このプロパティの説明については、[getSelectionMargin()](../../com.aspose.diagram/comboboxactivexcontrol\#getSelectionMargin--) を参照してください |
+| [setShowColumnHeads(boolean value)](#setShowColumnHeads-boolean-) | このプロパティの説明については、[getShowColumnHeads()](../../com.aspose.diagram/comboboxactivexcontrol\#getShowColumnHeads--) を参照してください |
+| [setShowDropButtonTypeWhen(int value)](#setShowDropButtonTypeWhen-int-) | このプロパティの説明については、[getShowDropButtonTypeWhen()](../../com.aspose.diagram/comboboxactivexcontrol\#getShowDropButtonTypeWhen--) を参照してください |
+| [setSpecialEffect(int value)](#setSpecialEffect-int-) | このプロパティの説明については、[getSpecialEffect()](../../com.aspose.diagram/comboboxactivexcontrol\#getSpecialEffect--) を参照してください |
+| [setTextColumn(int value)](#setTextColumn-int-) | このプロパティの説明については、[getTextColumn()](../../com.aspose.diagram/comboboxactivexcontrol\#getTextColumn--) を参照してください |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | このプロパティの説明については、[isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) を参照してください |
+| [setValue(String value)](#setValue-java.lang.String-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/comboboxactivexcontrol\#getValue--) を参照してください |
+| [setWidth(double value)](#setWidth-double-) | このプロパティの説明については、[getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) を参照してください |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+背景の OLE カラー。
+
+**Returns:**
+int
+### getBorderOleColor() {#getBorderOleColor--}
+```
+public int getBorderOleColor()
+```
+
+
+背景の OLE カラー。
+
+**Returns:**
+int
+### getBorderStyle() {#getBorderStyle--}
+```
+public int getBorderStyle()
+```
+
+
+コントロールで使用される境界線の種類。
+
+**Returns:**
+int
+### getBoundColumn() {#getBoundColumn--}
+```
+public int getBoundColumn()
+```
+
+
+ComboBox または ListBox の Value プロパティが MultiSelect プロパティの値 (fmMultiSelectSingle) のときにどのように決定されるかを表します。
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColumnCount() {#getColumnCount--}
+```
+public int getColumnCount()
+```
+
+
+ComboBox または ListBox に表示する列数を表します。
+
+**Returns:**
+int
+### getColumnWidths() {#getColumnWidths--}
+```
+public double getColumnWidths()
+```
+
+
+列の幅。
+
+**Returns:**
+double
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+コントロールのバイナリ データ。
+
+**Returns:**
+byte[]
+### getDropButtonStyle() {#getDropButtonStyle--}
+```
+public int getDropButtonStyle()
+```
+
+
+ドロップボタンに表示されるシンボルを指定します。
+
+**Returns:**
+int
+### getEnterFieldBehavior() {#getEnterFieldBehavior--}
+```
+public boolean getEnterFieldBehavior()
+```
+
+
+コントロールに入るときの選択動作を指定します。True の場合、選択は前回コントロールがアクティブだったときから変更されません。False の場合、コントロールに入るときにテキスト全体が選択されます。
+
+**Returns:**
+boolean
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+前景の OLE カラーです。Image コントロールには適用されません。
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+ポイント単位のコントロールの高さ。
+
+**Returns:**
+double
+### getHideSelection() {#getHideSelection--}
+```
+public boolean getHideSelection()
+```
+
+
+コントロールがフォーカスを持っていないときに、コントロール内の選択されたテキストがハイライト表示されるかどうかを示します。
+
+**Returns:**
+boolean
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+コントロールがフォーカスを受け取る際の Input Method Editor のデフォルト実行時モード。
+
+**Returns:**
+int
+### getListRows() {#getListRows--}
+```
+public int getListRows()
+```
+
+
+リストに表示する最大行数を表します。
+
+**Returns:**
+int
+### getListStyle() {#getListStyle--}
+```
+public int getListStyle()
+```
+
+
+視覚的な外観です。
+
+**Returns:**
+int
+### getListWidth() {#getListWidth--}
+```
+public double getListWidth()
+```
+
+
+ポイント単位の幅です。
+
+**Returns:**
+double
+### getMatchEntry() {#getMatchEntry--}
+```
+public int getMatchEntry()
+```
+
+
+ユーザーが入力する際に ListBox または ComboBox がリストを検索する方法を示します。
+
+**Returns:**
+int
+### getMaxLength() {#getMaxLength--}
+```
+public int getMaxLength()
+```
+
+
+最大文字数
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+コントロールのマウスポインタとして表示するカスタムアイコンです。
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+コントロールのマウスポインタとして表示されるアイコンの種類です。
+
+**Returns:**
+int
+### getSelectionMargin() {#getSelectionMargin--}
+```
+public boolean getSelectionMargin()
+```
+
+
+ユーザーがテキストの左側領域をクリックしてテキスト行を選択できるかどうかを示します。
+
+**Returns:**
+boolean
+### getShowColumnHeads() {#getShowColumnHeads--}
+```
+public boolean getShowColumnHeads()
+```
+
+
+列見出しが表示されるかどうかを示します。
+
+**Returns:**
+boolean
+### getShowDropButtonTypeWhen() {#getShowDropButtonTypeWhen--}
+```
+public int getShowDropButtonTypeWhen()
+```
+
+
+ドロップボタンに表示されるシンボルを指定します。
+
+**Returns:**
+int
+### getSpecialEffect() {#getSpecialEffect--}
+```
+public int getSpecialEffect()
+```
+
+
+コントロールの特殊効果です。
+
+**Returns:**
+int
+### getTextColumn() {#getTextColumn--}
+```
+public int getTextColumn()
+```
+
+
+ユーザーに表示する ComboBox または ListBox の列を表します。
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+ActiveX コントロールのタイプを取得します。
+
+**Returns:**
+int
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+コントロールの値です。
+
+**Returns:**
+java.lang.String
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+ポイント単位のコントロールの幅です。
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+コントロールが全内容を表示するために自動的にサイズ変更されるかどうかを示します。
+
+**Returns:**
+boolean
+### isAutoWordSelected() {#isAutoWordSelected--}
+```
+public boolean isAutoWordSelected()
+```
+
+
+選択を拡張する際に使用される基本単位を指定します。True の場合、基本単位は単一文字です。false の場合、基本単位は単語全体です。
+
+**Returns:**
+boolean
+### isDragBehaviorEnabled() {#isDragBehaviorEnabled--}
+```
+public boolean isDragBehaviorEnabled()
+```
+
+
+コントロールでドラッグ アンド ドロップが有効かどうかを示します。
+
+**Returns:**
+boolean
+### isEditable() {#isEditable--}
+```
+public boolean isEditable()
+```
+
+
+ユーザーがコントロールに入力できるかどうかを示します。
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+コントロールがフォーカスを受け取り、ユーザー生成イベントに応答できるかどうかを示します。
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+コントロール内のデータが編集ロックされているかどうかを示します。
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+コントロールが透明かどうかを示します。
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+このプロパティの説明については、[isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setAutoWordSelected(boolean value) {#setAutoWordSelected-boolean-}
+```
+public void setAutoWordSelected(boolean value)
+```
+
+
+このプロパティの説明については、[isAutoWordSelected()](../../com.aspose.diagram/comboboxactivexcontrol\#isAutoWordSelected--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+このプロパティの説明については、[getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setBorderOleColor(int value) {#setBorderOleColor-int-}
+```
+public void setBorderOleColor(int value)
+```
+
+
+このプロパティの説明については、[getBorderOleColor()](../../com.aspose.diagram/comboboxactivexcontrol\#getBorderOleColor--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setBorderStyle(int value) {#setBorderStyle-int-}
+```
+public void setBorderStyle(int value)
+```
+
+
+このプロパティの説明については、[getBorderStyle()](../../com.aspose.diagram/comboboxactivexcontrol\#getBorderStyle--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setBoundColumn(int value) {#setBoundColumn-int-}
+```
+public void setBoundColumn(int value)
+```
+
+
+このプロパティの説明については、[getBoundColumn()](../../com.aspose.diagram/comboboxactivexcontrol\#getBoundColumn--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setColumnCount(int value) {#setColumnCount-int-}
+```
+public void setColumnCount(int value)
+```
+
+
+このプロパティの説明については、[getColumnCount()](../../com.aspose.diagram/comboboxactivexcontrol\#getColumnCount--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setColumnWidths(double value) {#setColumnWidths-double-}
+```
+public void setColumnWidths(double value)
+```
+
+
+このプロパティの説明については、[getColumnWidths()](../../com.aspose.diagram/comboboxactivexcontrol\#getColumnWidths--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double |  |
+
+### setDragBehaviorEnabled(boolean value) {#setDragBehaviorEnabled-boolean-}
+```
+public void setDragBehaviorEnabled(boolean value)
+```
+
+
+このプロパティの説明については、[isDragBehaviorEnabled()](../../com.aspose.diagram/comboboxactivexcontrol\#isDragBehaviorEnabled--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setDropButtonStyle(int value) {#setDropButtonStyle-int-}
+```
+public void setDropButtonStyle(int value)
+```
+
+
+このプロパティの説明については、[getDropButtonStyle()](../../com.aspose.diagram/comboboxactivexcontrol\#getDropButtonStyle--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setEditable(boolean value) {#setEditable-boolean-}
+```
+public void setEditable(boolean value)
+```
+
+
+このプロパティの説明については、[isEditable()](../../com.aspose.diagram/comboboxactivexcontrol\#isEditable--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+このプロパティの説明については、[isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setEnterFieldBehavior(boolean value) {#setEnterFieldBehavior-boolean-}
+```
+public void setEnterFieldBehavior(boolean value)
+```
+
+
+このプロパティの説明については、[getEnterFieldBehavior()](../../com.aspose.diagram/comboboxactivexcontrol\#getEnterFieldBehavior--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+このプロパティの説明については、[getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+このプロパティの説明については、[getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double |  |
+
+### setHideSelection(boolean value) {#setHideSelection-boolean-}
+```
+public void setHideSelection(boolean value)
+```
+
+
+このプロパティの説明については、[getHideSelection()](../../com.aspose.diagram/comboboxactivexcontrol\#getHideSelection--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+このプロパティの説明については、[getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setListRows(int value) {#setListRows-int-}
+```
+public void setListRows(int value)
+```
+
+
+このプロパティの説明については、[getListRows()](../../com.aspose.diagram/comboboxactivexcontrol\#getListRows--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setListStyle(int value) {#setListStyle-int-}
+```
+public void setListStyle(int value)
+```
+
+
+このプロパティの説明については、[getListStyle()](../../com.aspose.diagram/comboboxactivexcontrol\#getListStyle--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setListWidth(double value) {#setListWidth-double-}
+```
+public void setListWidth(double value)
+```
+
+
+このプロパティの説明については、[getListWidth()](../../com.aspose.diagram/comboboxactivexcontrol\#getListWidth--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+このプロパティの説明については、[isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setMatchEntry(int value) {#setMatchEntry-int-}
+```
+public void setMatchEntry(int value)
+```
+
+
+このプロパティの説明については、[getMatchEntry()](../../com.aspose.diagram/comboboxactivexcontrol\#getMatchEntry--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setMaxLength(int value) {#setMaxLength-int-}
+```
+public void setMaxLength(int value)
+```
+
+
+このプロパティの説明については、[getMaxLength()](../../com.aspose.diagram/comboboxactivexcontrol\#getMaxLength--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+このプロパティの説明については、[getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+このプロパティの説明については、[getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setSelectionMargin(boolean value) {#setSelectionMargin-boolean-}
+```
+public void setSelectionMargin(boolean value)
+```
+
+
+このプロパティの説明については、[getSelectionMargin()](../../com.aspose.diagram/comboboxactivexcontrol\#getSelectionMargin--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setShowColumnHeads(boolean value) {#setShowColumnHeads-boolean-}
+```
+public void setShowColumnHeads(boolean value)
+```
+
+
+このプロパティの説明については、[getShowColumnHeads()](../../com.aspose.diagram/comboboxactivexcontrol\#getShowColumnHeads--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setShowDropButtonTypeWhen(int value) {#setShowDropButtonTypeWhen-int-}
+```
+public void setShowDropButtonTypeWhen(int value)
+```
+
+
+このプロパティの説明については、[getShowDropButtonTypeWhen()](../../com.aspose.diagram/comboboxactivexcontrol\#getShowDropButtonTypeWhen--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setSpecialEffect(int value) {#setSpecialEffect-int-}
+```
+public void setSpecialEffect(int value)
+```
+
+
+このプロパティの説明については、[getSpecialEffect()](../../com.aspose.diagram/comboboxactivexcontrol\#getSpecialEffect--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setTextColumn(int value) {#setTextColumn-int-}
+```
+public void setTextColumn(int value)
+```
+
+
+このプロパティの説明については、[getTextColumn()](../../com.aspose.diagram/comboboxactivexcontrol\#getTextColumn--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+このプロパティの説明については、[isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setValue(String value) {#setValue-java.lang.String-}
+```
+public void setValue(String value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/comboboxactivexcontrol\#getValue--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+このプロパティの説明については、[getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/commandbuttonactivexcontrol/_index.md
+++ b/japanese/java/com.aspose.diagram/commandbuttonactivexcontrol/_index.md
@@ -1,0 +1,572 @@
+---
+title: CommandButtonActiveXControl
+second_title: Aspose.Diagram for Java API リファレンス
+description: コマンドボタンを表します。
+type: docs
+weight: 56
+url: /ja/java/com.aspose.diagram/commandbuttonactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class CommandButtonActiveXControl extends ActiveXControl
+```
+
+コマンドボタンを表します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAccelerator()](#getAccelerator--) | コントロールのアクセラレータキーです。 |
+| [getBackOleColor()](#getBackOleColor--) | 背景の OLE カラー。 |
+| [getCaption()](#getCaption--) | コントロール上に表示される説明テキストです。 |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | コントロールのバイナリ データ。 |
+| [getForeOleColor()](#getForeOleColor--) | 前景の OLE カラー。 |
+| [getHeight()](#getHeight--) | ポイント単位のコントロールの高さ。 |
+| [getIMEMode()](#getIMEMode--) | コントロールがフォーカスを受け取る際の Input Method Editor のデフォルト実行時モード。 |
+| [getMouseIcon()](#getMouseIcon--) | コントロールのマウスポインタとして表示するカスタムアイコンです。 |
+| [getMousePointer()](#getMousePointer--) | コントロールのマウスポインタとして表示されるアイコンの種類です。 |
+| [getPicture()](#getPicture--) | 画像のデータです。 |
+| [getPicturePosition()](#getPicturePosition--) | コントロールのキャプションに対する画像の位置。 |
+| [getTakeFocusOnClick()](#getTakeFocusOnClick--) | コントロールがクリックされたときにフォーカスを取得するかどうかを示します。 |
+| [getType()](#getType--) | ActiveX コントロールのタイプを取得します。 |
+| [getWidth()](#getWidth--) | ポイント単位のコントロールの幅です。 |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | コントロールが全内容を表示するために自動的にサイズ変更されるかどうかを示します。 |
+| [isEnabled()](#isEnabled--) | コントロールがフォーカスを受け取り、ユーザー生成イベントに応答できるかどうかを示します。 |
+| [isLocked()](#isLocked--) | コントロール内のデータが編集ロックされているかどうかを示します。 |
+| [isTransparent()](#isTransparent--) | コントロールが透明かどうかを示します。 |
+| [isWordWrapped()](#isWordWrapped--) | コントロールの内容が行末で自動的に折り返されるかどうかを示します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAccelerator(char value)](#setAccelerator-char-) | このプロパティの説明については、[getAccelerator()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getAccelerator--)をご覧ください。 |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | このプロパティの説明については、[isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) を参照してください |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | このプロパティの説明については、[getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) を参照してください |
+| [setCaption(String value)](#setCaption-java.lang.String-) | このプロパティの説明については、[getCaption()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getCaption--)をご覧ください。 |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | このプロパティの説明については、[isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) を参照してください |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | このプロパティの説明については、[getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) を参照してください |
+| [setHeight(double value)](#setHeight-double-) | このプロパティの説明については、[getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) を参照してください |
+| [setIMEMode(int value)](#setIMEMode-int-) | このプロパティの説明については、[getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) を参照してください |
+| [setLocked(boolean value)](#setLocked-boolean-) | このプロパティの説明については、[isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) を参照してください |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | このプロパティの説明については、[getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) を参照してください |
+| [setMousePointer(int value)](#setMousePointer-int-) | このプロパティの説明については、[getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) を参照してください |
+| [setPicture(byte[] value)](#setPicture-byte---) | このプロパティの説明については、[getPicture()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getPicture--)をご覧ください。 |
+| [setPicturePosition(int value)](#setPicturePosition-int-) | このプロパティの説明については、[getPicturePosition()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getPicturePosition--)をご覧ください。 |
+| [setTakeFocusOnClick(boolean value)](#setTakeFocusOnClick-boolean-) | このプロパティの説明については、[getTakeFocusOnClick()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getTakeFocusOnClick--)をご覧ください。 |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | このプロパティの説明については、[isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) を参照してください |
+| [setWidth(double value)](#setWidth-double-) | このプロパティの説明については、[getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) を参照してください |
+| [setWordWrapped(boolean value)](#setWordWrapped-boolean-) | このプロパティの説明については、[isWordWrapped()](../../com.aspose.diagram/commandbuttonactivexcontrol\#isWordWrapped--)をご覧ください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAccelerator() {#getAccelerator--}
+```
+public char getAccelerator()
+```
+
+
+コントロールのアクセラレータキーです。
+
+**Returns:**
+char
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+背景の OLE カラー。
+
+**Returns:**
+int
+### getCaption() {#getCaption--}
+```
+public String getCaption()
+```
+
+
+コントロール上に表示される説明テキストです。
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+コントロールのバイナリ データ。
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+前景の OLE カラーです。Image コントロールには適用されません。
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+ポイント単位のコントロールの高さ。
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+コントロールがフォーカスを受け取る際の Input Method Editor のデフォルト実行時モード。
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+コントロールのマウスポインタとして表示するカスタムアイコンです。
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+コントロールのマウスポインタとして表示されるアイコンの種類です。
+
+**Returns:**
+int
+### getPicture() {#getPicture--}
+```
+public byte[] getPicture()
+```
+
+
+画像のデータです。
+
+**Returns:**
+byte[]
+### getPicturePosition() {#getPicturePosition--}
+```
+public int getPicturePosition()
+```
+
+
+コントロールのキャプションに対する画像の位置。
+
+**Returns:**
+int
+### getTakeFocusOnClick() {#getTakeFocusOnClick--}
+```
+public boolean getTakeFocusOnClick()
+```
+
+
+コントロールがクリックされたときにフォーカスを取得するかどうかを示します。
+
+**Returns:**
+boolean
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+ActiveX コントロールのタイプを取得します。
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+ポイント単位のコントロールの幅です。
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+コントロールが全内容を表示するために自動的にサイズ変更されるかどうかを示します。
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+コントロールがフォーカスを受け取り、ユーザー生成イベントに応答できるかどうかを示します。
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+コントロール内のデータが編集ロックされているかどうかを示します。
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+コントロールが透明かどうかを示します。
+
+**Returns:**
+boolean
+### isWordWrapped() {#isWordWrapped--}
+```
+public boolean isWordWrapped()
+```
+
+
+コントロールの内容が行末で自動的に折り返されるかどうかを示します。
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAccelerator(char value) {#setAccelerator-char-}
+```
+public void setAccelerator(char value)
+```
+
+
+このプロパティの説明については、[getAccelerator()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getAccelerator--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | char |  |
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+このプロパティの説明については、[isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+このプロパティの説明については、[getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setCaption(String value) {#setCaption-java.lang.String-}
+```
+public void setCaption(String value)
+```
+
+
+このプロパティの説明については、[getCaption()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getCaption--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+このプロパティの説明については、[isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+このプロパティの説明については、[getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+このプロパティの説明については、[getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+このプロパティの説明については、[getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+このプロパティの説明については、[isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+このプロパティの説明については、[getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+このプロパティの説明については、[getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setPicture(byte[] value) {#setPicture-byte---}
+```
+public void setPicture(byte[] value)
+```
+
+
+このプロパティの説明については、[getPicture()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getPicture--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | byte[] |  |
+
+### setPicturePosition(int value) {#setPicturePosition-int-}
+```
+public void setPicturePosition(int value)
+```
+
+
+このプロパティの説明については、[getPicturePosition()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getPicturePosition--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setTakeFocusOnClick(boolean value) {#setTakeFocusOnClick-boolean-}
+```
+public void setTakeFocusOnClick(boolean value)
+```
+
+
+このプロパティの説明については、[getTakeFocusOnClick()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getTakeFocusOnClick--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+このプロパティの説明については、[isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+このプロパティの説明については、[getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double |  |
+
+### setWordWrapped(boolean value) {#setWordWrapped-boolean-}
+```
+public void setWordWrapped(boolean value)
+```
+
+
+このプロパティの説明については、[isWordWrapped()](../../com.aspose.diagram/commandbuttonactivexcontrol\#isWordWrapped--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/compositingquality/_index.md
+++ b/japanese/java/com.aspose.diagram/compositingquality/_index.md
@@ -1,0 +1,183 @@
+---
+title: CompositingQuality
+second_title: Aspose.Diagram for Java API リファレンス
+description: 合成時に使用する品質レベルを指定します。
+type: docs
+weight: 57
+url: /ja/java/com.aspose.diagram/compositingquality/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class CompositingQuality
+```
+
+合成時に使用する品質レベルを指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [ASSUME_LINEAR](#ASSUME-LINEAR) | 線形値と仮定します。 |
+| [DEFAULT](#DEFAULT) | デフォルト品質。 |
+| [GAMMA_CORRECTED](#GAMMA-CORRECTED) | ガンマ補正が使用されます。 |
+| [HIGH_QUALITY](#HIGH-QUALITY) | 高品質、低速の合成。 |
+| [HIGH_SPEED](#HIGH-SPEED) | 高速、低品質。 |
+| [INVALID](#INVALID) | 無効な品質。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ASSUME_LINEAR {#ASSUME-LINEAR}
+```
+public static final int ASSUME_LINEAR
+```
+
+
+線形値と仮定します。
+
+### DEFAULT {#DEFAULT}
+```
+public static final int DEFAULT
+```
+
+
+デフォルト品質。
+
+### GAMMA_CORRECTED {#GAMMA-CORRECTED}
+```
+public static final int GAMMA_CORRECTED
+```
+
+
+ガンマ補正が使用されます。
+
+### HIGH_QUALITY {#HIGH-QUALITY}
+```
+public static final int HIGH_QUALITY
+```
+
+
+高品質、低速の合成。
+
+### HIGH_SPEED {#HIGH-SPEED}
+```
+public static final int HIGH_SPEED
+```
+
+
+高速、低品質。
+
+### INVALID {#INVALID}
+```
+public static final int INVALID
+```
+
+
+無効な品質。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/compoundtype/_index.md
+++ b/japanese/java/com.aspose.diagram/compoundtype/_index.md
@@ -1,0 +1,179 @@
+---
+title: CompoundType
+second_title: Aspose.Diagram for Java API リファレンス
+description: 線の矢じりのサイズを指定します。
+type: docs
+weight: 58
+url: /ja/java/com.aspose.diagram/compoundtype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class CompoundType
+```
+
+線の矢じりのサイズを指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [CompoundType(int value)](#CompoundType-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | 線の矢じりのサイズを指定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/compoundtype\#getValue--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CompoundType(int value) {#CompoundType-int-}
+```
+public CompoundType(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+線の矢じりのサイズを指定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/compoundtype\#getValue--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/compoundtypevalue/_index.md
+++ b/japanese/java/com.aspose.diagram/compoundtypevalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: CompoundTypeValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: 線を描画するスタイルを表します。
+type: docs
+weight: 59
+url: /ja/java/com.aspose.diagram/compoundtypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class CompoundTypeValue
+```
+
+線を描画するスタイルを表します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [SINGLE](#SINGLE) | 単一線（幅 lineWidth） |
+| [THICK_BETWEEN_THIN](#THICK-BETWEEN-THIN) | 3本の線、細、太、細 |
+| [THICK_THIN](#THICK-THIN) | 二重線、一本は太く、一本は細く |
+| [THIN_THICK](#THIN-THICK) | 二重線、一本は細く、一本は太く |
+| [THIN_THIN](#THIN-THIN) | 等幅の二重線 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SINGLE {#SINGLE}
+```
+public static final int SINGLE
+```
+
+
+単一線（幅 lineWidth）
+
+### THICK_BETWEEN_THIN {#THICK-BETWEEN-THIN}
+```
+public static final int THICK_BETWEEN_THIN
+```
+
+
+3本の線、細、太、細
+
+### THICK_THIN {#THICK-THIN}
+```
+public static final int THICK_THIN
+```
+
+
+二重線、一本は太く、一本は細く
+
+### THIN_THICK {#THIN-THICK}
+```
+public static final int THIN_THICK
+```
+
+
+二重線、一本は細く、一本は太く
+
+### THIN_THIN {#THIN-THIN}
+```
+public static final int THIN_THIN
+```
+
+
+等幅の二重線
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/compressiontype/_index.md
+++ b/japanese/java/com.aspose.diagram/compressiontype/_index.md
@@ -1,0 +1,183 @@
+---
+title: CompressionType
+second_title: Aspose.Diagram for Java API リファレンス
+description: この属性は、外部データが DIB、JPG、PNG、TIFF、または GIF ファイルなどのラスタベースの外部オブジェクトである場合にのみ意味があります。
+type: docs
+weight: 60
+url: /ja/java/com.aspose.diagram/compressiontype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class CompressionType
+```
+
+この属性は、外部データが DIB、JPG、PNG、TIFF、または GIF ファイルなどのラスタベースの外部オブジェクトの場合にのみ意味があります。値はファイルに適用された圧縮タイプを示します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [GIF](#GIF) | GIF 圧縮。 |
+| [JPEG](#JPEG) | JPEG 圧縮。 |
+| [NO](#NO) | 圧縮なし（デフォルト）。 |
+| [PNG](#PNG) | PNG 圧縮。 |
+| [TIFF](#TIFF) | TIFF 圧縮。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GIF {#GIF}
+```
+public static final int GIF
+```
+
+
+GIF 圧縮。
+
+### JPEG {#JPEG}
+```
+public static final int JPEG
+```
+
+
+JPEG 圧縮。
+
+### NO {#NO}
+```
+public static final int NO
+```
+
+
+圧縮なし（デフォルト）。
+
+### PNG {#PNG}
+```
+public static final int PNG
+```
+
+
+PNG 圧縮。
+
+### TIFF {#TIFF}
+```
+public static final int TIFF
+```
+
+
+TIFF 圧縮。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/confixedcode/_index.md
+++ b/japanese/java/com.aspose.diagram/confixedcode/_index.md
@@ -1,0 +1,179 @@
+---
+title: ConFixedCode
+second_title: Aspose.Diagram for Java API リファレンス
+description: コネクタが再ルーティングするタイミングを決定します。
+type: docs
+weight: 61
+url: /ja/java/com.aspose.diagram/confixedcode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ConFixedCode
+```
+
+コネクタが再ルーティングするタイミングを決定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [ConFixedCode(int value)](#ConFixedCode-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | コネクタが再ルーティングするタイミングを決定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | For the description of this property, please see [getValue()](../../com.aspose.diagram/confixedcode\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ConFixedCode(int value) {#ConFixedCode-int-}
+```
+public ConFixedCode(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+コネクタが再ルーティングするタイミングを決定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+For the description of this property, please see [getValue()](../../com.aspose.diagram/confixedcode\#getValue--)
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/confixedcodevalue/_index.md
+++ b/japanese/java/com.aspose.diagram/confixedcodevalue/_index.md
@@ -1,0 +1,201 @@
+---
+title: ConFixedCodeValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: コネクタが再ルーティングするタイミングを決定します。
+type: docs
+weight: 62
+url: /ja/java/com.aspose.diagram/confixedcodevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConFixedCodeValue
+```
+
+コネクタが再ルーティングするタイミングを決定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [NEVER_REROUTE](#NEVER-REROUTE) | Never reroute. |
+| [REROUTE_FREELY](#REROUTE-FREELY) | Reroute freely. |
+| [REROUTE_NEEDED](#REROUTE-NEEDED) | Reroute as needed. |
+| [REROUTE_ON_CROSSOVER](#REROUTE-ON-CROSSOVER) | Reroute on crossover. |
+| [RESERVED_1](#RESERVED-1) | Reserved for internal use only. |
+| [RESERVED_2](#RESERVED-2) | Reserved for internal use only. |
+| [RESERVED_3](#RESERVED-3) | Reserved for internal use only. |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### NEVER_REROUTE {#NEVER-REROUTE}
+```
+public static final int NEVER_REROUTE
+```
+
+
+Never reroute.
+
+### REROUTE_FREELY {#REROUTE-FREELY}
+```
+public static final int REROUTE_FREELY
+```
+
+
+Reroute freely.
+
+### REROUTE_NEEDED {#REROUTE-NEEDED}
+```
+public static final int REROUTE_NEEDED
+```
+
+
+Reroute as needed.
+
+### REROUTE_ON_CROSSOVER {#REROUTE-ON-CROSSOVER}
+```
+public static final int REROUTE_ON_CROSSOVER
+```
+
+
+Reroute on crossover.
+
+### RESERVED_1 {#RESERVED-1}
+```
+public static final int RESERVED_1
+```
+
+
+Reserved for internal use only.
+
+### RESERVED_2 {#RESERVED-2}
+```
+public static final int RESERVED_2
+```
+
+
+Reserved for internal use only.
+
+### RESERVED_3 {#RESERVED-3}
+```
+public static final int RESERVED_3
+```
+
+
+Reserved for internal use only.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/conlinejumpcode/_index.md
+++ b/japanese/java/com.aspose.diagram/conlinejumpcode/_index.md
@@ -1,0 +1,179 @@
+---
+title: ConLineJumpCode
+second_title: Aspose.Diagram for Java API リファレンス
+description: 2 本のコネクタが交差したときにコネクタがジャンプするかどうかを決定します。
+type: docs
+weight: 63
+url: /ja/java/com.aspose.diagram/conlinejumpcode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ConLineJumpCode
+```
+
+2 本のコネクタが交差したときにコネクタがジャンプするかどうかを決定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [ConLineJumpCode(int value)](#ConLineJumpCode-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | 2 本のコネクタが交差したときにコネクタがジャンプするかどうかを決定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/conlinejumpcode\#getValue--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ConLineJumpCode(int value) {#ConLineJumpCode-int-}
+```
+public ConLineJumpCode(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+2 本のコネクタが交差したときにコネクタがジャンプするかどうかを決定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/conlinejumpcode\#getValue--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/conlinejumpcodevalue/_index.md
+++ b/japanese/java/com.aspose.diagram/conlinejumpcodevalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: ConLineJumpCodeValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: 2 本のコネクタが交差したときにコネクタがジャンプするかどうかを決定します。
+type: docs
+weight: 64
+url: /ja/java/com.aspose.diagram/conlinejumpcodevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConLineJumpCodeValue
+```
+
+2 本のコネクタが交差したときにコネクタがジャンプするかどうかを決定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [ALWAYS](#ALWAYS) | Always |
+| [NEITHER_CONNECTOR_JUMPS](#NEITHER-CONNECTOR-JUMPS) | Neither connector jumps. |
+| [NEVER](#NEVER) | Never. |
+| [OTHER_CONNECTOR_JUMPS](#OTHER-CONNECTOR-JUMPS) | Other connector jumps. |
+| [PAGE_DEFAULT](#PAGE-DEFAULT) | Page default. |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALWAYS {#ALWAYS}
+```
+public static final int ALWAYS
+```
+
+
+Always
+
+### NEITHER_CONNECTOR_JUMPS {#NEITHER-CONNECTOR-JUMPS}
+```
+public static final int NEITHER_CONNECTOR_JUMPS
+```
+
+
+Neither connector jumps.
+
+### NEVER {#NEVER}
+```
+public static final int NEVER
+```
+
+
+Never.
+
+### OTHER_CONNECTOR_JUMPS {#OTHER-CONNECTOR-JUMPS}
+```
+public static final int OTHER_CONNECTOR_JUMPS
+```
+
+
+Other connector jumps.
+
+### PAGE_DEFAULT {#PAGE-DEFAULT}
+```
+public static final int PAGE_DEFAULT
+```
+
+
+Page default.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/conlinejumpdirx/_index.md
+++ b/japanese/java/com.aspose.diagram/conlinejumpdirx/_index.md
@@ -1,0 +1,179 @@
+---
+title: ConLineJumpDirX
+second_title: Aspose.Diagram for Java API リファレンス
+description: 動的コネクタの水平セグメントで発生するラインジャンプの方向を決定します。
+type: docs
+weight: 65
+url: /ja/java/com.aspose.diagram/conlinejumpdirx/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ConLineJumpDirX
+```
+
+動的コネクタの水平セグメントで発生するラインジャンプの方向を決定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [ConLineJumpDirX(int value)](#ConLineJumpDirX-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | 動的コネクタの水平セグメントで発生するラインジャンプの方向を決定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/conlinejumpdirx\#getValue--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ConLineJumpDirX(int value) {#ConLineJumpDirX-int-}
+```
+public ConLineJumpDirX(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+動的コネクタの水平セグメントで発生するラインジャンプの方向を決定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/conlinejumpdirx\#getValue--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/conlinejumpdirxvalue/_index.md
+++ b/japanese/java/com.aspose.diagram/conlinejumpdirxvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: ConLineJumpDirXValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: 動的コネクタの水平セグメントで発生するラインジャンプの方向を決定します。
+type: docs
+weight: 66
+url: /ja/java/com.aspose.diagram/conlinejumpdirxvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConLineJumpDirXValue
+```
+
+動的コネクタの水平セグメントで発生するラインジャンプの方向を決定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [DOWN](#DOWN) | 下。 |
+| [PAGE_DEFAULT](#PAGE-DEFAULT) | Page default. |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+| [UP](#UP) | 上。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DOWN {#DOWN}
+```
+public static final int DOWN
+```
+
+
+下。
+
+### PAGE_DEFAULT {#PAGE-DEFAULT}
+```
+public static final int PAGE_DEFAULT
+```
+
+
+Page default.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### UP {#UP}
+```
+public static final int UP
+```
+
+
+上。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/conlinejumpdiry/_index.md
+++ b/japanese/java/com.aspose.diagram/conlinejumpdiry/_index.md
@@ -1,0 +1,179 @@
+---
+title: ConLineJumpDirY
+second_title: Aspose.Diagram for Java API リファレンス
+description: 動的コネクタの垂直セグメントで発生するラインジャンプの方向を決定します。
+type: docs
+weight: 67
+url: /ja/java/com.aspose.diagram/conlinejumpdiry/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ConLineJumpDirY
+```
+
+動的コネクタの垂直セグメントで発生するラインジャンプの方向を決定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [ConLineJumpDirY(int value)](#ConLineJumpDirY-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | 動的コネクタの垂直セグメントで発生するラインジャンプの方向を決定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/conlinejumpdiry\#getValue--) をご覧ください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ConLineJumpDirY(int value) {#ConLineJumpDirY-int-}
+```
+public ConLineJumpDirY(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+動的コネクタの垂直セグメントで発生するラインジャンプの方向を決定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/conlinejumpdiry\#getValue--) をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/conlinejumpdiryvalue/_index.md
+++ b/japanese/java/com.aspose.diagram/conlinejumpdiryvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: ConLineJumpDirYValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: 動的コネクタの垂直セグメントで発生するラインジャンプの方向を決定します。
+type: docs
+weight: 68
+url: /ja/java/com.aspose.diagram/conlinejumpdiryvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConLineJumpDirYValue
+```
+
+動的コネクタの垂直セグメントで発生するラインジャンプの方向を決定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [LEFT](#LEFT) | 左。 |
+| [PAGE_DEFAULT](#PAGE-DEFAULT) | Page default. |
+| [RIGHT](#RIGHT) | 右。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LEFT {#LEFT}
+```
+public static final int LEFT
+```
+
+
+左。
+
+### PAGE_DEFAULT {#PAGE-DEFAULT}
+```
+public static final int PAGE_DEFAULT
+```
+
+
+Page default.
+
+### RIGHT {#RIGHT}
+```
+public static final int RIGHT
+```
+
+
+右。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/conlinejumpstyle/_index.md
+++ b/japanese/java/com.aspose.diagram/conlinejumpstyle/_index.md
@@ -1,0 +1,179 @@
+---
+title: ConLineJumpStyle
+second_title: Aspose.Diagram for Java API リファレンス
+description: 動的コネクタ上のラインジャンプのスタイルを決定します。
+type: docs
+weight: 69
+url: /ja/java/com.aspose.diagram/conlinejumpstyle/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ConLineJumpStyle
+```
+
+動的コネクタ上のラインジャンプのスタイルを決定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [ConLineJumpStyle(int value)](#ConLineJumpStyle-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | 動的コネクタ上のラインジャンプのスタイルを決定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/conlinejumpstyle\#getValue--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ConLineJumpStyle(int value) {#ConLineJumpStyle-int-}
+```
+public ConLineJumpStyle(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+動的コネクタ上のラインジャンプのスタイルを決定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/conlinejumpstyle\#getValue--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/conlinejumpstylevalue/_index.md
+++ b/japanese/java/com.aspose.diagram/conlinejumpstylevalue/_index.md
@@ -1,0 +1,228 @@
+---
+title: ConLineJumpStyleValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: 動的コネクタ上のラインジャンプのスタイルを決定します。
+type: docs
+weight: 70
+url: /ja/java/com.aspose.diagram/conlinejumpstylevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConLineJumpStyleValue
+```
+
+動的コネクタ上のラインジャンプのスタイルを決定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [ARC](#ARC) | 弧。 |
+| [GAP](#GAP) | ギャップ。 |
+| [PAGE_DEFAULT](#PAGE-DEFAULT) | Page default. |
+| [SIDES_2](#SIDES-2) | Sides2. |
+| [SIDES_3](#SIDES-3) | Sides3. |
+| [SIDES_4](#SIDES-4) | Sides4. |
+| [SIDES_5](#SIDES-5) | Sides5. |
+| [SIDES_6](#SIDES-6) | Sides6. |
+| [SIDES_7](#SIDES-7) | Sides7 |
+| [SQUARE](#SQUARE) | 正方形。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ARC {#ARC}
+```
+public static final int ARC
+```
+
+
+弧。
+
+### GAP {#GAP}
+```
+public static final int GAP
+```
+
+
+ギャップ。
+
+### PAGE_DEFAULT {#PAGE-DEFAULT}
+```
+public static final int PAGE_DEFAULT
+```
+
+
+Page default.
+
+### SIDES_2 {#SIDES-2}
+```
+public static final int SIDES_2
+```
+
+
+Sides2.
+
+### SIDES_3 {#SIDES-3}
+```
+public static final int SIDES_3
+```
+
+
+Sides3.
+
+### SIDES_4 {#SIDES-4}
+```
+public static final int SIDES_4
+```
+
+
+Sides4.
+
+### SIDES_5 {#SIDES-5}
+```
+public static final int SIDES_5
+```
+
+
+Sides5.
+
+### SIDES_6 {#SIDES-6}
+```
+public static final int SIDES_6
+```
+
+
+Sides6.
+
+### SIDES_7 {#SIDES-7}
+```
+public static final int SIDES_7
+```
+
+
+Sides7
+
+### SQUARE {#SQUARE}
+```
+public static final int SQUARE
+```
+
+
+正方形。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/conlinerouteext/_index.md
+++ b/japanese/java/com.aspose.diagram/conlinerouteext/_index.md
@@ -1,0 +1,179 @@
+---
+title: ConLineRouteExt
+second_title: Aspose.Diagram for Java API リファレンス
+description: コネクタの外観を決定します。
+type: docs
+weight: 71
+url: /ja/java/com.aspose.diagram/conlinerouteext/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ConLineRouteExt
+```
+
+コネクタの外観を決定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [ConLineRouteExt(int value)](#ConLineRouteExt-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | コネクタの外観を決定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、こちらをご覧ください [getValue()](../../com.aspose.diagram/conlinerouteext\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ConLineRouteExt(int value) {#ConLineRouteExt-int-}
+```
+public ConLineRouteExt(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+コネクタの外観を決定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、こちらをご覧ください [getValue()](../../com.aspose.diagram/conlinerouteext\#getValue--)
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/conlinerouteextvalue/_index.md
+++ b/japanese/java/com.aspose.diagram/conlinerouteextvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: ConLineRouteExtValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: コネクタの外観を決定します。
+type: docs
+weight: 72
+url: /ja/java/com.aspose.diagram/conlinerouteextvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConLineRouteExtValue
+```
+
+コネクタの外観を決定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [CURVED](#CURVED) | 曲線。 |
+| [PAGE_DEFAULT](#PAGE-DEFAULT) | Page default. |
+| [STRAIGHT](#STRAIGHT) | Straight. |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CURVED {#CURVED}
+```
+public static final int CURVED
+```
+
+
+曲線。
+
+### PAGE_DEFAULT {#PAGE-DEFAULT}
+```
+public static final int PAGE_DEFAULT
+```
+
+
+Page default.
+
+### STRAIGHT {#STRAIGHT}
+```
+public static final int STRAIGHT
+```
+
+
+Straight.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/connect/_index.md
+++ b/japanese/java/com.aspose.diagram/connect/_index.md
@@ -1,0 +1,299 @@
+---
+title: Connect
+second_title: Aspose.Diagram for Java API リファレンス
+description: 図面内の 2 つの図形（たとえば組織図の線とボックス）間の接続を表します。
+type: docs
+weight: 75
+url: /ja/java/com.aspose.diagram/connect/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Connect
+```
+
+組織図などの図面で、線とボックスのように 2 つの図形間の接続を表します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Connect()](#Connect--) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFromCell()](#getFromCell--) | 接続が作成されるセル。 |
+| [getFromPart()](#getFromPart--) | 接続が開始されるセル。 |
+| [getFromSheet()](#getFromSheet--) | 接続（または複数の接続）が開始される図形の ID。 |
+| [getToCell()](#getToCell--) | 接続が行われるセル。 |
+| [getToPart()](#getToPart--) | 接続が行われるシェイプの部分。 |
+| [getToSheet()](#getToSheet--) | 1 つまたは複数の接続が行われる図形の ID。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setFromCell(String value)](#setFromCell-java.lang.String-) | このプロパティの説明については、[getFromCell()](../../com.aspose.diagram/connect\#getFromCell--) を参照してください。 |
+| [setFromPart(int value)](#setFromPart-int-) | このプロパティの説明については、[getFromPart()](../../com.aspose.diagram/connect\#getFromPart--) を参照してください。 |
+| [setFromSheet(long value)](#setFromSheet-long-) | このプロパティの説明については、[getFromSheet()](../../com.aspose.diagram/connect\#getFromSheet--) を参照してください。 |
+| [setToCell(String value)](#setToCell-java.lang.String-) | このプロパティの説明については、[getToCell()](../../com.aspose.diagram/connect\#getToCell--) を参照してください。 |
+| [setToPart(int value)](#setToPart-int-) | このプロパティの説明については、[getToPart()](../../com.aspose.diagram/connect\#getToPart--) を参照してください。 |
+| [setToSheet(long value)](#setToSheet-long-) | このプロパティの説明については、[getToSheet()](../../com.aspose.diagram/connect\#getToSheet--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Connect() {#Connect--}
+```
+public Connect()
+```
+
+
+コンストラクタ。
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFromCell() {#getFromCell--}
+```
+public String getFromCell()
+```
+
+
+接続が作成されるセル。
+
+**Returns:**
+java.lang.String
+### getFromPart() {#getFromPart--}
+```
+public int getFromPart()
+```
+
+
+接続が開始されるセル。
+
+**Returns:**
+int
+### getFromSheet() {#getFromSheet--}
+```
+public long getFromSheet()
+```
+
+
+接続（または複数の接続）が開始される図形の ID。
+
+**Returns:**
+long
+### getToCell() {#getToCell--}
+```
+public String getToCell()
+```
+
+
+接続が行われるセル。
+
+**Returns:**
+java.lang.String
+### getToPart() {#getToPart--}
+```
+public int getToPart()
+```
+
+
+接続が行われるシェイプの部分。
+
+**Returns:**
+int
+### getToSheet() {#getToSheet--}
+```
+public long getToSheet()
+```
+
+
+1 つまたは複数の接続が行われる図形の ID。
+
+**Returns:**
+long
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setFromCell(String value) {#setFromCell-java.lang.String-}
+```
+public void setFromCell(String value)
+```
+
+
+このプロパティの説明については、[getFromCell()](../../com.aspose.diagram/connect\#getFromCell--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setFromPart(int value) {#setFromPart-int-}
+```
+public void setFromPart(int value)
+```
+
+
+このプロパティの説明については、[getFromPart()](../../com.aspose.diagram/connect\#getFromPart--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setFromSheet(long value) {#setFromSheet-long-}
+```
+public void setFromSheet(long value)
+```
+
+
+このプロパティの説明については、[getFromSheet()](../../com.aspose.diagram/connect\#getFromSheet--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | long |  |
+
+### setToCell(String value) {#setToCell-java.lang.String-}
+```
+public void setToCell(String value)
+```
+
+
+このプロパティの説明については、[getToCell()](../../com.aspose.diagram/connect\#getToCell--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setToPart(int value) {#setToPart-int-}
+```
+public void setToPart(int value)
+```
+
+
+このプロパティの説明については、[getToPart()](../../com.aspose.diagram/connect\#getToPart--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setToSheet(long value) {#setToSheet-long-}
+```
+public void setToSheet(long value)
+```
+
+
+このプロパティの説明については、[getToSheet()](../../com.aspose.diagram/connect\#getToSheet--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | long |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/connectcollection/_index.md
+++ b/japanese/java/com.aspose.diagram/connectcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: ConnectCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: Connect コレクション。
+type: docs
+weight: 76
+url: /ja/java/com.aspose.diagram/connectcollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ConnectCollection extends Collection
+```
+
+Connect コレクション。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(Connect connect)](#add-com.aspose.diagram.Connect-) | Add the connect in the collection. |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Connect connect)](#remove-com.aspose.diagram.Connect-) | Remove the connect from the collection. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Connect connect) {#add-com.aspose.diagram.Connect-}
+```
+public int add(Connect connect)
+```
+
+
+Add the connect in the collection.
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| connect | [Connect](../../com.aspose.diagram/connect) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Connect get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[Connect](../../com.aspose.diagram/connect) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Connect connect) {#remove-com.aspose.diagram.Connect-}
+```
+public void remove(Connect connect)
+```
+
+
+Remove the connect from the collection.
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| connect | [Connect](../../com.aspose.diagram/connect) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/connectedshapesflags/_index.md
+++ b/japanese/java/com.aspose.diagram/connectedshapesflags/_index.md
@@ -1,0 +1,156 @@
+---
+title: ConnectedShapesFlags
+second_title: Aspose.Diagram for Java API リファレンス
+description: コネクタの方向性に基づいて返されるシェイプ ID の配列をフィルタリングします。
+type: docs
+weight: 77
+url: /ja/java/com.aspose.diagram/connectedshapesflags/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConnectedShapesFlags
+```
+
+コネクタの方向性に基づいて返されるシェイプ ID の配列をフィルタリングします。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [CONNECTED_SHAPES_ALL_NODES](#CONNECTED-SHAPES-ALL-NODES) | 受信および送信の接続の両方に関連付けられているシェイプの ID を返します。 |
+| [CONNECTED_SHAPES_INCOMING_NODES](#CONNECTED-SHAPES-INCOMING-NODES) | 受信接続に関連付けられているシェイプの ID を返します。 |
+| [CONNECTED_SHAPES_OUTGOING_NODES](#CONNECTED-SHAPES-OUTGOING-NODES) | 送信接続に関連付けられているシェイプの ID を返します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CONNECTED_SHAPES_ALL_NODES {#CONNECTED-SHAPES-ALL-NODES}
+```
+public static final int CONNECTED_SHAPES_ALL_NODES
+```
+
+
+受信および送信の接続の両方に関連付けられているシェイプの ID を返します。
+
+### CONNECTED_SHAPES_INCOMING_NODES {#CONNECTED-SHAPES-INCOMING-NODES}
+```
+public static final int CONNECTED_SHAPES_INCOMING_NODES
+```
+
+
+受信接続に関連付けられているシェイプの ID を返します。
+
+### CONNECTED_SHAPES_OUTGOING_NODES {#CONNECTED-SHAPES-OUTGOING-NODES}
+```
+public static final int CONNECTED_SHAPES_OUTGOING_NODES
+```
+
+
+送信接続に関連付けられているシェイプの ID を返します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/connection/_index.md
+++ b/japanese/java/com.aspose.diagram/connection/_index.md
@@ -1,0 +1,351 @@
+---
+title: 接続
+second_title: Aspose.Diagram for Java API リファレンス
+description: シェイプに定義された 1 つの接続点の要素を含みます。
+type: docs
+weight: 78
+url: /ja/java/com.aspose.diagram/connection/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Connection
+```
+
+シェイプに定義された 1 つの接続点の要素を含みます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Connection()](#Connection--) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAutoGen()](#getAutoGen--) | 接続ポイントが自動的に生成されるかどうかを指定します。 |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getDirX()](#getDirX--) | 一致する接続ポイントの必要な整列ベクトルの x 成分を指定します。 |
+| [getDirY()](#getDirY--) | 一致する接続ポイントの必要な整列ベクトルの y 成分を指定します。 |
+| [getID()](#getID--) | 要素の親要素内における一意の ID。 |
+| [getIX()](#getIX--) | 親要素内の要素のゼロベースインデックスです。 |
+| [getName()](#getName--) | 要素の名前。 |
+| [getNameU()](#getNameU--) | 要素のユニバーサル名。 |
+| [getPrompt()](#getPrompt--) | 含まれる要素に基づいて、さまざまなプロンプト情報を含みます。 |
+| [getType()](#getType--) | 含まれる要素に基づいてさまざまなタイプを指定します。 |
+| [getX()](#getX--) | ローカル座標系でシェイプ上の x 座標を指定します。 |
+| [getY()](#getY--) | ローカル座標系でシェイプ上の y 座標を指定します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | このプロパティの説明については、[getDel()](../../com.aspose.diagram/connection\#getDel--) を参照してください。 |
+| [setID(int value)](#setID-int-) | このプロパティの説明については、[getID()](../../com.aspose.diagram/connection\#getID--) を参照してください。 |
+| [setIX(int value)](#setIX-int-) | このプロパティの説明については、[getIX()](../../com.aspose.diagram/connection\#getIX--) を参照してください。 |
+| [setName(String value)](#setName-java.lang.String-) | このプロパティの説明については、[getName()](../../com.aspose.diagram/connection\#getName--) を参照してください。 |
+| [setNameU(String value)](#setNameU-java.lang.String-) | このプロパティの説明については、[getNameU()](../../com.aspose.diagram/connection\#getNameU--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Connection() {#Connection--}
+```
+public Connection()
+```
+
+
+コンストラクタ。
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAutoGen() {#getAutoGen--}
+```
+public BoolValue getAutoGen()
+```
+
+
+接続ポイントが自動的に生成されるかどうかを指定します。値が 1 の場合、接続ポイントが自動的に生成されることを示します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getDirX() {#getDirX--}
+```
+public DoubleValue getDirX()
+```
+
+
+一致する接続ポイントの必要な整列ベクトルの x 成分を指定します。DirX 要素は、動的コネクタの接続された脚を向けるためにも使用されます。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDirY() {#getDirY--}
+```
+public DoubleValue getDirY()
+```
+
+
+一致する接続ポイントの必要な整列ベクトルの y 成分を指定します。DirY 要素は、動的コネクタの接続された脚を向けるためにも使用されます。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+要素の親要素内における一意の ID。
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+親要素内の要素のゼロベースインデックスです。
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素の名前。
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+要素のユニバーサル名。
+
+**Returns:**
+java.lang.String
+### getPrompt() {#getPrompt--}
+```
+public Str2Value getPrompt()
+```
+
+
+含まれる要素に基づいて、さまざまなプロンプト情報を含みます。
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getType() {#getType--}
+```
+public TypeConnection getType()
+```
+
+
+含まれる要素に基づいてさまざまなタイプを指定します。
+
+**Returns:**
+[TypeConnection](../../com.aspose.diagram/typeconnection)
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+ローカル座標系でシェイプ上の x 座標を指定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+ローカル座標系でシェイプ上の y 座標を指定します。ローカル座標系とは、ページではなくシェイプを基準とした座標系です。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+このプロパティの説明については、[getDel()](../../com.aspose.diagram/connection\#getDel--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+このプロパティの説明については、[getID()](../../com.aspose.diagram/connection\#getID--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+このプロパティの説明については、[getIX()](../../com.aspose.diagram/connection\#getIX--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+このプロパティの説明については、[getName()](../../com.aspose.diagram/connection\#getName--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+このプロパティの説明については、[getNameU()](../../com.aspose.diagram/connection\#getNameU--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/connectionabcd/_index.md
+++ b/japanese/java/com.aspose.diagram/connectionabcd/_index.md
@@ -1,0 +1,340 @@
+---
+title: ConnectionABCD
+second_title: Aspose.Diagram for Java API リファレンス
+description: ConnectionABCD 要素は Connection 要素の廃止されたバージョンで、下位互換性のためだけに存在します。
+type: docs
+weight: 79
+url: /ja/java/com.aspose.diagram/connectionabcd/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ConnectionABCD
+```
+
+ConnectionABCD 要素は Connection 要素の廃止されたバージョンで、下位互換性のためだけに存在します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [ConnectionABCD()](#ConnectionABCD--) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | 親要素に応じて異なる情報を表します。 |
+| [getB()](#getB--) | 親要素に応じて異なる情報を表します。 |
+| [getC()](#getC--) | 親要素に基づいて異なる情報を表します。 |
+| [getClass()](#getClass--) |  |
+| [getD()](#getD--) | 親要素に基づいて異なる情報を表します。 |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getID()](#getID--) | 要素の親要素内における一意の ID。 |
+| [getIX()](#getIX--) | 親要素内の要素のゼロベースインデックスです。 |
+| [getName()](#getName--) | 要素の名前。 |
+| [getNameU()](#getNameU--) | 要素のユニバーサル名。 |
+| [getX()](#getX--) | ローカル座標系でシェイプ上の x 座標を指定します。 |
+| [getY()](#getY--) | ローカル座標系でシェイプ上の y 座標を指定します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | このプロパティの説明については、[getDel()](../../com.aspose.diagram/connectionabcd\#getDel--) を参照してください。 |
+| [setID(int value)](#setID-int-) | このプロパティの説明については、[getID()](../../com.aspose.diagram/connectionabcd\#getID--) を参照してください。 |
+| [setIX(int value)](#setIX-int-) | このプロパティの説明については、[getIX()](../../com.aspose.diagram/connectionabcd\#getIX--) を参照してください。 |
+| [setName(String value)](#setName-java.lang.String-) | このプロパティの説明については、[getName()](../../com.aspose.diagram/connectionabcd\#getName--) を参照してください。 |
+| [setNameU(String value)](#setNameU-java.lang.String-) | このプロパティの説明については、[getNameU()](../../com.aspose.diagram/connectionabcd\#getNameU--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ConnectionABCD() {#ConnectionABCD--}
+```
+public ConnectionABCD()
+```
+
+
+コンストラクタ。
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+親要素に応じて異なる情報を表します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getB() {#getB--}
+```
+public DoubleValue getB()
+```
+
+
+親要素に応じて異なる情報を表します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getC() {#getC--}
+```
+public DoubleValue getC()
+```
+
+
+親要素に基づいて異なる情報を表します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getD() {#getD--}
+```
+public DoubleValue getD()
+```
+
+
+親要素に基づいて異なる情報を表します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+要素の親要素内における一意の ID。
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+親要素内の要素のゼロベースインデックスです。
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素の名前。
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+要素のユニバーサル名。
+
+**Returns:**
+java.lang.String
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+ローカル座標系でシェイプ上の x 座標を指定します。以下の表は、それを含む要素に基づく X 要素を説明しています。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+ローカル座標系でシェイプ上の y 座標を指定します。ローカル座標系とは、ページではなくシェイプを基準とした座標系です。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+このプロパティの説明については、[getDel()](../../com.aspose.diagram/connectionabcd\#getDel--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+このプロパティの説明については、[getID()](../../com.aspose.diagram/connectionabcd\#getID--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+このプロパティの説明については、[getIX()](../../com.aspose.diagram/connectionabcd\#getIX--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+このプロパティの説明については、[getName()](../../com.aspose.diagram/connectionabcd\#getName--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+このプロパティの説明については、[getNameU()](../../com.aspose.diagram/connectionabcd\#getNameU--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/connectionabcdcollection/_index.md
+++ b/japanese/java/com.aspose.diagram/connectionabcdcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: ConnectionABCDCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: ConnectionABCD コレクション。
+type: docs
+weight: 80
+url: /ja/java/com.aspose.diagram/connectionabcdcollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ConnectionABCDCollection extends Collection
+```
+
+ConnectionABCD コレクション。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(ConnectionABCD item)](#add-com.aspose.diagram.ConnectionABCD-) | コレクションに ConnectionABCD オブジェクトを追加します。 |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(ConnectionABCD item)](#remove-com.aspose.diagram.ConnectionABCD-) | コレクションから ConnectionABCD オブジェクトを削除します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(ConnectionABCD item) {#add-com.aspose.diagram.ConnectionABCD-}
+```
+public int add(ConnectionABCD item)
+```
+
+
+コレクションに ConnectionABCD オブジェクトを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [ConnectionABCD](../../com.aspose.diagram/connectionabcd) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public ConnectionABCD get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[ConnectionABCD](../../com.aspose.diagram/connectionabcd) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(ConnectionABCD item) {#remove-com.aspose.diagram.ConnectionABCD-}
+```
+public void remove(ConnectionABCD item)
+```
+
+
+コレクションから ConnectionABCD オブジェクトを削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [ConnectionABCD](../../com.aspose.diagram/connectionabcd) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/connectioncollection/_index.md
+++ b/japanese/java/com.aspose.diagram/connectioncollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: ConnectionCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: Connection コレクション。
+type: docs
+weight: 81
+url: /ja/java/com.aspose.diagram/connectioncollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ConnectionCollection extends Collection
+```
+
+Connection コレクション。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(Connection item)](#add-com.aspose.diagram.Connection-) | コレクションに Connection オブジェクトを追加します。 |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Connection item)](#remove-com.aspose.diagram.Connection-) | コレクションから Connection オブジェクトを削除します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Connection item) {#add-com.aspose.diagram.Connection-}
+```
+public int add(Connection item)
+```
+
+
+コレクションに Connection オブジェクトを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [Connection](../../com.aspose.diagram/connection) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Connection get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[Connection](../../com.aspose.diagram/connection) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Connection item) {#remove-com.aspose.diagram.Connection-}
+```
+public void remove(Connection item)
+```
+
+
+コレクションから Connection オブジェクトを削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [Connection](../../com.aspose.diagram/connection) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/connectionpointplace/_index.md
+++ b/japanese/java/com.aspose.diagram/connectionpointplace/_index.md
@@ -1,0 +1,174 @@
+---
+title: ConnectionPointPlace
+second_title: Aspose.Diagram for Java API リファレンス
+description: コネクタが接続されるシェイプ上の位置を指定します。
+type: docs
+weight: 82
+url: /ja/java/com.aspose.diagram/connectionpointplace/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConnectionPointPlace
+```
+
+コネクタが接続されるシェイプ上の位置を指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [BOTTOM](#BOTTOM) | 形状の下部。 |
+| [CENTER](#CENTER) | 形状の中心。 |
+| [LEFT](#LEFT) | 形状の左側。 |
+| [RIGHT](#RIGHT) | 形状の右側。 |
+| [TOP](#TOP) | 形状の上部。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOTTOM {#BOTTOM}
+```
+public static final int BOTTOM
+```
+
+
+形状の下部。
+
+### CENTER {#CENTER}
+```
+public static final int CENTER
+```
+
+
+形状の中心。
+
+### LEFT {#LEFT}
+```
+public static final int LEFT
+```
+
+
+形状の左側。
+
+### RIGHT {#RIGHT}
+```
+public static final int RIGHT
+```
+
+
+形状の右側。
+
+### TOP {#TOP}
+```
+public static final int TOP
+```
+
+
+形状の上部。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/connectorrule/_index.md
+++ b/japanese/java/com.aspose.diagram/connectorrule/_index.md
@@ -1,0 +1,169 @@
+---
+title: ConnectorRule
+second_title: Aspose.Diagram for Java API リファレンス
+description: 2つの図形間のコネクタールールを表します。connectorIncluding は、どの図形のどの接続点から開始し、終了図形とその接続点へ接続するかを示します。
+type: docs
+weight: 83
+url: /ja/java/com.aspose.diagram/connectorrule/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ConnectorRule
+```
+
+コネクタを持つ 2 つのシェイプ間のコネクタルールを表し、開始シェイプのどの接続点から始まるか、終了シェイプとその接続点を含みます。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getEndShapeConnection()](#getEndShapeConnection--) | 接続が行われる図形の接続先。 |
+| [getEndShapeId()](#getEndShapeId--) | 接続が行われる図形。 |
+| [getStartShapeConnection()](#getStartShapeConnection--) | 接続が開始される図形の接続元。 |
+| [getStartShapeId()](#getStartShapeId--) | 接続が開始される図形。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getEndShapeConnection() {#getEndShapeConnection--}
+```
+public Connection getEndShapeConnection()
+```
+
+
+接続が行われる図形の接続先。
+
+**Returns:**
+[Connection](../../com.aspose.diagram/connection)
+### getEndShapeId() {#getEndShapeId--}
+```
+public long getEndShapeId()
+```
+
+
+接続が行われる図形。
+
+**Returns:**
+long
+### getStartShapeConnection() {#getStartShapeConnection--}
+```
+public Connection getStartShapeConnection()
+```
+
+
+接続が開始される図形の接続元。
+
+**Returns:**
+[Connection](../../com.aspose.diagram/connection)
+### getStartShapeId() {#getStartShapeId--}
+```
+public long getStartShapeId()
+```
+
+
+接続が開始される図形。
+
+**Returns:**
+long
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/connectorstypevalue/_index.md
+++ b/japanese/java/com.aspose.diagram/connectorstypevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: ConnectorsTypeValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: May be one of the following values RightAngle StraightLines or CurvedLines.
+type: docs
+weight: 84
+url: /ja/java/com.aspose.diagram/connectorstypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConnectorsTypeValue
+```
+
+May be one of the following values: RightAngle, StraightLines, or CurvedLines. Only relevant when WindowType is specified as Drawing or Sheet.
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [CURVED_LINES](#CURVED-LINES) | CurvedLines. |
+| [RIGHT_ANGLE](#RIGHT-ANGLE) | RightAngle. |
+| [STRAIGHT_LINES](#STRAIGHT-LINES) | StraightLines. |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CURVED_LINES {#CURVED-LINES}
+```
+public static final int CURVED_LINES
+```
+
+
+CurvedLines.
+
+### RIGHT_ANGLE {#RIGHT-ANGLE}
+```
+public static final int RIGHT_ANGLE
+```
+
+
+RightAngle.
+
+### STRAIGHT_LINES {#STRAIGHT-LINES}
+```
+public static final int STRAIGHT_LINES
+```
+
+
+StraightLines.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/containertypevalue/_index.md
+++ b/japanese/java/com.aspose.diagram/containertypevalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: ContainerTypeValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: May be one of the following values Document Page or Master.
+type: docs
+weight: 85
+url: /ja/java/com.aspose.diagram/containertypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ContainerTypeValue
+```
+
+May be one of the following values: Document, Page, or Master. Only relevant when WindowType is specified as Drawing or Sheet.
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [DOCUMENT](#DOCUMENT) | Document. |
+| [MASTER](#MASTER) | Master. |
+| [PAGE](#PAGE) | Page. |
+| [STYLE](#STYLE) | Master. |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DOCUMENT {#DOCUMENT}
+```
+public static final int DOCUMENT
+```
+
+
+Document.
+
+### MASTER {#MASTER}
+```
+public static final int MASTER
+```
+
+
+Master.
+
+### PAGE {#PAGE}
+```
+public static final int PAGE
+```
+
+
+Page.
+
+### STYLE {#STYLE}
+```
+public static final int STYLE
+```
+
+
+Master.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/contexttypevalue/_index.md
+++ b/japanese/java/com.aspose.diagram/contexttypevalue/_index.md
@@ -1,0 +1,255 @@
+---
+title: ContextTypeValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: 比較に使用するグループまたはシェイプのプロパティを指定します。
+type: docs
+weight: 86
+url: /ja/java/com.aspose.diagram/contexttypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ContextTypeValue
+```
+
+比較に使用するグループまたはシェイプのプロパティを指定します。可能な値は以下の表に示されています。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [DATA_1](#DATA-1) | データ1。 |
+| [DATA_2](#DATA-2) | データ2。 |
+| [DATA_3](#DATA-3) | データ3。 |
+| [GEOMETRY_ANGLE](#GEOMETRY-ANGLE) | ジオメトリの角度。 |
+| [GEOMETRY_HEIGHT](#GEOMETRY-HEIGHT) | ジオメトリの高さ。 |
+| [GEOMETRY_WIDTH](#GEOMETRY-WIDTH) | Geometry width. |
+| [MASTER_NAME](#MASTER-NAME) | Master name. |
+| [SHAPE_DATA_ITEM_CUSTOM_PROPERTY_LABEL](#SHAPE-DATA-ITEM-CUSTOM-PROPERTY-LABEL) | Shape-data-item (custom property) label. |
+| [SHAPE_ID](#SHAPE-ID) | Shape ID. |
+| [SHAPE_LOCAL_NAME](#SHAPE-LOCAL-NAME) | Shape local name. |
+| [SHAPE_TEXT](#SHAPE-TEXT) | Shape text. |
+| [SHAPE_TYPE](#SHAPE-TYPE) | Shape type. |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+| [USER_CELL_LOCAL_ROW_NAME](#USER-CELL-LOCAL-ROW-NAME) | User cell local row name. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DATA_1 {#DATA-1}
+```
+public static final int DATA_1
+```
+
+
+データ1。
+
+### DATA_2 {#DATA-2}
+```
+public static final int DATA_2
+```
+
+
+データ2。
+
+### DATA_3 {#DATA-3}
+```
+public static final int DATA_3
+```
+
+
+データ3。
+
+### GEOMETRY_ANGLE {#GEOMETRY-ANGLE}
+```
+public static final int GEOMETRY_ANGLE
+```
+
+
+ジオメトリの角度。
+
+### GEOMETRY_HEIGHT {#GEOMETRY-HEIGHT}
+```
+public static final int GEOMETRY_HEIGHT
+```
+
+
+ジオメトリの高さ。
+
+### GEOMETRY_WIDTH {#GEOMETRY-WIDTH}
+```
+public static final int GEOMETRY_WIDTH
+```
+
+
+Geometry width.
+
+### MASTER_NAME {#MASTER-NAME}
+```
+public static final int MASTER_NAME
+```
+
+
+Master name.
+
+### SHAPE_DATA_ITEM_CUSTOM_PROPERTY_LABEL {#SHAPE-DATA-ITEM-CUSTOM-PROPERTY-LABEL}
+```
+public static final int SHAPE_DATA_ITEM_CUSTOM_PROPERTY_LABEL
+```
+
+
+Shape-data-item (custom property) label.
+
+### SHAPE_ID {#SHAPE-ID}
+```
+public static final int SHAPE_ID
+```
+
+
+Shape ID.
+
+### SHAPE_LOCAL_NAME {#SHAPE-LOCAL-NAME}
+```
+public static final int SHAPE_LOCAL_NAME
+```
+
+
+Shape local name.
+
+### SHAPE_TEXT {#SHAPE-TEXT}
+```
+public static final int SHAPE_TEXT
+```
+
+
+Shape text.
+
+### SHAPE_TYPE {#SHAPE-TYPE}
+```
+public static final int SHAPE_TYPE
+```
+
+
+Shape type.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### USER_CELL_LOCAL_ROW_NAME {#USER-CELL-LOCAL-ROW-NAME}
+```
+public static final int USER_CELL_LOCAL_ROW_NAME
+```
+
+
+User cell local row name.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/control/_index.md
+++ b/japanese/java/com.aspose.diagram/control/_index.md
@@ -1,0 +1,474 @@
+---
+title: コントロール
+second_title: Aspose.Diagram for Java API リファレンス
+description: シェイプに定義された各コントロールハンドルの x および y 座標の要素と、コントロールハンドルの動作方法を指定する要素を含みます。
+type: docs
+weight: 87
+url: /ja/java/com.aspose.diagram/control/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Control
+```
+
+シェイプに定義された各コントロールハンドルの x および y 座標の要素と、コントロールハンドルの動作方法を指定する要素を含みます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Control()](#Control--) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [canGlue()](#canGlue--) | コントロールハンドルを他のシェイプに貼り付けできるかどうかを決定します。 |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getID()](#getID--) | 要素の親要素内における一意の ID。 |
+| [getIX()](#getIX--) | 親要素内の要素のゼロベースインデックスです。 |
+| [getName()](#getName--) | 要素の名前。 |
+| [getNameU()](#getNameU--) | 要素のユニバーサル名。 |
+| [getPrompt()](#getPrompt--) | プロンプト要素は、マウスポインタがシェイプのコントロールハンドル上に停止したときにツールチップとして表示される説明テキストを指定します。 |
+| [getX()](#getX--) | シェイプのコントロールハンドルの位置を示す x 座標です。 |
+| [getXCon()](#getXCon--) | ハンドルが移動した後のコントロールハンドルの x 座標が示す動作の種類を指定します。 |
+| [getXDyn()](#getXDyn--) | ローカル座標系でのコントロールハンドルのアンカーポイントの x 座標を指定します。 |
+| [getY()](#getY--) | シェイプのコントロールハンドルの位置を示す y 座標です。 |
+| [getYCon()](#getYCon--) | ハンドルが移動した後のコントロールハンドルの x 座標が示す動作の種類を指定します。 |
+| [getYDyn()](#getYDyn--) | ローカル座標系でのコントロールハンドルのアンカーポイントの y 座標を指定します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCanGlue(BoolValue value)](#setCanGlue-com.aspose.diagram.BoolValue-) | このプロパティの説明については、[canGlue()](../../com.aspose.diagram/control\#canGlue--) を参照してください。 |
+| [setDel(int value)](#setDel-int-) | このプロパティの説明については、[getDel()](../../com.aspose.diagram/control\#getDel--) を参照してください。 |
+| [setID(int value)](#setID-int-) | このプロパティの説明については、[getID()](../../com.aspose.diagram/control\#getID--) を参照してください。 |
+| [setIX(int value)](#setIX-int-) | このプロパティの説明については、[getIX()](../../com.aspose.diagram/control\#getIX--) を参照してください。 |
+| [setName(String value)](#setName-java.lang.String-) | このプロパティの説明については、[getName()](../../com.aspose.diagram/control\#getName--) を参照してください。 |
+| [setNameU(String value)](#setNameU-java.lang.String-) | このプロパティの説明については、[getNameU()](../../com.aspose.diagram/control\#getNameU--) を参照してください。 |
+| [setPrompt(Str2Value value)](#setPrompt-com.aspose.diagram.Str2Value-) | このプロパティの説明については、[getPrompt()](../../com.aspose.diagram/control\#getPrompt--) を参照してください。 |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getX()](../../com.aspose.diagram/control\#getX--) を参照してください。 |
+| [setXCon(ConType value)](#setXCon-com.aspose.diagram.ConType-) | このプロパティの説明については、[getXCon()](../../com.aspose.diagram/control\#getXCon--) を参照してください。 |
+| [setXDyn(DoubleValue value)](#setXDyn-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getXDyn()](../../com.aspose.diagram/control\#getXDyn--) を参照してください。 |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getY()](../../com.aspose.diagram/control\#getY--) を参照してください。 |
+| [setYCon(ConType value)](#setYCon-com.aspose.diagram.ConType-) | このプロパティの説明については、[getYCon()](../../com.aspose.diagram/control\#getYCon--) を参照してください。 |
+| [setYDyn(DoubleValue value)](#setYDyn-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getYDyn()](../../com.aspose.diagram/control\#getYDyn--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Control() {#Control--}
+```
+public Control()
+```
+
+
+コンストラクタ。
+
+### canGlue() {#canGlue--}
+```
+public BoolValue canGlue()
+```
+
+
+コントロールハンドルを他のシェイプに貼り付けできるかどうかを決定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+要素の親要素内における一意の ID。
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+親要素内の要素のゼロベースインデックスです。
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素の名前。
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+要素のユニバーサル名。
+
+**Returns:**
+java.lang.String
+### getPrompt() {#getPrompt--}
+```
+public Str2Value getPrompt()
+```
+
+
+プロンプト要素は、マウスポインタがシェイプのコントロールハンドル上に停止したときにツールチップとして表示される説明テキストを指定します。
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+シェイプのコントロールハンドルの位置を示す x 座標です。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getXCon() {#getXCon--}
+```
+public ConType getXCon()
+```
+
+
+ハンドルが移動した後のコントロールハンドルの x 座標が示す動作の種類を指定します。
+
+**Returns:**
+[ConType](../../com.aspose.diagram/contype)
+### getXDyn() {#getXDyn--}
+```
+public DoubleValue getXDyn()
+```
+
+
+ローカル座標系におけるコントロールハンドルのアンカーポイントの x 座標を指定します。アンカーポイントは動的処理中のラバーバンドに使用されます。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+シェイプのコントロールハンドルの位置を示す y 座標です。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getYCon() {#getYCon--}
+```
+public ConType getYCon()
+```
+
+
+ハンドルが移動した後のコントロールハンドルの x 座標が示す動作の種類を指定します。
+
+**Returns:**
+[ConType](../../com.aspose.diagram/contype)
+### getYDyn() {#getYDyn--}
+```
+public DoubleValue getYDyn()
+```
+
+
+ローカル座標系におけるコントロールハンドルのアンカーポイントの y 座標を指定します。アンカーポイントは動的処理中のラバーバンドに使用されます。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCanGlue(BoolValue value) {#setCanGlue-com.aspose.diagram.BoolValue-}
+```
+public void setCanGlue(BoolValue value)
+```
+
+
+このプロパティの説明については、[canGlue()](../../com.aspose.diagram/control\#canGlue--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+このプロパティの説明については、[getDel()](../../com.aspose.diagram/control\#getDel--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+このプロパティの説明については、[getID()](../../com.aspose.diagram/control\#getID--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+このプロパティの説明については、[getIX()](../../com.aspose.diagram/control\#getIX--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+このプロパティの説明については、[getName()](../../com.aspose.diagram/control\#getName--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+このプロパティの説明については、[getNameU()](../../com.aspose.diagram/control\#getNameU--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setPrompt(Str2Value value) {#setPrompt-com.aspose.diagram.Str2Value-}
+```
+public void setPrompt(Str2Value value)
+```
+
+
+このプロパティの説明については、[getPrompt()](../../com.aspose.diagram/control\#getPrompt--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [Str2Value](../../com.aspose.diagram/str2value) |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getX()](../../com.aspose.diagram/control\#getX--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setXCon(ConType value) {#setXCon-com.aspose.diagram.ConType-}
+```
+public void setXCon(ConType value)
+```
+
+
+このプロパティの説明については、[getXCon()](../../com.aspose.diagram/control\#getXCon--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [ConType](../../com.aspose.diagram/contype) |  |
+
+### setXDyn(DoubleValue value) {#setXDyn-com.aspose.diagram.DoubleValue-}
+```
+public void setXDyn(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getXDyn()](../../com.aspose.diagram/control\#getXDyn--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getY()](../../com.aspose.diagram/control\#getY--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setYCon(ConType value) {#setYCon-com.aspose.diagram.ConType-}
+```
+public void setYCon(ConType value)
+```
+
+
+このプロパティの説明については、[getYCon()](../../com.aspose.diagram/control\#getYCon--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [ConType](../../com.aspose.diagram/contype) |  |
+
+### setYDyn(DoubleValue value) {#setYDyn-com.aspose.diagram.DoubleValue-}
+```
+public void setYDyn(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getYDyn()](../../com.aspose.diagram/control\#getYDyn--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/controlbordertype/_index.md
+++ b/japanese/java/com.aspose.diagram/controlbordertype/_index.md
@@ -1,0 +1,147 @@
+---
+title: ControlBorderType
+second_title: Aspose.Diagram for Java API リファレンス
+description: ActiveX コントロールの境界タイプを表します。
+type: docs
+weight: 88
+url: /ja/java/com.aspose.diagram/controlbordertype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlBorderType
+```
+
+ActiveX コントロールの境界タイプを表します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [NONE](#NONE) | 枠なし。 |
+| [SINGLE](#SINGLE) | 単一の線。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+枠なし。
+
+### SINGLE {#SINGLE}
+```
+public static final int SINGLE
+```
+
+
+単一の線。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/controlcaptionalignmenttype/_index.md
+++ b/japanese/java/com.aspose.diagram/controlcaptionalignmenttype/_index.md
@@ -1,0 +1,147 @@
+---
+title: ControlCaptionAlignmentType
+second_title: Aspose.Diagram for Java API リファレンス
+description: コントロールに対する Caption の位置を表します。
+type: docs
+weight: 89
+url: /ja/java/com.aspose.diagram/controlcaptionalignmenttype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlCaptionAlignmentType
+```
+
+コントロールに対する Caption の位置を表します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [LEFT](#LEFT) | コントロールの左側。 |
+| [RIGHT](#RIGHT) | コントロールの右側。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LEFT {#LEFT}
+```
+public static final int LEFT
+```
+
+
+コントロールの左側。
+
+### RIGHT {#RIGHT}
+```
+public static final int RIGHT
+```
+
+
+コントロールの右側。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/controlcollection/_index.md
+++ b/japanese/java/com.aspose.diagram/controlcollection/_index.md
@@ -1,0 +1,266 @@
+---
+title: ControlCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: Control コレクション。
+type: docs
+weight: 90
+url: /ja/java/com.aspose.diagram/controlcollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ControlCollection extends Collection
+```
+
+Control コレクション。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(Control item)](#add-com.aspose.diagram.Control-) | コレクションに Control オブジェクトを追加します。 |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getControl(int IX)](#getControl-int-) | 指定されたインデックス IX の要素を取得します。 |
+| [getControlFromId(int ID)](#getControlFromId-int-) | 指定された ID の要素を取得します。 |
+| [getControlFromName(String name)](#getControlFromName-java.lang.String-) | 指定された名前の要素を取得します。 |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Control item)](#remove-com.aspose.diagram.Control-) | コレクションから Control オブジェクトを削除します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Control item) {#add-com.aspose.diagram.Control-}
+```
+public int add(Control item)
+```
+
+
+コレクションに Control オブジェクトを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [Control](../../com.aspose.diagram/control) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Control get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[Control](../../com.aspose.diagram/control) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getControl(int IX) {#getControl-int-}
+```
+public Control getControl(int IX)
+```
+
+
+指定されたインデックス IX の要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| IX | int |  |
+
+**Returns:**
+[Control](../../com.aspose.diagram/control) - 
+### getControlFromId(int ID) {#getControlFromId-int-}
+```
+public Control getControlFromId(int ID)
+```
+
+
+指定された ID の要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ID | int |  |
+
+**Returns:**
+[Control](../../com.aspose.diagram/control) - 
+### getControlFromName(String name) {#getControlFromName-java.lang.String-}
+```
+public Control getControlFromName(String name)
+```
+
+
+指定された名前の要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String |  |
+
+**Returns:**
+[Control](../../com.aspose.diagram/control) - 
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Control item) {#remove-com.aspose.diagram.Control-}
+```
+public void remove(Control item)
+```
+
+
+コレクションから Control オブジェクトを削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [Control](../../com.aspose.diagram/control) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/controlliststyle/_index.md
+++ b/japanese/java/com.aspose.diagram/controlliststyle/_index.md
@@ -1,0 +1,147 @@
+---
+title: ControlListStyle
+second_title: Aspose.Diagram for Java API リファレンス
+description: ListBox または ComboBox のリストの視覚的外観を表します。
+type: docs
+weight: 91
+url: /ja/java/com.aspose.diagram/controlliststyle/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlListStyle
+```
+
+ListBox または ComboBox のリストの視覚的外観を表します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [OPTION](#OPTION) | 各項目の横にオプションボタンまたはチェックボックスが表示され、その項目の選択状態を示すリストを表示します。 |
+| [PLAIN](#PLAIN) | 項目が選択されたときに背景がハイライト表示されるリストを表示します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### OPTION {#OPTION}
+```
+public static final int OPTION
+```
+
+
+各項目の横にオプションボタンまたはチェックボックスが表示され、その項目の選択状態を示すリストを表示します。
+
+### PLAIN {#PLAIN}
+```
+public static final int PLAIN
+```
+
+
+項目が選択されたときに背景がハイライト表示されるリストを表示します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/controlmatchentrytype/_index.md
+++ b/japanese/java/com.aspose.diagram/controlmatchentrytype/_index.md
@@ -1,0 +1,156 @@
+---
+title: ControlMatchEntryType
+second_title: Aspose.Diagram for Java API リファレンス
+description: ユーザーが入力する際に、ListBox または ComboBox がリストを検索する方法を表します。
+type: docs
+weight: 92
+url: /ja/java/com.aspose.diagram/controlmatchentrytype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlMatchEntryType
+```
+
+ユーザーが入力する際に、ListBox または ComboBox がリストを検索する方法を表します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [COMPLETE](#COMPLETE) | 各文字が入力されるたびに、コントロールは入力されたすべての文字に一致するエントリを検索します。 |
+| [FIRST_LETTER](#FIRST-LETTER) | コントロールは、入力された文字で始まる次のエントリを検索します。 |
+| [NONE](#NONE) | 文字が入力されている間は、リストは検索されません。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### COMPLETE {#COMPLETE}
+```
+public static final int COMPLETE
+```
+
+
+各文字が入力されるたびに、コントロールは入力されたすべての文字に一致するエントリを検索します。
+
+### FIRST_LETTER {#FIRST-LETTER}
+```
+public static final int FIRST_LETTER
+```
+
+
+コントロールは、入力された文字で始まる次のエントリを検索します。同じ文字を繰り返し入力すると、その文字で始まるすべてのエントリを順に巡回します。
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+文字が入力されている間は、リストは検索されません。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/controlmousepointertype/_index.md
+++ b/japanese/java/com.aspose.diagram/controlmousepointertype/_index.md
@@ -1,0 +1,264 @@
+---
+title: ControlMousePointerType
+second_title: Aspose.Diagram for Java API リファレンス
+description: コントロールのマウスポインタとして表示されるアイコンの種類を表します。
+type: docs
+weight: 93
+url: /ja/java/com.aspose.diagram/controlmousepointertype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlMousePointerType
+```
+
+コントロールのマウスポインタとして表示されるアイコンの種類を表します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [APP_STARTING](#APP-STARTING) | Arrow with an hourglass. |
+| [ARROW](#ARROW) | Arrow. |
+| [CROSS](#CROSS) | Cross-hair pointer. |
+| [CUSTOM](#CUSTOM) | Uses the icon specified by the MouseIcon property. |
+| [DEFAULT](#DEFAULT) | Standard pointer. |
+| [HELP](#HELP) | Arrow with a question mark. |
+| [HOUR_GLASS](#HOUR-GLASS) | 砂時計。 |
+| [I_BEAM](#I-BEAM) | I字形ビーム。 |
+| [NO_DROP](#NO-DROP) | \\u9225\\u6de3ot\\u9225? |
+| [SIZE_ALL](#SIZE-ALL) | \\u9225\\u6deaize-all\\u9225? |
+| [SIZE_NESW](#SIZE-NESW) | 北東と南西を指す二重矢印。 |
+| [SIZE_NS](#SIZE-NS) | 北と南を指す二重矢印。 |
+| [SIZE_NWSE](#SIZE-NWSE) | 北西と南東を指す二重矢印。 |
+| [SIZE_WE](#SIZE-WE) | 西と東を指す二重矢印。 |
+| [UP_ARROW](#UP-ARROW) | 上向き矢印。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### APP_STARTING {#APP-STARTING}
+```
+public static final int APP_STARTING
+```
+
+
+Arrow with an hourglass.
+
+### ARROW {#ARROW}
+```
+public static final int ARROW
+```
+
+
+Arrow.
+
+### CROSS {#CROSS}
+```
+public static final int CROSS
+```
+
+
+Cross-hair pointer.
+
+### CUSTOM {#CUSTOM}
+```
+public static final int CUSTOM
+```
+
+
+Uses the icon specified by the MouseIcon property.
+
+### DEFAULT {#DEFAULT}
+```
+public static final int DEFAULT
+```
+
+
+Standard pointer.
+
+### HELP {#HELP}
+```
+public static final int HELP
+```
+
+
+Arrow with a question mark.
+
+### HOUR_GLASS {#HOUR-GLASS}
+```
+public static final int HOUR_GLASS
+```
+
+
+砂時計。
+
+### I_BEAM {#I-BEAM}
+```
+public static final int I_BEAM
+```
+
+
+I字形ビーム。
+
+### NO_DROP {#NO-DROP}
+```
+public static final int NO_DROP
+```
+
+
+\\u9225\\u6de3ot\\u9225?シンボル（斜線付きの円）がドラッグ中のオブジェクトの上にあります。
+
+### SIZE_ALL {#SIZE-ALL}
+```
+public static final int SIZE_ALL
+```
+
+
+\\u9225\\u6deaize-all\\u9225?カーソル（北、南、東、西を指す矢印）。
+
+### SIZE_NESW {#SIZE-NESW}
+```
+public static final int SIZE_NESW
+```
+
+
+北東と南西を指す二重矢印。
+
+### SIZE_NS {#SIZE-NS}
+```
+public static final int SIZE_NS
+```
+
+
+北と南を指す二重矢印。
+
+### SIZE_NWSE {#SIZE-NWSE}
+```
+public static final int SIZE_NWSE
+```
+
+
+北西と南東を指す二重矢印。
+
+### SIZE_WE {#SIZE-WE}
+```
+public static final int SIZE_WE
+```
+
+
+西と東を指す二重矢印。
+
+### UP_ARROW {#UP-ARROW}
+```
+public static final int UP_ARROW
+```
+
+
+上向き矢印。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/controlpicturealignmenttype/_index.md
+++ b/japanese/java/com.aspose.diagram/controlpicturealignmenttype/_index.md
@@ -1,0 +1,174 @@
+---
+title: ControlPictureAlignmentType
+second_title: Aspose.Diagram for Java API リファレンス
+description: Form または Image 内の画像の配置を表します。
+type: docs
+weight: 94
+url: /ja/java/com.aspose.diagram/controlpicturealignmenttype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlPictureAlignmentType
+```
+
+Form または Image 内の画像の配置を表します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [BOTTOM_LEFT](#BOTTOM-LEFT) | 左下隅。 |
+| [BOTTOM_RIGHT](#BOTTOM-RIGHT) | 右下隅。 |
+| [CENTER](#CENTER) | 中心。 |
+| [TOP_LEFT](#TOP-LEFT) | 左上隅。 |
+| [TOP_RIGHT](#TOP-RIGHT) | 右上隅。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOTTOM_LEFT {#BOTTOM-LEFT}
+```
+public static final int BOTTOM_LEFT
+```
+
+
+左下隅。
+
+### BOTTOM_RIGHT {#BOTTOM-RIGHT}
+```
+public static final int BOTTOM_RIGHT
+```
+
+
+右下隅。
+
+### CENTER {#CENTER}
+```
+public static final int CENTER
+```
+
+
+中心。
+
+### TOP_LEFT {#TOP-LEFT}
+```
+public static final int TOP_LEFT
+```
+
+
+左上隅。
+
+### TOP_RIGHT {#TOP-RIGHT}
+```
+public static final int TOP_RIGHT
+```
+
+
+右上隅。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/controlpicturepositiontype/_index.md
+++ b/japanese/java/com.aspose.diagram/controlpicturepositiontype/_index.md
@@ -1,0 +1,246 @@
+---
+title: ControlPicturePositionType
+second_title: Aspose.Diagram for Java API リファレンス
+description: コントロールの画像がキャプションに対してどの位置にあるかを表します。
+type: docs
+weight: 95
+url: /ja/java/com.aspose.diagram/controlpicturepositiontype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlPicturePositionType
+```
+
+コントロールの画像がキャプションに対してどの位置にあるかを表します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [ABOVE_CENTER](#ABOVE-CENTER) | 画像はキャプションの上に表示されます。 |
+| [ABOVE_LEFT](#ABOVE-LEFT) | 画像はキャプションの上に表示されます。 |
+| [ABOVE_RIGHT](#ABOVE-RIGHT) | 画像はキャプションの上に表示されます。 |
+| [BELOW_CENTER](#BELOW-CENTER) | 画像はキャプションの下に表示されます。 |
+| [BELOW_LEFT](#BELOW-LEFT) | 画像はキャプションの下に表示されます。 |
+| [BELOW_RIGHT](#BELOW-RIGHT) | 画像はキャプションの下に表示されます。 |
+| [CENTER](#CENTER) | 画像はコントロールの中央に表示されます。 |
+| [LEFT_BOTTOM](#LEFT-BOTTOM) | 画像はキャプションの左側に表示されます。 |
+| [LEFT_CENTER](#LEFT-CENTER) | 画像はキャプションの左側に表示されます。 |
+| [LEFT_TOP](#LEFT-TOP) | 画像はキャプションの左側に表示されます。 |
+| [RIGHT_BOTTOM](#RIGHT-BOTTOM) | 画像はキャプションの右側に表示されます。 |
+| [RIGHT_CENTER](#RIGHT-CENTER) | 画像はキャプションの右側に表示されます。 |
+| [RIGHT_TOP](#RIGHT-TOP) | 画像はキャプションの右側に表示されます。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ABOVE_CENTER {#ABOVE-CENTER}
+```
+public static final int ABOVE_CENTER
+```
+
+
+画像はキャプションの上に表示されます。キャプションは画像の下で中央揃えです。
+
+### ABOVE_LEFT {#ABOVE-LEFT}
+```
+public static final int ABOVE_LEFT
+```
+
+
+画像はキャプションの上に表示されます。キャプションは画像の左端に揃えられます。
+
+### ABOVE_RIGHT {#ABOVE-RIGHT}
+```
+public static final int ABOVE_RIGHT
+```
+
+
+画像はキャプションの上に表示されます。キャプションは画像の右端に揃えられます。
+
+### BELOW_CENTER {#BELOW-CENTER}
+```
+public static final int BELOW_CENTER
+```
+
+
+画像はキャプションの下に表示されます。キャプションは画像の上で中央揃えです。
+
+### BELOW_LEFT {#BELOW-LEFT}
+```
+public static final int BELOW_LEFT
+```
+
+
+画像はキャプションの下に表示されます。キャプションは画像の左端に揃えられています。
+
+### BELOW_RIGHT {#BELOW-RIGHT}
+```
+public static final int BELOW_RIGHT
+```
+
+
+画像はキャプションの下に表示されます。キャプションは画像の右端に揃えられています。
+
+### CENTER {#CENTER}
+```
+public static final int CENTER
+```
+
+
+画像はコントロールの中央に表示されます。キャプションは画像の上で水平・垂直に中央揃えです。
+
+### LEFT_BOTTOM {#LEFT-BOTTOM}
+```
+public static final int LEFT_BOTTOM
+```
+
+
+画像はキャプションの左側に表示されます。キャプションは画像の下端に揃えられています。
+
+### LEFT_CENTER {#LEFT-CENTER}
+```
+public static final int LEFT_CENTER
+```
+
+
+画像はキャプションの左側に表示されます。キャプションは画像に対して中央に配置されています。
+
+### LEFT_TOP {#LEFT-TOP}
+```
+public static final int LEFT_TOP
+```
+
+
+画像はキャプションの左側に表示されます。キャプションは画像の上端に揃えられています。
+
+### RIGHT_BOTTOM {#RIGHT-BOTTOM}
+```
+public static final int RIGHT_BOTTOM
+```
+
+
+画像はキャプションの右側に表示されます。キャプションは画像の下端に揃えられています。
+
+### RIGHT_CENTER {#RIGHT-CENTER}
+```
+public static final int RIGHT_CENTER
+```
+
+
+画像はキャプションの右側に表示されます。キャプションは画像に対して中央に配置されています。
+
+### RIGHT_TOP {#RIGHT-TOP}
+```
+public static final int RIGHT_TOP
+```
+
+
+画像はキャプションの右側に表示されます。キャプションは画像の上端に揃えられています。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/controlpicturesizemode/_index.md
+++ b/japanese/java/com.aspose.diagram/controlpicturesizemode/_index.md
@@ -1,0 +1,156 @@
+---
+title: ControlPictureSizeMode
+second_title: Aspose.Diagram for Java API リファレンス
+description: 画像の表示方法を表します。
+type: docs
+weight: 96
+url: /ja/java/com.aspose.diagram/controlpicturesizemode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlPictureSizeMode
+```
+
+画像の表示方法を表します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [CLIP](#CLIP) | コントロールの境界より大きい画像の部分をすべて切り取ります。 |
+| [STRETCH](#STRETCH) | 画像を伸ばしてコントロール領域全体を埋めます。 |
+| [ZOOM](#ZOOM) | 画像を拡大しますが、水平または垂直方向に歪めません。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CLIP {#CLIP}
+```
+public static final int CLIP
+```
+
+
+コントロールの境界より大きい画像の部分をすべて切り取ります。
+
+### STRETCH {#STRETCH}
+```
+public static final int STRETCH
+```
+
+
+画像を伸ばしてコントロール領域全体を埋めます。この設定は水平または垂直方向に画像を歪めます。
+
+### ZOOM {#ZOOM}
+```
+public static final int ZOOM
+```
+
+
+画像を拡大しますが、水平または垂直方向に歪めません。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/controlscrollbartype/_index.md
+++ b/japanese/java/com.aspose.diagram/controlscrollbartype/_index.md
@@ -1,0 +1,165 @@
+---
+title: ControlScrollBarType
+second_title: Aspose.Diagram for Java API リファレンス
+description: スクロールバーの種類を表します。
+type: docs
+weight: 97
+url: /ja/java/com.aspose.diagram/controlscrollbartype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlScrollBarType
+```
+
+スクロールバーの種類を表します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [BARS_BOTH](#BARS-BOTH) | 水平スクロールバーと垂直スクロールバーの両方を表示します。 |
+| [BARS_VERTICAL](#BARS-VERTICAL) | 垂直スクロールバーを表示します。 |
+| [HORIZONTAL](#HORIZONTAL) | 水平スクロールバーを表示します。 |
+| [NONE](#NONE) | スクロールバーを表示しません。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BARS_BOTH {#BARS-BOTH}
+```
+public static final int BARS_BOTH
+```
+
+
+水平スクロールバーと垂直スクロールバーの両方を表示します。
+
+### BARS_VERTICAL {#BARS-VERTICAL}
+```
+public static final int BARS_VERTICAL
+```
+
+
+垂直スクロールバーを表示します。
+
+### HORIZONTAL {#HORIZONTAL}
+```
+public static final int HORIZONTAL
+```
+
+
+水平スクロールバーを表示します。
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+スクロールバーを表示しません。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/controlscrollorientation/_index.md
+++ b/japanese/java/com.aspose.diagram/controlscrollorientation/_index.md
@@ -1,0 +1,156 @@
+---
+title: ControlScrollOrientation
+second_title: Aspose.Diagram for Java API リファレンス
+description: スクロールの向きの種類を表します。
+type: docs
+weight: 98
+url: /ja/java/com.aspose.diagram/controlscrollorientation/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlScrollOrientation
+```
+
+スクロールの向きの種類を表します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [AUTO](#AUTO) | コントロールの幅が高さより大きい場合、コントロールは横方向に描画されます。 |
+| [HORIZONTAL](#HORIZONTAL) | コントロールは横方向に描画されます。 |
+| [VERTICAL](#VERTICAL) | コントロールは縦方向に描画されます。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AUTO {#AUTO}
+```
+public static final int AUTO
+```
+
+
+コントロールの幅が高さより大きい場合、コントロールは横方向に描画されます。そうでない場合は縦方向に描画されます。
+
+### HORIZONTAL {#HORIZONTAL}
+```
+public static final int HORIZONTAL
+```
+
+
+コントロールは横方向に描画されます。
+
+### VERTICAL {#VERTICAL}
+```
+public static final int VERTICAL
+```
+
+
+コントロールは縦方向に描画されます。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/controlspecialeffecttype/_index.md
+++ b/japanese/java/com.aspose.diagram/controlspecialeffecttype/_index.md
@@ -1,0 +1,174 @@
+---
+title: ControlSpecialEffectType
+second_title: Aspose.Diagram for Java API リファレンス
+description: 特殊効果の種類を表します。
+type: docs
+weight: 99
+url: /ja/java/com.aspose.diagram/controlspecialeffecttype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlSpecialEffectType
+```
+
+特殊効果の種類を表します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [BUMP](#BUMP) | Bump |
+| [ETCHED](#ETCHED) | Etched |
+| [FLAT](#FLAT) | Flat |
+| [RAISED](#RAISED) | Raised |
+| [SUNKEN](#SUNKEN) | Sunken |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BUMP {#BUMP}
+```
+public static final int BUMP
+```
+
+
+Bump
+
+### ETCHED {#ETCHED}
+```
+public static final int ETCHED
+```
+
+
+Etched
+
+### FLAT {#FLAT}
+```
+public static final int FLAT
+```
+
+
+Flat
+
+### RAISED {#RAISED}
+```
+public static final int RAISED
+```
+
+
+Raised
+
+### SUNKEN {#SUNKEN}
+```
+public static final int SUNKEN
+```
+
+
+Sunken
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/controltype/_index.md
+++ b/japanese/java/com.aspose.diagram/controltype/_index.md
@@ -1,0 +1,237 @@
+---
+title: ControlType
+second_title: Aspose.Diagram for Java API リファレンス
+description: すべての ActiveX コントロールの種類を表します。
+type: docs
+weight: 100
+url: /ja/java/com.aspose.diagram/controltype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlType
+```
+
+すべての ActiveX コントロールの種類を表します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [CHECK_BOX](#CHECK-BOX) | CheckBox |
+| [COMBO_BOX](#COMBO-BOX) | ComboBox |
+| [COMMAND_BUTTON](#COMMAND-BUTTON) | Button |
+| [IMAGE](#IMAGE) | Image |
+| [LABEL](#LABEL) | Label |
+| [LIST_BOX](#LIST-BOX) | ListBox |
+| [RADIO_BUTTON](#RADIO-BUTTON) | RadioButton |
+| [SCROLL_BAR](#SCROLL-BAR) | ScrollBar |
+| [SPIN_BUTTON](#SPIN-BUTTON) | Spinner |
+| [TEXT_BOX](#TEXT-BOX) | TextBox |
+| [TOGGLE_BUTTON](#TOGGLE-BUTTON) | ToggleButton |
+| [UNKNOWN](#UNKNOWN) | Unknown |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CHECK_BOX {#CHECK-BOX}
+```
+public static final int CHECK_BOX
+```
+
+
+CheckBox
+
+### COMBO_BOX {#COMBO-BOX}
+```
+public static final int COMBO_BOX
+```
+
+
+ComboBox
+
+### COMMAND_BUTTON {#COMMAND-BUTTON}
+```
+public static final int COMMAND_BUTTON
+```
+
+
+Button
+
+### IMAGE {#IMAGE}
+```
+public static final int IMAGE
+```
+
+
+Image
+
+### LABEL {#LABEL}
+```
+public static final int LABEL
+```
+
+
+Label
+
+### LIST_BOX {#LIST-BOX}
+```
+public static final int LIST_BOX
+```
+
+
+ListBox
+
+### RADIO_BUTTON {#RADIO-BUTTON}
+```
+public static final int RADIO_BUTTON
+```
+
+
+RadioButton
+
+### SCROLL_BAR {#SCROLL-BAR}
+```
+public static final int SCROLL_BAR
+```
+
+
+ScrollBar
+
+### SPIN_BUTTON {#SPIN-BUTTON}
+```
+public static final int SPIN_BUTTON
+```
+
+
+Spinner
+
+### TEXT_BOX {#TEXT-BOX}
+```
+public static final int TEXT_BOX
+```
+
+
+TextBox
+
+### TOGGLE_BUTTON {#TOGGLE-BUTTON}
+```
+public static final int TOGGLE_BUTTON
+```
+
+
+ToggleButton
+
+### UNKNOWN {#UNKNOWN}
+```
+public static final int UNKNOWN
+```
+
+
+Unknown
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/contype/_index.md
+++ b/japanese/java/com.aspose.diagram/contype/_index.md
@@ -1,0 +1,204 @@
+---
+title: ConType
+second_title: Aspose.Diagram for Java API リファレンス
+description: ハンドルが移動した後にコントロールハンドルの x または y 座標が示す動作の種類を指定します。
+type: docs
+weight: 73
+url: /ja/java/com.aspose.diagram/contype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ConType
+```
+
+ハンドルが移動した後にコントロールハンドルの x または y 座標が示す動作の種類を指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [ConType(int value)](#ConType-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | ハンドルが移動した後にコントロールハンドルの x または y 座標が示す動作の種類を指定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | このプロパティの説明については、[getUfe()](../../com.aspose.diagram/contype\#getUfe--) を参照してください。 |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/contype\#getValue--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ConType(int value) {#ConType-int-}
+```
+public ConType(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+ハンドルが移動した後にコントロールハンドルの x または y 座標が示す動作の種類を指定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+このプロパティの説明については、[getUfe()](../../com.aspose.diagram/contype\#getUfe--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/contype\#getValue--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/convalue/_index.md
+++ b/japanese/java/com.aspose.diagram/convalue/_index.md
@@ -1,0 +1,228 @@
+---
+title: ConValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: ハンドルが移動した後にコントロールハンドルの x または y 座標が示す動作の種類を指定します。
+type: docs
+weight: 74
+url: /ja/java/com.aspose.diagram/convalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConValue
+```
+
+ハンドルが移動した後にコントロールハンドルの x または y 座標が示す動作の種類を指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [OFFSET_FROM_CENTER](#OFFSET-FROM-CENTER) | 中心からのオフセット。 |
+| [OFFSET_FROM_CENTER_HIDDEN](#OFFSET-FROM-CENTER-HIDDEN) | 中心からのオフセット、非表示。 |
+| [OFFSET_FROM_LEFT_EDGE](#OFFSET-FROM-LEFT-EDGE) | 左端からのオフセット。 |
+| [OFFSET_FROM_LEFT_EDGE_HIDDEN](#OFFSET-FROM-LEFT-EDGE-HIDDEN) | 左端からのオフセット、非表示。 |
+| [OFFSET_FROM_RIGHT_EDGE](#OFFSET-FROM-RIGHT-EDGE) | 右端からのオフセット。 |
+| [OFFSET_FROM_RIGHT_EDGE_HIDDEN](#OFFSET-FROM-RIGHT-EDGE-HIDDEN) | 右端からのオフセット、非表示。 |
+| [PROPORTIONAL](#PROPORTIONAL) | 比例。 |
+| [PROPORTIONAL_HIDDEN](#PROPORTIONAL-HIDDEN) | 比例、非表示。0 と同じですが、コントロールハンドルは表示されません。 |
+| [PROPORTIONAL_LOCKED](#PROPORTIONAL-LOCKED) | 比例ロック。 |
+| [PROPORTIONAL_LOCKED_HIDDEN](#PROPORTIONAL-LOCKED-HIDDEN) | 比例ロック、非表示。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### OFFSET_FROM_CENTER {#OFFSET-FROM-CENTER}
+```
+public static final int OFFSET_FROM_CENTER
+```
+
+
+中心からのオフセット。コントロールハンドルは形状の中心から一定距離だけオフセットされています。
+
+### OFFSET_FROM_CENTER_HIDDEN {#OFFSET-FROM-CENTER-HIDDEN}
+```
+public static final int OFFSET_FROM_CENTER_HIDDEN
+```
+
+
+中心からのオフセット、非表示。3 と同じですが、コントロールハンドルは表示されません。
+
+### OFFSET_FROM_LEFT_EDGE {#OFFSET-FROM-LEFT-EDGE}
+```
+public static final int OFFSET_FROM_LEFT_EDGE
+```
+
+
+左端からのオフセット。コントロールハンドルは形状の左側から一定距離だけオフセットされています。
+
+### OFFSET_FROM_LEFT_EDGE_HIDDEN {#OFFSET-FROM-LEFT-EDGE-HIDDEN}
+```
+public static final int OFFSET_FROM_LEFT_EDGE_HIDDEN
+```
+
+
+左端からのオフセット、非表示。2 と同じですが、コントロールハンドルは表示されません。
+
+### OFFSET_FROM_RIGHT_EDGE {#OFFSET-FROM-RIGHT-EDGE}
+```
+public static final int OFFSET_FROM_RIGHT_EDGE
+```
+
+
+右端からのオフセット。コントロールハンドルは形状の右側から一定距離だけオフセットされています。
+
+### OFFSET_FROM_RIGHT_EDGE_HIDDEN {#OFFSET-FROM-RIGHT-EDGE-HIDDEN}
+```
+public static final int OFFSET_FROM_RIGHT_EDGE_HIDDEN
+```
+
+
+右端からのオフセット、非表示。4 と同じですが、コントロールハンドルは表示されません。
+
+### PROPORTIONAL {#PROPORTIONAL}
+```
+public static final int PROPORTIONAL
+```
+
+
+比例。コントロールハンドルは移動可能で、形状が伸縮するときに比例して動きます。
+
+### PROPORTIONAL_HIDDEN {#PROPORTIONAL-HIDDEN}
+```
+public static final int PROPORTIONAL_HIDDEN
+```
+
+
+比例、非表示。0 と同じですが、コントロールハンドルは表示されません。
+
+### PROPORTIONAL_LOCKED {#PROPORTIONAL-LOCKED}
+```
+public static final int PROPORTIONAL_LOCKED
+```
+
+
+比例ロック。コントロールハンドルは形状に比例して動きますが、ハンドル自体は移動できません。
+
+### PROPORTIONAL_LOCKED_HIDDEN {#PROPORTIONAL-LOCKED-HIDDEN}
+```
+public static final int PROPORTIONAL_LOCKED_HIDDEN
+```
+
+
+比例ロック、非表示。1 と同じですが、コントロールハンドルは表示されません。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/coordinate/_index.md
+++ b/japanese/java/com.aspose.diagram/coordinate/_index.md
@@ -1,0 +1,197 @@
+---
+title: 座標
+second_title: Aspose.Diagram for Java API リファレンス
+description: x および y 座標の抽象クラスです。
+type: docs
+weight: 101
+url: /ja/java/com.aspose.diagram/coordinate/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public abstract class Coordinate
+```
+
+x および y 座標の抽象クラスです。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Coordinate()](#Coordinate--) |  |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getIX()](#getIX--) | 親要素内の要素のゼロベースインデックスです。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | このプロパティの説明については、@PREF1\_をご参照ください |
+| [setIX(int value)](#setIX-int-) | このプロパティの説明については、@PREF0\_をご参照ください |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Coordinate() {#Coordinate--}
+```
+public Coordinate()
+```
+
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public abstract int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public abstract int getIX()
+```
+
+
+親要素内の要素のゼロベースインデックスです。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public abstract void setDel(int value)
+```
+
+
+このプロパティの説明については、@PREF1\_をご参照ください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public abstract void setIX(int value)
+```
+
+
+このプロパティの説明については、@PREF0\_をご参照ください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/coordinatecollection/_index.md
+++ b/japanese/java/com.aspose.diagram/coordinatecollection/_index.md
@@ -1,0 +1,833 @@
+---
+title: CoordinateCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: 座標コレクション。
+type: docs
+weight: 102
+url: /ja/java/com.aspose.diagram/coordinatecollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class CoordinateCollection extends Collection
+```
+
+座標コレクション。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(ArcTo item)](#add-com.aspose.diagram.ArcTo-) | コレクションに ArcTo オブジェクトを追加します。 |
+| [add(Coordinate item)](#add-com.aspose.diagram.Coordinate-) | コレクションに Coordinate オブジェクトを追加します。 |
+| [add(Ellipse item)](#add-com.aspose.diagram.Ellipse-) | コレクションに Ellipse オブジェクトを追加します。 |
+| [add(EllipticalArcTo item)](#add-com.aspose.diagram.EllipticalArcTo-) | コレクションに EllipticalArcTo オブジェクトを追加します。 |
+| [add(InfiniteLine item)](#add-com.aspose.diagram.InfiniteLine-) | コレクションに InfiniteLine オブジェクトを追加します。 |
+| [add(LineTo item)](#add-com.aspose.diagram.LineTo-) | コレクションに LineTo オブジェクトを追加します。 |
+| [add(MoveTo item)](#add-com.aspose.diagram.MoveTo-) | コレクションに MoveTo オブジェクトを追加します。 |
+| [add(NURBSTo item)](#add-com.aspose.diagram.NURBSTo-) | コレクションに NURBSTo オブジェクトを追加します。 |
+| [add(PolylineTo item)](#add-com.aspose.diagram.PolylineTo-) | コレクションに PolylineTo オブジェクトを追加します。 |
+| [add(RelCubBezTo item)](#add-com.aspose.diagram.RelCubBezTo-) | コレクションに RelCubBezTo オブジェクトを追加します。 |
+| [add(RelEllipticalArcTo item)](#add-com.aspose.diagram.RelEllipticalArcTo-) | コレクションに RelEllipticalArcTo オブジェクトを追加します。 |
+| [add(RelLineTo item)](#add-com.aspose.diagram.RelLineTo-) | コレクションに RelLineTo オブジェクトを追加します。 |
+| [add(RelMoveTo item)](#add-com.aspose.diagram.RelMoveTo-) | コレクションに RelMoveTo オブジェクトを追加します。 |
+| [add(RelQuadBezTo item)](#add-com.aspose.diagram.RelQuadBezTo-) | コレクションに RelQuadBezTo オブジェクトを追加します。 |
+| [add(SplineKnot item)](#add-com.aspose.diagram.SplineKnot-) | コレクションに SplineKnot オブジェクトを追加します。 |
+| [add(SplineStart item)](#add-com.aspose.diagram.SplineStart-) | コレクションに SplineStart オブジェクトを追加します。 |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getArcToCol()](#getArcToCol--) | 円弧の X、Y、A 要素でそれぞれ表される x 座標、y 座標、そして弧度を含みます。 |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [getEllipseCol()](#getEllipseCol--) | 楕円の中心点および楕円上の 2 点の x 座標と y 座標を指定する要素を含みます。 |
+| [getEllipticalArcToCol()](#getEllipticalArcToCol--) | 楕円弧に関する情報を指定する要素を含みます。 |
+| [getInfiniteLineCol()](#getInfiniteLineCol--) | 無限直線上の2点の x および y 座標を指定する要素を含みます。 |
+| [getLineToCol()](#getLineToCol--) | 直線セグメントの終点頂点の x および y 座標を含みます。 |
+| [getMoveToCol()](#getMoveToCol--) | シェイプの最初の頂点の x および y 座標、またはパスの途中で切れた後の最初の頂点の x および y 座標を含みます。 |
+| [getNURBSToCol()](#getNURBSToCol--) | x および y 座標、2 番目から最後のノットの位置、最後のウェイトの位置、最初のノットの位置、最初のウェイトの位置、そして非一様有理 B スプライン (NURBS) の式を含みます。 |
+| [getPolylineToCol()](#getPolylineToCol--) | ポリラインの最後の点の x および y 座標とポリラインの式を含みます。 |
+| [getRelCubBezToCol()](#getRelCubBezToCol--) | RelCubBezTo の点の x 座標と y 座標を含みます。座標は相対座標として指定されます。 |
+| [getRelEllipticalArcToCol()](#getRelEllipticalArcToCol--) | 楕円弧に関する情報を指定する要素を含みます。座標は相対座標として指定されます。 |
+| [getRelLineToCol()](#getRelLineToCol--) | 直線セグメントの終点頂点の x および y 座標を含みます。 |
+| [getRelMoveToCol()](#getRelMoveToCol--) | 形状の最初の頂点の x および y 座標、またはパスの途中で切れ目が入った後の最初の頂点の x および y 座標を含みます。座標は相対座標として指定されます。 |
+| [getRelQuadBezToCol()](#getRelQuadBezToCol--) | RelQuadBezTo の点の x 座標と y 座標を含みます。座標は相対座標として指定されます。 |
+| [getSplineKnotCol()](#getSplineKnotCol--) | スプラインの制御点およびスプラインのノットの x および y 座標を含み、これらはそれぞれ X、Y、A 要素で表されます。 |
+| [getSplineStartCol()](#getSplineStartCol--) | スプラインの第2制御点、その第2ノット、第1ノット、最後のノット、およびスプラインの次数の x と y 座標を含みます。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(ArcTo item)](#remove-com.aspose.diagram.ArcTo-) | コレクションから ArcTo オブジェクトを削除します。 |
+| [remove(Coordinate item)](#remove-com.aspose.diagram.Coordinate-) | コレクションから Coordinate オブジェクトを削除します。 |
+| [remove(Ellipse item)](#remove-com.aspose.diagram.Ellipse-) | コレクションから Ellipse オブジェクトを削除します。 |
+| [remove(EllipticalArcTo item)](#remove-com.aspose.diagram.EllipticalArcTo-) | コレクションから EllipticalArcTo オブジェクトを削除します。 |
+| [remove(InfiniteLine item)](#remove-com.aspose.diagram.InfiniteLine-) | コレクションから InfiniteLine オブジェクトを削除します。 |
+| [remove(LineTo item)](#remove-com.aspose.diagram.LineTo-) | コレクションから LineTo オブジェクトを削除します。 |
+| [remove(MoveTo item)](#remove-com.aspose.diagram.MoveTo-) | コレクションから MoveTo オブジェクトを削除します。 |
+| [remove(NURBSTo item)](#remove-com.aspose.diagram.NURBSTo-) | コレクションから NURBSTo オブジェクトを削除します。 |
+| [remove(PolylineTo item)](#remove-com.aspose.diagram.PolylineTo-) | コレクションから PolylineTo オブジェクトを削除します。 |
+| [remove(RelCubBezTo item)](#remove-com.aspose.diagram.RelCubBezTo-) | コレクションから RelCubBezTo オブジェクトを削除します。 |
+| [remove(RelEllipticalArcTo item)](#remove-com.aspose.diagram.RelEllipticalArcTo-) | コレクションから RelEllipticalArcTo オブジェクトを削除します。 |
+| [remove(RelLineTo item)](#remove-com.aspose.diagram.RelLineTo-) | コレクションから RelLineTo オブジェクトを削除します。 |
+| [remove(RelMoveTo item)](#remove-com.aspose.diagram.RelMoveTo-) | コレクションから RelMoveTo オブジェクトを削除します。 |
+| [remove(RelQuadBezTo item)](#remove-com.aspose.diagram.RelQuadBezTo-) | コレクションから RelQuadBezTo オブジェクトを削除します。 |
+| [remove(SplineKnot item)](#remove-com.aspose.diagram.SplineKnot-) | コレクションから SplineKnot オブジェクトを削除します。 |
+| [remove(SplineStart item)](#remove-com.aspose.diagram.SplineStart-) | コレクションから SplineStart オブジェクトを削除します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(ArcTo item) {#add-com.aspose.diagram.ArcTo-}
+```
+public int add(ArcTo item)
+```
+
+
+コレクションに ArcTo オブジェクトを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [ArcTo](../../com.aspose.diagram/arcto) |  |
+
+**Returns:**
+int -
+### add(Coordinate item) {#add-com.aspose.diagram.Coordinate-}
+```
+public int add(Coordinate item)
+```
+
+
+コレクションに Coordinate オブジェクトを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [Coordinate](../../com.aspose.diagram/coordinate) |  |
+
+**Returns:**
+int
+### add(Ellipse item) {#add-com.aspose.diagram.Ellipse-}
+```
+public int add(Ellipse item)
+```
+
+
+コレクションに Ellipse オブジェクトを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [Ellipse](../../com.aspose.diagram/ellipse) |  |
+
+**Returns:**
+int -
+### add(EllipticalArcTo item) {#add-com.aspose.diagram.EllipticalArcTo-}
+```
+public int add(EllipticalArcTo item)
+```
+
+
+コレクションに EllipticalArcTo オブジェクトを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [EllipticalArcTo](../../com.aspose.diagram/ellipticalarcto) |  |
+
+**Returns:**
+int -
+### add(InfiniteLine item) {#add-com.aspose.diagram.InfiniteLine-}
+```
+public int add(InfiniteLine item)
+```
+
+
+コレクションに InfiniteLine オブジェクトを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [InfiniteLine](../../com.aspose.diagram/infiniteline) |  |
+
+**Returns:**
+int -
+### add(LineTo item) {#add-com.aspose.diagram.LineTo-}
+```
+public int add(LineTo item)
+```
+
+
+コレクションに LineTo オブジェクトを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [LineTo](../../com.aspose.diagram/lineto) |  |
+
+**Returns:**
+int -
+### add(MoveTo item) {#add-com.aspose.diagram.MoveTo-}
+```
+public int add(MoveTo item)
+```
+
+
+コレクションに MoveTo オブジェクトを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [MoveTo](../../com.aspose.diagram/moveto) |  |
+
+**Returns:**
+int -
+### add(NURBSTo item) {#add-com.aspose.diagram.NURBSTo-}
+```
+public int add(NURBSTo item)
+```
+
+
+コレクションに NURBSTo オブジェクトを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [NURBSTo](../../com.aspose.diagram/nurbsto) |  |
+
+**Returns:**
+int -
+### add(PolylineTo item) {#add-com.aspose.diagram.PolylineTo-}
+```
+public int add(PolylineTo item)
+```
+
+
+コレクションに PolylineTo オブジェクトを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [PolylineTo](../../com.aspose.diagram/polylineto) |  |
+
+**Returns:**
+int -
+### add(RelCubBezTo item) {#add-com.aspose.diagram.RelCubBezTo-}
+```
+public int add(RelCubBezTo item)
+```
+
+
+コレクションに RelCubBezTo オブジェクトを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [RelCubBezTo](../../com.aspose.diagram/relcubbezto) |  |
+
+**Returns:**
+int -
+### add(RelEllipticalArcTo item) {#add-com.aspose.diagram.RelEllipticalArcTo-}
+```
+public int add(RelEllipticalArcTo item)
+```
+
+
+コレクションに RelEllipticalArcTo オブジェクトを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [RelEllipticalArcTo](../../com.aspose.diagram/relellipticalarcto) |  |
+
+**Returns:**
+int -
+### add(RelLineTo item) {#add-com.aspose.diagram.RelLineTo-}
+```
+public int add(RelLineTo item)
+```
+
+
+コレクションに RelLineTo オブジェクトを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [RelLineTo](../../com.aspose.diagram/rellineto) |  |
+
+**Returns:**
+int -
+### add(RelMoveTo item) {#add-com.aspose.diagram.RelMoveTo-}
+```
+public int add(RelMoveTo item)
+```
+
+
+コレクションに RelMoveTo オブジェクトを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [RelMoveTo](../../com.aspose.diagram/relmoveto) |  |
+
+**Returns:**
+int -
+### add(RelQuadBezTo item) {#add-com.aspose.diagram.RelQuadBezTo-}
+```
+public int add(RelQuadBezTo item)
+```
+
+
+コレクションに RelQuadBezTo オブジェクトを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [RelQuadBezTo](../../com.aspose.diagram/relquadbezto) |  |
+
+**Returns:**
+int -
+### add(SplineKnot item) {#add-com.aspose.diagram.SplineKnot-}
+```
+public int add(SplineKnot item)
+```
+
+
+コレクションに SplineKnot オブジェクトを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [SplineKnot](../../com.aspose.diagram/splineknot) |  |
+
+**Returns:**
+int -
+### add(SplineStart item) {#add-com.aspose.diagram.SplineStart-}
+```
+public int add(SplineStart item)
+```
+
+
+コレクションに SplineStart オブジェクトを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [SplineStart](../../com.aspose.diagram/splinestart) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Coordinate get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[Coordinate](../../com.aspose.diagram/coordinate) - 
+### getArcToCol() {#getArcToCol--}
+```
+public ArcToCollection getArcToCol()
+```
+
+
+円弧の X、Y、A 要素でそれぞれ表される x 座標、y 座標、そして弧度を含みます。
+
+**Returns:**
+[ArcToCollection](../../com.aspose.diagram/arctocollection)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### getEllipseCol() {#getEllipseCol--}
+```
+public EllipseCollection getEllipseCol()
+```
+
+
+楕円の中心点および楕円上の 2 点の x 座標と y 座標を指定する要素を含みます。
+
+**Returns:**
+[EllipseCollection](../../com.aspose.diagram/ellipsecollection)
+### getEllipticalArcToCol() {#getEllipticalArcToCol--}
+```
+public EllipticalArcToCollection getEllipticalArcToCol()
+```
+
+
+楕円弧に関する情報を指定する要素を含みます。
+
+**Returns:**
+[EllipticalArcToCollection](../../com.aspose.diagram/ellipticalarctocollection)
+### getInfiniteLineCol() {#getInfiniteLineCol--}
+```
+public InfiniteLineCollection getInfiniteLineCol()
+```
+
+
+無限直線上の 2 点の x 座標と y 座標を指定する要素を含みます。X と Y 要素は最初の点の x 座標と y 座標を指定し、A と B 要素は2 番目の点の x 座標と y 座標を指定します。
+
+**Returns:**
+[InfiniteLineCollection](../../com.aspose.diagram/infinitelinecollection)
+### getLineToCol() {#getLineToCol--}
+```
+public LineToCollection getLineToCol()
+```
+
+
+直線セグメントの終点の x および y 座標を含みます。これらの座標はそれぞれ X 要素と Y 要素に格納されています。
+
+**Returns:**
+[LineToCollection](../../com.aspose.diagram/linetocollection)
+### getMoveToCol() {#getMoveToCol--}
+```
+public MoveToCollection getMoveToCol()
+```
+
+
+シェイプの最初の頂点の x および y 座標、またはパスの途中で切れた後の最初の頂点の x および y 座標を含みます。
+
+**Returns:**
+[MoveToCollection](../../com.aspose.diagram/movetocollection)
+### getNURBSToCol() {#getNURBSToCol--}
+```
+public NURBSToCollection getNURBSToCol()
+```
+
+
+x および y 座標、最後から2番目のノット位置、最後の重み位置、最初のノット位置、最初の重み位置、そして非均一有理 B スプライン (NURBS) の数式を含みます。この情報はそれぞれ X、Y、A、B、C、D、E 要素で指定されます。
+
+**Returns:**
+[NURBSToCollection](../../com.aspose.diagram/nurbstocollection)
+### getPolylineToCol() {#getPolylineToCol--}
+```
+public PolylineToCollection getPolylineToCol()
+```
+
+
+ポリラインの最後の点の x および y 座標とポリライン式を含みます。座標は X 要素と Y 要素で指定され、式は A 要素で指定されます。
+
+**Returns:**
+[PolylineToCollection](../../com.aspose.diagram/polylinetocollection)
+### getRelCubBezToCol() {#getRelCubBezToCol--}
+```
+public RelCubBezToCollection getRelCubBezToCol()
+```
+
+
+RelCubBezTo の点の x 座標と y 座標を含みます。座標は相対座標として指定されます。
+
+**Returns:**
+[RelCubBezToCollection](../../com.aspose.diagram/relcubbeztocollection)
+### getRelEllipticalArcToCol() {#getRelEllipticalArcToCol--}
+```
+public RelEllipticalArcToCollection getRelEllipticalArcToCol()
+```
+
+
+楕円弧に関する情報を指定する要素を含みます。座標は相対座標として指定されます。
+
+**Returns:**
+[RelEllipticalArcToCollection](../../com.aspose.diagram/relellipticalarctocollection)
+### getRelLineToCol() {#getRelLineToCol--}
+```
+public RelLineToCollection getRelLineToCol()
+```
+
+
+直線セグメントの終点の x および y 座標を含みます。これらの座標はそれぞれ X 要素と Y 要素に格納されています。座標は相対座標として指定されます。
+
+**Returns:**
+[RelLineToCollection](../../com.aspose.diagram/rellinetocollection)
+### getRelMoveToCol() {#getRelMoveToCol--}
+```
+public RelMoveToCollection getRelMoveToCol()
+```
+
+
+形状の最初の頂点の x および y 座標、またはパスの途中で切れ目が入った後の最初の頂点の x および y 座標を含みます。座標は相対座標として指定されます。
+
+**Returns:**
+[RelMoveToCollection](../../com.aspose.diagram/relmovetocollection)
+### getRelQuadBezToCol() {#getRelQuadBezToCol--}
+```
+public RelQuadBezToCollection getRelQuadBezToCol()
+```
+
+
+RelQuadBezTo の点の x 座標と y 座標を含みます。座標は相対座標として指定されます。
+
+**Returns:**
+[RelQuadBezToCollection](../../com.aspose.diagram/relquadbeztocollection)
+### getSplineKnotCol() {#getSplineKnotCol--}
+```
+public SplineKnotCollection getSplineKnotCol()
+```
+
+
+スプラインの制御点およびスプラインのノットの x および y 座標を含み、これらはそれぞれ X、Y、A 要素で表されます。
+
+**Returns:**
+[SplineKnotCollection](../../com.aspose.diagram/splineknotcollection)
+### getSplineStartCol() {#getSplineStartCol--}
+```
+public SplineStartCollection getSplineStartCol()
+```
+
+
+スプラインの第2制御点、その第2ノット、第1ノット、最後のノット、およびスプラインの次数の x および y 座標を含みます。この情報はそれぞれ X、Y、A、B、C、D 要素に格納されています。
+
+**Returns:**
+[SplineStartCollection](../../com.aspose.diagram/splinestartcollection)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(ArcTo item) {#remove-com.aspose.diagram.ArcTo-}
+```
+public void remove(ArcTo item)
+```
+
+
+コレクションから ArcTo オブジェクトを削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [ArcTo](../../com.aspose.diagram/arcto) |  |
+
+### remove(Coordinate item) {#remove-com.aspose.diagram.Coordinate-}
+```
+public void remove(Coordinate item)
+```
+
+
+コレクションから Coordinate オブジェクトを削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [Coordinate](../../com.aspose.diagram/coordinate) |  |
+
+### remove(Ellipse item) {#remove-com.aspose.diagram.Ellipse-}
+```
+public void remove(Ellipse item)
+```
+
+
+コレクションから Ellipse オブジェクトを削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [Ellipse](../../com.aspose.diagram/ellipse) |  |
+
+### remove(EllipticalArcTo item) {#remove-com.aspose.diagram.EllipticalArcTo-}
+```
+public void remove(EllipticalArcTo item)
+```
+
+
+コレクションから EllipticalArcTo オブジェクトを削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [EllipticalArcTo](../../com.aspose.diagram/ellipticalarcto) |  |
+
+### remove(InfiniteLine item) {#remove-com.aspose.diagram.InfiniteLine-}
+```
+public void remove(InfiniteLine item)
+```
+
+
+コレクションから InfiniteLine オブジェクトを削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [InfiniteLine](../../com.aspose.diagram/infiniteline) |  |
+
+### remove(LineTo item) {#remove-com.aspose.diagram.LineTo-}
+```
+public void remove(LineTo item)
+```
+
+
+コレクションから LineTo オブジェクトを削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [LineTo](../../com.aspose.diagram/lineto) |  |
+
+### remove(MoveTo item) {#remove-com.aspose.diagram.MoveTo-}
+```
+public void remove(MoveTo item)
+```
+
+
+コレクションから MoveTo オブジェクトを削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [MoveTo](../../com.aspose.diagram/moveto) |  |
+
+### remove(NURBSTo item) {#remove-com.aspose.diagram.NURBSTo-}
+```
+public void remove(NURBSTo item)
+```
+
+
+コレクションから NURBSTo オブジェクトを削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [NURBSTo](../../com.aspose.diagram/nurbsto) |  |
+
+### remove(PolylineTo item) {#remove-com.aspose.diagram.PolylineTo-}
+```
+public void remove(PolylineTo item)
+```
+
+
+コレクションから PolylineTo オブジェクトを削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [PolylineTo](../../com.aspose.diagram/polylineto) |  |
+
+### remove(RelCubBezTo item) {#remove-com.aspose.diagram.RelCubBezTo-}
+```
+public void remove(RelCubBezTo item)
+```
+
+
+コレクションから RelCubBezTo オブジェクトを削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [RelCubBezTo](../../com.aspose.diagram/relcubbezto) |  |
+
+### remove(RelEllipticalArcTo item) {#remove-com.aspose.diagram.RelEllipticalArcTo-}
+```
+public void remove(RelEllipticalArcTo item)
+```
+
+
+コレクションから RelEllipticalArcTo オブジェクトを削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [RelEllipticalArcTo](../../com.aspose.diagram/relellipticalarcto) |  |
+
+### remove(RelLineTo item) {#remove-com.aspose.diagram.RelLineTo-}
+```
+public void remove(RelLineTo item)
+```
+
+
+コレクションから RelLineTo オブジェクトを削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [RelLineTo](../../com.aspose.diagram/rellineto) |  |
+
+### remove(RelMoveTo item) {#remove-com.aspose.diagram.RelMoveTo-}
+```
+public void remove(RelMoveTo item)
+```
+
+
+コレクションから RelMoveTo オブジェクトを削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [RelMoveTo](../../com.aspose.diagram/relmoveto) |  |
+
+### remove(RelQuadBezTo item) {#remove-com.aspose.diagram.RelQuadBezTo-}
+```
+public void remove(RelQuadBezTo item)
+```
+
+
+コレクションから RelQuadBezTo オブジェクトを削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [RelQuadBezTo](../../com.aspose.diagram/relquadbezto) |  |
+
+### remove(SplineKnot item) {#remove-com.aspose.diagram.SplineKnot-}
+```
+public void remove(SplineKnot item)
+```
+
+
+コレクションから SplineKnot オブジェクトを削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [SplineKnot](../../com.aspose.diagram/splineknot) |  |
+
+### remove(SplineStart item) {#remove-com.aspose.diagram.SplineStart-}
+```
+public void remove(SplineStart item)
+```
+
+
+コレクションから SplineStart オブジェクトを削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [SplineStart](../../com.aspose.diagram/splinestart) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/countrycode/_index.md
+++ b/japanese/java/com.aspose.diagram/countrycode/_index.md
@@ -1,0 +1,579 @@
+---
+title: CountryCode
+second_title: Aspose.Diagram for Java API リファレンス
+description: Diagram の国識別子を表します。
+type: docs
+weight: 103
+url: /ja/java/com.aspose.diagram/countrycode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class CountryCode
+```
+
+Diagram の国識別子を表します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [ALGERIA](#ALGERIA) | アルジェリア |
+| [AUSTRALIA](#AUSTRALIA) | オーストラリア |
+| [AUSTRIA](#AUSTRIA) | オーストリア |
+| [BELGIUM](#BELGIUM) | ベルギー |
+| [BRAZIL](#BRAZIL) | ブラジル |
+| [CANADA](#CANADA) | カナダ |
+| [CHINA](#CHINA) | 中華人民共和国 |
+| [CZECH](#CZECH) | チェコ共和国 |
+| [DEFAULT](#DEFAULT) |  |
+| [DENMARK](#DENMARK) | デンマーク |
+| [EGYPT](#EGYPT) | エジプト |
+| [FINLAND](#FINLAND) | フィンランド |
+| [FRANCE](#FRANCE) | フランス |
+| [GERMANY](#GERMANY) | ドイツ |
+| [GREECE](#GREECE) | ギリシャ |
+| [HUNGARY](#HUNGARY) | ハンガリー |
+| [ICELAND](#ICELAND) | アイスランド |
+| [INDIA](#INDIA) | インド |
+| [IRAN](#IRAN) | イラン |
+| [IRAQ](#IRAQ) | イラク |
+| [ISRAEL](#ISRAEL) | イスラエル |
+| [ITALY](#ITALY) | イタリア |
+| [JAPAN](#JAPAN) | 日本 |
+| [JORDAN](#JORDAN) | ヨルダン |
+| [KUWAIT](#KUWAIT) | クウェート |
+| [LATIN_AMERIC](#LATIN-AMERIC) | ラテンアメリカ（ブラジル除く） |
+| [LEBANON](#LEBANON) | レバノン |
+| [LIBYA](#LIBYA) | リビア |
+| [MEXICO](#MEXICO) | メキシコ |
+| [MOROCCO](#MOROCCO) | Morocco |
+| [NETHERLANDS](#NETHERLANDS) | Netherlands |
+| [NEW_ZEALAND](#NEW-ZEALAND) | New Zealand |
+| [NORWAY](#NORWAY) | Norway |
+| [POLAND](#POLAND) | Poland |
+| [PORTUGAL](#PORTUGAL) | Portugal |
+| [QATAR](#QATAR) | Qatar |
+| [RUSSIA](#RUSSIA) | Russia |
+| [SAUDI](#SAUDI) | Saudi Arabia |
+| [SOUTH_KOREA](#SOUTH-KOREA) | SouthKorea |
+| [SPAIN](#SPAIN) | Spain |
+| [SWEDEN](#SWEDEN) | Sweden |
+| [SWITZERLAND](#SWITZERLAND) | Switzerland |
+| [SYRIA](#SYRIA) | Syria |
+| [TAIWAN](#TAIWAN) | Taiwan |
+| [THAILAND](#THAILAND) | Thailand |
+| [TURKEY](#TURKEY) | Turkey |
+| [UNITED_ARAB_EMIRATES](#UNITED-ARAB-EMIRATES) | United Arab Emirates |
+| [UNITED_KINGDOM](#UNITED-KINGDOM) | United Kingdom |
+| [USA](#USA) | United States |
+| [VIET_NAM](#VIET-NAM) | Viet Nam |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALGERIA {#ALGERIA}
+```
+public static final int ALGERIA
+```
+
+
+アルジェリア
+
+### AUSTRALIA {#AUSTRALIA}
+```
+public static final int AUSTRALIA
+```
+
+
+オーストラリア
+
+### AUSTRIA {#AUSTRIA}
+```
+public static final int AUSTRIA
+```
+
+
+オーストリア
+
+### BELGIUM {#BELGIUM}
+```
+public static final int BELGIUM
+```
+
+
+ベルギー
+
+### BRAZIL {#BRAZIL}
+```
+public static final int BRAZIL
+```
+
+
+ブラジル
+
+### CANADA {#CANADA}
+```
+public static final int CANADA
+```
+
+
+カナダ
+
+### CHINA {#CHINA}
+```
+public static final int CHINA
+```
+
+
+中華人民共和国
+
+### CZECH {#CZECH}
+```
+public static final int CZECH
+```
+
+
+チェコ共和国
+
+### DEFAULT {#DEFAULT}
+```
+public static final int DEFAULT
+```
+
+
+
+
+### DENMARK {#DENMARK}
+```
+public static final int DENMARK
+```
+
+
+デンマーク
+
+### EGYPT {#EGYPT}
+```
+public static final int EGYPT
+```
+
+
+エジプト
+
+### FINLAND {#FINLAND}
+```
+public static final int FINLAND
+```
+
+
+フィンランド
+
+### FRANCE {#FRANCE}
+```
+public static final int FRANCE
+```
+
+
+フランス
+
+### GERMANY {#GERMANY}
+```
+public static final int GERMANY
+```
+
+
+ドイツ
+
+### GREECE {#GREECE}
+```
+public static final int GREECE
+```
+
+
+ギリシャ
+
+### HUNGARY {#HUNGARY}
+```
+public static final int HUNGARY
+```
+
+
+ハンガリー
+
+### ICELAND {#ICELAND}
+```
+public static final int ICELAND
+```
+
+
+アイスランド
+
+### INDIA {#INDIA}
+```
+public static final int INDIA
+```
+
+
+インド
+
+### IRAN {#IRAN}
+```
+public static final int IRAN
+```
+
+
+イラン
+
+### IRAQ {#IRAQ}
+```
+public static final int IRAQ
+```
+
+
+イラク
+
+### ISRAEL {#ISRAEL}
+```
+public static final int ISRAEL
+```
+
+
+イスラエル
+
+### ITALY {#ITALY}
+```
+public static final int ITALY
+```
+
+
+イタリア
+
+### JAPAN {#JAPAN}
+```
+public static final int JAPAN
+```
+
+
+日本
+
+### JORDAN {#JORDAN}
+```
+public static final int JORDAN
+```
+
+
+ヨルダン
+
+### KUWAIT {#KUWAIT}
+```
+public static final int KUWAIT
+```
+
+
+クウェート
+
+### LATIN_AMERIC {#LATIN-AMERIC}
+```
+public static final int LATIN_AMERIC
+```
+
+
+ラテンアメリカ（ブラジル除く）
+
+### LEBANON {#LEBANON}
+```
+public static final int LEBANON
+```
+
+
+レバノン
+
+### LIBYA {#LIBYA}
+```
+public static final int LIBYA
+```
+
+
+リビア
+
+### MEXICO {#MEXICO}
+```
+public static final int MEXICO
+```
+
+
+メキシコ
+
+### MOROCCO {#MOROCCO}
+```
+public static final int MOROCCO
+```
+
+
+Morocco
+
+### NETHERLANDS {#NETHERLANDS}
+```
+public static final int NETHERLANDS
+```
+
+
+Netherlands
+
+### NEW_ZEALAND {#NEW-ZEALAND}
+```
+public static final int NEW_ZEALAND
+```
+
+
+New Zealand
+
+### NORWAY {#NORWAY}
+```
+public static final int NORWAY
+```
+
+
+Norway
+
+### POLAND {#POLAND}
+```
+public static final int POLAND
+```
+
+
+Poland
+
+### PORTUGAL {#PORTUGAL}
+```
+public static final int PORTUGAL
+```
+
+
+Portugal
+
+### QATAR {#QATAR}
+```
+public static final int QATAR
+```
+
+
+Qatar
+
+### RUSSIA {#RUSSIA}
+```
+public static final int RUSSIA
+```
+
+
+Russia
+
+### SAUDI {#SAUDI}
+```
+public static final int SAUDI
+```
+
+
+Saudi Arabia
+
+### SOUTH_KOREA {#SOUTH-KOREA}
+```
+public static final int SOUTH_KOREA
+```
+
+
+SouthKorea
+
+### SPAIN {#SPAIN}
+```
+public static final int SPAIN
+```
+
+
+Spain
+
+### SWEDEN {#SWEDEN}
+```
+public static final int SWEDEN
+```
+
+
+Sweden
+
+### SWITZERLAND {#SWITZERLAND}
+```
+public static final int SWITZERLAND
+```
+
+
+Switzerland
+
+### SYRIA {#SYRIA}
+```
+public static final int SYRIA
+```
+
+
+Syria
+
+### TAIWAN {#TAIWAN}
+```
+public static final int TAIWAN
+```
+
+
+Taiwan
+
+### THAILAND {#THAILAND}
+```
+public static final int THAILAND
+```
+
+
+Thailand
+
+### TURKEY {#TURKEY}
+```
+public static final int TURKEY
+```
+
+
+Turkey
+
+### UNITED_ARAB_EMIRATES {#UNITED-ARAB-EMIRATES}
+```
+public static final int UNITED_ARAB_EMIRATES
+```
+
+
+United Arab Emirates
+
+### UNITED_KINGDOM {#UNITED-KINGDOM}
+```
+public static final int UNITED_KINGDOM
+```
+
+
+United Kingdom
+
+### USA {#USA}
+```
+public static final int USA
+```
+
+
+United States
+
+### VIET_NAM {#VIET-NAM}
+```
+public static final int VIET_NAM
+```
+
+
+Viet Nam
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/cp/_index.md
+++ b/japanese/java/com.aspose.diagram/cp/_index.md
@@ -1,0 +1,154 @@
+---
+title: Cp
+second_title: Aspose.Diagram for Java API リファレンス
+description: 対応する Char 要素に従って書式設定された文字プロパティのランの開始を示します。
+type: docs
+weight: 104
+url: /ja/java/com.aspose.diagram/cp/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.FormatTxt](../../com.aspose.diagram/formattxt)
+```
+public class Cp extends FormatTxt
+```
+
+対応する Char 要素に従って書式設定された文字プロパティ ランの開始を示します。このランはテキストの末尾または次のものまで定義されます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Cp(int IX)](#Cp-int-) | コンストラクタ |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getValue()](#getValue--) | 値 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Cp(int IX) {#Cp-int-}
+```
+public Cp(int IX)
+```
+
+
+コンストラクタ
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| IX | int | このプロパティ ランが表す Char 要素のインデックスです。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+値
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/customprop/_index.md
+++ b/japanese/java/com.aspose.diagram/customprop/_index.md
@@ -1,0 +1,211 @@
+---
+title: CustomProp
+second_title: Aspose.Diagram for Java API リファレンス
+description: CustomProp 構造体。
+type: docs
+weight: 105
+url: /ja/java/com.aspose.diagram/customprop/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class CustomProp
+```
+
+CustomProp 構造体。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [CustomProp()](#CustomProp--) |  |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCustomValue()](#getCustomValue--) | プロパティの値。 |
+| [getName()](#getName--) | カスタムプロパティの名前。 |
+| [getPropType()](#getPropType--) | カスタムプロパティのデータ型。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCustomValue(CustomValue value)](#setCustomValue-com.aspose.diagram.CustomValue-) | このプロパティの説明については、[getCustomValue()](../../com.aspose.diagram/customprop\#getCustomValue--) を参照してください。 |
+| [setName(String value)](#setName-java.lang.String-) | このプロパティの説明については、[getName()](../../com.aspose.diagram/customprop\#getName--) を参照してください。 |
+| [setPropType(int value)](#setPropType-int-) | このプロパティの説明については、[getPropType()](../../com.aspose.diagram/customprop\#getPropType--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CustomProp() {#CustomProp--}
+```
+public CustomProp()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCustomValue() {#getCustomValue--}
+```
+public CustomValue getCustomValue()
+```
+
+
+プロパティの値。
+
+**Returns:**
+[CustomValue](../../com.aspose.diagram/customvalue)
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+カスタムプロパティの名前。
+
+**Returns:**
+java.lang.String
+### getPropType() {#getPropType--}
+```
+public int getPropType()
+```
+
+
+カスタムプロパティのデータ型。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCustomValue(CustomValue value) {#setCustomValue-com.aspose.diagram.CustomValue-}
+```
+public void setCustomValue(CustomValue value)
+```
+
+
+このプロパティの説明については、[getCustomValue()](../../com.aspose.diagram/customprop\#getCustomValue--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [CustomValue](../../com.aspose.diagram/customvalue) |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+このプロパティの説明については、[getName()](../../com.aspose.diagram/customprop\#getName--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setPropType(int value) {#setPropType-int-}
+```
+public void setPropType(int value)
+```
+
+
+このプロパティの説明については、[getPropType()](../../com.aspose.diagram/customprop\#getPropType--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/custompropcollection/_index.md
+++ b/japanese/java/com.aspose.diagram/custompropcollection/_index.md
@@ -1,0 +1,231 @@
+---
+title: CustomPropCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: CustomProps コレクション。
+type: docs
+weight: 106
+url: /ja/java/com.aspose.diagram/custompropcollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class CustomPropCollection extends Collection
+```
+
+CustomProps コレクション。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [CustomPropCollection()](#CustomPropCollection--) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(CustomProp customProp)](#add-com.aspose.diagram.CustomProp-) | コレクションにCustomPropオブジェクトを追加します。 |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(CustomProp customProp)](#remove-com.aspose.diagram.CustomProp-) | コレクションからCustomPropオブジェクトを削除します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CustomPropCollection() {#CustomPropCollection--}
+```
+public CustomPropCollection()
+```
+
+
+コンストラクタ。
+
+### add(CustomProp customProp) {#add-com.aspose.diagram.CustomProp-}
+```
+public int add(CustomProp customProp)
+```
+
+
+コレクションにCustomPropオブジェクトを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| customProp | [CustomProp](../../com.aspose.diagram/customprop) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public CustomProp get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[CustomProp](../../com.aspose.diagram/customprop) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(CustomProp customProp) {#remove-com.aspose.diagram.CustomProp-}
+```
+public void remove(CustomProp customProp)
+```
+
+
+コレクションからCustomPropオブジェクトを削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| customProp | [CustomProp](../../com.aspose.diagram/customprop) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/customvalue/_index.md
+++ b/japanese/java/com.aspose.diagram/customvalue/_index.md
@@ -1,0 +1,236 @@
+---
+title: CustomValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: プロパティの値。
+type: docs
+weight: 107
+url: /ja/java/com.aspose.diagram/customvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class CustomValue
+```
+
+プロパティの値。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [CustomValue()](#CustomValue--) |  |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getValueBool()](#getValueBool--) | ブール値。 |
+| [getValueDate()](#getValueDate--) | 日付と時刻の値。 |
+| [getValueNumber()](#getValueNumber--) | 数値。 |
+| [getValueString()](#getValueString--) | 文字列の値。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValueBool(boolean value)](#setValueBool-boolean-) | このプロパティの説明については、[getValueBool()](../../com.aspose.diagram/customvalue\#getValueBool--) を参照してください。 |
+| [setValueDate(DateTime value)](#setValueDate-com.aspose.diagram.DateTime-) | このプロパティの説明については、[getValueDate()](../../com.aspose.diagram/customvalue\#getValueDate--) を参照してください。 |
+| [setValueNumber(double value)](#setValueNumber-double-) | このプロパティの説明については、[getValueNumber()](../../com.aspose.diagram/customvalue\#getValueNumber--) を参照してください。 |
+| [setValueString(String value)](#setValueString-java.lang.String-) | このプロパティの説明については、[getValueString()](../../com.aspose.diagram/customvalue\#getValueString--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CustomValue() {#CustomValue--}
+```
+public CustomValue()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getValueBool() {#getValueBool--}
+```
+public boolean getValueBool()
+```
+
+
+ブール値。
+
+**Returns:**
+boolean
+### getValueDate() {#getValueDate--}
+```
+public DateTime getValueDate()
+```
+
+
+日付と時刻の値。
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### getValueNumber() {#getValueNumber--}
+```
+public double getValueNumber()
+```
+
+
+数値。
+
+**Returns:**
+double
+### getValueString() {#getValueString--}
+```
+public String getValueString()
+```
+
+
+文字列の値。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValueBool(boolean value) {#setValueBool-boolean-}
+```
+public void setValueBool(boolean value)
+```
+
+
+このプロパティの説明については、[getValueBool()](../../com.aspose.diagram/customvalue\#getValueBool--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setValueDate(DateTime value) {#setValueDate-com.aspose.diagram.DateTime-}
+```
+public void setValueDate(DateTime value)
+```
+
+
+このプロパティの説明については、[getValueDate()](../../com.aspose.diagram/customvalue\#getValueDate--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setValueNumber(double value) {#setValueNumber-double-}
+```
+public void setValueNumber(double value)
+```
+
+
+このプロパティの説明については、[getValueNumber()](../../com.aspose.diagram/customvalue\#getValueNumber--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double |  |
+
+### setValueString(String value) {#setValueString-java.lang.String-}
+```
+public void setValueString(String value)
+```
+
+
+このプロパティの説明については、[getValueString()](../../com.aspose.diagram/customvalue\#getValueString--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/datacolumn/_index.md
+++ b/japanese/java/com.aspose.diagram/datacolumn/_index.md
@@ -1,0 +1,488 @@
+---
+title: DataColumn
+second_title: Aspose.Diagram for Java API リファレンス
+description: Visio ユーザーインターフェイスの外部データウィンドウでデータ列がどのように表示されるかを定義し、データ型と書式設定を定義することで列のデータを限定します。
+type: docs
+weight: 108
+url: /ja/java/com.aspose.diagram/datacolumn/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DataColumn
+```
+
+Visio ユーザーインターフェイスの外部データウィンドウでデータ列がどのように表示されるかを定義し、データ型と書式設定を定義することで列のデータを限定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [DataColumn()](#DataColumn--) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCalendar()](#getCalendar--) | データ列のカレンダー ID。 |
+| [getClass()](#getClass--) |  |
+| [getColumnNameID()](#getColumnNameID--) | データ列の外部名。 |
+| [getCurrency()](#getCurrency--) | データ列の通貨 ID。 |
+| [getDataType()](#getDataType--) | データ列のデータ型。 |
+| [getDegree()](#getDegree--) | 単位の次数（べき）を指定します。例: 二乗、三乗。 |
+| [getDisplayOrder()](#getDisplayOrder--) | 外部データウィンドウ内でデータ列の表示位置を定義します。左端の列 (0) から右端の列 (最大値) まで。 |
+| [getDisplayWidth()](#getDisplayWidth--) | 外部データウィンドウ内のデータ列の幅。 |
+| [getHyperlink()](#getHyperlink--) | シェイプがデータにリンクされている場合に、データ列がシェイプ内にハイパーリンクを作成するかどうか。 |
+| [getLabel()](#getLabel--) | データ列のラベル。 |
+| [getLangID()](#getLangID--) | データ列の言語 ID |
+| [getMapped()](#getMapped--) | 外部データウィンドウで列が表示されるかどうかを指定します。 |
+| [getName()](#getName--) | データ列の内部名。 |
+| [getOrigLabel()](#getOrigLabel--) | 基礎となる ADO インターフェイスによって Visio に返される列ラベルです。 |
+| [getUnitType()](#getUnitType--) | データ列のデータの単位タイプです。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCalendar(int value)](#setCalendar-int-) | このプロパティの説明については、以下をご参照ください \{@link DataColumn\#(getCalendar() & 0xFFFF)\} |
+| [setColumnNameID(String value)](#setColumnNameID-java.lang.String-) | このプロパティの説明については、[getColumnNameID()](../../com.aspose.diagram/datacolumn\#getColumnNameID--)をご参照ください |
+| [setCurrency(int value)](#setCurrency-int-) | このプロパティの説明については、\{@link DataColumn\#(getCurrency() & 0xFFFF)\}をご参照ください |
+| [setDataType(int value)](#setDataType-int-) | このプロパティの説明については、\{@link DataColumn\#(getDataType() & 0xFFFF)\}をご参照ください |
+| [setDegree(long value)](#setDegree-long-) | このプロパティの説明については、[getDegree()](../../com.aspose.diagram/datacolumn\#getDegree--)をご参照ください |
+| [setDisplayOrder(long value)](#setDisplayOrder-long-) | このプロパティの説明については、[getDisplayOrder()](../../com.aspose.diagram/datacolumn\#getDisplayOrder--)をご参照ください |
+| [setDisplayWidth(long value)](#setDisplayWidth-long-) | このプロパティの説明については、[getDisplayWidth()](../../com.aspose.diagram/datacolumn\#getDisplayWidth--)をご参照ください |
+| [setHyperlink(int value)](#setHyperlink-int-) | このプロパティの説明については、[getHyperlink()](../../com.aspose.diagram/datacolumn\#getHyperlink--)をご参照ください |
+| [setLabel(String value)](#setLabel-java.lang.String-) | このプロパティの説明については、[getLabel()](../../com.aspose.diagram/datacolumn\#getLabel--)をご参照ください |
+| [setLangID(long value)](#setLangID-long-) | このプロパティの説明については、[getLangID()](../../com.aspose.diagram/datacolumn\#getLangID--)をご参照ください |
+| [setMapped(int value)](#setMapped-int-) | このプロパティの説明については、[getMapped()](../../com.aspose.diagram/datacolumn\#getMapped--)をご参照ください |
+| [setName(String value)](#setName-java.lang.String-) | このプロパティの説明については、[getName()](../../com.aspose.diagram/datacolumn\#getName--)をご参照ください |
+| [setOrigLabel(String value)](#setOrigLabel-java.lang.String-) | このプロパティの説明については、[getOrigLabel()](../../com.aspose.diagram/datacolumn\#getOrigLabel--)をご参照ください |
+| [setUnitType(String value)](#setUnitType-java.lang.String-) | このプロパティの説明については、[getUnitType()](../../com.aspose.diagram/datacolumn\#getUnitType--)をご参照ください |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DataColumn() {#DataColumn--}
+```
+public DataColumn()
+```
+
+
+コンストラクタ。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCalendar() {#getCalendar--}
+```
+public int getCalendar()
+```
+
+
+データ列のカレンダー ID。
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColumnNameID() {#getColumnNameID--}
+```
+public String getColumnNameID()
+```
+
+
+データ列の外部名です。外部データウィンドウの見出しやデータ グラフィックのラベルに表示されます。
+
+**Returns:**
+java.lang.String
+### getCurrency() {#getCurrency--}
+```
+public int getCurrency()
+```
+
+
+データ列の通貨 ID。
+
+**Returns:**
+int
+### getDataType() {#getDataType--}
+```
+public int getDataType()
+```
+
+
+データ列のデータ型。
+
+**Returns:**
+int
+### getDegree() {#getDegree--}
+```
+public long getDegree()
+```
+
+
+単位の次数（べき）を指定します。たとえば二乗や三乗です。デフォルト（属性がない場合）は 1 です。
+
+**Returns:**
+long
+### getDisplayOrder() {#getDisplayOrder--}
+```
+public long getDisplayOrder()
+```
+
+
+外部データウィンドウ内でデータ列の表示位置を定義します。左端の列 (0) から右端の列 (最大値) まで。
+
+**Returns:**
+long
+### getDisplayWidth() {#getDisplayWidth--}
+```
+public long getDisplayWidth()
+```
+
+
+外部データウィンドウ内のデータ列の幅。
+
+**Returns:**
+long
+### getHyperlink() {#getHyperlink--}
+```
+public int getHyperlink()
+```
+
+
+シェイプがデータにリンクされている場合に、データ列がシェイプ内にハイパーリンクを作成するかどうか。
+
+**Returns:**
+int
+### getLabel() {#getLabel--}
+```
+public String getLabel()
+```
+
+
+データ列のラベル。
+
+**Returns:**
+java.lang.String
+### getLangID() {#getLangID--}
+```
+public long getLangID()
+```
+
+
+データ列の言語 ID
+
+**Returns:**
+long
+### getMapped() {#getMapped--}
+```
+public int getMapped()
+```
+
+
+列が外部データウィンドウに表示されるかどうかを指定します。表示する場合は true (1)、表示しない場合は false (0) です。デフォルト（属性がない場合）は列が表示される設定です。
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+データ列の内部名です。シェイプがデータ行にリンクされる際にシェイプに追加されるシェイプ データ アイテム（カスタム プロパティ）の行名として使用されます。
+
+**Returns:**
+java.lang.String
+### getOrigLabel() {#getOrigLabel--}
+```
+public String getOrigLabel()
+```
+
+
+基礎となる ADO インターフェイスによって Visio に返される列ラベルです。
+
+**Returns:**
+java.lang.String
+### getUnitType() {#getUnitType--}
+```
+public String getUnitType()
+```
+
+
+データ列のデータの単位タイプです。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCalendar(int value) {#setCalendar-int-}
+```
+public void setCalendar(int value)
+```
+
+
+このプロパティの説明については、以下をご参照ください \{@link DataColumn\#(getCalendar() & 0xFFFF)\}
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setColumnNameID(String value) {#setColumnNameID-java.lang.String-}
+```
+public void setColumnNameID(String value)
+```
+
+
+このプロパティの説明については、[getColumnNameID()](../../com.aspose.diagram/datacolumn\#getColumnNameID--)をご参照ください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setCurrency(int value) {#setCurrency-int-}
+```
+public void setCurrency(int value)
+```
+
+
+このプロパティの説明については、\{@link DataColumn\#(getCurrency() & 0xFFFF)\}をご参照ください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setDataType(int value) {#setDataType-int-}
+```
+public void setDataType(int value)
+```
+
+
+このプロパティの説明については、\{@link DataColumn\#(getDataType() & 0xFFFF)\}をご参照ください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setDegree(long value) {#setDegree-long-}
+```
+public void setDegree(long value)
+```
+
+
+このプロパティの説明については、[getDegree()](../../com.aspose.diagram/datacolumn\#getDegree--)をご参照ください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | long |  |
+
+### setDisplayOrder(long value) {#setDisplayOrder-long-}
+```
+public void setDisplayOrder(long value)
+```
+
+
+このプロパティの説明については、[getDisplayOrder()](../../com.aspose.diagram/datacolumn\#getDisplayOrder--)をご参照ください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | long |  |
+
+### setDisplayWidth(long value) {#setDisplayWidth-long-}
+```
+public void setDisplayWidth(long value)
+```
+
+
+このプロパティの説明については、[getDisplayWidth()](../../com.aspose.diagram/datacolumn\#getDisplayWidth--)をご参照ください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | long |  |
+
+### setHyperlink(int value) {#setHyperlink-int-}
+```
+public void setHyperlink(int value)
+```
+
+
+このプロパティの説明については、[getHyperlink()](../../com.aspose.diagram/datacolumn\#getHyperlink--)をご参照ください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setLabel(String value) {#setLabel-java.lang.String-}
+```
+public void setLabel(String value)
+```
+
+
+このプロパティの説明については、[getLabel()](../../com.aspose.diagram/datacolumn\#getLabel--)をご参照ください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setLangID(long value) {#setLangID-long-}
+```
+public void setLangID(long value)
+```
+
+
+このプロパティの説明については、[getLangID()](../../com.aspose.diagram/datacolumn\#getLangID--)をご参照ください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | long |  |
+
+### setMapped(int value) {#setMapped-int-}
+```
+public void setMapped(int value)
+```
+
+
+このプロパティの説明については、[getMapped()](../../com.aspose.diagram/datacolumn\#getMapped--)をご参照ください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+このプロパティの説明については、[getName()](../../com.aspose.diagram/datacolumn\#getName--)をご参照ください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setOrigLabel(String value) {#setOrigLabel-java.lang.String-}
+```
+public void setOrigLabel(String value)
+```
+
+
+このプロパティの説明については、[getOrigLabel()](../../com.aspose.diagram/datacolumn\#getOrigLabel--)をご参照ください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setUnitType(String value) {#setUnitType-java.lang.String-}
+```
+public void setUnitType(String value)
+```
+
+
+このプロパティの説明については、[getUnitType()](../../com.aspose.diagram/datacolumn\#getUnitType--)をご参照ください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/datacolumncollection/_index.md
+++ b/japanese/java/com.aspose.diagram/datacolumncollection/_index.md
@@ -1,0 +1,268 @@
+---
+title: DataColumnCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: DataColumn コレクション。
+type: docs
+weight: 109
+url: /ja/java/com.aspose.diagram/datacolumncollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class DataColumnCollection extends Collection
+```
+
+DataColumn コレクション。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(DataColumn dataColumn)](#add-com.aspose.diagram.DataColumn-) | コレクションに dataColumn を追加します。 |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [getSortAsc()](#getSortAsc--) | SortColumn 列を昇順 (1) または降順 (0) でソートするかどうかを指定します。 |
+| [getSortColumn()](#getSortColumn--) | データをソートする対象の列です。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(DataColumn dataColumn)](#remove-com.aspose.diagram.DataColumn-) | コレクションから dataColumn を削除します。 |
+| [setSortAsc(int value)](#setSortAsc-int-) | このプロパティの説明については、[getSortAsc()](../../com.aspose.diagram/datacolumncollection\#getSortAsc--)をご覧ください。 |
+| [setSortColumn(String value)](#setSortColumn-java.lang.String-) | このプロパティの説明については、[getSortColumn()](../../com.aspose.diagram/datacolumncollection\#getSortColumn--)をご覧ください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(DataColumn dataColumn) {#add-com.aspose.diagram.DataColumn-}
+```
+public int add(DataColumn dataColumn)
+```
+
+
+コレクションに dataColumn を追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| dataColumn | [DataColumn](../../com.aspose.diagram/datacolumn) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public DataColumn get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[DataColumn](../../com.aspose.diagram/datacolumn) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### getSortAsc() {#getSortAsc--}
+```
+public int getSortAsc()
+```
+
+
+SortColumn 列を昇順 (1) または降順 (0) でソートするかどうかを指定します。
+
+**Returns:**
+int
+### getSortColumn() {#getSortColumn--}
+```
+public String getSortColumn()
+```
+
+
+データをソートする対象の列です。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(DataColumn dataColumn) {#remove-com.aspose.diagram.DataColumn-}
+```
+public void remove(DataColumn dataColumn)
+```
+
+
+コレクションから dataColumn を削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| dataColumn | [DataColumn](../../com.aspose.diagram/datacolumn) |  |
+
+### setSortAsc(int value) {#setSortAsc-int-}
+```
+public void setSortAsc(int value)
+```
+
+
+このプロパティの説明については、[getSortAsc()](../../com.aspose.diagram/datacolumncollection\#getSortAsc--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setSortColumn(String value) {#setSortColumn-java.lang.String-}
+```
+public void setSortColumn(String value)
+```
+
+
+このプロパティの説明については、[getSortColumn()](../../com.aspose.diagram/datacolumncollection\#getSortColumn--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/dataconnection/_index.md
+++ b/japanese/java/com.aspose.diagram/dataconnection/_index.md
@@ -1,0 +1,288 @@
+---
+title: DataConnection
+second_title: Aspose.Diagram for Java API リファレンス
+description: 1 つまたは複数の DataRecordset 要素と非 XML データ ソース間の通信を抽象化します。
+type: docs
+weight: 110
+url: /ja/java/com.aspose.diagram/dataconnection/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DataConnection
+```
+
+1 つまたは複数の DataRecordset 要素と非 XML データ ソース間の通信を抽象化します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [DataConnection()](#DataConnection--) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAlwaysUseConnectionFile()](#getAlwaysUseConnectionFile--) | デフォルト値は false です。 |
+| [getClass()](#getClass--) |  |
+| [getCommand()](#getCommand--) | データ ソースをクエリするために使用されるコマンド文字列です。 |
+| [getConnectionString()](#getConnectionString--) | データ ソースに接続するために必要なパラメータを定義する接続文字列です。 |
+| [getFileName()](#getFileName--) | 接続ファイルの名前です。 |
+| [getID()](#getID--) | Visio が割り当てた、ドキュメント内で一意の接続 ID です。 |
+| [getTimeout()](#getTimeout--) | 接続確立を試みる際の待機時間（分）で、試行を終了する前の時間です。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAlwaysUseConnectionFile(int value)](#setAlwaysUseConnectionFile-int-) | このプロパティの説明については、[getAlwaysUseConnectionFile()](../../com.aspose.diagram/dataconnection\#getAlwaysUseConnectionFile--) を参照してください。 |
+| [setCommand(String value)](#setCommand-java.lang.String-) | このプロパティの説明については、[getCommand()](../../com.aspose.diagram/dataconnection\#getCommand--) を参照してください。 |
+| [setConnectionString(String value)](#setConnectionString-java.lang.String-) | このプロパティの説明については、[getConnectionString()](../../com.aspose.diagram/dataconnection\#getConnectionString--) を参照してください。 |
+| [setFileName(String value)](#setFileName-java.lang.String-) | このプロパティの説明については、[getFileName()](../../com.aspose.diagram/dataconnection\#getFileName--) を参照してください。 |
+| [setID(long value)](#setID-long-) | このプロパティの説明については、\{@link DataConnection\#(getID() & 0xFFFFFFFFL)\} を参照してください。 |
+| [setTimeout(long value)](#setTimeout-long-) | このプロパティの説明については、[getTimeout()](../../com.aspose.diagram/dataconnection\#getTimeout--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DataConnection() {#DataConnection--}
+```
+public DataConnection()
+```
+
+
+コンストラクタ。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAlwaysUseConnectionFile() {#getAlwaysUseConnectionFile--}
+```
+public int getAlwaysUseConnectionFile()
+```
+
+
+デフォルト値は false です。詳細については Remarks を参照してください。
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCommand() {#getCommand--}
+```
+public String getCommand()
+```
+
+
+データ ソースをクエリするために使用されるコマンド文字列です。
+
+**Returns:**
+java.lang.String
+### getConnectionString() {#getConnectionString--}
+```
+public String getConnectionString()
+```
+
+
+データ ソースに接続するために必要なパラメータを定義する接続文字列です。
+
+**Returns:**
+java.lang.String
+### getFileName() {#getFileName--}
+```
+public String getFileName()
+```
+
+
+接続ファイルの名前です。詳細については Remarks を参照してください。
+
+**Returns:**
+java.lang.String
+### getID() {#getID--}
+```
+public long getID()
+```
+
+
+Visio が割り当てた、ドキュメント内で一意の接続 ID です。
+
+**Returns:**
+long
+### getTimeout() {#getTimeout--}
+```
+public long getTimeout()
+```
+
+
+接続確立を試みる際の待機時間（分）で、試行を終了する前の時間です。
+
+**Returns:**
+long
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAlwaysUseConnectionFile(int value) {#setAlwaysUseConnectionFile-int-}
+```
+public void setAlwaysUseConnectionFile(int value)
+```
+
+
+このプロパティの説明については、[getAlwaysUseConnectionFile()](../../com.aspose.diagram/dataconnection\#getAlwaysUseConnectionFile--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setCommand(String value) {#setCommand-java.lang.String-}
+```
+public void setCommand(String value)
+```
+
+
+このプロパティの説明については、[getCommand()](../../com.aspose.diagram/dataconnection\#getCommand--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setConnectionString(String value) {#setConnectionString-java.lang.String-}
+```
+public void setConnectionString(String value)
+```
+
+
+このプロパティの説明については、[getConnectionString()](../../com.aspose.diagram/dataconnection\#getConnectionString--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setFileName(String value) {#setFileName-java.lang.String-}
+```
+public void setFileName(String value)
+```
+
+
+このプロパティの説明については、[getFileName()](../../com.aspose.diagram/dataconnection\#getFileName--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setID(long value) {#setID-long-}
+```
+public void setID(long value)
+```
+
+
+このプロパティの説明については、\{@link DataConnection\#(getID() & 0xFFFFFFFFL)\} を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | long |  |
+
+### setTimeout(long value) {#setTimeout-long-}
+```
+public void setTimeout(long value)
+```
+
+
+このプロパティの説明については、[getTimeout()](../../com.aspose.diagram/dataconnection\#getTimeout--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | long |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/dataconnectioncollection/_index.md
+++ b/japanese/java/com.aspose.diagram/dataconnectioncollection/_index.md
@@ -1,0 +1,259 @@
+---
+title: DataConnectionCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: DataConnection コレクション。
+type: docs
+weight: 111
+url: /ja/java/com.aspose.diagram/dataconnectioncollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class DataConnectionCollection extends Collection
+```
+
+DataConnection コレクション。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(DataConnection dataConnection)](#add-com.aspose.diagram.DataConnection-) | Add the dataConnection in the collection. |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [getDataConnection(long ID)](#getDataConnection-long-) | 指定された ID の要素を取得します。 |
+| [getNextID()](#getNextID--) | The next available ID for new connections. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(DataConnection dataConnection)](#remove-com.aspose.diagram.DataConnection-) | Remove the dataConnection from the collection. |
+| [setNextID(long value)](#setNextID-long-) | For the description of this property, please see \{@link DataConnectionCollection\#(getNextID() & 0xFFFFFFFFL)\} |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(DataConnection dataConnection) {#add-com.aspose.diagram.DataConnection-}
+```
+public int add(DataConnection dataConnection)
+```
+
+
+Add the dataConnection in the collection.
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| dataConnection | [DataConnection](../../com.aspose.diagram/dataconnection) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public DataConnection get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[DataConnection](../../com.aspose.diagram/dataconnection) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### getDataConnection(long ID) {#getDataConnection-long-}
+```
+public DataConnection getDataConnection(long ID)
+```
+
+
+指定された ID の要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ID | long | ID of DataConnectionUInt32. |
+
+**Returns:**
+[DataConnection](../../com.aspose.diagram/dataconnection) - DataConnection [DataConnection](../../com.aspose.diagram/dataconnection).
+### getNextID() {#getNextID--}
+```
+public long getNextID()
+```
+
+
+The next available ID for new connections.
+
+**Returns:**
+long
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(DataConnection dataConnection) {#remove-com.aspose.diagram.DataConnection-}
+```
+public void remove(DataConnection dataConnection)
+```
+
+
+Remove the dataConnection from the collection.
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| dataConnection | [DataConnection](../../com.aspose.diagram/dataconnection) |  |
+
+### setNextID(long value) {#setNextID-long-}
+```
+public void setNextID(long value)
+```
+
+
+For the description of this property, please see \{@link DataConnectionCollection\#(getNextID() & 0xFFFFFFFFL)\}
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | long |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/dataconnectiontype/_index.md
+++ b/japanese/java/com.aspose.diagram/dataconnectiontype/_index.md
@@ -1,0 +1,165 @@
+---
+title: DataConnectionType
+second_title: Aspose.Diagram for Java API リファレンス
+description: データベースへの接続オプションを構成できるようにします。
+type: docs
+weight: 112
+url: /ja/java/com.aspose.diagram/dataconnectiontype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class DataConnectionType
+```
+
+データベースへの接続オプションを構成できるようにします。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [ODBC](#ODBC) | 使用法 System.Data.Odbc.OdbcConnection. |
+| [QLEDB](#QLEDB) | 使用法 System.Data.OleDb.OleDbConnection. |
+| [SQL](#SQL) | 使用法 System.Data.SqlClient.SqlConnection. |
+| [UNKNOWN](#UNKNOWN) | 不明な接続タイプです。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ODBC {#ODBC}
+```
+public static final int ODBC
+```
+
+
+使用法 System.Data.Odbc.OdbcConnection.
+
+### QLEDB {#QLEDB}
+```
+public static final int QLEDB
+```
+
+
+使用法 System.Data.OleDb.OleDbConnection.
+
+### SQL {#SQL}
+```
+public static final int SQL
+```
+
+
+使用法 System.Data.SqlClient.SqlConnection.
+
+### UNKNOWN {#UNKNOWN}
+```
+public static final int UNKNOWN
+```
+
+
+不明な接続タイプです。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/datarecordset/_index.md
+++ b/japanese/java/com.aspose.diagram/datarecordset/_index.md
@@ -1,0 +1,557 @@
+---
+title: DataRecordSet
+second_title: Aspose.Diagram for Java API リファレンス
+description: Microsoft Visio でデータベースからクエリされたデータを保存し、形式を更新し、公開します。
+type: docs
+weight: 113
+url: /ja/java/com.aspose.diagram/datarecordset/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DataRecordSet
+```
+
+Microsoft Visio でデータベースから取得したデータを保存、書式設定、更新、公開します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [DataRecordSet()](#DataRecordSet--) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getADOData()](#getADOData--) | ADO レコードセット用のクラシック XML スキーマに準拠し、データレコードセットのデータを記述する XML を含みます。 |
+| [getAutoLinkComparison()](#getAutoLinkComparison--) | 親 DataRecordset 要素の列と、ユーザーインターフェイスで最後に成功した自動リンク操作から取得されたシェイプ データ項目を比較するルールを定義します。 |
+| [getChecksum()](#getChecksum--) | Visio が生成し、データレコードセットのプロパティに基づくチェックサム値です。 |
+| [getClass()](#getClass--) |  |
+| [getCommand()](#getCommand--) | データ ソースからデータをクエリするために使用されるコマンド文字列です。 |
+| [getConnectionID()](#getConnectionID--) | 関連する DataConnection オブジェクトの接続 ID です。 |
+| [getDataColumns()](#getDataColumns--) | データレコードセット内のすべての DataColumn 要素を含みます。 |
+| [getID()](#getID--) | ドキュメント内で一意のデータレコードセット ID です。 |
+| [getName()](#getName--) | データレコードセットの表示名（または「フレンドリー」名）です。 |
+| [getNextRowID()](#getNextRowID--) | 次に利用可能な Visio 行 ID です。 |
+| [getOptions()](#getOptions--) | データレコードセットに適用するオプションです。 |
+| [getPrimaryKeys()](#getPrimaryKeys--) | データレコードセット内の 1 つ以上の主キー列を識別します。 |
+| [getRefreshConflicts()](#getRefreshConflicts--) | データレコードセットが更新された後、競合状態にあるシェイプにリンクされたデータレコードセット内の行を示します。 |
+| [getRefreshInterval()](#getRefreshInterval--) | Visio がデータレコードセットを自動的に更新する頻度（分単位）です。 |
+| [getRefreshNoReconciliationUI()](#getRefreshNoReconciliationUI--) | データ調整ユーザーインターフェイスを無効にするかどうかです。 |
+| [getRefreshOverwriteAll()](#getRefreshOverwriteAll--) | データレコードセットが更新されたときに、データにリンクされたシェイプのシェイプ データ項目に対するユーザーの変更を上書きするかどうかです。 |
+| [getReplaceLinks()](#getReplaceLinks--) | シェイプがコピーまたは切り取られたときにシェイプ データ リンクがどのように扱われるかを定義します。1 は対象シェイプの既存リンクを置き換え、0 は対象シェイプの既存リンクを維持します。 |
+| [getRowMaps()](#getRowMaps--) | データレコードセットの行をシェイプにマッピングします。 |
+| [getRowOrder()](#getRowOrder--) | データレコードセットの行順序を主キーとして使用するかどうかです。 |
+| [getTimeRefreshed()](#getTimeRefreshed--) | データレコードセットが最後に更新された日時です。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [refresh(int connectionType)](#refresh-int-) | 接続された（XML 以外の）DataRecordset に関連付けられたクエリ文字列を実行し、クエリで返されたデータソースからの新しいデータでリンクされたシェイプを更新します。 |
+| [setADOData(String value)](#setADOData-java.lang.String-) | このプロパティの説明については、[getADOData()](../../com.aspose.diagram/datarecordset\\#getADOData--) を参照してください。 |
+| [setChecksum(long value)](#setChecksum-long-) | このプロパティの説明については、\\{@link DataRecordSet\\#(getChecksum() & 0xFFFFFFFFL)\\} を参照してください。 |
+| [setCommand(String value)](#setCommand-java.lang.String-) | このプロパティの説明については、[getCommand()](../../com.aspose.diagram/datarecordset\\#getCommand--) を参照してください。 |
+| [setConnectionID(long value)](#setConnectionID-long-) | このプロパティの説明については、\\{@link DataRecordSet\\#(getConnectionID() & 0xFFFFFFFFL)\\} を参照してください。 |
+| [setID(long value)](#setID-long-) | このプロパティの説明については、\\{@link DataRecordSet\\#(getID() & 0xFFFFFFFFL)\\} を参照してください。 |
+| [setName(String value)](#setName-java.lang.String-) | このプロパティの説明については、[getName()](../../com.aspose.diagram/datarecordset\#getName--)をご覧ください。 |
+| [setNextRowID(long value)](#setNextRowID-long-) | このプロパティの説明については、\{@link DataRecordSet\#(getNextRowID() & 0xFFFFFFFFL)\}をご参照ください。 |
+| [setOptions(int value)](#setOptions-int-) | このプロパティの説明については、[getOptions()](../../com.aspose.diagram/datarecordset\#getOptions--)をご覧ください。 |
+| [setRefreshInterval(long value)](#setRefreshInterval-long-) | このプロパティの説明については、\{@link DataRecordSet\#(getRefreshInterval() & 0xFFFFFFFFL)\}をご参照ください。 |
+| [setRefreshNoReconciliationUI(int value)](#setRefreshNoReconciliationUI-int-) | このプロパティの説明については、[getRefreshNoReconciliationUI()](../../com.aspose.diagram/datarecordset\#getRefreshNoReconciliationUI--)をご覧ください。 |
+| [setRefreshOverwriteAll(int value)](#setRefreshOverwriteAll-int-) | このプロパティの説明については、[getRefreshOverwriteAll()](../../com.aspose.diagram/datarecordset\#getRefreshOverwriteAll--)をご覧ください。 |
+| [setReplaceLinks(int value)](#setReplaceLinks-int-) | このプロパティの説明については、[getReplaceLinks()](../../com.aspose.diagram/datarecordset\#getReplaceLinks--)をご覧ください。 |
+| [setRowOrder(int value)](#setRowOrder-int-) | このプロパティの説明については、[getRowOrder()](../../com.aspose.diagram/datarecordset\#getRowOrder--)をご覧ください。 |
+| [setTimeRefreshed(DateTime value)](#setTimeRefreshed-com.aspose.diagram.DateTime-) | このプロパティの説明については、[getTimeRefreshed()](../../com.aspose.diagram/datarecordset\#getTimeRefreshed--)をご覧ください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DataRecordSet() {#DataRecordSet--}
+```
+public DataRecordSet()
+```
+
+
+コンストラクタ。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getADOData() {#getADOData--}
+```
+public String getADOData()
+```
+
+
+ADO レコードセット用のクラシック XML スキーマに準拠し、データレコードセットのデータを記述する XML を含みます。
+
+**Returns:**
+java.lang.String
+### getAutoLinkComparison() {#getAutoLinkComparison--}
+```
+public AutoLinkComparison getAutoLinkComparison()
+```
+
+
+親 DataRecordset 要素の列と、ユーザーインターフェイスで最後に成功した自動リンク操作から取得されたシェイプ データ項目を比較するルールを定義します。
+
+**Returns:**
+[AutoLinkComparison](../../com.aspose.diagram/autolinkcomparison)
+### getChecksum() {#getChecksum--}
+```
+public long getChecksum()
+```
+
+
+Visio が生成し、data-recordset のプロパティに基づくチェックサム値です。この属性を 0 に設定してください。Visio は実行時にこの値を再計算します。
+
+**Returns:**
+long
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCommand() {#getCommand--}
+```
+public String getCommand()
+```
+
+
+データ ソースからデータをクエリするために使用されるコマンド文字列です。
+
+**Returns:**
+java.lang.String
+### getConnectionID() {#getConnectionID--}
+```
+public long getConnectionID()
+```
+
+
+関連付けられた DataConnection オブジェクトの接続 ID です。XML データ ソースには存在しません。
+
+**Returns:**
+long
+### getDataColumns() {#getDataColumns--}
+```
+public DataColumnCollection getDataColumns()
+```
+
+
+データレコードセット内のすべての DataColumn 要素を含みます。
+
+**Returns:**
+[DataColumnCollection](../../com.aspose.diagram/datacolumncollection)
+### getID() {#getID--}
+```
+public long getID()
+```
+
+
+ドキュメント内で一意のデータレコードセット ID です。
+
+**Returns:**
+long
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+データレコードセットの表示名（または「フレンドリー」名）です。
+
+**Returns:**
+java.lang.String
+### getNextRowID() {#getNextRowID--}
+```
+public long getNextRowID()
+```
+
+
+次に利用可能な Visio 行 ID です。
+
+**Returns:**
+long
+### getOptions() {#getOptions--}
+```
+public int getOptions()
+```
+
+
+データ レコードセットに適用するオプションです。可能な値は、以下の表に示すものの 1 つ以上の組み合わせです。
+
+**Returns:**
+int
+### getPrimaryKeys() {#getPrimaryKeys--}
+```
+public ArrayList<String> getPrimaryKeys()
+```
+
+
+データレコードセット内の 1 つ以上の主キー列を識別します。
+
+**Returns:**
+java.util.ArrayList<java.lang.String>
+### getRefreshConflicts() {#getRefreshConflicts--}
+```
+public RowCollection getRefreshConflicts()
+```
+
+
+データ レコードセットが更新された後、競合状態にあるシェイプにリンクされたレコードセットの行を示します。RowID - データ レコードセットが更新された後、競合状態にあるシェイプにリンクされたレコードセットの行を示します。ShapeID - 競合に関与するシェイプのシェイプ ID。PageID - 競合に関与するシェイプのページ ID。
+
+**Returns:**
+[RowCollection](../../com.aspose.diagram/rowcollection)
+### getRefreshInterval() {#getRefreshInterval--}
+```
+public long getRefreshInterval()
+```
+
+
+Visio がデータ レコードセットを自動的に更新する頻度（分単位）です。この値は 1 以上でなければなりません。
+
+**Returns:**
+long
+### getRefreshNoReconciliationUI() {#getRefreshNoReconciliationUI--}
+```
+public int getRefreshNoReconciliationUI()
+```
+
+
+データ 照合ユーザー インターフェイスを無効にするかどうかです。True (1) は UI を無効にし、False (0) は UI を有効にします。
+
+**Returns:**
+int
+### getRefreshOverwriteAll() {#getRefreshOverwriteAll--}
+```
+public int getRefreshOverwriteAll()
+```
+
+
+データレコードセットが更新されたときに、データにリンクされたシェイプのシェイプ データ項目に対するユーザーの変更を上書きするかどうかです。
+
+**Returns:**
+int
+### getReplaceLinks() {#getReplaceLinks--}
+```
+public int getReplaceLinks()
+```
+
+
+シェイプがコピーまたは切り取りされる際の shape-data リンクの扱いを定義します。1 は対象シェイプの既存リンクを置き換え、0 は既存リンクを維持します。この属性が存在しない場合、Visio はコピーまたは切り取り時にリンクを置き換えるかどうかユーザーに問い合わせます。
+
+**Returns:**
+int
+### getRowMaps() {#getRowMaps--}
+```
+public RowCollection getRowMaps()
+```
+
+
+データ レコードセットの行をシェイプにマッピングします。RowID - データ レコードセット内で一意の行 ID。ShapeID - RowID で識別されたデータ レコードセットの行にリンクされたシェイプのシェイプ ID。PageID - RowID で識別されたデータ レコードセットの行にリンクされたシェイプのページ ID。
+
+**Returns:**
+[RowCollection](../../com.aspose.diagram/rowcollection)
+### getRowOrder() {#getRowOrder--}
+```
+public int getRowOrder()
+```
+
+
+データ レコードセットの行順序を主キーとして使用するかどうかです。行 ID が行順序で決定される場合は True (1)、データ レコードセットの主キー列の値で決定される場合は False (0) です。
+
+**Returns:**
+int
+### getTimeRefreshed() {#getTimeRefreshed--}
+```
+public DateTime getTimeRefreshed()
+```
+
+
+データレコードセットが最後に更新された日時です。
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### refresh(int connectionType) {#refresh-int-}
+```
+public void refresh(int connectionType)
+```
+
+
+接続された（XML 以外の）DataRecordset に関連付けられたクエリ文字列を実行し、クエリで返されたデータソースからの新しいデータでリンクされたシェイプを更新します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| connectionType | int | 接続に使用されるプロバイダーのタイプです Aspose.Diagram.Manipulation.DataConnectionType。 |
+
+### setADOData(String value) {#setADOData-java.lang.String-}
+```
+public void setADOData(String value)
+```
+
+
+このプロパティの説明については、[getADOData()](../../com.aspose.diagram/datarecordset\\#getADOData--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setChecksum(long value) {#setChecksum-long-}
+```
+public void setChecksum(long value)
+```
+
+
+このプロパティの説明については、\\{@link DataRecordSet\\#(getChecksum() & 0xFFFFFFFFL)\\} を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | long |  |
+
+### setCommand(String value) {#setCommand-java.lang.String-}
+```
+public void setCommand(String value)
+```
+
+
+このプロパティの説明については、[getCommand()](../../com.aspose.diagram/datarecordset\\#getCommand--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setConnectionID(long value) {#setConnectionID-long-}
+```
+public void setConnectionID(long value)
+```
+
+
+このプロパティの説明については、\\{@link DataRecordSet\\#(getConnectionID() & 0xFFFFFFFFL)\\} を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | long |  |
+
+### setID(long value) {#setID-long-}
+```
+public void setID(long value)
+```
+
+
+このプロパティの説明については、\\{@link DataRecordSet\\#(getID() & 0xFFFFFFFFL)\\} を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | long |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+このプロパティの説明については、[getName()](../../com.aspose.diagram/datarecordset\#getName--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setNextRowID(long value) {#setNextRowID-long-}
+```
+public void setNextRowID(long value)
+```
+
+
+このプロパティの説明については、\{@link DataRecordSet\#(getNextRowID() & 0xFFFFFFFFL)\}をご参照ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | long |  |
+
+### setOptions(int value) {#setOptions-int-}
+```
+public void setOptions(int value)
+```
+
+
+このプロパティの説明については、[getOptions()](../../com.aspose.diagram/datarecordset\#getOptions--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setRefreshInterval(long value) {#setRefreshInterval-long-}
+```
+public void setRefreshInterval(long value)
+```
+
+
+このプロパティの説明については、\{@link DataRecordSet\#(getRefreshInterval() & 0xFFFFFFFFL)\}をご参照ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | long |  |
+
+### setRefreshNoReconciliationUI(int value) {#setRefreshNoReconciliationUI-int-}
+```
+public void setRefreshNoReconciliationUI(int value)
+```
+
+
+このプロパティの説明については、[getRefreshNoReconciliationUI()](../../com.aspose.diagram/datarecordset\#getRefreshNoReconciliationUI--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setRefreshOverwriteAll(int value) {#setRefreshOverwriteAll-int-}
+```
+public void setRefreshOverwriteAll(int value)
+```
+
+
+このプロパティの説明については、[getRefreshOverwriteAll()](../../com.aspose.diagram/datarecordset\#getRefreshOverwriteAll--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setReplaceLinks(int value) {#setReplaceLinks-int-}
+```
+public void setReplaceLinks(int value)
+```
+
+
+このプロパティの説明については、[getReplaceLinks()](../../com.aspose.diagram/datarecordset\#getReplaceLinks--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setRowOrder(int value) {#setRowOrder-int-}
+```
+public void setRowOrder(int value)
+```
+
+
+このプロパティの説明については、[getRowOrder()](../../com.aspose.diagram/datarecordset\#getRowOrder--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setTimeRefreshed(DateTime value) {#setTimeRefreshed-com.aspose.diagram.DateTime-}
+```
+public void setTimeRefreshed(DateTime value)
+```
+
+
+このプロパティの説明については、[getTimeRefreshed()](../../com.aspose.diagram/datarecordset\#getTimeRefreshed--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/datarecordsetcollection/_index.md
+++ b/japanese/java/com.aspose.diagram/datarecordsetcollection/_index.md
@@ -1,0 +1,268 @@
+---
+title: DataRecordSetCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: DataRecordSet コレクション。
+type: docs
+weight: 114
+url: /ja/java/com.aspose.diagram/datarecordsetcollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class DataRecordSetCollection extends Collection
+```
+
+DataRecordSet コレクション。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(DataRecordSet dataRecordSet)](#add-com.aspose.diagram.DataRecordSet-) | コレクションに dataRecordSet を追加します。 |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getActiveRecordsetId()](#getActiveRecordsetId--) | ActiveRecordsetID |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [getNextId()](#getNextId--) | NextID |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(DataRecordSet dataRecordSet)](#remove-com.aspose.diagram.DataRecordSet-) | コレクションから dataRecordSet を削除します。 |
+| [setActiveRecordsetId(String value)](#setActiveRecordsetId-java.lang.String-) | このプロパティの説明については、[getActiveRecordsetId()](../../com.aspose.diagram/datarecordsetcollection\#getActiveRecordsetId--) を参照してください。 |
+| [setNextId(String value)](#setNextId-java.lang.String-) | このプロパティの説明については、[getNextId()](../../com.aspose.diagram/datarecordsetcollection\#getNextId--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(DataRecordSet dataRecordSet) {#add-com.aspose.diagram.DataRecordSet-}
+```
+public int add(DataRecordSet dataRecordSet)
+```
+
+
+コレクションに dataRecordSet を追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| dataRecordSet | [DataRecordSet](../../com.aspose.diagram/datarecordset) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public DataRecordSet get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[DataRecordSet](../../com.aspose.diagram/datarecordset) - 
+### getActiveRecordsetId() {#getActiveRecordsetId--}
+```
+public String getActiveRecordsetId()
+```
+
+
+ActiveRecordsetID
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### getNextId() {#getNextId--}
+```
+public String getNextId()
+```
+
+
+NextID
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(DataRecordSet dataRecordSet) {#remove-com.aspose.diagram.DataRecordSet-}
+```
+public void remove(DataRecordSet dataRecordSet)
+```
+
+
+コレクションから dataRecordSet を削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| dataRecordSet | [DataRecordSet](../../com.aspose.diagram/datarecordset) |  |
+
+### setActiveRecordsetId(String value) {#setActiveRecordsetId-java.lang.String-}
+```
+public void setActiveRecordsetId(String value)
+```
+
+
+このプロパティの説明については、[getActiveRecordsetId()](../../com.aspose.diagram/datarecordsetcollection\#getActiveRecordsetId--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setNextId(String value) {#setNextId-java.lang.String-}
+```
+public void setNextId(String value)
+```
+
+
+このプロパティの説明については、[getNextId()](../../com.aspose.diagram/datarecordsetcollection\#getNextId--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/datetime/_index.md
+++ b/japanese/java/com.aspose.diagram/datetime/_index.md
@@ -1,0 +1,510 @@
+---
+title: DateTime
+second_title: Aspose.Diagram for Java API リファレンス
+description: 通常、日付と時刻として表される瞬間を表します。
+type: docs
+weight: 115
+url: /ja/java/com.aspose.diagram/datetime/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DateTime
+```
+
+通常、日付と時刻として表される特定の時点を表します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [DateTime(int year, int month, int day)](#DateTime-int-int-int-) | 指定された年、月、日で DateTime オブジェクトの新しいインスタンスを初期化します。 |
+| [DateTime(int year, int month, int day, int hour, int minute, int second)](#DateTime-int-int-int-int-int-int-) | 指定された年、月、日、時、分、秒で DateTime オブジェクトの新しいインスタンスを初期化します。 |
+| [DateTime(int year, int month, int day, int hour, int minute, int second, int millisecond)](#DateTime-int-int-int-int-int-int-int-) | 指定された年、月、日、時、分、秒、ミリ秒で DateTime オブジェクトの新しいインスタンスを初期化します。 |
+| [DateTime(Date date)](#DateTime-java.util.Date-) | 指定された Date オブジェクトで DateTime オブジェクトの新しいインスタンスを初期化します。 |
+| [DateTime(Calendar cld)](#DateTime-java.util.Calendar-) | 指定された Calendar オブジェクトで DateTime オブジェクトの新しいインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [addDays(double value)](#addDays-double-) | このインスタンスの値に指定された日数を加算します。 |
+| [addHours(double value)](#addHours-double-) | このインスタンスの値に指定された時間数を加算します。 |
+| [addMilliseconds(double value)](#addMilliseconds-double-) | このインスタンスの値に指定されたミリ秒数を加算します。 |
+| [addMinutes(double value)](#addMinutes-double-) | このインスタンスの値に指定された分数を加算します。 |
+| [addMonths(int months)](#addMonths-int-) | このインスタンスの値に指定された月数を加算します。 |
+| [addSeconds(double value)](#addSeconds-double-) | このインスタンスの値に指定された秒数を加算します。 |
+| [addYears(int value)](#addYears-int-) | このインスタンスの値に指定された年数を加算します。 |
+| [compareTo(DateTime value)](#compareTo-com.aspose.diagram.DateTime-) | このインスタンスの値を指定された DateTime 値と比較し、このインスタンスが指定された DateTime 値より前か、同じか、後かを示す整数を返します。 |
+| [compareTo(Object value)](#compareTo-java.lang.Object-) | このインスタンスの値を、指定された DateTime 値を含むオブジェクトと比較し、このインスタンスがその DateTime 値より前か、同じか、後かを示す整数を返します。 |
+| [equals(Object value)](#equals-java.lang.Object-) | このインスタンスが指定されたオブジェクトと等しいかどうかを示す値を返します。 |
+| [getClass()](#getClass--) |  |
+| [getDay()](#getDay--) | このインスタンスが表す月の日を取得します。 |
+| [getDayOfWeek()](#getDayOfWeek--) | このインスタンスが表す曜日を取得します。 |
+| [getDayOfYear()](#getDayOfYear--) | このインスタンスが表す年の日を取得します。 |
+| [getHour()](#getHour--) | このインスタンスが表す日付の時間コンポーネントを取得します。 |
+| [getMillisecond()](#getMillisecond--) | このインスタンスが表す日付のミリ秒コンポーネントを取得します。 |
+| [getMinute()](#getMinute--) | このインスタンスが表す日付の分コンポーネントを取得します。 |
+| [getMonth()](#getMonth--) | このインスタンスが表す日付の月コンポーネントを取得します。 |
+| [getNow()](#getNow--) | このコンピューターの現在の日付と時刻をローカル時間として設定した DateTime オブジェクトを取得します。 |
+| [getSecond()](#getSecond--) | このインスタンスが表す日付の秒コンポーネントを取得します。 |
+| [getYear()](#getYear--) | このインスタンスが表す日付の年コンポーネントを取得します。 |
+| [hashCode()](#hashCode--) | このインスタンスのハッシュコードを返します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toCalendar()](#toCalendar--) | 現在の DateTime オブジェクトの値を Calendar オブジェクトに変換します。 |
+| [toDate()](#toDate--) | 現在の DateTime オブジェクトの値を Date オブジェクトに変換します。 |
+| [toLocalTime()](#toLocalTime--) | 現在の DateTime オブジェクトの値をローカル時間に変換します。 |
+| [toString()](#toString--) | 現在の DateTime オブジェクトの値を等価な文字列表現に変換します。 |
+| [toUniversalTime()](#toUniversalTime--) | 現在の DateTime オブジェクトの値を協定世界時 (UTC) に変換します。 |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DateTime(int year, int month, int day) {#DateTime-int-int-int-}
+```
+public DateTime(int year, int month, int day)
+```
+
+
+指定された年、月、日で DateTime オブジェクトの新しいインスタンスを初期化します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 年 | int | 年 (1 から 9999)。 |
+| 月 | int | 月 (1 から 12)。 |
+| 日 | int | 日 (1 からその月の日数まで)。 |
+
+### DateTime(int year, int month, int day, int hour, int minute, int second) {#DateTime-int-int-int-int-int-int-}
+```
+public DateTime(int year, int month, int day, int hour, int minute, int second)
+```
+
+
+指定された年、月、日、時、分、秒で DateTime オブジェクトの新しいインスタンスを初期化します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 年 | int | 年 (1 から 9999)。 |
+| 月 | int | 月 (1 から 12)。 |
+| 日 | int | 日 (1 からその月の日数まで)。 |
+| 時 | int | 時 (0 から 23)。 |
+| 分 | int | 分 (0 から 59)。 |
+| 秒 | int | 秒 (0 から 59)。 |
+
+### DateTime(int year, int month, int day, int hour, int minute, int second, int millisecond) {#DateTime-int-int-int-int-int-int-int-}
+```
+public DateTime(int year, int month, int day, int hour, int minute, int second, int millisecond)
+```
+
+
+指定された年、月、日、時、分、秒、ミリ秒で DateTime オブジェクトの新しいインスタンスを初期化します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 年 | int | 年 (1 から 9999)。 |
+| 月 | int | 月 (1 から 12)。 |
+| 日 | int | 日 (1 からその月の日数まで)。 |
+| 時 | int | 時 (0 から 23)。 |
+| 分 | int | 分 (0 から 59)。 |
+| 秒 | int | 秒 (0 から 59)。 |
+| ミリ秒 | int | ミリ秒 (0 から 999)。 |
+
+### DateTime(Date date) {#DateTime-java.util.Date-}
+```
+public DateTime(Date date)
+```
+
+
+指定された Date オブジェクトで DateTime オブジェクトの新しいインスタンスを初期化します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 日付 | java.util.Date | Date オブジェクト |
+
+### DateTime(Calendar cld) {#DateTime-java.util.Calendar-}
+```
+public DateTime(Calendar cld)
+```
+
+
+指定された Calendar オブジェクトで DateTime オブジェクトの新しいインスタンスを初期化します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| cld | java.util.Calendar | Calendar オブジェクト |
+
+### addDays(double value) {#addDays-double-}
+```
+public DateTime addDays(double value)
+```
+
+
+このインスタンスの値に指定された日数を加算します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double | 整数部と小数部を含む日数。value パラメーターは負の値または正の値にできます。 |
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object whose value is the sum of the date and time represented by this instance and the number of days represented by value.
+### addHours(double value) {#addHours-double-}
+```
+public DateTime addHours(double value)
+```
+
+
+このインスタンスの値に指定された時間数を加算します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double | 整数部と小数部を含む時間数。value パラメーターは負の値または正の値にできます。 |
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object whose value is the sum of the date and time represented by this instance and the number of hours represented by value.
+### addMilliseconds(double value) {#addMilliseconds-double-}
+```
+public DateTime addMilliseconds(double value)
+```
+
+
+このインスタンスの値に指定されたミリ秒数を加算します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double | 整数部と小数部を含むミリ秒数。value パラメーターは負の値または正の値にできます。この値は最も近い整数に丸められることに注意してください。 |
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object whose value is the sum of the date and time represented by this instance and the number of milliseconds represented by value.
+### addMinutes(double value) {#addMinutes-double-}
+```
+public DateTime addMinutes(double value)
+```
+
+
+このインスタンスの値に指定された分数を加算します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double | 整数部と小数部を含む分数。value パラメーターは負の値または正の値にできます。 |
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object whose value is the sum of the date and time represented by this instance and the number of minutes represented by value.
+### addMonths(int months) {#addMonths-int-}
+```
+public DateTime addMonths(int months)
+```
+
+
+このインスタンスの値に指定された月数を加算します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 月 | int | 月数。months パラメーターは負の値または正の値にできます。 |
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object whose value is the sum of the date and time represented by this instance and months.
+### addSeconds(double value) {#addSeconds-double-}
+```
+public DateTime addSeconds(double value)
+```
+
+
+このインスタンスの値に指定された秒数を加算します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double | 整数部と小数部を含む秒数。value パラメーターは負の値または正の値にできます。 |
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object whose value is the sum of the date and time represented by this instance and the number of seconds represented by value.
+### addYears(int value) {#addYears-int-}
+```
+public DateTime addYears(int value)
+```
+
+
+このインスタンスの値に指定された年数を加算します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int | 年数。value パラメーターは負の値または正の値にできます。 |
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object whose value is the sum of the date and time represented by this instance and the number of years represented by value.
+### compareTo(DateTime value) {#compareTo-com.aspose.diagram.DateTime-}
+```
+public int compareTo(DateTime value)
+```
+
+
+このインスタンスの値を指定された DateTime 値と比較し、このインスタンスが指定された DateTime 値より前か、同じか、後かを示す整数を返します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) | 比較対象の DateTime オブジェクト。 |
+
+**Returns:**
+int - このインスタンスと value パラメーターの相対的な値を示す符号付き数。値の説明: ゼロ未満 このインスタンスは value より前です。ゼロ このインスタンスは value と同じです。ゼロより大きい このインスタンスは value より後です。
+### compareTo(Object value) {#compareTo-java.lang.Object-}
+```
+public int compareTo(Object value)
+```
+
+
+このインスタンスの値を、指定された DateTime 値を含むオブジェクトと比較し、このインスタンスがその DateTime 値より前か、同じか、後かを示す整数を返します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object | 比較対象のボックス化された DateTime オブジェクト、または null。 |
+
+**Returns:**
+int - このインスタンスと value の相対的な値を示す符号付き数。値の説明: ゼロ未満 このインスタンスは value より前です。ゼロ このインスタンスは value と同じです。ゼロより大きい このインスタンスは value より後です。または value が null の場合。
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+このインスタンスが指定されたオブジェクトと等しいかどうかを示す値を返します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object | このインスタンスと比較するオブジェクト。 |
+
+**Returns:**
+boolean - value が DateTime のインスタンスであり、このインスタンスの値と等しい場合は true。そうでなければ false。
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDay() {#getDay--}
+```
+public int getDay()
+```
+
+
+このインスタンスが表す月の日を取得します。
+
+**Returns:**
+int - 1 から 31 の範囲で表される日コンポーネント。
+### getDayOfWeek() {#getDayOfWeek--}
+```
+public int getDayOfWeek()
+```
+
+
+このインスタンスが表す曜日を取得します。
+
+**Returns:**
+int - この DateTime 値の曜日。
+### getDayOfYear() {#getDayOfYear--}
+```
+public int getDayOfYear()
+```
+
+
+このインスタンスが表す年の日を取得します。
+
+**Returns:**
+int - 年の日（1 から 366 の値で表されます）。
+### getHour() {#getHour--}
+```
+public int getHour()
+```
+
+
+このインスタンスが表す日付の時間コンポーネントを取得します。
+
+**Returns:**
+int - 時間コンポーネント（0 から 23 の値で表されます）。
+### getMillisecond() {#getMillisecond--}
+```
+public int getMillisecond()
+```
+
+
+このインスタンスが表す日付のミリ秒コンポーネントを取得します。
+
+**Returns:**
+int - ミリ秒コンポーネント（0 から 999 の値で表されます）。
+### getMinute() {#getMinute--}
+```
+public int getMinute()
+```
+
+
+このインスタンスが表す日付の分コンポーネントを取得します。
+
+**Returns:**
+int - 分コンポーネント（0 から 59 の値で表されます）。
+### getMonth() {#getMonth--}
+```
+public int getMonth()
+```
+
+
+このインスタンスが表す日付の月コンポーネントを取得します。
+
+**Returns:**
+int - 月コンポーネント（1 から 12 の値で表されます）。
+### getNow() {#getNow--}
+```
+public static DateTime getNow()
+```
+
+
+このコンピューターの現在の日付と時刻をローカル時間として設定した DateTime オブジェクトを取得します。
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object whose value is the current local date and time.
+### getSecond() {#getSecond--}
+```
+public int getSecond()
+```
+
+
+このインスタンスが表す日付の秒コンポーネントを取得します。
+
+**Returns:**
+int - 秒（0 から 59 の範囲）。
+### getYear() {#getYear--}
+```
+public int getYear()
+```
+
+
+このインスタンスが表す日付の年コンポーネントを取得します。
+
+**Returns:**
+int - 年（1 から 9999 の範囲）。
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+このインスタンスのハッシュコードを返します。
+
+**Returns:**
+int - 32 ビット符号付き整数のハッシュコード。
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toCalendar() {#toCalendar--}
+```
+public Calendar toCalendar()
+```
+
+
+現在の DateTime オブジェクトの値を Calendar オブジェクトに変換します。
+
+**Returns:**
+[Calendar](../../java.util/calendar) - Calendar object
+### toDate() {#toDate--}
+```
+public Date toDate()
+```
+
+
+現在の DateTime オブジェクトの値を Date オブジェクトに変換します。
+
+**Returns:**
+java.util.Date - 日付オブジェクト。
+### toLocalTime() {#toLocalTime--}
+```
+public DateTime toLocalTime()
+```
+
+
+現在の DateTime オブジェクトの値をローカル時間に変換します。
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object of local
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+現在の DateTime オブジェクトの値を等価な文字列表現に変換します。
+
+**Returns:**
+java.lang.String - 現在の DateTime オブジェクトの値を表す文字列。
+### toUniversalTime() {#toUniversalTime--}
+```
+public DateTime toUniversalTime()
+```
+
+
+現在の DateTime オブジェクトの値を協定世界時 (UTC) に変換します。
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object of UTC
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/datevalue/_index.md
+++ b/japanese/java/com.aspose.diagram/datevalue/_index.md
@@ -1,0 +1,180 @@
+---
+title: DateValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: 日付と時刻の値。
+type: docs
+weight: 116
+url: /ja/java/com.aspose.diagram/datevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DateValue
+```
+
+日付と時刻の値。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [DateValue(DateTime value, int unit)](#DateValue-com.aspose.diagram.DateTime-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性。 |
+| [getValue()](#getValue--) | 日付と時刻の値。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(DateTime value)](#setValue-com.aspose.diagram.DateTime-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/datevalue\#getValue--)をご覧ください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DateValue(DateTime value, int unit) {#DateValue-com.aspose.diagram.DateTime-int-}
+```
+public DateValue(DateTime value, int unit)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+| 単位 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public DateTime getValue()
+```
+
+
+日付と時刻の値。
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(DateTime value) {#setValue-com.aspose.diagram.DateTime-}
+```
+public void setValue(DateTime value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/datevalue\#getValue--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/diagram/_index.md
+++ b/japanese/java/com.aspose.diagram/diagram/_index.md
@@ -1,0 +1,1130 @@
+---
+title: 図
+second_title: Aspose.Diagram for Java API リファレンス
+description: Visio オブジェクト階層のルート要素です。
+type: docs
+weight: 117
+url: /ja/java/com.aspose.diagram/diagram/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Diagram
+```
+
+Visio オブジェクト階層のルート要素です。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Diagram()](#Diagram--) |  |
+| [Diagram(String filename)](#Diagram-java.lang.String-) | パブリック クラス コンストラクタは、ファイルからダイアグラムをロードします。 |
+| [Diagram(InputStream stream)](#Diagram-java.io.InputStream-) | パブリック クラス コンストラクタは、ストリームからダイアグラムをロードします。 |
+| [Diagram(InputStream stream, int format)](#Diagram-java.io.InputStream-int-) | パブリック クラス コンストラクタは、事前定義された形式を使用してストリームからダイアグラムをロードします。 |
+| [Diagram(InputStream stream, LoadOptions options)](#Diagram-java.io.InputStream-com.aspose.diagram.LoadOptions-) | パブリック クラス コンストラクタは、事前定義されたロード ファイル オプションを使用してストリームからダイアグラムをロードします。 |
+| [Diagram(String filename, int format)](#Diagram-java.lang.String-int-) | パブリック クラス コンストラクタは、事前定義された形式を使用してファイルからダイアグラムをロードします。 |
+| [Diagram(String filename, LoadOptions options)](#Diagram-java.lang.String-com.aspose.diagram.LoadOptions-) | パブリック クラス コンストラクタは、事前定義されたロード ファイル オプションを使用してファイルからダイアグラムをロードします。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [addMaster(Diagram srcDiagram, String masterName)](#addMaster-com.aspose.diagram.Diagram-java.lang.String-) | マスターの Name または NameU によって、ソース ダイアグラムからマスターをダイアグラムに追加します。 |
+| [addMaster(InputStream templateStream, int masterID)](#addMaster-java.io.InputStream-int-) | マスターの ID によって、テンプレート ストリームからマスターをダイアグラムに追加します。 |
+| [addMaster(InputStream templateStream, String masterName)](#addMaster-java.io.InputStream-java.lang.String-) | マスターの Name または NameU によって、テンプレート ストリームからマスターをダイアグラムに追加します。 |
+| [addMaster(String templateFilePath, int masterID)](#addMaster-java.lang.String-int-) | マスターの ID によって、テンプレート ファイルからマスターをダイアグラムに追加します。 |
+| [addMaster(String templateFilePath, String masterName)](#addMaster-java.lang.String-java.lang.String-) | マスターの Name または NameU によって、テンプレート ファイルからマスターをダイアグラムに追加します。 |
+| [addShape(Shape newShape, String masterName, int pageNumber)](#addShape-com.aspose.diagram.Shape-java.lang.String-int-) | マスターで作成されたシェイプを特定のページに追加します。 |
+| [addShape(double pinX, double pinY, double width, double height, String masterName, int pageNumber)](#addShape-double-double-double-double-java.lang.String-int-) | 定義された PinX、PinY、幅、そして高さを使用して、ページ上にマスターで作成されたシェイプを追加します。 |
+| [addShape(double pinX, double pinY, String masterName, int pageNumber)](#addShape-double-double-java.lang.String-int-) | 定義された PinX と PinY を使用して、ページ上にマスターで作成されたシェイプを追加します。 |
+| [combine(Diagram secondDiagram)](#combine-com.aspose.diagram.Diagram-) | 別の Diagram オブジェクトを結合します。 |
+| [copyTheme(Diagram source)](#copyTheme-com.aspose.diagram.Diagram-) | ソース Diagram から Theme をコピーします。 |
+| [dispose()](#dispose--) | アンマネージド リソースの解放、リリース、またはリセットに関連するアプリケーション定義のタスクを実行します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [export(InputStream inputVsd, InputStream outputVdw)](#export-java.io.InputStream-java.io.InputStream-) | vsd ストリームから vdw ストリーム形式へダイアグラムをエクスポートします。 |
+| [export(InputStream inputVsd, String outputVdw)](#export-java.io.InputStream-java.lang.String-) | vsd ストリームから *.vdw ファイル形式へダイアグラムをエクスポートします。 |
+| [export(String inputVsd, InputStream outputVdw)](#export-java.lang.String-java.io.InputStream-) | vsd ファイルから vdw ストリーム形式へダイアグラムをエクスポートします。 |
+| [export(String inputVsd, String outputVdw)](#export-java.lang.String-java.lang.String-) | vsd から vdw 形式へダイアグラムをエクスポートします。 |
+| [getActivePage()](#getActivePage--) | アクティブ ページを指定します |
+| [getBuildnum()](#getBuildnum--) | ドキュメント作成に使用された Visio インスタンスのビルド番号です。 |
+| [getClass()](#getClass--) |  |
+| [getColors()](#getColors--) | ドキュメントのカラーテーブルを含みます。 |
+| [getDataConnections()](#getDataConnections--) | ドキュメントの DataConnection 要素を含みます。 |
+| [getDataRecordSets()](#getDataRecordSets--) | Document オブジェクトに関連付けられた DataRecordset オブジェクトのコレクションです。 |
+| [getDefaultFontDir()](#getDefaultFontDir--) | デフォルト フォント フォルダーのパスを取得します |
+| [getDocLangID()](#getDocLangID--) | ユーザーが Microsoft Office 2010 言語設定で指定したユーザー インターフェイス言語の一意の ID です。 |
+| [getDocumentProps()](#getDocumentProps--) | ドキュメントのタイトル、作成者などのプロパティ要素を含みます。 |
+| [getDocumentSettings()](#getDocumentSettings--) | ドキュメント設定を指定する要素を含みます。 |
+| [getDocumentSheet()](#getDocumentSheet--) | ドキュメントの ShapeSheet 構造を指定します。 |
+| [getEmailRoutingData()](#getEmailRoutingData--) | ドキュメント用の MIME（Multipurpose Internet Mail Extensions） エンコードされた MAPI 電子メールルーティングスリップを含みます。 |
+| [getEventItems()](#getEventItems--) | オブジェクトが応答すべき各イベントに対する EventItem 要素を含みます。 |
+| [getFonts()](#getFonts--) | Font 要素のコレクションを含みます |
+| [getHeaderFooter()](#getHeaderFooter--) | ドキュメントのヘッダーとフッターの要素を含みます。 |
+| [getInterruptMonitor()](#getInterruptMonitor--) | 割り込みモニター。 |
+| [getKey()](#getKey--) | ドキュメントが Visio の外部で変更されたかどうかを示します。 |
+| [getMasters()](#getMasters--) | Master オブジェクトのコレクションです。 |
+| [getMetric()](#getMetric--) | 図面でメートル法単位を使用するかどうか。 |
+| [getPages()](#getPages--) | Page オブジェクトのコレクションです。 |
+| [getRibbonX()](#getRibbonX--) | リボンのユーザーインターフェイスをカスタマイズするためにドキュメントに渡される Ribbon XML 文字列です。 |
+| [getSolutionXMLs()](#getSolutionXMLs--) | XML 値です。 |
+| [getStart()](#getStart--) | ドキュメントが Visio の外部で変更されたかどうかを示します。 |
+| [getStyleSheets()](#getStyleSheets--) | StyleSheet オブジェクトのコレクションです。 |
+| [getUnusedStyles()](#getUnusedStyles--) | 未使用のスタイルを取得する |
+| [getUserCustomUI()](#getUserCustomUI--) | クイックアクセスツールバーまたはリボンをカスタマイズするためにドキュメントに渡される Ribbon XML 文字列です。 |
+| [getValidation()](#getValidation--) | ドキュメントの図表検証に関する情報を格納します。 |
+| [getVbProjectData()](#getVbProjectData--) | MIME（Multipurpose Internet Mail Extensions） エンコード形式の Microsoft Visual Basic for Applications プロジェクト データを含みます。 |
+| [getVbaProject()](#getVbaProject--) | VbaProject を取得します[getVbaProject()](../../com.aspose.diagram/diagram\#getVbaProject--)。 |
+| [getVersion()](#getVersion--) | Visio インスタンスのバージョン番号です。 |
+| [getWindows()](#getWindows--) | ドキュメントの Window 要素を含みます。 |
+| [hasHiddenInfo()](#hasHiddenInfo--) | この図が非表示情報を持つかどうかを示します。 |
+| [hashCode()](#hashCode--) |  |
+| [layout(LayoutOptions options)](#layout-com.aspose.diagram.LayoutOptions-) | 図のすべてのページのシェイプを配置し、またはコネクタを再ルーティングします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [print(String printerName)](#print-java.lang.String-) | 指定されたプリンターへドキュメント全体を印刷します、標準（ユーザーインターフェイスなし）印刷コントローラを使用して。 |
+| [print(String printerName, PrintSaveOptions options)](#print-java.lang.String-com.aspose.diagram.PrintSaveOptions-) | 指定されたプリンターへドキュメント全体を印刷します、標準（ユーザーインターフェイスなし）印刷コントローラを使用して。 |
+| [print(String printerName, String documentName)](#print-java.lang.String-java.lang.String-) | ドキュメントを印刷します、標準（ユーザーインターフェイスなし）印刷コントローラとドキュメント名を使用して。 |
+| [print(String printerName, String documentName, PrintSaveOptions options)](#print-java.lang.String-java.lang.String-com.aspose.diagram.PrintSaveOptions-) | ドキュメントを印刷します、標準（ユーザーインターフェイスなし）印刷コントローラとドキュメント名を使用して。 |
+| [removeHiddenInformation(int item)](#removeHiddenInformation-int-) | 未使用情報を削除する |
+| [removeMacro()](#removeMacro--) | この図から VBA/マクロ を削除します。 |
+| [save(OutputStream stream, SaveOptions saveOptions)](#save-java.io.OutputStream-com.aspose.diagram.SaveOptions-) | 図をストリームに保存します。 |
+| [save(OutputStream stream, int format)](#save-java.io.OutputStream-int-) | 図をストリームに保存します。 |
+| [save(String filename, SaveOptions options)](#save-java.lang.String-com.aspose.diagram.SaveOptions-) | 指定された保存オプションを使用してドキュメントをファイルに保存します。 |
+| [save(String filename, int format)](#save-java.lang.String-int-) | 図データをファイルに保存します。 |
+| [setBuildnum(long value)](#setBuildnum-long-) | このプロパティの説明については、[getBuildnum()](../../com.aspose.diagram/diagram\#getBuildnum--) を参照してください。 |
+| [setDocLangID(int value)](#setDocLangID-int-) | このプロパティの説明については、[getDocLangID()](../../com.aspose.diagram/diagram\#getDocLangID--) を参照してください。 |
+| [setEmailRoutingData(byte[] value)](#setEmailRoutingData-byte---) | このプロパティの説明については、[getEmailRoutingData()](../../com.aspose.diagram/diagram\#getEmailRoutingData--) を参照してください。 |
+| [setFontDirs(String[] value)](#setFontDirs-java.lang.String---) | フォント フォルダーのパスを示します |
+| [setInterruptMonitor(AbstractInterruptMonitor value)](#setInterruptMonitor-com.aspose.diagram.AbstractInterruptMonitor-) | このプロパティの説明については、[getInterruptMonitor()](../../com.aspose.diagram/diagram\#getInterruptMonitor--) を参照してください。 |
+| [setKey(String value)](#setKey-java.lang.String-) | このプロパティの説明については、[getKey()](../../com.aspose.diagram/diagram\#getKey--) を参照してください。 |
+| [setMetric(int value)](#setMetric-int-) | このプロパティの説明については、[getMetric()](../../com.aspose.diagram/diagram\#getMetric--) を参照してください。 |
+| [setRibbonX(String value)](#setRibbonX-java.lang.String-) | このプロパティの説明については、[getRibbonX()](../../com.aspose.diagram/diagram\#getRibbonX--) を参照してください。 |
+| [setStart(long value)](#setStart-long-) | このプロパティの説明については、[getStart()](../../com.aspose.diagram/diagram\#getStart--) を参照してください。 |
+| [setUserCustomUI(String value)](#setUserCustomUI-java.lang.String-) | このプロパティの説明については、[getUserCustomUI()](../../com.aspose.diagram/diagram\#getUserCustomUI--) を参照してください。 |
+| [setVbProjectData(byte[] value)](#setVbProjectData-byte---) | このプロパティの説明については、[getVbProjectData()](../../com.aspose.diagram/diagram\#getVbProjectData--) を参照してください。 |
+| [setVersion(String value)](#setVersion-java.lang.String-) | このプロパティの説明については、[getVersion()](../../com.aspose.diagram/diagram\#getVersion--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Diagram() {#Diagram--}
+```
+public Diagram()
+```
+
+
+### Diagram(String filename) {#Diagram-java.lang.String-}
+```
+public Diagram(String filename)
+```
+
+
+パブリック クラス コンストラクタは、ファイルからダイアグラムをロードします。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ファイル名 | java.lang.String | ファイル名です。 |
+
+### Diagram(InputStream stream) {#Diagram-java.io.InputStream-}
+```
+public Diagram(InputStream stream)
+```
+
+
+パブリック クラス コンストラクタは、ストリームからダイアグラムをロードします。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ストリーム | java.io.InputStream | データ ストリームです。 |
+
+### Diagram(InputStream stream, int format) {#Diagram-java.io.InputStream-int-}
+```
+public Diagram(InputStream stream, int format)
+```
+
+
+パブリック クラス コンストラクタは、事前定義された形式を使用してストリームからダイアグラムをロードします。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ストリーム | java.io.InputStream | データ ストリームです。 |
+| フォーマット | int | Aspose.Diagram.LoadFileFormat のデータです。 |
+
+### Diagram(InputStream stream, LoadOptions options) {#Diagram-java.io.InputStream-com.aspose.diagram.LoadOptions-}
+```
+public Diagram(InputStream stream, LoadOptions options)
+```
+
+
+パブリック クラス コンストラクタは、事前定義されたロード ファイル オプションを使用してストリームからダイアグラムをロードします。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ストリーム | java.io.InputStream | データ ストリームです。 |
+| options | [LoadOptions](../../com.aspose.diagram/loadoptions) | データ [LoadOptions](../../com.aspose.diagram/loadoptions) です。 |
+
+### Diagram(String filename, int format) {#Diagram-java.lang.String-int-}
+```
+public Diagram(String filename, int format)
+```
+
+
+パブリック クラス コンストラクタは、事前定義された形式を使用してファイルからダイアグラムをロードします。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ファイル名 | java.lang.String | ファイル名です。 |
+| フォーマット | int | ファイル形式です。 |
+
+### Diagram(String filename, LoadOptions options) {#Diagram-java.lang.String-com.aspose.diagram.LoadOptions-}
+```
+public Diagram(String filename, LoadOptions options)
+```
+
+
+パブリック クラス コンストラクタは、事前定義されたロード ファイル オプションを使用してファイルからダイアグラムをロードします。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ファイル名 | java.lang.String | ファイル名です。 |
+| options | [LoadOptions](../../com.aspose.diagram/loadoptions) | データ [LoadOptions](../../com.aspose.diagram/loadoptions) です。 |
+
+### addMaster(Diagram srcDiagram, String masterName) {#addMaster-com.aspose.diagram.Diagram-java.lang.String-}
+```
+public int addMaster(Diagram srcDiagram, String masterName)
+```
+
+
+マスターの Name または NameU によって、ソース ダイアグラムからマスターをダイアグラムに追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| srcDiagram | [Diagram](../../com.aspose.diagram/diagram) | ソース ダイアグラムです。 |
+| masterName | java.lang.String | マスターの Name または NameU。 |
+
+**Returns:**
+int - このダイアグラムのマスター コレクション内のマスターの一意の ID です。
+### addMaster(InputStream templateStream, int masterID) {#addMaster-java.io.InputStream-int-}
+```
+public int addMaster(InputStream templateStream, int masterID)
+```
+
+
+マスターの ID によって、テンプレート ストリームからマスターをダイアグラムに追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| templateStream | java.io.InputStream | テンプレート ストリームです。 |
+| masterID | int | テンプレートのマスター コレクション内のマスターの一意の ID です。 |
+
+**Returns:**
+int - このダイアグラムのマスター コレクション内のマスターの一意の ID です。
+### addMaster(InputStream templateStream, String masterName) {#addMaster-java.io.InputStream-java.lang.String-}
+```
+public int addMaster(InputStream templateStream, String masterName)
+```
+
+
+マスターの Name または NameU によって、テンプレート ストリームからマスターをダイアグラムに追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| templateStream | java.io.InputStream | テンプレート ストリームです。 |
+| masterName | java.lang.String | マスターの Name または NameU。 |
+
+**Returns:**
+int - このダイアグラムのマスター コレクション内のマスターの一意の ID です。
+### addMaster(String templateFilePath, int masterID) {#addMaster-java.lang.String-int-}
+```
+public int addMaster(String templateFilePath, int masterID)
+```
+
+
+マスターの ID によって、テンプレート ファイルからマスターをダイアグラムに追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| templateFilePath | java.lang.String | Path to template file(can be vdx, vst or vsd format). |
+| masterID | int | テンプレートのマスター コレクション内のマスターの一意の ID です。 |
+
+**Returns:**
+int - このダイアグラムのマスター コレクション内のマスターの一意の ID です。
+### addMaster(String templateFilePath, String masterName) {#addMaster-java.lang.String-java.lang.String-}
+```
+public int addMaster(String templateFilePath, String masterName)
+```
+
+
+マスターの Name または NameU によって、テンプレート ファイルからマスターをダイアグラムに追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| templateFilePath | java.lang.String | Path to template file(can be vdx, vst or vsd format). |
+| masterName | java.lang.String | マスターの Name または NameU。 |
+
+**Returns:**
+int - このダイアグラムのマスター コレクション内のマスターの一意の ID です。
+### addShape(Shape newShape, String masterName, int pageNumber) {#addShape-com.aspose.diagram.Shape-java.lang.String-int-}
+```
+public long addShape(Shape newShape, String masterName, int pageNumber)
+```
+
+
+マスターで作成されたシェイプを特定のページに追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| newShape | [Shape](../../com.aspose.diagram/shape) | 新しいシェイプオブジェクト[Shape](../../com.aspose.diagram/shape)。 |
+| masterName | java.lang.String | マスターの名前です。 |
+| pageNumber | int | Index of page. |
+
+**Returns:**
+long - 指定されたページ上のシェイプコレクション内でのシェイプの一意のIDです。
+### addShape(double pinX, double pinY, double width, double height, String masterName, int pageNumber) {#addShape-double-double-double-double-java.lang.String-int-}
+```
+public long addShape(double pinX, double pinY, double width, double height, String masterName, int pageNumber)
+```
+
+
+定義された PinX、PinY、幅、そして高さを使用して、ページ上にマスターで作成されたシェイプを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| pinX | double | ページに対するシェイプのピン（回転中心）のX座標を指定します。 |
+| pinY | double | ページに対するシェイプのピン（回転中心）のY座標を指定します。 |
+| width | double | シェイプの幅をインチ単位で指定します。 |
+| height | double | シェイプの高さをインチ単位で指定します。 |
+| masterName | java.lang.String | マスターの名前です。 |
+| pageNumber | int | Index of page. |
+
+**Returns:**
+long - 指定されたページ上のシェイプコレクション内でのシェイプの一意のIDです。
+### addShape(double pinX, double pinY, String masterName, int pageNumber) {#addShape-double-double-java.lang.String-int-}
+```
+public long addShape(double pinX, double pinY, String masterName, int pageNumber)
+```
+
+
+定義された PinX と PinY を使用して、ページ上にマスターで作成されたシェイプを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| pinX | double | ページに対するシェイプのピン（回転中心）のX座標を指定します。 |
+| pinY | double | ページに対するシェイプのピン（回転中心）のY座標を指定します。 |
+| masterName | java.lang.String | マスターの名前です。 |
+| pageNumber | int | Index of page. |
+
+**Returns:**
+long - 指定されたページ上のシェイプコレクション内でのシェイプの一意のIDです。
+### combine(Diagram secondDiagram) {#combine-com.aspose.diagram.Diagram-}
+```
+public void combine(Diagram secondDiagram)
+```
+
+
+別の Diagram オブジェクトを結合します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| secondDiagram | [Diagram](../../com.aspose.diagram/diagram) | Another Diagram object. |
+
+### copyTheme(Diagram source) {#copyTheme-com.aspose.diagram.Diagram-}
+```
+public void copyTheme(Diagram source)
+```
+
+
+ソース Diagram から Theme をコピーします。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| source | [Diagram](../../com.aspose.diagram/diagram) | ソース ダイアグラムです。 |
+
+### dispose() {#dispose--}
+```
+public void dispose()
+```
+
+
+アンマネージド リソースの解放、リリース、またはリセットに関連するアプリケーション定義のタスクを実行します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### export(InputStream inputVsd, InputStream outputVdw) {#export-java.io.InputStream-java.io.InputStream-}
+```
+public static void export(InputStream inputVsd, InputStream outputVdw)
+```
+
+
+Exports the diagram from vsd stream to vdw stream format. Not implemented yet.
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| inputVsd | java.io.InputStream | vsd stream. |
+| outputVdw | java.io.InputStream | vdw stream. |
+
+### export(InputStream inputVsd, String outputVdw) {#export-java.io.InputStream-java.lang.String-}
+```
+public static void export(InputStream inputVsd, String outputVdw)
+```
+
+
+Exports the diagram from vsd stream to \*.vdw file format. Not implemented yet.
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| inputVsd | java.io.InputStream | \*.vsd file name. |
+| outputVdw | java.lang.String | vdw stream. |
+
+### export(String inputVsd, InputStream outputVdw) {#export-java.lang.String-java.io.InputStream-}
+```
+public static void export(String inputVsd, InputStream outputVdw)
+```
+
+
+Exports the diagram from vsd file to vdw stream format. Not implemented yet.
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| inputVsd | java.lang.String | \*.vsd file name. |
+| outputVdw | java.io.InputStream | vdw stream. |
+
+### export(String inputVsd, String outputVdw) {#export-java.lang.String-java.lang.String-}
+```
+public static void export(String inputVsd, String outputVdw)
+```
+
+
+Exports the diagram from vsd to vdw format. Not implemented yet.
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| inputVsd | java.lang.String | \*.vsd file name. |
+| outputVdw | java.lang.String | \*.vdw file name. |
+
+### getActivePage() {#getActivePage--}
+```
+public Page getActivePage()
+```
+
+
+アクティブ ページを指定します
+
+**Returns:**
+[Page](../../com.aspose.diagram/page)
+### getBuildnum() {#getBuildnum--}
+```
+public long getBuildnum()
+```
+
+
+ドキュメント作成に使用された Visio インスタンスのビルド番号です。
+
+**Returns:**
+long
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColors() {#getColors--}
+```
+public ColorEntryCollection getColors()
+```
+
+
+ドキュメントのカラーテーブルを含みます。各ドキュメントは 1 つのカラーテーブルを持ち、シェイプ、テキスト、レイヤーなどのオブジェクトに適用できる 24 の標準色が一覧されています。
+
+**Returns:**
+[ColorEntryCollection](../../com.aspose.diagram/colorentrycollection)
+### getDataConnections() {#getDataConnections--}
+```
+public DataConnectionCollection getDataConnections()
+```
+
+
+ドキュメントの DataConnection 要素を含みます。
+
+**Returns:**
+[DataConnectionCollection](../../com.aspose.diagram/dataconnectioncollection)
+### getDataRecordSets() {#getDataRecordSets--}
+```
+public DataRecordSetCollection getDataRecordSets()
+```
+
+
+Document オブジェクトに関連付けられた DataRecordset オブジェクトのコレクションです。
+
+**Returns:**
+[DataRecordSetCollection](../../com.aspose.diagram/datarecordsetcollection)
+### getDefaultFontDir() {#getDefaultFontDir--}
+```
+public String getDefaultFontDir()
+```
+
+
+デフォルト フォント フォルダーのパスを取得します
+
+**Returns:**
+java.lang.String
+### getDocLangID() {#getDocLangID--}
+```
+public int getDocLangID()
+```
+
+
+ユーザーが Microsoft Office 2010 言語設定で指定したユーザー インターフェイス言語の一意の ID です。
+
+**Returns:**
+int
+### getDocumentProps() {#getDocumentProps--}
+```
+public DocumentProperties getDocumentProps()
+```
+
+
+ドキュメントのタイトル、作成者などのプロパティ要素を含みます。
+
+**Returns:**
+[DocumentProperties](../../com.aspose.diagram/documentproperties)
+### getDocumentSettings() {#getDocumentSettings--}
+```
+public DocumentSettings getDocumentSettings()
+```
+
+
+ドキュメント設定を指定する要素を含みます。
+
+**Returns:**
+[DocumentSettings](../../com.aspose.diagram/documentsettings)
+### getDocumentSheet() {#getDocumentSheet--}
+```
+public DocumentSheet getDocumentSheet()
+```
+
+
+ドキュメントの ShapeSheet 構造を指定します。
+
+**Returns:**
+[DocumentSheet](../../com.aspose.diagram/documentsheet)
+### getEmailRoutingData() {#getEmailRoutingData--}
+```
+public byte[] getEmailRoutingData()
+```
+
+
+ドキュメント用の MIME（Multipurpose Internet Mail Extensions） エンコードされた MAPI 電子メールルーティングスリップを含みます。
+
+**Returns:**
+byte[]
+### getEventItems() {#getEventItems--}
+```
+public EventItemCollection getEventItems()
+```
+
+
+オブジェクトが応答すべき各イベントに対する EventItem 要素を含みます。
+
+**Returns:**
+[EventItemCollection](../../com.aspose.diagram/eventitemcollection)
+### getFonts() {#getFonts--}
+```
+public FontCollection getFonts()
+```
+
+
+Font 要素のコレクションを含みます
+
+**Returns:**
+[FontCollection](../../com.aspose.diagram/fontcollection)
+### getHeaderFooter() {#getHeaderFooter--}
+```
+public HeaderFooter getHeaderFooter()
+```
+
+
+ドキュメントのヘッダーとフッターの要素を含みます。
+
+**Returns:**
+[HeaderFooter](../../com.aspose.diagram/headerfooter)
+### getInterruptMonitor() {#getInterruptMonitor--}
+```
+public AbstractInterruptMonitor getInterruptMonitor()
+```
+
+
+割り込みモニター。
+
+**Returns:**
+[AbstractInterruptMonitor](../../com.aspose.diagram/abstractinterruptmonitor)
+### getKey() {#getKey--}
+```
+public String getKey()
+```
+
+
+Indicates whether the document has been modified outside of Visio. If present, Visio will fully test the contents of the file. Omit for files you create outside of Visio.
+
+**Returns:**
+java.lang.String
+### getMasters() {#getMasters--}
+```
+public MasterCollection getMasters()
+```
+
+
+Master オブジェクトのコレクションです。
+
+**Returns:**
+[MasterCollection](../../com.aspose.diagram/mastercollection)
+### getMetric() {#getMetric--}
+```
+public int getMetric()
+```
+
+
+Whether to use metric units in the drawing. Set this attribute to True (1) to use metric units; set it to False (0) to use English units.
+
+**Returns:**
+int
+### getPages() {#getPages--}
+```
+public PageCollection getPages()
+```
+
+
+Page オブジェクトのコレクションです。
+
+**Returns:**
+[PageCollection](../../com.aspose.diagram/pagecollection)
+### getRibbonX() {#getRibbonX--}
+```
+public String getRibbonX()
+```
+
+
+リボンのユーザーインターフェイスをカスタマイズするためにドキュメントに渡される Ribbon XML 文字列です。
+
+**Returns:**
+java.lang.String
+### getSolutionXMLs() {#getSolutionXMLs--}
+```
+public SolutionXMLCollection getSolutionXMLs()
+```
+
+
+XML 値です。
+
+**Returns:**
+[SolutionXMLCollection](../../com.aspose.diagram/solutionxmlcollection)
+### getStart() {#getStart--}
+```
+public long getStart()
+```
+
+
+Indicates whether the document has been modified outside of Visio. If present, Visio will fully test the contents of the file. Omit for files you create outside of Visio.
+
+**Returns:**
+long
+### getStyleSheets() {#getStyleSheets--}
+```
+public StyleSheetCollection getStyleSheets()
+```
+
+
+StyleSheet オブジェクトのコレクションです。
+
+**Returns:**
+[StyleSheetCollection](../../com.aspose.diagram/stylesheetcollection)
+### getUnusedStyles() {#getUnusedStyles--}
+```
+public StyleSheetCollection getUnusedStyles()
+```
+
+
+未使用のスタイルを取得する
+
+**Returns:**
+[StyleSheetCollection](../../com.aspose.diagram/stylesheetcollection)
+### getUserCustomUI() {#getUserCustomUI--}
+```
+public String getUserCustomUI()
+```
+
+
+クイックアクセスツールバーまたはリボンをカスタマイズするためにドキュメントに渡される Ribbon XML 文字列です。
+
+**Returns:**
+java.lang.String
+### getValidation() {#getValidation--}
+```
+public Validation getValidation()
+```
+
+
+ドキュメントの図表検証に関する情報を格納します。
+
+**Returns:**
+[Validation](../../com.aspose.diagram/validation)
+### getVbProjectData() {#getVbProjectData--}
+```
+public byte[] getVbProjectData()
+```
+
+
+MIME（Multipurpose Internet Mail Extensions） エンコード形式の Microsoft Visual Basic for Applications プロジェクト データを含みます。
+
+**Returns:**
+byte[]
+### getVbaProject() {#getVbaProject--}
+```
+public VbaProject getVbaProject()
+```
+
+
+VbaProject を取得します[getVbaProject()](../../com.aspose.diagram/diagram\#getVbaProject--)。
+
+**Returns:**
+[VbaProject](../../com.aspose.diagram/vbaproject)
+### getVersion() {#getVersion--}
+```
+public String getVersion()
+```
+
+
+The version number of the Visio instance. Microsoft Visio 2010 = 14.
+
+**Returns:**
+java.lang.String
+### getWindows() {#getWindows--}
+```
+public WindowCollection getWindows()
+```
+
+
+ドキュメントの Window 要素を含みます。
+
+**Returns:**
+[WindowCollection](../../com.aspose.diagram/windowcollection)
+### hasHiddenInfo() {#hasHiddenInfo--}
+```
+public boolean hasHiddenInfo()
+```
+
+
+この図が非表示情報を持つかどうかを示します。
+
+**Returns:**
+boolean
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### layout(LayoutOptions options) {#layout-com.aspose.diagram.LayoutOptions-}
+```
+public void layout(LayoutOptions options)
+```
+
+
+図のすべてのページのシェイプを配置し、またはコネクタを再ルーティングします。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| options | [LayoutOptions](../../com.aspose.diagram/layoutoptions) | [LayoutOptions](../../com.aspose.diagram/layoutoptions) を使用してレイアウトのオプションを構成します。 |
+
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### print(String printerName) {#print-java.lang.String-}
+```
+public void print(String printerName)
+```
+
+
+Print the whole document to the specified printer,using the standard (no User Interface) print controller. If printerName is Null or empty will be used default printer.
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| printerName | java.lang.String | The name of the printer.Can be Null |
+
+### print(String printerName, PrintSaveOptions options) {#print-java.lang.String-com.aspose.diagram.PrintSaveOptions-}
+```
+public void print(String printerName, PrintSaveOptions options)
+```
+
+
+Print the whole document to the specified printer,using the standard (no User Interface) print controller. If printerName is Null or empty will be used default printer.
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| printerName | java.lang.String | The name of the printer.Can be Null |
+| options | [PrintSaveOptions](../../com.aspose.diagram/printsaveoptions) | The print options. |
+
+### print(String printerName, String documentName) {#print-java.lang.String-java.lang.String-}
+```
+public void print(String printerName, String documentName)
+```
+
+
+ドキュメントを印刷します、標準（ユーザーインターフェイスなし）印刷コントローラとドキュメント名を使用して。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| printerName | java.lang.String | The name of the printer.Can be Null |
+| documentName | java.lang.String | The document name to display (for example, in a print status dialog box or printer queue) while printing the document. |
+
+### print(String printerName, String documentName, PrintSaveOptions options) {#print-java.lang.String-java.lang.String-com.aspose.diagram.PrintSaveOptions-}
+```
+public void print(String printerName, String documentName, PrintSaveOptions options)
+```
+
+
+ドキュメントを印刷します、標準（ユーザーインターフェイスなし）印刷コントローラとドキュメント名を使用して。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| printerName | java.lang.String | The name of the printer.Can be Null |
+| documentName | java.lang.String | The document name to display (for example, in a print status dialog box or printer queue) while printing the document. |
+| options | [PrintSaveOptions](../../com.aspose.diagram/printsaveoptions) | The print options. |
+
+### removeHiddenInformation(int item) {#removeHiddenInformation-int-}
+```
+public void removeHiddenInformation(int item)
+```
+
+
+未使用情報を削除する
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | int | RemoveHiddenInfoItem. |
+
+### removeMacro() {#removeMacro--}
+```
+public void removeMacro()
+```
+
+
+この図から VBA/マクロ を削除します。
+
+### save(OutputStream stream, SaveOptions saveOptions) {#save-java.io.OutputStream-com.aspose.diagram.SaveOptions-}
+```
+public void save(OutputStream stream, SaveOptions saveOptions)
+```
+
+
+図をストリームに保存します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ストリーム | java.io.OutputStream | ファイルストリーム。 |
+| saveOptions | [SaveOptions](../../com.aspose.diagram/saveoptions) | 保存オプション。 |
+
+### save(OutputStream stream, int format) {#save-java.io.OutputStream-int-}
+```
+public void save(OutputStream stream, int format)
+```
+
+
+図をストリームに保存します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ストリーム | java.io.OutputStream | ファイルストリーム。 |
+| フォーマット | int |  |
+
+### save(String filename, SaveOptions options) {#save-java.lang.String-com.aspose.diagram.SaveOptions-}
+```
+public void save(String filename, SaveOptions options)
+```
+
+
+指定された保存オプションを使用してドキュメントをファイルに保存します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ファイル名 | java.lang.String | ファイル名です。 |
+| options | [SaveOptions](../../com.aspose.diagram/saveoptions) | [SaveOptions](../../com.aspose.diagram/saveoptions) ダイアグラム保存オプション。 |
+
+### save(String filename, int format) {#save-java.lang.String-int-}
+```
+public void save(String filename, int format)
+```
+
+
+図データをファイルに保存します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ファイル名 | java.lang.String | ファイル名です。 |
+| フォーマット | int | Aspose.Diagram.SaveFileFormat 保存ファイル形式。 |
+
+### setBuildnum(long value) {#setBuildnum-long-}
+```
+public void setBuildnum(long value)
+```
+
+
+このプロパティの説明については、[getBuildnum()](../../com.aspose.diagram/diagram\#getBuildnum--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | long |  |
+
+### setDocLangID(int value) {#setDocLangID-int-}
+```
+public void setDocLangID(int value)
+```
+
+
+このプロパティの説明については、[getDocLangID()](../../com.aspose.diagram/diagram\#getDocLangID--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setEmailRoutingData(byte[] value) {#setEmailRoutingData-byte---}
+```
+public void setEmailRoutingData(byte[] value)
+```
+
+
+このプロパティの説明については、[getEmailRoutingData()](../../com.aspose.diagram/diagram\#getEmailRoutingData--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | byte[] |  |
+
+### setFontDirs(String[] value) {#setFontDirs-java.lang.String---}
+```
+public void setFontDirs(String[] value)
+```
+
+
+フォント フォルダーのパスを示します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String[] |  |
+
+### setInterruptMonitor(AbstractInterruptMonitor value) {#setInterruptMonitor-com.aspose.diagram.AbstractInterruptMonitor-}
+```
+public void setInterruptMonitor(AbstractInterruptMonitor value)
+```
+
+
+このプロパティの説明については、[getInterruptMonitor()](../../com.aspose.diagram/diagram\#getInterruptMonitor--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [AbstractInterruptMonitor](../../com.aspose.diagram/abstractinterruptmonitor) |  |
+
+### setKey(String value) {#setKey-java.lang.String-}
+```
+public void setKey(String value)
+```
+
+
+このプロパティの説明については、[getKey()](../../com.aspose.diagram/diagram\#getKey--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setMetric(int value) {#setMetric-int-}
+```
+public void setMetric(int value)
+```
+
+
+このプロパティの説明については、[getMetric()](../../com.aspose.diagram/diagram\#getMetric--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setRibbonX(String value) {#setRibbonX-java.lang.String-}
+```
+public void setRibbonX(String value)
+```
+
+
+このプロパティの説明については、[getRibbonX()](../../com.aspose.diagram/diagram\#getRibbonX--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setStart(long value) {#setStart-long-}
+```
+public void setStart(long value)
+```
+
+
+このプロパティの説明については、[getStart()](../../com.aspose.diagram/diagram\#getStart--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | long |  |
+
+### setUserCustomUI(String value) {#setUserCustomUI-java.lang.String-}
+```
+public void setUserCustomUI(String value)
+```
+
+
+このプロパティの説明については、[getUserCustomUI()](../../com.aspose.diagram/diagram\#getUserCustomUI--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setVbProjectData(byte[] value) {#setVbProjectData-byte---}
+```
+public void setVbProjectData(byte[] value)
+```
+
+
+このプロパティの説明については、[getVbProjectData()](../../com.aspose.diagram/diagram\#getVbProjectData--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | byte[] |  |
+
+### setVersion(String value) {#setVersion-java.lang.String-}
+```
+public void setVersion(String value)
+```
+
+
+このプロパティの説明については、[getVersion()](../../com.aspose.diagram/diagram\#getVersion--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/diagramexception/_index.md
+++ b/japanese/java/com.aspose.diagram/diagramexception/_index.md
@@ -1,0 +1,290 @@
+---
+title: DiagramException
+second_title: Aspose.Diagram for Java API リファレンス
+description: すべての Aspose.Diagram 例外の基底クラスです。
+type: docs
+weight: 118
+url: /ja/java/com.aspose.diagram/diagramexception/
+---
+
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception
+```
+public class DiagramException extends Exception
+```
+
+すべての Aspose.Diagram 例外の基底クラスです。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [DiagramException(String msg)](#DiagramException-java.lang.String-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DiagramException(String msg) {#DiagramException-java.lang.String-}
+```
+public DiagramException(String msg)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| msg | java.lang.String |  |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/diagramsaveoptions/_index.md
+++ b/japanese/java/com.aspose.diagram/diagramsaveoptions/_index.md
@@ -1,0 +1,268 @@
+---
+title: DiagramSaveOptions
+second_title: Aspose.Diagram for Java API リファレンス
+description: Can be used to specify additional options when saving a diagram into Visio VDXVSX format.
+type: docs
+weight: 119
+url: /ja/java/com.aspose.diagram/diagramsaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.SaveOptions](../../com.aspose.diagram/saveoptions)
+```
+public class DiagramSaveOptions extends SaveOptions
+```
+
+Can be used to specify additional options when saving a diagram into Visio (VDX\\VSX) format. At the moment provides only the SaveFormat property, but in the future will have other options added.
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [DiagramSaveOptions()](#DiagramSaveOptions--) | Initializes a new instance of this class that can be used to save a diagram in the VDX format. |
+| [DiagramSaveOptions(int saveFormat)](#DiagramSaveOptions-int-) | このクラスの新しいインスタンスを初期化します。このインスタンスは VDX または VSX 形式で図を保存するために使用できます。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | 指定された保存形式に適したクラスの保存オプションオブジェクトを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAutoFitPageToDrawingContent()](#getAutoFitPageToDrawingContent--) | 描画内容に合わせてページを拡大する必要があるかどうかを定義します。 |
+| [getClass()](#getClass--) |  |
+| [getDefaultFont()](#getDefaultFont--) | 図内の文字が Unicode で、正しいフォント値が設定されていない、またはフォントがローカルにインストールされていない場合、pdf、画像、または XPS でブロックとして表示されることがあります。 |
+| [getSaveFormat()](#getSaveFormat--) | この保存オプションオブジェクトが使用された場合に、レンダリングされた図が保存される形式を指定します。 |
+| [getWarningCallback()](#getWarningCallback--) | 警告コールバック。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAutoFitPageToDrawingContent(boolean value)](#setAutoFitPageToDrawingContent-boolean-) | このプロパティの説明については、[getAutoFitPageToDrawingContent()](../../com.aspose.diagram/diagramsaveoptions\#getAutoFitPageToDrawingContent--) を参照してください。 |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | このプロパティの説明については、[getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--) を参照してください。 |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | このプロパティの説明については、[getSaveFormat()](../../com.aspose.diagram/diagramsaveoptions\#getSaveFormat--) を参照してください。 |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DiagramSaveOptions() {#DiagramSaveOptions--}
+```
+public DiagramSaveOptions()
+```
+
+
+Initializes a new instance of this class that can be used to save a diagram in the VDX format.
+
+### DiagramSaveOptions(int saveFormat) {#DiagramSaveOptions-int-}
+```
+public DiagramSaveOptions(int saveFormat)
+```
+
+
+このクラスの新しいインスタンスを初期化します。このインスタンスは VDX または VSX 形式で図を保存するために使用できます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| saveFormat | int |  |
+
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+指定された保存形式に適したクラスの保存オプションオブジェクトを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| saveFormat | int | 保存オプションオブジェクトを作成するための Aspose.Diagram.SaveFileFormat です。 |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAutoFitPageToDrawingContent() {#getAutoFitPageToDrawingContent--}
+```
+public boolean getAutoFitPageToDrawingContent()
+```
+
+
+描画内容に合わせてページを拡大する必要があるかどうかを定義します。デフォルト値は false です。
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+ダイアグラム内の文字が Unicode で、正しいフォントが設定されていない、またはフォントがローカルにインストールされていない場合、PDF、画像、または XPS で文字がブロックとして表示されることがあります。MingLiu や MS Gothic などの DefaultFont を設定して、これらの文字を表示してください。
+
+**Returns:**
+java.lang.String
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+この保存オプションオブジェクトが使用された場合に、レンダリングされた図が保存される形式を指定します。形式は Aspose.Diagram.SaveFileFormat または Aspose.Diagram.SaveFileFormat のいずれかです。
+
+**Returns:**
+int
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+警告コールバック。
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAutoFitPageToDrawingContent(boolean value) {#setAutoFitPageToDrawingContent-boolean-}
+```
+public void setAutoFitPageToDrawingContent(boolean value)
+```
+
+
+このプロパティの説明については、[getAutoFitPageToDrawingContent()](../../com.aspose.diagram/diagramsaveoptions\#getAutoFitPageToDrawingContent--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+このプロパティの説明については、[getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+このプロパティの説明については、[getSaveFormat()](../../com.aspose.diagram/diagramsaveoptions\#getSaveFormat--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/displaymode/_index.md
+++ b/japanese/java/com.aspose.diagram/displaymode/_index.md
@@ -1,0 +1,179 @@
+---
+title: DisplayMode
+second_title: Aspose.Diagram for Java API リファレンス
+description: Group 要素に含まれる場合、DisplayMode 要素はグループ シェイプとそのメンバーの表示方法を指定します。
+type: docs
+weight: 120
+url: /ja/java/com.aspose.diagram/displaymode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DisplayMode
+```
+
+Group 要素に含まれる場合、DisplayMode 要素はグループ シェイプとそのメンバーの表示方法を指定します。SmartTagDef 要素に含まれる場合、DisplayMode 要素はユーザーがタグ上でマウスを止めたとき、シェイプが選択されたとき、または常に、スマート タグが表示されるかどうかを決定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [DisplayMode(int value)](#DisplayMode-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | Group 要素に含まれる場合、DisplayMode 要素はグループ シェイプとそのメンバーの表示方法を指定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/displaymode\#getValue--)をご覧ください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DisplayMode(int value) {#DisplayMode-int-}
+```
+public DisplayMode(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Group 要素に含まれる場合、DisplayMode 要素はグループ シェイプとそのメンバーの表示方法を指定します。SmartTagDef 要素に含まれる場合、DisplayMode 要素はユーザーがタグ上でマウスを止めたとき、シェイプが選択されたとき、または常に、スマート タグが表示されるかどうかを決定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/displaymode\#getValue--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/displaymodesmarttagdef/_index.md
+++ b/japanese/java/com.aspose.diagram/displaymodesmarttagdef/_index.md
@@ -1,0 +1,179 @@
+---
+title: DisplayModeSmartTagDef
+second_title: Aspose.Diagram for Java API リファレンス
+description: DisplayMode 要素は、形状が選択されているときにユーザーがタグ上でマウスを停止したときにスマートタグを表示するか、常に表示するかを決定します。
+type: docs
+weight: 121
+url: /ja/java/com.aspose.diagram/displaymodesmarttagdef/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DisplayModeSmartTagDef
+```
+
+DisplayMode 要素は、ユーザーがタグ上でマウスを止めたとき、シェイプが選択されたとき、または常にスマート タグを表示するかどうかを決定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [DisplayModeSmartTagDef(int value)](#DisplayModeSmartTagDef-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | DisplayMode 要素は、ユーザーがタグ上でマウスを止めたとき、シェイプが選択されたとき、または常にスマート タグを表示するかどうかを決定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/displaymodesmarttagdef\#getValue--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DisplayModeSmartTagDef(int value) {#DisplayModeSmartTagDef-int-}
+```
+public DisplayModeSmartTagDef(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+DisplayMode 要素は、ユーザーがタグ上でマウスを止めたとき、シェイプが選択されたとき、または常にスマート タグを表示するかどうかを決定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/displaymodesmarttagdef\#getValue--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/displaymodesmarttagdefvalue/_index.md
+++ b/japanese/java/com.aspose.diagram/displaymodesmarttagdefvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: DisplayModeSmartTagDefValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: DisplayMode 要素は、形状が選択されているときにユーザーがタグ上でマウスを停止したときにスマートタグを表示するか、常に表示するかを決定します。
+type: docs
+weight: 122
+url: /ja/java/com.aspose.diagram/displaymodesmarttagdefvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class DisplayModeSmartTagDefValue
+```
+
+DisplayMode 要素は、ユーザーがタグ上でマウスを止めたとき、シェイプが選択されたとき、または常にスマート タグを表示するかどうかを決定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [ALL_TIME](#ALL-TIME) | グループ形状をメンバー形状の前面に表示します。 |
+| [MOUSE_IS_PAUSED](#MOUSE-IS-PAUSED) | グループ形状とテキストを非表示にします。 |
+| [SHAPE_IS_SELECTED](#SHAPE-IS-SELECTED) | グループ形状をメンバー形状の背面に表示します。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALL_TIME {#ALL-TIME}
+```
+public static final int ALL_TIME
+```
+
+
+グループ形状をメンバー形状の前面に表示します。
+
+### MOUSE_IS_PAUSED {#MOUSE-IS-PAUSED}
+```
+public static final int MOUSE_IS_PAUSED
+```
+
+
+グループ形状とテキストを非表示にします。
+
+### SHAPE_IS_SELECTED {#SHAPE-IS-SELECTED}
+```
+public static final int SHAPE_IS_SELECTED
+```
+
+
+グループ形状をメンバー形状の背面に表示します。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/displaymodevalue/_index.md
+++ b/japanese/java/com.aspose.diagram/displaymodevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: DisplayModeValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: Group 要素に含まれる場合、DisplayMode 要素はグループ シェイプとそのメンバーの表示方法を指定します。
+type: docs
+weight: 123
+url: /ja/java/com.aspose.diagram/displaymodevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class DisplayModeValue
+```
+
+Group 要素に含まれる場合、DisplayMode 要素はグループ シェイプとそのメンバーの表示方法を指定します。SmartTagDef 要素に含まれる場合、DisplayMode 要素はユーザーがタグ上でマウスを止めたとき、シェイプが選択されたとき、または常に、スマート タグが表示されるかどうかを決定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [DISPLAYS_SHAPE_BEHIND_MEMBER_SHAPES](#DISPLAYS-SHAPE-BEHIND-MEMBER-SHAPES) | グループ形状をメンバー形状の背面に表示します。 |
+| [DISPLAYS_SHAPE_FRONT_MEMBER_SHAPES](#DISPLAYS-SHAPE-FRONT-MEMBER-SHAPES) | グループ形状をメンバー形状の前面に表示します。 |
+| [HIDES_SHAPE_TEXT](#HIDES-SHAPE-TEXT) | グループ形状とテキストを非表示にします。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DISPLAYS_SHAPE_BEHIND_MEMBER_SHAPES {#DISPLAYS-SHAPE-BEHIND-MEMBER-SHAPES}
+```
+public static final int DISPLAYS_SHAPE_BEHIND_MEMBER_SHAPES
+```
+
+
+グループ形状をメンバー形状の背面に表示します。
+
+### DISPLAYS_SHAPE_FRONT_MEMBER_SHAPES {#DISPLAYS-SHAPE-FRONT-MEMBER-SHAPES}
+```
+public static final int DISPLAYS_SHAPE_FRONT_MEMBER_SHAPES
+```
+
+
+グループ形状をメンバー形状の前面に表示します。
+
+### HIDES_SHAPE_TEXT {#HIDES-SHAPE-TEXT}
+```
+public static final int HIDES_SHAPE_TEXT
+```
+
+
+グループ形状とテキストを非表示にします。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/docprops/_index.md
+++ b/japanese/java/com.aspose.diagram/docprops/_index.md
@@ -1,0 +1,227 @@
+---
+title: DocProps
+second_title: Aspose.Diagram for Java API リファレンス
+description: ドキュメントのプレビュー品質範囲と出力形式を制御する要素を含みます。
+type: docs
+weight: 124
+url: /ja/java/com.aspose.diagram/docprops/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DocProps
+```
+
+ドキュメントのプレビュー品質、範囲、出力形式を制御する要素を含みます。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAddMarkup()](#getAddMarkup--) | ドキュメントがマークアップのレビュー対象であるかどうかを示します。 |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getDocLangID()](#getDocLangID--) | ドキュメントのデフォルト言語を示します。 |
+| [getLockPreview()](#getLockPreview--) | 描画を保存するたびにプレビューが保存されるかどうかを指定します。 |
+| [getOutputFormat()](#getOutputFormat--) | 図面の出力形式を指定します。 |
+| [getPreviewQuality()](#getPreviewQuality--) | 描画プレビューがドラフト品質か詳細かを指定します。 |
+| [getPreviewScope()](#getPreviewScope--) | ドキュメントにプレビューが含まれるかどうか、含まれる場合はプレビューが最初のページのみを表示するか、ドキュメント全体のページを表示するかを指定します。 |
+| [getViewMarkup()](#getViewMarkup--) | マークアップが描画ウィンドウに表示されるかどうかを決定します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | このプロパティの説明については、[getDel()](../../com.aspose.diagram/docprops\#getDel--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAddMarkup() {#getAddMarkup--}
+```
+public BoolValue getAddMarkup()
+```
+
+
+ドキュメントがマークアップのレビュー対象であるかどうかを示します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getDocLangID() {#getDocLangID--}
+```
+public IntValue getDocLangID()
+```
+
+
+ドキュメントのデフォルト言語を示します。
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getLockPreview() {#getLockPreview--}
+```
+public BoolValue getLockPreview()
+```
+
+
+描画を保存するたびにプレビューが保存されるかどうかを指定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getOutputFormat() {#getOutputFormat--}
+```
+public OutputFormat getOutputFormat()
+```
+
+
+図面の出力形式を指定します。
+
+**Returns:**
+[OutputFormat](../../com.aspose.diagram/outputformat)
+### getPreviewQuality() {#getPreviewQuality--}
+```
+public BoolValue getPreviewQuality()
+```
+
+
+描画プレビューがドラフト品質か詳細かを指定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getPreviewScope() {#getPreviewScope--}
+```
+public PreviewScope getPreviewScope()
+```
+
+
+ドキュメントにプレビューが含まれるかどうか、含まれる場合はプレビューが最初のページのみを表示するか、ドキュメント全体のページを表示するかを指定します。
+
+**Returns:**
+[PreviewScope](../../com.aspose.diagram/previewscope)
+### getViewMarkup() {#getViewMarkup--}
+```
+public BoolValue getViewMarkup()
+```
+
+
+マークアップが描画ウィンドウに表示されるかどうかを決定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+このプロパティの説明については、[getDel()](../../com.aspose.diagram/docprops\#getDel--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/documentproperties/_index.md
+++ b/japanese/java/com.aspose.diagram/documentproperties/_index.md
@@ -1,0 +1,616 @@
+---
+title: DocumentProperties
+second_title: Aspose.Diagram for Java API リファレンス
+description: ドキュメントのタイトル、作成者などのプロパティ要素が含まれます。
+type: docs
+weight: 125
+url: /ja/java/com.aspose.diagram/documentproperties/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DocumentProperties
+```
+
+ドキュメントのタイトル、作成者などのプロパティ要素を含みます。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAlternateNames()](#getAlternateNames--) | ドキュメントの代替名を指定します。 |
+| [getBuildNumberCreated()](#getBuildNumberCreated--) | ドキュメント作成に使用されたインスタンスの完全なビルド番号が含まれます。 |
+| [getBuildNumberEdited()](#getBuildNumberEdited--) | ドキュメントの最終編集に使用されたインスタンスのビルド番号が含まれます。 |
+| [getCategory()](#getCategory--) | フローチャートやオフィスレイアウトなど、図面の種類を示す説明テキストを指定します。 |
+| [getClass()](#getClass--) |  |
+| [getCompany()](#getCompany--) | 図面を作成した会社、または図面の作成先となる会社を示すユーザー入力情報が含まれます。 |
+| [getCreator()](#getCreator--) | ファイルを作成した人または最終更新した人を識別します。 |
+| [getCustomProps()](#getCustomProps--) | CustomProp のコレクションです。 |
+| [getDesc()](#getDesc--) | ドキュメントの説明テキスト文字列が含まれます。 |
+| [getHyperlinkBase()](#getHyperlinkBase--) | 相対ハイパーリンクに使用されるパスを含みます（リンクされたファイルの場所が Microsoft Visio 図に対して相対的に記述されているハイパーリンク）。 |
+| [getKeywords()](#getKeywords--) | プロジェクト名、クライアント名、バージョン番号など、ファイルに関するトピックやその他の重要な情報を識別するテキスト文字列が含まれます。 |
+| [getLanguage()](#getLanguage--) | 言語を指定します |
+| [getManager()](#getManager--) | プロジェクトまたは部門の責任者を識別するユーザー入力のテキスト文字列が含まれます。 |
+| [getPreviewPicture()](#getPreviewPicture--) | ドキュメントのプレビューとして機能するメタファイルストリームが含まれます。 |
+| [getSubject()](#getSubject--) | ドキュメントの内容を記述するユーザー定義のテキスト文字列が含まれます。 |
+| [getTemplate()](#getTemplate--) | ドキュメントが作成されたテンプレートのファイル名を指定する文字列値が含まれます。 |
+| [getTimeCreated()](#getTimeCreated--) | ドキュメントが作成された日時を示す日付と時刻の値が含まれます。 |
+| [getTimeEdited()](#getTimeEdited--) | ドキュメントが最後に編集された日時を示す日付と時刻の値が含まれます。 |
+| [getTimePrinted()](#getTimePrinted--) | ドキュメントが最後に印刷された日時を示す日付と時刻の値が含まれます。 |
+| [getTimeSaved()](#getTimeSaved--) | ドキュメントが最後に保存された日時を示す日付と時刻の値が含まれます。 |
+| [getTitle()](#getTitle--) | ドキュメントの説明タイトルとして機能するユーザー定義のテキスト文字列が含まれます。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAlternateNames(String value)](#setAlternateNames-java.lang.String-) | このプロパティの説明については、[getAlternateNames()](../../com.aspose.diagram/documentproperties\#getAlternateNames--) を参照してください。 |
+| [setBuildNumberCreated(String value)](#setBuildNumberCreated-java.lang.String-) | このプロパティの説明については、[getBuildNumberCreated()](../../com.aspose.diagram/documentproperties\#getBuildNumberCreated--) を参照してください。 |
+| [setBuildNumberEdited(String value)](#setBuildNumberEdited-java.lang.String-) | このプロパティの説明については、[getBuildNumberEdited()](../../com.aspose.diagram/documentproperties\#getBuildNumberEdited--) を参照してください。 |
+| [setCategory(String value)](#setCategory-java.lang.String-) | このプロパティの説明については、[getCategory()](../../com.aspose.diagram/documentproperties\#getCategory--) を参照してください。 |
+| [setCompany(String value)](#setCompany-java.lang.String-) | このプロパティの説明については、[getCompany()](../../com.aspose.diagram/documentproperties\#getCompany--) を参照してください。 |
+| [setCreator(String value)](#setCreator-java.lang.String-) | このプロパティの説明については、[getCreator()](../../com.aspose.diagram/documentproperties\#getCreator--) を参照してください。 |
+| [setDesc(String value)](#setDesc-java.lang.String-) | このプロパティの説明については、[getDesc()](../../com.aspose.diagram/documentproperties\#getDesc--) を参照してください。 |
+| [setHyperlinkBase(String value)](#setHyperlinkBase-java.lang.String-) | このプロパティの説明については、[getHyperlinkBase()](../../com.aspose.diagram/documentproperties\#getHyperlinkBase--) を参照してください。 |
+| [setKeywords(String value)](#setKeywords-java.lang.String-) | このプロパティの説明については、[getKeywords()](../../com.aspose.diagram/documentproperties\#getKeywords--) を参照してください。 |
+| [setLanguage(String value)](#setLanguage-java.lang.String-) | このプロパティの説明については、[getLanguage()](../../com.aspose.diagram/documentproperties\#getLanguage--) を参照してください。 |
+| [setManager(String value)](#setManager-java.lang.String-) | このプロパティの説明については、[getManager()](../../com.aspose.diagram/documentproperties\#getManager--) を参照してください。 |
+| [setPreviewPicture(byte[] value)](#setPreviewPicture-byte---) | このプロパティの説明については、[getPreviewPicture()](../../com.aspose.diagram/documentproperties\#getPreviewPicture--) を参照してください。 |
+| [setSubject(String value)](#setSubject-java.lang.String-) | このプロパティの説明については、[getSubject()](../../com.aspose.diagram/documentproperties\#getSubject--) を参照してください。 |
+| [setTemplate(String value)](#setTemplate-java.lang.String-) | このプロパティの説明については、[getTemplate()](../../com.aspose.diagram/documentproperties\#getTemplate--) を参照してください。 |
+| [setTimeCreated(DateTime value)](#setTimeCreated-com.aspose.diagram.DateTime-) | このプロパティの説明については、[getTimeCreated()](../../com.aspose.diagram/documentproperties\#getTimeCreated--) を参照してください。 |
+| [setTimeEdited(DateTime value)](#setTimeEdited-com.aspose.diagram.DateTime-) | このプロパティの説明については、[getTimeEdited()](../../com.aspose.diagram/documentproperties\#getTimeEdited--)をご覧ください。 |
+| [setTimePrinted(DateTime value)](#setTimePrinted-com.aspose.diagram.DateTime-) | このプロパティの説明については、[getTimePrinted()](../../com.aspose.diagram/documentproperties\#getTimePrinted--)をご覧ください。 |
+| [setTimeSaved(DateTime value)](#setTimeSaved-com.aspose.diagram.DateTime-) | このプロパティの説明については、[getTimeSaved()](../../com.aspose.diagram/documentproperties\#getTimeSaved--)をご覧ください。 |
+| [setTitle(String value)](#setTitle-java.lang.String-) | このプロパティの説明については、[getTitle()](../../com.aspose.diagram/documentproperties\#getTitle--)をご覧ください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAlternateNames() {#getAlternateNames--}
+```
+public String getAlternateNames()
+```
+
+
+ドキュメントの代替名を指定します。
+
+**Returns:**
+java.lang.String
+### getBuildNumberCreated() {#getBuildNumberCreated--}
+```
+public String getBuildNumberCreated()
+```
+
+
+ドキュメント作成に使用されたインスタンスの完全なビルド番号が含まれます。
+
+**Returns:**
+java.lang.String
+### getBuildNumberEdited() {#getBuildNumberEdited--}
+```
+public String getBuildNumberEdited()
+```
+
+
+ドキュメントの最終編集に使用されたインスタンスのビルド番号が含まれます。
+
+**Returns:**
+java.lang.String
+### getCategory() {#getCategory--}
+```
+public String getCategory()
+```
+
+
+フローチャートやオフィスレイアウトなど、図面の種類を示す説明テキストを指定します。このテキストは、Microsoft Visio のユーザーインターフェイスのプロパティ ダイアログ ボックスの「カテゴリ」ボックスにも入力できます。
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCompany() {#getCompany--}
+```
+public String getCompany()
+```
+
+
+図面を作成する会社または図面の作成先の会社を識別するユーザー入力情報が含まれます。最大長は 63 文字です。
+
+**Returns:**
+java.lang.String
+### getCreator() {#getCreator--}
+```
+public String getCreator()
+```
+
+
+ファイルを作成した人または最後に更新した人を識別します。最大長は 63 文字です。
+
+**Returns:**
+java.lang.String
+### getCustomProps() {#getCustomProps--}
+```
+public CustomPropCollection getCustomProps()
+```
+
+
+CustomProp のコレクションです。
+
+**Returns:**
+[CustomPropCollection](../../com.aspose.diagram/custompropcollection)
+### getDesc() {#getDesc--}
+```
+public String getDesc()
+```
+
+
+文書の説明テキスト文字列が含まれます。この要素を使用して、文書の目的、最近の変更、保留中の変更など、重要な情報を保存します。最大は 191 文字です。
+
+**Returns:**
+java.lang.String
+### getHyperlinkBase() {#getHyperlinkBase--}
+```
+public String getHyperlinkBase()
+```
+
+
+相対ハイパーリンクに使用するパスが含まれます（リンクされたファイルの場所が Microsoft Visio 図に対して相対的に記述されているハイパーリンク）。デフォルトでは、ハイパーリンク パスは現在の文書に対して相対になりますが、この要素で別のパスが指定された場合はそれが使用されます。最大長は 256 文字です。
+
+**Returns:**
+java.lang.String
+### getKeywords() {#getKeywords--}
+```
+public String getKeywords()
+```
+
+
+プロジェクト名、クライアント名、バージョン番号など、ファイルに関するトピックやその他の重要情報を識別するテキスト文字列が含まれます。最大文字列長は 63 文字です。
+
+**Returns:**
+java.lang.String
+### getLanguage() {#getLanguage--}
+```
+public String getLanguage()
+```
+
+
+言語を指定します
+
+```
+setLanguage("en-GB");
+         setLanguage("en-US");
+```
+
+**Returns:**
+java.lang.String
+### getManager() {#getManager--}
+```
+public String getManager()
+```
+
+
+プロジェクトまたは部門の担当者を識別するユーザー入力テキスト文字列が含まれます。最大長は 63 文字です。
+
+**Returns:**
+java.lang.String
+### getPreviewPicture() {#getPreviewPicture--}
+```
+public byte[] getPreviewPicture()
+```
+
+
+ドキュメントのプレビューとして機能するメタファイルストリームが含まれます。
+
+**Returns:**
+byte[]
+### getSubject() {#getSubject--}
+```
+public String getSubject()
+```
+
+
+文書の内容を説明するユーザー定義テキスト文字列が含まれます。最大長は 63 文字です。
+
+**Returns:**
+java.lang.String
+### getTemplate() {#getTemplate--}
+```
+public String getTemplate()
+```
+
+
+ドキュメントが作成されたテンプレートのファイル名を指定する文字列値が含まれます。
+
+**Returns:**
+java.lang.String
+### getTimeCreated() {#getTimeCreated--}
+```
+public DateTime getTimeCreated()
+```
+
+
+ドキュメントが作成された日時を示す日付と時刻の値が含まれます。
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### getTimeEdited() {#getTimeEdited--}
+```
+public DateTime getTimeEdited()
+```
+
+
+ドキュメントが最後に編集された日時を示す日付と時刻の値が含まれます。
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### getTimePrinted() {#getTimePrinted--}
+```
+public DateTime getTimePrinted()
+```
+
+
+ドキュメントが最後に印刷された日時を示す日付と時刻の値が含まれます。
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### getTimeSaved() {#getTimeSaved--}
+```
+public DateTime getTimeSaved()
+```
+
+
+ドキュメントが最後に保存された日時を示す日付と時刻の値が含まれます。
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### getTitle() {#getTitle--}
+```
+public String getTitle()
+```
+
+
+文書の説明タイトルとして機能するユーザー定義テキスト文字列が含まれます。最大長は 63 文字です。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAlternateNames(String value) {#setAlternateNames-java.lang.String-}
+```
+public void setAlternateNames(String value)
+```
+
+
+このプロパティの説明については、[getAlternateNames()](../../com.aspose.diagram/documentproperties\#getAlternateNames--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setBuildNumberCreated(String value) {#setBuildNumberCreated-java.lang.String-}
+```
+public void setBuildNumberCreated(String value)
+```
+
+
+このプロパティの説明については、[getBuildNumberCreated()](../../com.aspose.diagram/documentproperties\#getBuildNumberCreated--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setBuildNumberEdited(String value) {#setBuildNumberEdited-java.lang.String-}
+```
+public void setBuildNumberEdited(String value)
+```
+
+
+このプロパティの説明については、[getBuildNumberEdited()](../../com.aspose.diagram/documentproperties\#getBuildNumberEdited--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setCategory(String value) {#setCategory-java.lang.String-}
+```
+public void setCategory(String value)
+```
+
+
+このプロパティの説明については、[getCategory()](../../com.aspose.diagram/documentproperties\#getCategory--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setCompany(String value) {#setCompany-java.lang.String-}
+```
+public void setCompany(String value)
+```
+
+
+このプロパティの説明については、[getCompany()](../../com.aspose.diagram/documentproperties\#getCompany--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setCreator(String value) {#setCreator-java.lang.String-}
+```
+public void setCreator(String value)
+```
+
+
+このプロパティの説明については、[getCreator()](../../com.aspose.diagram/documentproperties\#getCreator--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setDesc(String value) {#setDesc-java.lang.String-}
+```
+public void setDesc(String value)
+```
+
+
+このプロパティの説明については、[getDesc()](../../com.aspose.diagram/documentproperties\#getDesc--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setHyperlinkBase(String value) {#setHyperlinkBase-java.lang.String-}
+```
+public void setHyperlinkBase(String value)
+```
+
+
+このプロパティの説明については、[getHyperlinkBase()](../../com.aspose.diagram/documentproperties\#getHyperlinkBase--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setKeywords(String value) {#setKeywords-java.lang.String-}
+```
+public void setKeywords(String value)
+```
+
+
+このプロパティの説明については、[getKeywords()](../../com.aspose.diagram/documentproperties\#getKeywords--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setLanguage(String value) {#setLanguage-java.lang.String-}
+```
+public void setLanguage(String value)
+```
+
+
+このプロパティの説明については、[getLanguage()](../../com.aspose.diagram/documentproperties\#getLanguage--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setManager(String value) {#setManager-java.lang.String-}
+```
+public void setManager(String value)
+```
+
+
+このプロパティの説明については、[getManager()](../../com.aspose.diagram/documentproperties\#getManager--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setPreviewPicture(byte[] value) {#setPreviewPicture-byte---}
+```
+public void setPreviewPicture(byte[] value)
+```
+
+
+このプロパティの説明については、[getPreviewPicture()](../../com.aspose.diagram/documentproperties\#getPreviewPicture--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | byte[] |  |
+
+### setSubject(String value) {#setSubject-java.lang.String-}
+```
+public void setSubject(String value)
+```
+
+
+このプロパティの説明については、[getSubject()](../../com.aspose.diagram/documentproperties\#getSubject--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setTemplate(String value) {#setTemplate-java.lang.String-}
+```
+public void setTemplate(String value)
+```
+
+
+このプロパティの説明については、[getTemplate()](../../com.aspose.diagram/documentproperties\#getTemplate--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setTimeCreated(DateTime value) {#setTimeCreated-com.aspose.diagram.DateTime-}
+```
+public void setTimeCreated(DateTime value)
+```
+
+
+このプロパティの説明については、[getTimeCreated()](../../com.aspose.diagram/documentproperties\#getTimeCreated--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setTimeEdited(DateTime value) {#setTimeEdited-com.aspose.diagram.DateTime-}
+```
+public void setTimeEdited(DateTime value)
+```
+
+
+このプロパティの説明については、[getTimeEdited()](../../com.aspose.diagram/documentproperties\#getTimeEdited--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setTimePrinted(DateTime value) {#setTimePrinted-com.aspose.diagram.DateTime-}
+```
+public void setTimePrinted(DateTime value)
+```
+
+
+このプロパティの説明については、[getTimePrinted()](../../com.aspose.diagram/documentproperties\#getTimePrinted--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setTimeSaved(DateTime value) {#setTimeSaved-com.aspose.diagram.DateTime-}
+```
+public void setTimeSaved(DateTime value)
+```
+
+
+このプロパティの説明については、[getTimeSaved()](../../com.aspose.diagram/documentproperties\#getTimeSaved--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setTitle(String value) {#setTitle-java.lang.String-}
+```
+public void setTitle(String value)
+```
+
+
+このプロパティの説明については、[getTitle()](../../com.aspose.diagram/documentproperties\#getTitle--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/documentsettings/_index.md
+++ b/japanese/java/com.aspose.diagram/documentsettings/_index.md
@@ -1,0 +1,550 @@
+---
+title: DocumentSettings
+second_title: Aspose.Diagram for Java API リファレンス
+description: ドキュメント設定を指定する要素を含みます。
+type: docs
+weight: 126
+url: /ja/java/com.aspose.diagram/documentsettings/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DocumentSettings
+```
+
+ドキュメント設定を指定する要素を含みます。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAttachedToolbars()](#getAttachedToolbars--) | カスタムツールバーを表す、MIME（Multipurpose Internet Mail Extensions）エンコードされた Microsoft Visio ユーザーインターフェイス（VSU）ファイルです。 |
+| [getClass()](#getClass--) |  |
+| [getCustomMenusFile()](#getCustomMenusFile--) | ドキュメント用のカスタムメニューとアクセラレータを定義する Microsoft Visio ユーザーインターフェイス（.vsu）ファイルの名前を含みます。 |
+| [getCustomToolbarsFile()](#getCustomToolbarsFile--) | ドキュメント用のカスタムツールバーとステータスバーを定義する Microsoft Visio ユーザーインターフェイス（.vsu）ファイルの名前を含みます。 |
+| [getDefaultFillStyle()](#getDefaultFillStyle--) | StyleSheet 要素の ID を指定します。 |
+| [getDefaultGuideStyle()](#getDefaultGuideStyle--) | StyleSheet 要素の ID を指定します。 |
+| [getDefaultLineStyle()](#getDefaultLineStyle--) | StyleSheet 要素の ID を指定します。 |
+| [getDefaultTextStyle()](#getDefaultTextStyle--) | StyleSheet 要素の ID を指定します。 |
+| [getDynamicGridEnabled()](#getDynamicGridEnabled--) | ドキュメントまたはウィンドウに対して動的グリッド機能が有効かどうかを指定します。 |
+| [getGlueSettings()](#getGlueSettings--) | ドキュメントで接着が有効な場合に、シェイプが接着するオブジェクトを指定します。 |
+| [getProtectBkgnds()](#getProtectBkgnds--) | ユーザーが背景ページを削除または編集できないようにするかどうかを指定します。 |
+| [getProtectMasters()](#getProtectMasters--) | ユーザーがマスターを作成、編集、または削除できないようにするかどうかを指定します。 |
+| [getProtectShapes()](#getProtectShapes--) | ユーザーが LockSelect 要素が 1 に設定されているシェイプの選択を防止されているかどうかを指定します。 |
+| [getProtectStyles()](#getProtectStyles--) | ユーザーがスタイルの作成または編集を防止されているかどうかを指定します。 |
+| [getSnapAngles()](#getSnapAngles--) | SnapAngle 要素のコレクションを含みます。 |
+| [getSnapExtensions()](#getSnapExtensions--) | アクティブ ウィンドウに対して特定のスナップ拡張設定が有効か無効かを指定します。 |
+| [getSnapSettings()](#getSnapSettings--) | ウィンドウでスナップが有効なときにシェイプがスナップするオブジェクトを指定します。 |
+| [getTopPage()](#getTopPage--) | Microsoft Visio でドキュメントが開かれたときに表示されるページの ID を指定します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAttachedToolbars(byte[] value)](#setAttachedToolbars-byte---) | このプロパティの説明については、[getAttachedToolbars()](../../com.aspose.diagram/documentsettings\#getAttachedToolbars--) を参照してください。 |
+| [setCustomMenusFile(String value)](#setCustomMenusFile-java.lang.String-) | このプロパティの説明については、[getCustomMenusFile()](../../com.aspose.diagram/documentsettings\#getCustomMenusFile--) を参照してください。 |
+| [setCustomToolbarsFile(String value)](#setCustomToolbarsFile-java.lang.String-) | このプロパティの説明については、[getCustomToolbarsFile()](../../com.aspose.diagram/documentsettings\#getCustomToolbarsFile--) を参照してください。 |
+| [setDefaultFillStyle(int value)](#setDefaultFillStyle-int-) | このプロパティの説明については、[getDefaultFillStyle()](../../com.aspose.diagram/documentsettings\#getDefaultFillStyle--) を参照してください。 |
+| [setDefaultGuideStyle(int value)](#setDefaultGuideStyle-int-) | このプロパティの説明については、[getDefaultGuideStyle()](../../com.aspose.diagram/documentsettings\#getDefaultGuideStyle--) を参照してください。 |
+| [setDefaultLineStyle(int value)](#setDefaultLineStyle-int-) | このプロパティの説明については、[getDefaultLineStyle()](../../com.aspose.diagram/documentsettings\#getDefaultLineStyle--) を参照してください。 |
+| [setDefaultTextStyle(int value)](#setDefaultTextStyle-int-) | このプロパティの説明については、[getDefaultTextStyle()](../../com.aspose.diagram/documentsettings\#getDefaultTextStyle--) を参照してください。 |
+| [setDynamicGridEnabled(int value)](#setDynamicGridEnabled-int-) | このプロパティの説明については、[getDynamicGridEnabled()](../../com.aspose.diagram/documentsettings\#getDynamicGridEnabled--) を参照してください。 |
+| [setGlueSettings(int value)](#setGlueSettings-int-) | このプロパティの説明については、[getGlueSettings()](../../com.aspose.diagram/documentsettings\#getGlueSettings--) を参照してください。 |
+| [setProtectBkgnds(int value)](#setProtectBkgnds-int-) | このプロパティの説明については、[getProtectBkgnds()](../../com.aspose.diagram/documentsettings\#getProtectBkgnds--) を参照してください。 |
+| [setProtectMasters(int value)](#setProtectMasters-int-) | このプロパティの説明については、[getProtectMasters()](../../com.aspose.diagram/documentsettings\#getProtectMasters--) を参照してください。 |
+| [setProtectShapes(int value)](#setProtectShapes-int-) | このプロパティの説明については、[getProtectShapes()](../../com.aspose.diagram/documentsettings\#getProtectShapes--) を参照してください。 |
+| [setProtectStyles(int value)](#setProtectStyles-int-) | このプロパティの説明については、[getProtectStyles()](../../com.aspose.diagram/documentsettings\#getProtectStyles--) を参照してください。 |
+| [setSnapAngles(FloatPointNumCollection value)](#setSnapAngles-com.aspose.diagram.FloatPointNumCollection-) | このプロパティの説明については、[getSnapAngles()](../../com.aspose.diagram/documentsettings\#getSnapAngles--) を参照してください。 |
+| [setSnapExtensions(int value)](#setSnapExtensions-int-) | このプロパティの説明については、[getSnapExtensions()](../../com.aspose.diagram/documentsettings\#getSnapExtensions--) を参照してください。 |
+| [setSnapSettings(int value)](#setSnapSettings-int-) | このプロパティの説明については、[getSnapSettings()](../../com.aspose.diagram/documentsettings\#getSnapSettings--) を参照してください。 |
+| [setTopPage(int value)](#setTopPage-int-) | このプロパティの説明については、[getTopPage()](../../com.aspose.diagram/documentsettings\#getTopPage--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAttachedToolbars() {#getAttachedToolbars--}
+```
+public byte[] getAttachedToolbars()
+```
+
+
+カスタムツールバーを表す、MIME（Multipurpose Internet Mail Extensions）エンコードされた Microsoft Visio ユーザーインターフェイス（VSU）ファイルです。
+
+**Returns:**
+byte[]
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCustomMenusFile() {#getCustomMenusFile--}
+```
+public String getCustomMenusFile()
+```
+
+
+ドキュメント用のカスタムメニューとアクセラレータを定義する Microsoft Visio ユーザーインターフェイス（.vsu）ファイルの名前を含みます。
+
+**Returns:**
+java.lang.String
+### getCustomToolbarsFile() {#getCustomToolbarsFile--}
+```
+public String getCustomToolbarsFile()
+```
+
+
+ドキュメント用のカスタムツールバーとステータスバーを定義する Microsoft Visio ユーザーインターフェイス（.vsu）ファイルの名前を含みます。
+
+**Returns:**
+java.lang.String
+### getDefaultFillStyle() {#getDefaultFillStyle--}
+```
+public int getDefaultFillStyle()
+```
+
+
+StyleSheet 要素の ID を指定します。次にユーザーが描画ツールを使用してシェイプを作成するとき、そのシェイプは指定された StyleSheet 要素から塗りつぶしスタイルを継承します。
+
+**Returns:**
+int
+### getDefaultGuideStyle() {#getDefaultGuideStyle--}
+```
+public int getDefaultGuideStyle()
+```
+
+
+StyleSheet 要素の ID を指定します。次にユーザーがガイドを作成するとき、そのガイドは指定された StyleSheet 要素からガイドスタイルを継承します。
+
+**Returns:**
+int
+### getDefaultLineStyle() {#getDefaultLineStyle--}
+```
+public int getDefaultLineStyle()
+```
+
+
+StyleSheet 要素の ID を指定します。次にユーザーが描画ツールを使用してシェイプを作成するとき、そのシェイプは指定された StyleSheet 要素から線スタイルを継承します。
+
+**Returns:**
+int
+### getDefaultTextStyle() {#getDefaultTextStyle--}
+```
+public int getDefaultTextStyle()
+```
+
+
+StyleSheet 要素の ID を指定します。次にユーザーが描画ツールを使用してシェイプを作成するとき、そのシェイプは指定された StyleSheet 要素からテキストスタイルを継承します。
+
+**Returns:**
+int
+### getDynamicGridEnabled() {#getDynamicGridEnabled--}
+```
+public int getDynamicGridEnabled()
+```
+
+
+ドキュメントまたはウィンドウに対して動的グリッド機能が有効かどうかを指定します。
+
+**Returns:**
+int
+### getGlueSettings() {#getGlueSettings--}
+```
+public int getGlueSettings()
+```
+
+
+ドキュメントで接着が有効な場合に、シェイプが接着するオブジェクトを指定します。
+
+**Returns:**
+int
+### getProtectBkgnds() {#getProtectBkgnds--}
+```
+public int getProtectBkgnds()
+```
+
+
+ユーザーが背景ページを削除または編集できないようにするかどうかを指定します。
+
+**Returns:**
+int
+### getProtectMasters() {#getProtectMasters--}
+```
+public int getProtectMasters()
+```
+
+
+ユーザーがマスターの作成、編集、削除を防止されているかどうかを指定します。この設定に関係なく、ユーザーはマスターのインスタンスを作成できます。
+
+**Returns:**
+int
+### getProtectShapes() {#getProtectShapes--}
+```
+public int getProtectShapes()
+```
+
+
+ユーザーが LockSelect 要素が 1 に設定されているシェイプの選択を防止されているかどうかを指定します。
+
+**Returns:**
+int
+### getProtectStyles() {#getProtectStyles--}
+```
+public int getProtectStyles()
+```
+
+
+ユーザーがスタイルの作成または編集を防止されているかどうかを指定します。ただし、この設定に関係なく、ユーザーはスタイルを適用できます。
+
+**Returns:**
+int
+### getSnapAngles() {#getSnapAngles--}
+```
+public FloatPointNumCollection getSnapAngles()
+```
+
+
+SnapAngle 要素のコレクションを含みます。
+
+**Returns:**
+[FloatPointNumCollection](../../com.aspose.diagram/floatpointnumcollection)
+### getSnapExtensions() {#getSnapExtensions--}
+```
+public int getSnapExtensions()
+```
+
+
+アクティブ ウィンドウに対して特定のスナップ拡張設定が有効か無効かを指定します。
+
+**Returns:**
+int
+### getSnapSettings() {#getSnapSettings--}
+```
+public int getSnapSettings()
+```
+
+
+ウィンドウでスナップが有効なときにシェイプがスナップするオブジェクトを指定します。
+
+**Returns:**
+int
+### getTopPage() {#getTopPage--}
+```
+public int getTopPage()
+```
+
+
+Microsoft Visio でドキュメントが開かれたときに表示されるページの ID を指定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAttachedToolbars(byte[] value) {#setAttachedToolbars-byte---}
+```
+public void setAttachedToolbars(byte[] value)
+```
+
+
+このプロパティの説明については、[getAttachedToolbars()](../../com.aspose.diagram/documentsettings\#getAttachedToolbars--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | byte[] |  |
+
+### setCustomMenusFile(String value) {#setCustomMenusFile-java.lang.String-}
+```
+public void setCustomMenusFile(String value)
+```
+
+
+このプロパティの説明については、[getCustomMenusFile()](../../com.aspose.diagram/documentsettings\#getCustomMenusFile--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setCustomToolbarsFile(String value) {#setCustomToolbarsFile-java.lang.String-}
+```
+public void setCustomToolbarsFile(String value)
+```
+
+
+このプロパティの説明については、[getCustomToolbarsFile()](../../com.aspose.diagram/documentsettings\#getCustomToolbarsFile--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setDefaultFillStyle(int value) {#setDefaultFillStyle-int-}
+```
+public void setDefaultFillStyle(int value)
+```
+
+
+このプロパティの説明については、[getDefaultFillStyle()](../../com.aspose.diagram/documentsettings\#getDefaultFillStyle--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setDefaultGuideStyle(int value) {#setDefaultGuideStyle-int-}
+```
+public void setDefaultGuideStyle(int value)
+```
+
+
+このプロパティの説明については、[getDefaultGuideStyle()](../../com.aspose.diagram/documentsettings\#getDefaultGuideStyle--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setDefaultLineStyle(int value) {#setDefaultLineStyle-int-}
+```
+public void setDefaultLineStyle(int value)
+```
+
+
+このプロパティの説明については、[getDefaultLineStyle()](../../com.aspose.diagram/documentsettings\#getDefaultLineStyle--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setDefaultTextStyle(int value) {#setDefaultTextStyle-int-}
+```
+public void setDefaultTextStyle(int value)
+```
+
+
+このプロパティの説明については、[getDefaultTextStyle()](../../com.aspose.diagram/documentsettings\#getDefaultTextStyle--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setDynamicGridEnabled(int value) {#setDynamicGridEnabled-int-}
+```
+public void setDynamicGridEnabled(int value)
+```
+
+
+このプロパティの説明については、[getDynamicGridEnabled()](../../com.aspose.diagram/documentsettings\#getDynamicGridEnabled--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setGlueSettings(int value) {#setGlueSettings-int-}
+```
+public void setGlueSettings(int value)
+```
+
+
+このプロパティの説明については、[getGlueSettings()](../../com.aspose.diagram/documentsettings\#getGlueSettings--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setProtectBkgnds(int value) {#setProtectBkgnds-int-}
+```
+public void setProtectBkgnds(int value)
+```
+
+
+このプロパティの説明については、[getProtectBkgnds()](../../com.aspose.diagram/documentsettings\#getProtectBkgnds--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setProtectMasters(int value) {#setProtectMasters-int-}
+```
+public void setProtectMasters(int value)
+```
+
+
+このプロパティの説明については、[getProtectMasters()](../../com.aspose.diagram/documentsettings\#getProtectMasters--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setProtectShapes(int value) {#setProtectShapes-int-}
+```
+public void setProtectShapes(int value)
+```
+
+
+このプロパティの説明については、[getProtectShapes()](../../com.aspose.diagram/documentsettings\#getProtectShapes--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setProtectStyles(int value) {#setProtectStyles-int-}
+```
+public void setProtectStyles(int value)
+```
+
+
+このプロパティの説明については、[getProtectStyles()](../../com.aspose.diagram/documentsettings\#getProtectStyles--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setSnapAngles(FloatPointNumCollection value) {#setSnapAngles-com.aspose.diagram.FloatPointNumCollection-}
+```
+public void setSnapAngles(FloatPointNumCollection value)
+```
+
+
+このプロパティの説明については、[getSnapAngles()](../../com.aspose.diagram/documentsettings\#getSnapAngles--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [FloatPointNumCollection](../../com.aspose.diagram/floatpointnumcollection) |  |
+
+### setSnapExtensions(int value) {#setSnapExtensions-int-}
+```
+public void setSnapExtensions(int value)
+```
+
+
+このプロパティの説明については、[getSnapExtensions()](../../com.aspose.diagram/documentsettings\#getSnapExtensions--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setSnapSettings(int value) {#setSnapSettings-int-}
+```
+public void setSnapSettings(int value)
+```
+
+
+このプロパティの説明については、[getSnapSettings()](../../com.aspose.diagram/documentsettings\#getSnapSettings--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setTopPage(int value) {#setTopPage-int-}
+```
+public void setTopPage(int value)
+```
+
+
+このプロパティの説明については、[getTopPage()](../../com.aspose.diagram/documentsettings\#getTopPage--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/documentsheet/_index.md
+++ b/japanese/java/com.aspose.diagram/documentsheet/_index.md
@@ -1,0 +1,396 @@
+---
+title: DocumentSheet
+second_title: Aspose.Diagram for Java API リファレンス
+description: ドキュメントの ShapeSheet 構造を指定します。
+type: docs
+weight: 127
+url: /ja/java/com.aspose.diagram/documentsheet/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DocumentSheet
+```
+
+ドキュメントの ShapeSheet 構造を指定します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAnnotations()](#getAnnotations--) | ドキュメントページに挿入されたコメントに関する情報を含む要素が含まれています。 |
+| [getClass()](#getClass--) |  |
+| [getConnectionABCDs()](#getConnectionABCDs--) | ConnectionABCD 要素のコレクションを含みます。 |
+| [getConnections()](#getConnections--) | Connection 要素のコレクションを含みます。 |
+| [getDocProps()](#getDocProps--) | ドキュメントのプレビュー品質、範囲、出力形式を制御する要素を含みます。 |
+| [getFillStyle()](#getFillStyle--) | このスタイルが塗りつぶし書式を継承する StyleSheet 要素。 |
+| [getForeign()](#getForeign--) | Microsoft Visio ドキュメントで使用される別のプログラムからのオブジェクトの幅と高さを指定する要素を含みます。 |
+| [getForeignData()](#getForeignData--) | Windows メタファイル、ビットマップ、または OLE データなどの画像データの MIME (Multipurpose Internet Mail Extensions) エンコード BLOB を含みます。 |
+| [getHyperlinks()](#getHyperlinks--) | Hyperlink 要素のコレクションを含みます。 |
+| [getLineStyle()](#getLineStyle--) | このスタイルが線書式を継承する StyleSheet 要素。 |
+| [getName()](#getName--) | 要素の名前。 |
+| [getNameU()](#getNameU--) | 要素のユニバーサル名。 |
+| [getProps()](#getProps--) | Prop 要素のコレクションを含みます。 |
+| [getReviewers()](#getReviewers--) | 文書レビュアーに関する識別情報を含む要素を含みます。 |
+| [getScratchs()](#getScratchs--) | Scratch 要素のコレクションを含みます。 |
+| [getTextStyle()](#getTextStyle--) | このスタイルがテキスト書式を継承する StyleSheet 要素。 |
+| [getUniqueID()](#getUniqueID--) | 形状を識別する GUID（グローバルに一意な識別子）です。 |
+| [getUsers()](#getUsers--) | User 要素のコレクションを含みます。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setFillStyle(StyleSheet value)](#setFillStyle-com.aspose.diagram.StyleSheet-) | このプロパティの説明については、[getFillStyle()](../../com.aspose.diagram/documentsheet\#getFillStyle--) を参照してください。 |
+| [setLineStyle(StyleSheet value)](#setLineStyle-com.aspose.diagram.StyleSheet-) | このプロパティの説明については、[getLineStyle()](../../com.aspose.diagram/documentsheet\#getLineStyle--) を参照してください。 |
+| [setName(String value)](#setName-java.lang.String-) | このプロパティの説明については、[getName()](../../com.aspose.diagram/documentsheet\#getName--) を参照してください。 |
+| [setNameU(String value)](#setNameU-java.lang.String-) | このプロパティの説明については、[getNameU()](../../com.aspose.diagram/documentsheet\#getNameU--) を参照してください。 |
+| [setTextStyle(StyleSheet value)](#setTextStyle-com.aspose.diagram.StyleSheet-) | このプロパティの説明については、[getTextStyle()](../../com.aspose.diagram/documentsheet\#getTextStyle--) を参照してください。 |
+| [setUniqueID(UUID value)](#setUniqueID-java.util.UUID-) | このプロパティの説明については、[getUniqueID()](../../com.aspose.diagram/documentsheet\#getUniqueID--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAnnotations() {#getAnnotations--}
+```
+public AnnotationCollection getAnnotations()
+```
+
+
+ドキュメントページに挿入されたコメントに関する情報を含む要素が含まれています。
+
+**Returns:**
+[AnnotationCollection](../../com.aspose.diagram/annotationcollection)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConnectionABCDs() {#getConnectionABCDs--}
+```
+public ConnectionABCDCollection getConnectionABCDs()
+```
+
+
+ConnectionABCD 要素のコレクションを含みます。
+
+**Returns:**
+[ConnectionABCDCollection](../../com.aspose.diagram/connectionabcdcollection)
+### getConnections() {#getConnections--}
+```
+public ConnectionCollection getConnections()
+```
+
+
+Connection 要素のコレクションを含みます。
+
+**Returns:**
+[ConnectionCollection](../../com.aspose.diagram/connectioncollection)
+### getDocProps() {#getDocProps--}
+```
+public DocProps getDocProps()
+```
+
+
+ドキュメントのプレビュー品質、範囲、出力形式を制御する要素を含みます。
+
+**Returns:**
+[DocProps](../../com.aspose.diagram/docprops)
+### getFillStyle() {#getFillStyle--}
+```
+public StyleSheet getFillStyle()
+```
+
+
+このスタイルが塗りつぶし書式を継承する StyleSheet 要素。
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getForeign() {#getForeign--}
+```
+public Foreign getForeign()
+```
+
+
+Microsoft Visio ドキュメントで使用される他のプログラムからのオブジェクトの幅と高さを指定する要素を含みます。また、オブジェクトの画像が境界内でオフセットされる距離を指定する要素も含みます。
+
+**Returns:**
+[Foreign](../../com.aspose.diagram/foreign)
+### getForeignData() {#getForeignData--}
+```
+public ForeignData getForeignData()
+```
+
+
+Windows メタファイル、ビットマップ、または OLE データなどの画像データの MIME (Multipurpose Internet Mail Extensions) エンコード BLOB を含みます。
+
+**Returns:**
+[ForeignData](../../com.aspose.diagram/foreigndata)
+### getHyperlinks() {#getHyperlinks--}
+```
+public HyperlinkCollection getHyperlinks()
+```
+
+
+Hyperlink 要素のコレクションを含みます。
+
+**Returns:**
+[HyperlinkCollection](../../com.aspose.diagram/hyperlinkcollection)
+### getLineStyle() {#getLineStyle--}
+```
+public StyleSheet getLineStyle()
+```
+
+
+このスタイルが線書式を継承する StyleSheet 要素。
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素の名前。
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+要素のユニバーサル名。
+
+**Returns:**
+java.lang.String
+### getProps() {#getProps--}
+```
+public PropCollection getProps()
+```
+
+
+Prop 要素のコレクションを含みます。
+
+**Returns:**
+[PropCollection](../../com.aspose.diagram/propcollection)
+### getReviewers() {#getReviewers--}
+```
+public ReviewerCollection getReviewers()
+```
+
+
+文書レビュアーに関する識別情報を含む要素を含みます。
+
+**Returns:**
+[ReviewerCollection](../../com.aspose.diagram/reviewercollection)
+### getScratchs() {#getScratchs--}
+```
+public ScratchCollection getScratchs()
+```
+
+
+Scratch 要素のコレクションを含みます。
+
+**Returns:**
+[ScratchCollection](../../com.aspose.diagram/scratchcollection)
+### getTextStyle() {#getTextStyle--}
+```
+public StyleSheet getTextStyle()
+```
+
+
+このスタイルがテキスト書式を継承する StyleSheet 要素。
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getUniqueID() {#getUniqueID--}
+```
+public UUID getUniqueID()
+```
+
+
+形状を識別する GUID（グローバルに一意な識別子）です。
+
+**Returns:**
+java.util.UUID
+### getUsers() {#getUsers--}
+```
+public UserCollection getUsers()
+```
+
+
+User 要素のコレクションを含みます。
+
+**Returns:**
+[UserCollection](../../com.aspose.diagram/usercollection)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setFillStyle(StyleSheet value) {#setFillStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setFillStyle(StyleSheet value)
+```
+
+
+このプロパティの説明については、[getFillStyle()](../../com.aspose.diagram/documentsheet\#getFillStyle--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setLineStyle(StyleSheet value) {#setLineStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setLineStyle(StyleSheet value)
+```
+
+
+このプロパティの説明については、[getLineStyle()](../../com.aspose.diagram/documentsheet\#getLineStyle--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+このプロパティの説明については、[getName()](../../com.aspose.diagram/documentsheet\#getName--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+このプロパティの説明については、[getNameU()](../../com.aspose.diagram/documentsheet\#getNameU--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setTextStyle(StyleSheet value) {#setTextStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setTextStyle(StyleSheet value)
+```
+
+
+このプロパティの説明については、[getTextStyle()](../../com.aspose.diagram/documentsheet\#getTextStyle--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setUniqueID(UUID value) {#setUniqueID-java.util.UUID-}
+```
+public void setUniqueID(UUID value)
+```
+
+
+このプロパティの説明については、[getUniqueID()](../../com.aspose.diagram/documentsheet\#getUniqueID--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.util.UUID |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/doublevalue/_index.md
+++ b/japanese/java/com.aspose.diagram/doublevalue/_index.md
@@ -1,0 +1,239 @@
+---
+title: DoubleValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: Double 値
+type: docs
+weight: 128
+url: /ja/java/com.aspose.diagram/doublevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DoubleValue
+```
+
+Double 値
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [DoubleValue(double value, int unit)](#DoubleValue-double-int-) | コンストラクタ。 |
+| [DoubleValue()](#DoubleValue--) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性。 |
+| [getValue()](#getValue--) | Double 値。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [isThemed()](#isThemed--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setThemed(boolean value)](#setThemed-boolean-) | このプロパティの説明については、[isThemed()](../../com.aspose.diagram/doublevalue\#isThemed--) を参照してください。 |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | このプロパティの説明については、[getUfe()](../../com.aspose.diagram/doublevalue\#getUfe--) を参照してください。 |
+| [setValue(double value)](#setValue-double-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/doublevalue\#getValue--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DoubleValue(double value, int unit) {#DoubleValue-double-int-}
+```
+public DoubleValue(double value, int unit)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double |  |
+| 単位 | int |  |
+
+### DoubleValue() {#DoubleValue--}
+```
+public DoubleValue()
+```
+
+
+コンストラクタ。
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public double getValue()
+```
+
+
+Double 値。
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### isThemed() {#isThemed--}
+```
+public boolean isThemed()
+```
+
+
+
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setThemed(boolean value) {#setThemed-boolean-}
+```
+public void setThemed(boolean value)
+```
+
+
+このプロパティの説明については、[isThemed()](../../com.aspose.diagram/doublevalue\#isThemed--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+このプロパティの説明については、[getUfe()](../../com.aspose.diagram/doublevalue\#getUfe--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(double value) {#setValue-double-}
+```
+public void setValue(double value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/doublevalue\#getValue--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/drawingresizetype/_index.md
+++ b/japanese/java/com.aspose.diagram/drawingresizetype/_index.md
@@ -1,0 +1,179 @@
+---
+title: DrawingResizeType
+second_title: Aspose.Diagram for Java API リファレンス
+description: 図に合わせて描画ページが自動的にサイズ変更されるかどうかを決定します。
+type: docs
+weight: 129
+url: /ja/java/com.aspose.diagram/drawingresizetype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DrawingResizeType
+```
+
+図に合わせて描画ページが自動的にサイズ変更されるかどうかを決定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [DrawingResizeType(int value)](#DrawingResizeType-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | 図に合わせて描画ページが自動的にサイズ変更されるかどうかを決定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/drawingresizetype\#getValue--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DrawingResizeType(int value) {#DrawingResizeType-int-}
+```
+public DrawingResizeType(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+図に合わせて描画ページが自動的にサイズ変更されるかどうかを決定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/drawingresizetype\#getValue--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/drawingresizetypevalue/_index.md
+++ b/japanese/java/com.aspose.diagram/drawingresizetypevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: DrawingResizeTypeValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: 図に合わせて描画ページが自動的にサイズ変更されるかどうかを決定します。
+type: docs
+weight: 130
+url: /ja/java/com.aspose.diagram/drawingresizetypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class DrawingResizeTypeValue
+```
+
+図に合わせて描画ページが自動的にサイズ変更されるかどうかを決定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [AUTOMATICALLY](#AUTOMATICALLY) | 図面ページは自動的にサイズ変更されます。 |
+| [DEPENDS_ON_DRAWING_SIZE_TYPE](#DEPENDS-ON-DRAWING-SIZE-TYPE) | ページが自動的にサイズ変更されるかどうかは、DrawingSizeType セルの値に依存します。 |
+| [NOT_AUTOMATICALLY](#NOT-AUTOMATICALLY) | 図面ページは自動的にサイズ変更されません。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AUTOMATICALLY {#AUTOMATICALLY}
+```
+public static final int AUTOMATICALLY
+```
+
+
+図面ページは自動的にサイズ変更されます。
+
+### DEPENDS_ON_DRAWING_SIZE_TYPE {#DEPENDS-ON-DRAWING-SIZE-TYPE}
+```
+public static final int DEPENDS_ON_DRAWING_SIZE_TYPE
+```
+
+
+ページが自動的にサイズ変更されるかどうかは、DrawingSizeType セルの値に依存します。DrawingSizeType = 0（図面ページのサイズが印刷ページのサイズと同じ）の場合、ページは自動的にサイズ変更されます。DrawingSizeType の値が 0 以外の場合、ページは自動的にサイズ変更されません。
+
+### NOT_AUTOMATICALLY {#NOT-AUTOMATICALLY}
+```
+public static final int NOT_AUTOMATICALLY
+```
+
+
+図面ページは自動的にサイズ変更されません。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/drawingscaletype/_index.md
+++ b/japanese/java/com.aspose.diagram/drawingscaletype/_index.md
@@ -1,0 +1,179 @@
+---
+title: DrawingScaleType
+second_title: Aspose.Diagram for Java API リファレンス
+description: ページに使用する描画スケールのタイプを指定します。
+type: docs
+weight: 131
+url: /ja/java/com.aspose.diagram/drawingscaletype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DrawingScaleType
+```
+
+ページに使用する描画スケールのタイプを指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [DrawingScaleType(int value)](#DrawingScaleType-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | ページに使用する描画スケールのタイプを指定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | For the description of this property, please see [getValue()](../../com.aspose.diagram/drawingscaletype\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DrawingScaleType(int value) {#DrawingScaleType-int-}
+```
+public DrawingScaleType(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+ページに使用する描画スケールのタイプを指定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+For the description of this property, please see [getValue()](../../com.aspose.diagram/drawingscaletype\#getValue--)
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/drawingscaletypevalue/_index.md
+++ b/japanese/java/com.aspose.diagram/drawingscaletypevalue/_index.md
@@ -1,0 +1,192 @@
+---
+title: DrawingScaleTypeValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: ページに使用する描画スケールのタイプを指定します。
+type: docs
+weight: 132
+url: /ja/java/com.aspose.diagram/drawingscaletypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class DrawingScaleTypeValue
+```
+
+ページに使用する描画スケールのタイプを指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [ARCHITECTURAL_SCALE](#ARCHITECTURAL-SCALE) | 建築スケール。 |
+| [CIVIL_ENGINEERING_SCALE](#CIVIL-ENGINEERING-SCALE) | 土木工学スケール。 |
+| [CUSTOM_SCALE](#CUSTOM-SCALE) | カスタムスケール。 |
+| [MECHANICAL_ENGINEERING_SCALE](#MECHANICAL-ENGINEERING-SCALE) | 機械工学スケール。 |
+| [METRIC_SCALE](#METRIC-SCALE) | メートルスケール。 |
+| [NO_SCALE](#NO-SCALE) | スケールなし。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ARCHITECTURAL_SCALE {#ARCHITECTURAL-SCALE}
+```
+public static final int ARCHITECTURAL_SCALE
+```
+
+
+建築スケール。
+
+### CIVIL_ENGINEERING_SCALE {#CIVIL-ENGINEERING-SCALE}
+```
+public static final int CIVIL_ENGINEERING_SCALE
+```
+
+
+土木工学スケール。
+
+### CUSTOM_SCALE {#CUSTOM-SCALE}
+```
+public static final int CUSTOM_SCALE
+```
+
+
+カスタムスケール。
+
+### MECHANICAL_ENGINEERING_SCALE {#MECHANICAL-ENGINEERING-SCALE}
+```
+public static final int MECHANICAL_ENGINEERING_SCALE
+```
+
+
+機械工学スケール。
+
+### METRIC_SCALE {#METRIC-SCALE}
+```
+public static final int METRIC_SCALE
+```
+
+
+メートルスケール。
+
+### NO_SCALE {#NO-SCALE}
+```
+public static final int NO_SCALE
+```
+
+
+スケールなし。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/drawingsizetype/_index.md
+++ b/japanese/java/com.aspose.diagram/drawingsizetype/_index.md
@@ -1,0 +1,179 @@
+---
+title: DrawingSizeType
+second_title: Aspose.Diagram for Java API リファレンス
+description: ページの描画サイズを指定します。
+type: docs
+weight: 133
+url: /ja/java/com.aspose.diagram/drawingsizetype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DrawingSizeType
+```
+
+ページの描画サイズを指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [DrawingSizeType(int value)](#DrawingSizeType-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | ページの描画サイズを指定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/drawingsizetype\#getValue--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DrawingSizeType(int value) {#DrawingSizeType-int-}
+```
+public DrawingSizeType(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+ページの描画サイズを指定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/drawingsizetype\#getValue--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/drawingsizetypevalue/_index.md
+++ b/japanese/java/com.aspose.diagram/drawingsizetypevalue/_index.md
@@ -1,0 +1,210 @@
+---
+title: DrawingSizeTypeValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: ページの描画サイズを指定します。
+type: docs
+weight: 134
+url: /ja/java/com.aspose.diagram/drawingsizetypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class DrawingSizeTypeValue
+```
+
+ページの描画サイズを指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [ANSI_ARCHITECTURAL](#ANSI-ARCHITECTURAL) | ANSI architectural. |
+| [ANSI_ENGINEERING](#ANSI-ENGINEERING) | ANSI engineering. |
+| [CUSTOM_PAGE_SIZE](#CUSTOM-PAGE-SIZE) | Custom page size. |
+| [CUSTOM_SCALED_DRAW_SIZE](#CUSTOM-SCALED-DRAW-SIZE) | Custom scaled drawing size. |
+| [FIT_PAGE_DRAW_CONTENTS](#FIT-PAGE-DRAW-CONTENTS) | Fit page to drawing contents. |
+| [METRIC_ISO](#METRIC-ISO) | Metric (ISO). |
+| [SAME_AS_PRINTER](#SAME-AS-PRINTER) | Same as printer. |
+| [STANDARD](#STANDARD) | 標準。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ANSI_ARCHITECTURAL {#ANSI-ARCHITECTURAL}
+```
+public static final int ANSI_ARCHITECTURAL
+```
+
+
+ANSI architectural.
+
+### ANSI_ENGINEERING {#ANSI-ENGINEERING}
+```
+public static final int ANSI_ENGINEERING
+```
+
+
+ANSI engineering.
+
+### CUSTOM_PAGE_SIZE {#CUSTOM-PAGE-SIZE}
+```
+public static final int CUSTOM_PAGE_SIZE
+```
+
+
+Custom page size.
+
+### CUSTOM_SCALED_DRAW_SIZE {#CUSTOM-SCALED-DRAW-SIZE}
+```
+public static final int CUSTOM_SCALED_DRAW_SIZE
+```
+
+
+Custom scaled drawing size.
+
+### FIT_PAGE_DRAW_CONTENTS {#FIT-PAGE-DRAW-CONTENTS}
+```
+public static final int FIT_PAGE_DRAW_CONTENTS
+```
+
+
+Fit page to drawing contents.
+
+### METRIC_ISO {#METRIC-ISO}
+```
+public static final int METRIC_ISO
+```
+
+
+Metric (ISO).
+
+### SAME_AS_PRINTER {#SAME-AS-PRINTER}
+```
+public static final int SAME_AS_PRINTER
+```
+
+
+Same as printer.
+
+### STANDARD {#STANDARD}
+```
+public static final int STANDARD
+```
+
+
+標準。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/dropbuttonstyle/_index.md
+++ b/japanese/java/com.aspose.diagram/dropbuttonstyle/_index.md
@@ -1,0 +1,165 @@
+---
+title: DropButtonStyle
+second_title: Aspose.Diagram for Java API リファレンス
+description: ドロップ ボタンに表示されるシンボルを表します。
+type: docs
+weight: 135
+url: /ja/java/com.aspose.diagram/dropbuttonstyle/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class DropButtonStyle
+```
+
+ドロップ ボタンに表示されるシンボルを表します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [ARROW](#ARROW) | 下向き矢印のボタンを表示します。 |
+| [ELLIPSIS](#ELLIPSIS) | 省略記号（...）のボタンを表示します。 |
+| [PLAIN](#PLAIN) | 記号のないボタンを表示します。 |
+| [REDUCE](#REDUCE) | アンダースコア文字のような水平線のボタンを表示します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ARROW {#ARROW}
+```
+public static final int ARROW
+```
+
+
+下向き矢印のボタンを表示します。
+
+### ELLIPSIS {#ELLIPSIS}
+```
+public static final int ELLIPSIS
+```
+
+
+省略記号（...）のボタンを表示します。
+
+### PLAIN {#PLAIN}
+```
+public static final int PLAIN
+```
+
+
+記号のないボタンを表示します。
+
+### REDUCE {#REDUCE}
+```
+public static final int REDUCE
+```
+
+
+アンダースコア文字のような水平線のボタンを表示します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/dynfeedback/_index.md
+++ b/japanese/java/com.aspose.diagram/dynfeedback/_index.md
@@ -1,0 +1,179 @@
+---
+title: DynFeedback
+second_title: Aspose.Diagram for Java API リファレンス
+description: コネクタをドラッグするときにユーザーに提供される視覚的フィードバックのタイプを指定します。
+type: docs
+weight: 136
+url: /ja/java/com.aspose.diagram/dynfeedback/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DynFeedback
+```
+
+コネクタをドラッグする際にユーザーに提供される視覚的フィードバックのタイプを指定します。マウスボタンを離すと、結果として得られるコネクタ形状はこの設定の影響を受けません。この要素はルーティング可能なコネクタには適用されません。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [DynFeedback(int value)](#DynFeedback-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | コネクタをドラッグするときにユーザーに提供される視覚的フィードバックのタイプを指定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/dynfeedback\#getValue--)をご覧ください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DynFeedback(int value) {#DynFeedback-int-}
+```
+public DynFeedback(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+コネクタをドラッグする際にユーザーに提供される視覚的フィードバックのタイプを指定します。マウスボタンを離すと、結果として得られるコネクタ形状はこの設定の影響を受けません。この要素はルーティング可能なコネクタには適用されません。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/dynfeedback\#getValue--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/dynfeedbackvalue/_index.md
+++ b/japanese/java/com.aspose.diagram/dynfeedbackvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: DynFeedbackValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: コネクタをドラッグするときにユーザーに提供される視覚的フィードバックのタイプを指定します。
+type: docs
+weight: 137
+url: /ja/java/com.aspose.diagram/dynfeedbackvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class DynFeedbackValue
+```
+
+コネクタをドラッグする際にユーザーに提供される視覚的フィードバックのタイプを指定します。マウスボタンを離すと、結果として得られるコネクタ形状はこの設定の影響を受けません。この要素はルーティング可能なコネクタには適用されません。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [REMAIN_STRAIGHT](#REMAIN-STRAIGHT) | Remain straight (no legs). |
+| [SHOW_FIVE_LEGS](#SHOW-FIVE-LEGS) | Show five legs when dragged. |
+| [SHOW_THREE_LEGS](#SHOW-THREE-LEGS) | Show three legs when dragged. |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### REMAIN_STRAIGHT {#REMAIN-STRAIGHT}
+```
+public static final int REMAIN_STRAIGHT
+```
+
+
+Remain straight (no legs).
+
+### SHOW_FIVE_LEGS {#SHOW-FIVE-LEGS}
+```
+public static final int SHOW_FIVE_LEGS
+```
+
+
+Show five legs when dragged.
+
+### SHOW_THREE_LEGS {#SHOW-THREE-LEGS}
+```
+public static final int SHOW_THREE_LEGS
+```
+
+
+Show three legs when dragged.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/ellipse/_index.md
+++ b/japanese/java/com.aspose.diagram/ellipse/_index.md
@@ -1,0 +1,349 @@
+---
+title: 楕円
+second_title: Aspose.Diagram for Java API リファレンス
+description: 楕円の中心点の x および y 座標と、楕円上の2点を指定する要素を含みます。
+type: docs
+weight: 138
+url: /ja/java/com.aspose.diagram/ellipse/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class Ellipse extends Coordinate
+```
+
+楕円の中心点および楕円上の 2 点の x 座標と y 座標を指定する要素を含みます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Ellipse()](#Ellipse--) | [Ellipse](../../com.aspose.diagram/ellipse) クラスのインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | 楕円上の点の x 座標で、B 要素で表される y 座標と組み合わされています。 |
+| [getB()](#getB--) | 楕円上の点の y 座標で、A 要素で表される x 座標と組み合わされています。 |
+| [getC()](#getC--) | 楕円上の点の x 座標で、D 要素で表される y 座標と組み合わされています。 |
+| [getClass()](#getClass--) |  |
+| [getD()](#getD--) | 楕円上の点の y 座標で、C 要素で表される x 座標と組み合わされています。 |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getIX()](#getIX--) | 親要素内の要素のゼロベースインデックスです。 |
+| [getX()](#getX--) | 楕円の中心の x 座標です。 |
+| [getY()](#getY--) | 楕円の中心の y 座標です。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getA()](../../com.aspose.diagram/ellipse\#getA--) を参照してください。 |
+| [setB(DoubleValue value)](#setB-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getB()](../../com.aspose.diagram/ellipse\#getB--) を参照してください。 |
+| [setC(DoubleValue value)](#setC-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getC()](../../com.aspose.diagram/ellipse\#getC--) を参照してください。 |
+| [setD(DoubleValue value)](#setD-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getD()](../../com.aspose.diagram/ellipse\\#getD--) を参照してください。 |
+| [setDel(int value)](#setDel-int-) | このプロパティの説明については、[getDel()](../../com.aspose.diagram/ellipse\\#getDel--) を参照してください。 |
+| [setIX(int value)](#setIX-int-) | このプロパティの説明については、[getIX()](../../com.aspose.diagram/ellipse\\#getIX--) を参照してください。 |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getX()](../../com.aspose.diagram/ellipse\\#getX--) を参照してください。 |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getY()](../../com.aspose.diagram/ellipse\\#getY--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Ellipse() {#Ellipse--}
+```
+public Ellipse()
+```
+
+
+[Ellipse](../../com.aspose.diagram/ellipse) クラスのインスタンスを作成します。
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+楕円上の点の x 座標で、B 要素で表される y 座標と組み合わされています。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getB() {#getB--}
+```
+public DoubleValue getB()
+```
+
+
+楕円上の点の y 座標で、A 要素で表される x 座標と組み合わされています。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getC() {#getC--}
+```
+public DoubleValue getC()
+```
+
+
+楕円上の点の x 座標で、D 要素で表される y 座標と組み合わされています。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getD() {#getD--}
+```
+public DoubleValue getD()
+```
+
+
+楕円上の点の y 座標で、C 要素で表される x 座標と組み合わされています。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+親要素内の要素のゼロベースインデックスです。
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+楕円の中心の x 座標です。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+楕円の中心の y 座標です。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getA()](../../com.aspose.diagram/ellipse\#getA--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setB(DoubleValue value) {#setB-com.aspose.diagram.DoubleValue-}
+```
+public void setB(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getB()](../../com.aspose.diagram/ellipse\#getB--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setC(DoubleValue value) {#setC-com.aspose.diagram.DoubleValue-}
+```
+public void setC(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getC()](../../com.aspose.diagram/ellipse\#getC--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setD(DoubleValue value) {#setD-com.aspose.diagram.DoubleValue-}
+```
+public void setD(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getD()](../../com.aspose.diagram/ellipse\\#getD--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+このプロパティの説明については、[getDel()](../../com.aspose.diagram/ellipse\\#getDel--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+このプロパティの説明については、[getIX()](../../com.aspose.diagram/ellipse\\#getIX--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getX()](../../com.aspose.diagram/ellipse\\#getX--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getY()](../../com.aspose.diagram/ellipse\\#getY--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/ellipsecollection/_index.md
+++ b/japanese/java/com.aspose.diagram/ellipsecollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: EllipseCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: 楕円コレクションです。
+type: docs
+weight: 139
+url: /ja/java/com.aspose.diagram/ellipsecollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class EllipseCollection extends Collection
+```
+
+楕円コレクションです。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Ellipse get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[Ellipse](../../com.aspose.diagram/ellipse) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/ellipticalarcto/_index.md
+++ b/japanese/java/com.aspose.diagram/ellipticalarcto/_index.md
@@ -1,0 +1,349 @@
+---
+title: EllipticalArcTo
+second_title: Aspose.Diagram for Java API リファレンス
+description: 楕円弧に関する情報を指定する要素を含みます。
+type: docs
+weight: 140
+url: /ja/java/com.aspose.diagram/ellipticalarcto/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class EllipticalArcTo extends Coordinate
+```
+
+楕円弧に関する情報を指定する要素を含みます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [EllipticalArcTo()](#EllipticalArcTo--) | [EllipticalArcTo](../../com.aspose.diagram/ellipticalarcto) クラスのインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | 円弧の制御点の x 座標。 |
+| [getB()](#getB--) | 円弧の制御点の y 座標。 |
+| [getC()](#getC--) | 円弧の主軸が親の x 軸に対してなす角度。 |
+| [getClass()](#getClass--) |  |
+| [getD()](#getD--) | 円弧の主軸と副軸の比率。 |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getIX()](#getIX--) | 親要素内の要素のゼロベースインデックスです。 |
+| [getX()](#getX--) | 楕円弧の終端頂点の x 座標。 |
+| [getY()](#getY--) | 楕円弧の終端頂点の y 座標。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getA()](../../com.aspose.diagram/ellipticalarcto\#getA--) を参照してください。 |
+| [setB(DoubleValue value)](#setB-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getB()](../../com.aspose.diagram/ellipticalarcto\#getB--) を参照してください。 |
+| [setC(DoubleValue value)](#setC-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getC()](../../com.aspose.diagram/ellipticalarcto\#getC--) を参照してください。 |
+| [setD(DoubleValue value)](#setD-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getD()](../../com.aspose.diagram/ellipticalarcto\#getD--) を参照してください。 |
+| [setDel(int value)](#setDel-int-) | このプロパティの説明については、[getDel()](../../com.aspose.diagram/ellipticalarcto\#getDel--) を参照してください。 |
+| [setIX(int value)](#setIX-int-) | このプロパティの説明については、[getIX()](../../com.aspose.diagram/ellipticalarcto\#getIX--) を参照してください。 |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getX()](../../com.aspose.diagram/ellipticalarcto\#getX--) を参照してください。 |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getY()](../../com.aspose.diagram/ellipticalarcto\#getY--)をご覧ください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### EllipticalArcTo() {#EllipticalArcTo--}
+```
+public EllipticalArcTo()
+```
+
+
+[EllipticalArcTo](../../com.aspose.diagram/ellipticalarcto) クラスのインスタンスを作成します。
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+円弧の制御点の x 座標です。制御点は円弧の開始点と終了点の中間付近に配置するのが最適です。そうしないと、円弧は制御点を通過させるために極端に大きくなる可能性があり、予測できない結果を招くことがあります。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getB() {#getB--}
+```
+public DoubleValue getB()
+```
+
+
+円弧の制御点の y 座標。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getC() {#getC--}
+```
+public DoubleValue getC()
+```
+
+
+円弧の主軸が親の x 軸に対してなす角度。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getD() {#getD--}
+```
+public DoubleValue getD()
+```
+
+
+円弧の長軸と短軸の比率です。これらの語の通常の意味にもかかわらず、長軸が短軸より大きい必要はなく、したがってこの比率が 1 より大きい必要もありません。この要素を 0 以下または 1000 超の値に設定すると、予測できない結果になる可能性があります。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+親要素内の要素のゼロベースインデックスです。
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+楕円弧の終端頂点の x 座標。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+楕円弧の終端頂点の y 座標。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getA()](../../com.aspose.diagram/ellipticalarcto\#getA--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setB(DoubleValue value) {#setB-com.aspose.diagram.DoubleValue-}
+```
+public void setB(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getB()](../../com.aspose.diagram/ellipticalarcto\#getB--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setC(DoubleValue value) {#setC-com.aspose.diagram.DoubleValue-}
+```
+public void setC(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getC()](../../com.aspose.diagram/ellipticalarcto\#getC--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setD(DoubleValue value) {#setD-com.aspose.diagram.DoubleValue-}
+```
+public void setD(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getD()](../../com.aspose.diagram/ellipticalarcto\#getD--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+このプロパティの説明については、[getDel()](../../com.aspose.diagram/ellipticalarcto\#getDel--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+このプロパティの説明については、[getIX()](../../com.aspose.diagram/ellipticalarcto\#getIX--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getX()](../../com.aspose.diagram/ellipticalarcto\#getX--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getY()](../../com.aspose.diagram/ellipticalarcto\#getY--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/ellipticalarctocollection/_index.md
+++ b/japanese/java/com.aspose.diagram/ellipticalarctocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: EllipticalArcToCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: EllipticalArcTo  collection.
+type: docs
+weight: 141
+url: /ja/java/com.aspose.diagram/ellipticalarctocollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class EllipticalArcToCollection extends Collection
+```
+
+EllipticalArcTo コレクションです。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public EllipticalArcTo get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[EllipticalArcTo](../../com.aspose.diagram/ellipticalarcto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/emfrendersetting/_index.md
+++ b/japanese/java/com.aspose.diagram/emfrendersetting/_index.md
@@ -1,0 +1,147 @@
+---
+title: EmfRenderSetting
+second_title: Aspose.Diagram for Java API リファレンス
+description: Emf メタファイルのレンダリング設定です。
+type: docs
+weight: 142
+url: /ja/java/com.aspose.diagram/emfrendersetting/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class EmfRenderSetting
+```
+
+Emf メタファイルのレンダリング設定です。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [EMF_ONLY](#EMF-ONLY) | Emf レコードのみをレンダリングします。 |
+| [EMF_PLUS_PREFER](#EMF-PLUS-PREFER) | EmfPlus レコードのレンダリングを優先します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### EMF_ONLY {#EMF-ONLY}
+```
+public static final int EMF_ONLY
+```
+
+
+Emf レコードのみをレンダリングします。
+
+### EMF_PLUS_PREFER {#EMF-PLUS-PREFER}
+```
+public static final int EMF_PLUS_PREFER
+```
+
+
+EmfPlus レコードのレンダリングを優先します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/encoding/_index.md
+++ b/japanese/java/com.aspose.diagram/encoding/_index.md
@@ -1,0 +1,277 @@
+---
+title: Encoding
+second_title: Aspose.Diagram for Java API リファレンス
+description: 文字エンコーディングを表します。
+type: docs
+weight: 143
+url: /ja/java/com.aspose.diagram/encoding/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Encoding
+```
+
+文字エンコーディングを表します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Encoding()](#Encoding--) |  |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Encoding other)](#equals-com.aspose.diagram.Encoding-) | 指定された Encoding オブジェクトが現在のインスタンスと等しいかどうかを判断します。 |
+| [equals(Object o)](#equals-java.lang.Object-) | 指定された Object が現在のインスタンスと等しいかどうかを判断します。 |
+| [getASCII()](#getASCII--) | ASCII（7 ビット）文字セット用のエンコーディングを取得します。 |
+| [getBigEndianUnicode()](#getBigEndianUnicode--) | ビッグエンディアン バイト順序を使用した UTF-16 形式のエンコーディングを取得します。 |
+| [getClass()](#getClass--) |  |
+| [getDefault()](#getDefault--) | オペレーティングシステムの現在の ANSI コードページ用のエンコーディングを取得します。 |
+| [getEncoding(int codePage)](#getEncoding-int-) | 指定されたコードページ識別子に関連付けられたエンコーディングを返します。 |
+| [getEncoding(String charsetName)](#getEncoding-java.lang.String-) | 指定された charset 名に関連付けられたエンコーディングを返します。 |
+| [getEncoding(Charset charset)](#getEncoding-java.nio.charset.Charset-) | 指定された charset オブジェクトに関連付けられたエンコーディングを返します。 |
+| [getUTF7()](#getUTF7--) | UTF-7 形式のエンコーディングを取得します。 |
+| [getUTF8()](#getUTF8--) | UTF-8 形式のエンコーディングを取得します。 |
+| [getUTF8NoBOM()](#getUTF8NoBOM--) | UTF-8 識別子なしの UTF-8 形式のエンコーディングを取得します。 |
+| [getUnicode()](#getUnicode--) | リトルエンディアン バイト順序を使用した UTF-16 形式のエンコーディングを取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Encoding() {#Encoding--}
+```
+public Encoding()
+```
+
+
+### equals(Encoding other) {#equals-com.aspose.diagram.Encoding-}
+```
+public boolean equals(Encoding other)
+```
+
+
+指定された Encoding オブジェクトが現在のインスタンスと等しいかどうかを判断します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| other | [Encoding](../../com.aspose.diagram/encoding) | 現在のインスタンスと比較する Encoding オブジェクトです。 |
+
+**Returns:**
+boolean - 値が現在のインスタンスと等しい場合は true、そうでない場合は false。
+### equals(Object o) {#equals-java.lang.Object-}
+```
+public boolean equals(Object o)
+```
+
+
+指定された Object が現在のインスタンスと等しいかどうかを判断します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| o | java.lang.Object | 現在のインスタンスと比較するオブジェクト。 |
+
+**Returns:**
+boolean - 値が Encoding のインスタンスであり現在のインスタンスと等しい場合は true、そうでない場合は false。
+### getASCII() {#getASCII--}
+```
+public static Encoding getASCII()
+```
+
+
+ASCII（7 ビット）文字セット用のエンコーディングを取得します。
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - A Encoding object for the ASCII (7-bit) character set.
+### getBigEndianUnicode() {#getBigEndianUnicode--}
+```
+public static Encoding getBigEndianUnicode()
+```
+
+
+ビッグエンディアン バイト順序を使用した UTF-16 形式のエンコーディングを取得します。
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - A Encoding object for the UTF-16 format using the big endian byte
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefault() {#getDefault--}
+```
+public static Encoding getDefault()
+```
+
+
+オペレーティングシステムの現在の ANSI コードページ用のエンコーディングを取得します。
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - An encoding for the operating system's current ANSI code page.
+### getEncoding(int codePage) {#getEncoding-int-}
+```
+public static Encoding getEncoding(int codePage)
+```
+
+
+指定されたコードページ識別子に関連付けられたエンコーディングを返します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| codePage | int | 優先エンコーディングのコードページ識別子。-or- 0 はデフォルトエンコーディングを使用します。 |
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - The Encoding object associated with the specified code page.
+### getEncoding(String charsetName) {#getEncoding-java.lang.String-}
+```
+public static Encoding getEncoding(String charsetName)
+```
+
+
+指定された charset 名に関連付けられたエンコーディングを返します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| charsetName | java.lang.String | 指定された文字セット名 |
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - The Encoding object associated with the specified charset name.
+### getEncoding(Charset charset) {#getEncoding-java.nio.charset.Charset-}
+```
+public static Encoding getEncoding(Charset charset)
+```
+
+
+指定された charset オブジェクトに関連付けられたエンコーディングを返します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| charset | java.nio.charset.Charset | 指定された文字セットオブジェクト |
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - The Encoding object associated with the specified charset object.
+### getUTF7() {#getUTF7--}
+```
+public static Encoding getUTF7()
+```
+
+
+UTF-7 形式のエンコーディングを取得します。
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - A Encoding object for the UTF-7 format.
+### getUTF8() {#getUTF8--}
+```
+public static Encoding getUTF8()
+```
+
+
+UTF-8 形式のエンコーディングを取得します。
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - A Encoding object for the UTF-8 format.
+### getUTF8NoBOM() {#getUTF8NoBOM--}
+```
+public static Encoding getUTF8NoBOM()
+```
+
+
+UTF-8 識別子なしの UTF-8 形式のエンコーディングを取得します。
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - A Encoding object for the UTF-8 format without UTF-8 identifier.
+### getUnicode() {#getUnicode--}
+```
+public static Encoding getUnicode()
+```
+
+
+リトルエンディアン バイト順序を使用した UTF-16 形式のエンコーディングを取得します。
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - A Encoding object for the UTF-16 format using the little endian byte
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/event/_index.md
+++ b/japanese/java/com.aspose.diagram/event/_index.md
@@ -1,0 +1,311 @@
+---
+title: イベント
+second_title: Aspose.Diagram for Java API リファレンス
+description: シェイプ イベントを制御する数式を指定する要素を含みます。
+type: docs
+weight: 144
+url: /ja/java/com.aspose.diagram/event/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Event
+```
+
+シェイプ イベントを制御する数式を指定する要素を含みます。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getEventDblClick()](#getEventDblClick--) | シェイプがダブルクリックされたときに評価されるイベント要素です。 |
+| [getEventDrop()](#getEventDrop--) | シェイプが描画ページにドロップされたとき（インスタンスとして、またはシェイプが複製または貼り付けされたとき）に評価されるイベント要素です。 |
+| [getEventMultiDrop()](#getEventMultiDrop--) | EventMultiDrop。 |
+| [getEventXFMod()](#getEventXFMod--) | ページ上でシェイプの位置または向きが変換されたときに評価されるイベント要素です。 |
+| [getTheData()](#getTheData--) | 将来の使用のために予約されています。 |
+| [getTheText()](#getTheText--) | シェイプのテキストまたはテキスト構成が変更されたときに評価されるイベント要素です。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | このプロパティの説明については、[getDel()](../../com.aspose.diagram/event\#getDel--) を参照してください。 |
+| [setEventDblClick(DoubleValue value)](#setEventDblClick-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getEventDblClick()](../../com.aspose.diagram/event\#getEventDblClick--) を参照してください。 |
+| [setEventDrop(DoubleValue value)](#setEventDrop-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getEventDrop()](../../com.aspose.diagram/event\#getEventDrop--) を参照してください。 |
+| [setEventMultiDrop(DoubleValue value)](#setEventMultiDrop-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getEventMultiDrop()](../../com.aspose.diagram/event\#getEventMultiDrop--) を参照してください。 |
+| [setEventXFMod(DoubleValue value)](#setEventXFMod-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getEventXFMod()](../../com.aspose.diagram/event\#getEventXFMod--) を参照してください。 |
+| [setTheData(DoubleValue value)](#setTheData-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getTheData()](../../com.aspose.diagram/event\#getTheData--) を参照してください。 |
+| [setTheText(DoubleValue value)](#setTheText-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getTheText()](../../com.aspose.diagram/event\#getTheText--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getEventDblClick() {#getEventDblClick--}
+```
+public DoubleValue getEventDblClick()
+```
+
+
+シェイプがダブルクリックされたときに評価されるイベント要素です。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getEventDrop() {#getEventDrop--}
+```
+public DoubleValue getEventDrop()
+```
+
+
+シェイプが描画ページにドロップされたとき（インスタンスとして、またはシェイプが複製または貼り付けされたとき）に評価されるイベント要素です。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getEventMultiDrop() {#getEventMultiDrop--}
+```
+public DoubleValue getEventMultiDrop()
+```
+
+
+EventMultiDrop。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getEventXFMod() {#getEventXFMod--}
+```
+public DoubleValue getEventXFMod()
+```
+
+
+ページ上でシェイプの位置または向きが変換されたときに評価されるイベント要素です。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTheData() {#getTheData--}
+```
+public DoubleValue getTheData()
+```
+
+
+将来の使用のために予約されています。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTheText() {#getTheText--}
+```
+public DoubleValue getTheText()
+```
+
+
+シェイプのテキストまたはテキスト構成が変更されたときに評価されるイベント要素です。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+このプロパティの説明については、[getDel()](../../com.aspose.diagram/event\#getDel--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setEventDblClick(DoubleValue value) {#setEventDblClick-com.aspose.diagram.DoubleValue-}
+```
+public void setEventDblClick(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getEventDblClick()](../../com.aspose.diagram/event\#getEventDblClick--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setEventDrop(DoubleValue value) {#setEventDrop-com.aspose.diagram.DoubleValue-}
+```
+public void setEventDrop(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getEventDrop()](../../com.aspose.diagram/event\#getEventDrop--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setEventMultiDrop(DoubleValue value) {#setEventMultiDrop-com.aspose.diagram.DoubleValue-}
+```
+public void setEventMultiDrop(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getEventMultiDrop()](../../com.aspose.diagram/event\#getEventMultiDrop--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setEventXFMod(DoubleValue value) {#setEventXFMod-com.aspose.diagram.DoubleValue-}
+```
+public void setEventXFMod(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getEventXFMod()](../../com.aspose.diagram/event\#getEventXFMod--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTheData(DoubleValue value) {#setTheData-com.aspose.diagram.DoubleValue-}
+```
+public void setTheData(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getTheData()](../../com.aspose.diagram/event\#getTheData--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTheText(DoubleValue value) {#setTheText-com.aspose.diagram.DoubleValue-}
+```
+public void setTheText(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getTheText()](../../com.aspose.diagram/event\#getTheText--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/eventitem/_index.md
+++ b/japanese/java/com.aspose.diagram/eventitem/_index.md
@@ -1,0 +1,288 @@
+---
+title: EventItem
+second_title: Aspose.Diagram for Java API リファレンス
+description: イベント コードをカプセル化します。
+type: docs
+weight: 145
+url: /ja/java/com.aspose.diagram/eventitem/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class EventItem
+```
+
+イベントコードをカプセル化します。EventItem 要素は 2 種類のアクションをトリガーできます：アドオンを実行するか、イベントの通知を呼び出し元プログラムに送信するかです。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [EventItem()](#EventItem--) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAction()](#getAction--) | 親の EventItem 要素のアクションコードを指定します。EventItem 要素を DatadiagramML ファイルに保存するには、永続可能である必要があります。 |
+| [getClass()](#getClass--) |  |
+| [getEnabled()](#getEnabled--) | イベントが有効か無効かを示すフラグを表します。 |
+| [getEventCode()](#getEventCode--) | アドオンをトリガーするイベントを示すコードです。 |
+| [getID()](#getID--) | イベントの ID です。 |
+| [getTarget()](#getTarget--) | イベントの対象を指定します。 |
+| [getTargetArgs()](#getTargetArgs--) | イベントの対象に送信される引数を含む文字列を指定します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAction(int value)](#setAction-int-) | このプロパティの説明については、[getAction()](../../com.aspose.diagram/eventitem\#getAction--) を参照してください。 |
+| [setEnabled(int value)](#setEnabled-int-) | このプロパティの説明については、[getEnabled()](../../com.aspose.diagram/eventitem\#getEnabled--) を参照してください。 |
+| [setEventCode(int value)](#setEventCode-int-) | このプロパティの説明については、[getEventCode()](../../com.aspose.diagram/eventitem\#getEventCode--) を参照してください。 |
+| [setID(int value)](#setID-int-) | このプロパティの説明については、[getID()](../../com.aspose.diagram/eventitem\#getID--) を参照してください。 |
+| [setTarget(String value)](#setTarget-java.lang.String-) | このプロパティの説明については、[getTarget()](../../com.aspose.diagram/eventitem\#getTarget--) を参照してください。 |
+| [setTargetArgs(String value)](#setTargetArgs-java.lang.String-) | このプロパティの説明については、[getTargetArgs()](../../com.aspose.diagram/eventitem\#getTargetArgs--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### EventItem() {#EventItem--}
+```
+public EventItem()
+```
+
+
+コンストラクタ。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAction() {#getAction--}
+```
+public int getAction()
+```
+
+
+親の EventItem 要素のアクションコードを指定します。EventItem 要素を DatadiagramML ファイルに保存するには、永続可能である必要があります。現在、永続可能なイベントが持つことができる唯一の有効なアクションコードは 1（ONEVENT_ACT_RUNADDON）です。
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getEnabled() {#getEnabled--}
+```
+public int getEnabled()
+```
+
+
+イベントが有効か無効かを示すフラグを表します。
+
+**Returns:**
+int
+### getEventCode() {#getEventCode--}
+```
+public int getEventCode()
+```
+
+
+アドオンをトリガーするイベントを示すコードです。イベントコードの詳細については、Microsoft Visio 2007 Automation Reference の Event Codes を参照してください。
+
+**Returns:**
+int
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+イベントの ID です。
+
+**Returns:**
+int
+### getTarget() {#getTarget--}
+```
+public String getTarget()
+```
+
+
+イベントの対象を指定します。
+
+**Returns:**
+java.lang.String
+### getTargetArgs() {#getTargetArgs--}
+```
+public String getTargetArgs()
+```
+
+
+イベントの対象に送信される引数を含む文字列を指定します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAction(int value) {#setAction-int-}
+```
+public void setAction(int value)
+```
+
+
+このプロパティの説明については、[getAction()](../../com.aspose.diagram/eventitem\#getAction--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setEnabled(int value) {#setEnabled-int-}
+```
+public void setEnabled(int value)
+```
+
+
+このプロパティの説明については、[getEnabled()](../../com.aspose.diagram/eventitem\#getEnabled--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setEventCode(int value) {#setEventCode-int-}
+```
+public void setEventCode(int value)
+```
+
+
+このプロパティの説明については、[getEventCode()](../../com.aspose.diagram/eventitem\#getEventCode--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+このプロパティの説明については、[getID()](../../com.aspose.diagram/eventitem\#getID--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setTarget(String value) {#setTarget-java.lang.String-}
+```
+public void setTarget(String value)
+```
+
+
+このプロパティの説明については、[getTarget()](../../com.aspose.diagram/eventitem\#getTarget--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setTargetArgs(String value) {#setTargetArgs-java.lang.String-}
+```
+public void setTargetArgs(String value)
+```
+
+
+このプロパティの説明については、[getTargetArgs()](../../com.aspose.diagram/eventitem\#getTargetArgs--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/eventitemcollection/_index.md
+++ b/japanese/java/com.aspose.diagram/eventitemcollection/_index.md
@@ -1,0 +1,231 @@
+---
+title: EventItemCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: EventItem コレクションです。
+type: docs
+weight: 146
+url: /ja/java/com.aspose.diagram/eventitemcollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class EventItemCollection extends Collection
+```
+
+EventItem コレクションです。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [EventItemCollection()](#EventItemCollection--) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(EventItem eventItem)](#add-com.aspose.diagram.EventItem-) | コレクションに eventItem を追加します。 |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(EventItem eventItem)](#remove-com.aspose.diagram.EventItem-) | コレクションから eventItem を削除します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### EventItemCollection() {#EventItemCollection--}
+```
+public EventItemCollection()
+```
+
+
+コンストラクタ。
+
+### add(EventItem eventItem) {#add-com.aspose.diagram.EventItem-}
+```
+public int add(EventItem eventItem)
+```
+
+
+コレクションに eventItem を追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| eventItem | [EventItem](../../com.aspose.diagram/eventitem) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public EventItem get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[EventItem](../../com.aspose.diagram/eventitem) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(EventItem eventItem) {#remove-com.aspose.diagram.EventItem-}
+```
+public void remove(EventItem eventItem)
+```
+
+
+コレクションから eventItem を削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| eventItem | [EventItem](../../com.aspose.diagram/eventitem) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/field/_index.md
+++ b/japanese/java/com.aspose.diagram/field/_index.md
@@ -1,0 +1,309 @@
+---
+title: Field
+second_title: Aspose.Diagram for Java API リファレンス
+description: シェイプのテキストに挿入された関数や数式を指定する要素を含みます。
+type: docs
+weight: 147
+url: /ja/java/com.aspose.diagram/field/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Field
+```
+
+シェイプのテキストに挿入された関数と数式を指定する要素を含みます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Field()](#Field--) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCalendar()](#getCalendar--) | カスタム プロパティ、テキスト フィールド、要素の数式に使用されるカレンダーを決定します。 |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getDisplayValue()](#getDisplayValue--) | このフィールドの書式設定された文字列値を取得します。 |
+| [getEditMode()](#getEditMode--) | 将来の使用のために予約されています。 |
+| [getFormat()](#getFormat--) | Format 要素は、文字列、数値、日付または時刻、期間、通貨のテキスト フィールドの書式設定を指定します。 |
+| [getIX()](#getIX--) | 親要素内の要素のゼロベースインデックスです。 |
+| [getObjectKind()](#getObjectKind--) | テキスト フィールドのタイプを示します。 |
+| [getType()](#getType--) | Type はテキスト フィールドの値のデータ型を指定します。 |
+| [getUICat()](#getUICat--) | Visio 2000 より前の Microsoft Visio バージョンで挿入されたフィールドのカテゴリを指定します。 |
+| [getUICod()](#getUICod--) | Visio 2000 より前の Microsoft Visio バージョンで挿入されたフィールドのコードを指定します。 |
+| [getUIFmt()](#getUIFmt--) | Visio 2000 より前の Microsoft Visio バージョンで挿入されたフィールドの書式を指定します。 |
+| [getValue()](#getValue--) | テキスト フィールドの値を含みます。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | このプロパティの説明については、[getDel()](../../com.aspose.diagram/field\#getDel--) を参照してください。 |
+| [setIX(int value)](#setIX-int-) | このプロパティの説明については、[getIX()](../../com.aspose.diagram/field\#getIX--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Field() {#Field--}
+```
+public Field()
+```
+
+
+コンストラクタ。
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCalendar() {#getCalendar--}
+```
+public Calendar getCalendar()
+```
+
+
+カスタム プロパティ、テキスト フィールド、要素の数式に使用されるカレンダーを決定します。
+
+**Returns:**
+[Calendar](../../com.aspose.diagram/calendar)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getDisplayValue() {#getDisplayValue--}
+```
+public String getDisplayValue()
+```
+
+
+このフィールドの書式設定された文字列値を取得します。
+
+**Returns:**
+java.lang.String
+### getEditMode() {#getEditMode--}
+```
+public DoubleValue getEditMode()
+```
+
+
+将来の使用のために予約されています。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getFormat() {#getFormat--}
+```
+public Value getFormat()
+```
+
+
+Format 要素は、文字列、数値、日付または時刻、期間、または通貨であるテキストフィールドの書式設定を指定します。テキストフィールドのタイプは、対応する Type 要素で指定されます。
+
+**Returns:**
+[Value](../../com.aspose.diagram/value)
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+親要素内の要素のゼロベースインデックスです。
+
+**Returns:**
+int
+### getObjectKind() {#getObjectKind--}
+```
+public ObjectKind getObjectKind()
+```
+
+
+テキスト フィールドのタイプを示します。
+
+**Returns:**
+[ObjectKind](../../com.aspose.diagram/objectkind)
+### getType() {#getType--}
+```
+public TypeField getType()
+```
+
+
+Type はテキスト フィールドの値のデータ型を指定します。
+
+**Returns:**
+[TypeField](../../com.aspose.diagram/typefield)
+### getUICat() {#getUICat--}
+```
+public DoubleValue getUICat()
+```
+
+
+Visio 2000 より前の Microsoft Visio バージョンで挿入されたフィールドのカテゴリを指定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getUICod() {#getUICod--}
+```
+public DoubleValue getUICod()
+```
+
+
+Visio 2000 より前の Microsoft Visio バージョンで挿入されたフィールドのコードを指定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getUIFmt() {#getUIFmt--}
+```
+public DoubleValue getUIFmt()
+```
+
+
+Visio 2000 より前の Microsoft Visio バージョンで挿入されたフィールドの書式を指定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getValue() {#getValue--}
+```
+public Value getValue()
+```
+
+
+テキスト フィールドの値を含みます。
+
+**Returns:**
+[Value](../../com.aspose.diagram/value)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+このプロパティの説明については、[getDel()](../../com.aspose.diagram/field\#getDel--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+このプロパティの説明については、[getIX()](../../com.aspose.diagram/field\#getIX--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/fieldcollection/_index.md
+++ b/japanese/java/com.aspose.diagram/fieldcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: FieldCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: フィールド コレクション。
+type: docs
+weight: 148
+url: /ja/java/com.aspose.diagram/fieldcollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class FieldCollection extends Collection
+```
+
+フィールド コレクション。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(Field item)](#add-com.aspose.diagram.Field-) | Add the Field object in the collection. |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Field item)](#remove-com.aspose.diagram.Field-) | Remove the Field object from the collection. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Field item) {#add-com.aspose.diagram.Field-}
+```
+public int add(Field item)
+```
+
+
+Add the Field object in the collection.
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [Field](../../com.aspose.diagram/field) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Field get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[Field](../../com.aspose.diagram/field) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Field item) {#remove-com.aspose.diagram.Field-}
+```
+public void remove(Field item)
+```
+
+
+Remove the Field object from the collection.
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [Field](../../com.aspose.diagram/field) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/filefontsource/_index.md
+++ b/japanese/java/com.aspose.diagram/filefontsource/_index.md
@@ -1,0 +1,165 @@
+---
+title: FileFontSource
+second_title: Aspose.Diagram for Java API リファレンス
+description: ファイルシステムに保存されている単一の TrueType フォント ファイルを表します。
+type: docs
+weight: 149
+url: /ja/java/com.aspose.diagram/filefontsource/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.FontSourceBase](../../com.aspose.diagram/fontsourcebase)
+```
+public class FileFontSource extends FontSourceBase
+```
+
+ファイルシステムに保存されている単一の TrueType フォント ファイルを表します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [FileFontSource(String filePath)](#FileFontSource-java.lang.String-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFilePath()](#getFilePath--) | フォント ファイルへのパスです。 |
+| [getType()](#getType--) | フォントソースのタイプを返します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FileFontSource(String filePath) {#FileFontSource-java.lang.String-}
+```
+public FileFontSource(String filePath)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| filePath | java.lang.String | フォント ファイルへのパス |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFilePath() {#getFilePath--}
+```
+public String getFilePath()
+```
+
+
+フォント ファイルへのパスです。
+
+**Returns:**
+java.lang.String
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+フォントソースのタイプを返します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/fileformatinfo/_index.md
+++ b/japanese/java/com.aspose.diagram/fileformatinfo/_index.md
@@ -1,0 +1,158 @@
+---
+title: FileFormatInfo
+second_title: Aspose.Diagram for Java API リファレンス
+description: ファイル形式検出メソッドによって返されるデータを含みます。
+type: docs
+weight: 150
+url: /ja/java/com.aspose.diagram/fileformatinfo/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class FileFormatInfo
+```
+
+ファイル形式検出メソッドである [FileFormatUtil](../../com.aspose.diagram/fileformatutil) が返すデータを含みます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [FileFormatInfo()](#FileFormatInfo--) |  |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFileFormatType()](#getFileFormatType--) | 検出されたファイル形式を取得します。 |
+| [getLoadFormat()](#getLoadFormat--) | 検出されたロード形式を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FileFormatInfo() {#FileFormatInfo--}
+```
+public FileFormatInfo()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFileFormatType() {#getFileFormatType--}
+```
+public int getFileFormatType()
+```
+
+
+検出されたファイル形式を取得します。
+
+**Returns:**
+int
+### getLoadFormat() {#getLoadFormat--}
+```
+public int getLoadFormat()
+```
+
+
+検出されたロード形式を取得します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/fileformattype/_index.md
+++ b/japanese/java/com.aspose.diagram/fileformattype/_index.md
@@ -1,0 +1,570 @@
+---
+title: FileFormatType
+second_title: Aspose.Diagram for Java API リファレンス
+description: スプレッドシートのファイル形式タイプを列挙します。
+type: docs
+weight: 151
+url: /ja/java/com.aspose.diagram/fileformattype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class FileFormatType
+```
+
+スプレッドシートのファイル形式タイプを列挙します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [CSV](#CSV) | CSV ファイルを表します。 |
+| [DIF](#DIF) | データ交換フォーマット。 |
+| [DOC](#DOC) | doc ファイルを表します。 |
+| [DOCM](#DOCM) | docm ファイルを表します。 |
+| [DOCX](#DOCX) | docx ファイルを表します。 |
+| [DOTM](#DOTM) | dotm ファイルを表します。 |
+| [DOTX](#DOTX) | dotx ファイルを表します。 |
+| [EXCEL_2003_XML](#EXCEL-2003-XML) | Excel 2003 xml ファイルを表します。 |
+| [EXCEL_97_TO_2003](#EXCEL-97-TO-2003) | Excel97-2003 xls ファイルを表します。 |
+| [HTML](#HTML) | html ファイルを表します。 |
+| [MAPI_MESSAGE](#MAPI-MESSAGE) | メール ファイルを表します。 |
+| [MS_EQUATION](#MS-EQUATION) | MS Equation 3.0 オブジェクトを表します。 |
+| [ODS](#ODS) | ods ファイルを表します。 |
+| [OLE_10_NATIVE](#OLE-10-NATIVE) | 埋め込みネイティブオブジェクトを表します。 |
+| [OOXML](#OOXML) | Office Open XML ファイル（例：xlsx、docx、pptx など）を表します。 |
+| [PDF](#PDF) | Pdf ファイルを表します。 |
+| [POTM](#POTM) | Potm ファイルを表します。 |
+| [POTX](#POTX) | Potx ファイルを表します。 |
+| [PPSM](#PPSM) | ppsm ファイルを表します。 |
+| [PPSX](#PPSX) | ppsx ファイルを表します。 |
+| [PPT](#PPT) | ppt ファイルを表します。 |
+| [PPTM](#PPTM) | pptm ファイルを表します。 |
+| [PPTX](#PPTX) | pptx ファイルを表します。 |
+| [SLDX](#SLDX) | sldx ファイルを表します。 |
+| [SVG](#SVG) | svg ファイルを表します。 |
+| [TAB_DELIMITED](#TAB-DELIMITED) | タブ区切りテキストファイルを表します。 |
+| [TIFF](#TIFF) | TIFF ファイルを表します。 |
+| [UNKNOWN](#UNKNOWN) | 認識できない形式を表します。読み込めません。 |
+| [VDW](#VDW) | MS Visio VDW Web 描画形式。 |
+| [VDX](#VDX) | MS Visio VDX XML 形式。 |
+| [VSD](#VSD) | MS Visio VSD バイナリ形式。 |
+| [VSDM](#VSDM) | MS Visio 2013 VSDM ファイル形式。 |
+| [VSDX](#VSDX) | MS Visio 2013 VSDX ファイル形式。 |
+| [VSS](#VSS) | MS Visio VSS バイナリステンシル形式。 |
+| [VSSM](#VSSM) | MS Visio 2013 VSSM ファイル形式。 |
+| [VSSX](#VSSX) | MS Visio 2013 VSSX ファイル形式。 |
+| [VST](#VST) | MS Visio VST バイナリテンプレート形式。 |
+| [VSTM](#VSTM) | MS Visio 2013 VSTM ファイル形式。 |
+| [VSTX](#VSTX) | MS Visio 2013 VSTX テンプレートファイル形式。 |
+| [VSX](#VSX) | MS Visio VSX XML ステンシル形式。 |
+| [VTX](#VTX) | MS Visio VTX XML テンプレート形式。 |
+| [XLAM](#XLAM) | addinMacro 対応テンプレート xltm ファイルを表します。 |
+| [XLSB](#XLSB) | xlsb ファイルを表します。 |
+| [XLSM](#XLSM) | xlsm ファイルを表します。マクロが有効です。 |
+| [XLSX](#XLSX) | xlsx ファイルを表します。 |
+| [XLTM](#XLTM) | マクロ対応テンプレート xltm ファイルを表します。 |
+| [XLTX](#XLTX) | テンプレート xltx ファイルを表します。 |
+| [XML](#XML) | シンプルな XML ファイルを表します。 |
+| [XPS](#XPS) | XPS ファイルを表します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CSV {#CSV}
+```
+public static final int CSV
+```
+
+
+CSV ファイルを表します。ファイル形式はサポートされていません。検出のみのためのファイルタイプです。
+
+### DIF {#DIF}
+```
+public static final int DIF
+```
+
+
+データ交換フォーマット。
+
+### DOC {#DOC}
+```
+public static final int DOC
+```
+
+
+doc ファイルを表します。ファイル形式はサポートされていません。検出のみのためのファイルタイプです。
+
+### DOCM {#DOCM}
+```
+public static final int DOCM
+```
+
+
+docm ファイルを表します。ファイル形式はサポートされていません。検出のみのためのファイルタイプです。
+
+### DOCX {#DOCX}
+```
+public static final int DOCX
+```
+
+
+docx ファイルを表します。ファイル形式はサポートされていません。検出のみのためのファイルタイプです。
+
+### DOTM {#DOTM}
+```
+public static final int DOTM
+```
+
+
+dotm ファイルを表します。ファイル形式はサポートされていません。検出のみのためのファイルタイプです。
+
+### DOTX {#DOTX}
+```
+public static final int DOTX
+```
+
+
+dotx ファイルを表します。ファイル形式はサポートされていません。検出のみのためのファイルタイプです。
+
+### EXCEL_2003_XML {#EXCEL-2003-XML}
+```
+public static final int EXCEL_2003_XML
+```
+
+
+Excel 2003 XML ファイルを表します。ファイル形式はサポートされていません。検出のみのためのファイルタイプです。
+
+### EXCEL_97_TO_2003 {#EXCEL-97-TO-2003}
+```
+public static final int EXCEL_97_TO_2003
+```
+
+
+Excel97-2003 xls ファイルを表します。ファイル形式はサポートされていません。ファイルタイプの検出のみです。
+
+### HTML {#HTML}
+```
+public static final int HTML
+```
+
+
+html ファイルを表します。
+
+### MAPI_MESSAGE {#MAPI-MESSAGE}
+```
+public static final int MAPI_MESSAGE
+```
+
+
+メールファイルを表します。ファイル形式はサポートされていません。ファイルタイプの検出のみです。
+
+### MS_EQUATION {#MS-EQUATION}
+```
+public static final int MS_EQUATION
+```
+
+
+MS Equation 3.0 オブジェクトを表します。ファイル形式はサポートされていません。ファイルタイプの検出のみです。
+
+### ODS {#ODS}
+```
+public static final int ODS
+```
+
+
+ods ファイルを表します。ファイル形式はサポートされていません。ファイルタイプの検出のみです。
+
+### OLE_10_NATIVE {#OLE-10-NATIVE}
+```
+public static final int OLE_10_NATIVE
+```
+
+
+埋め込みネイティブオブジェクトを表します。ファイル形式はサポートされていません。ファイルタイプの検出のみです。
+
+### OOXML {#OOXML}
+```
+public static final int OOXML
+```
+
+
+office open xml ファイル（xlsx、docx、pptx など）を表します。ファイル形式はサポートされていません。ファイルタイプの検出のみです。office open xml ファイルが暗号化されている場合、xlsx、docx、pptx などとして検出できません。
+
+### PDF {#PDF}
+```
+public static final int PDF
+```
+
+
+Pdf ファイルを表します。
+
+### POTM {#POTM}
+```
+public static final int POTM
+```
+
+
+Potm ファイルを表します。ファイル形式はサポートされていません。ファイルタイプの検出のみです。
+
+### POTX {#POTX}
+```
+public static final int POTX
+```
+
+
+Potx ファイルを表します。ファイル形式はサポートされていません。ファイルタイプの検出のみです。
+
+### PPSM {#PPSM}
+```
+public static final int PPSM
+```
+
+
+ppsm ファイルを表します。ファイル形式はサポートされていません。ファイルタイプの検出のみです。
+
+### PPSX {#PPSX}
+```
+public static final int PPSX
+```
+
+
+ppsx ファイルを表します。ファイル形式はサポートされていません。ファイルタイプの検出のみです。
+
+### PPT {#PPT}
+```
+public static final int PPT
+```
+
+
+ppt ファイルを表します。ファイル形式はサポートされていません。ファイルタイプの検出のみです。
+
+### PPTM {#PPTM}
+```
+public static final int PPTM
+```
+
+
+pptm ファイルを表します。ファイル形式はサポートされていません。ファイルタイプの検出のみです。
+
+### PPTX {#PPTX}
+```
+public static final int PPTX
+```
+
+
+pptx ファイルを表します。ファイル形式はサポートされていません。ファイルタイプの検出のみです。
+
+### SLDX {#SLDX}
+```
+public static final int SLDX
+```
+
+
+sldx ファイルを表します。ファイル形式はサポートされていません。ファイルタイプの検出のみです。
+
+### SVG {#SVG}
+```
+public static final int SVG
+```
+
+
+svg ファイルを表します。
+
+### TAB_DELIMITED {#TAB-DELIMITED}
+```
+public static final int TAB_DELIMITED
+```
+
+
+タブ区切りテキストファイルを表します。ファイル形式はサポートされていません。ファイルタイプの検出のみです。
+
+### TIFF {#TIFF}
+```
+public static final int TIFF
+```
+
+
+TIFF ファイルを表します。
+
+### UNKNOWN {#UNKNOWN}
+```
+public static final int UNKNOWN
+```
+
+
+認識できない形式を表します。読み込めません。
+
+### VDW {#VDW}
+```
+public static final int VDW
+```
+
+
+MS Visio VDW Web 描画形式。
+
+### VDX {#VDX}
+```
+public static final int VDX
+```
+
+
+MS Visio VDX XML 形式。
+
+### VSD {#VSD}
+```
+public static final int VSD
+```
+
+
+MS Visio VSD バイナリ形式。
+
+### VSDM {#VSDM}
+```
+public static final int VSDM
+```
+
+
+MS Visio 2013 VSDM ファイル形式。
+
+### VSDX {#VSDX}
+```
+public static final int VSDX
+```
+
+
+MS Visio 2013 VSDX ファイル形式。
+
+### VSS {#VSS}
+```
+public static final int VSS
+```
+
+
+MS Visio VSS バイナリステンシル形式。
+
+### VSSM {#VSSM}
+```
+public static final int VSSM
+```
+
+
+MS Visio 2013 VSSM ファイル形式。
+
+### VSSX {#VSSX}
+```
+public static final int VSSX
+```
+
+
+MS Visio 2013 VSSX ファイル形式。
+
+### VST {#VST}
+```
+public static final int VST
+```
+
+
+MS Visio VST バイナリテンプレート形式。
+
+### VSTM {#VSTM}
+```
+public static final int VSTM
+```
+
+
+MS Visio 2013 VSTM ファイル形式。
+
+### VSTX {#VSTX}
+```
+public static final int VSTX
+```
+
+
+MS Visio 2013 VSTX テンプレートファイル形式。
+
+### VSX {#VSX}
+```
+public static final int VSX
+```
+
+
+MS Visio VSX XML ステンシル形式。
+
+### VTX {#VTX}
+```
+public static final int VTX
+```
+
+
+MS Visio VTX XML テンプレート形式。
+
+### XLAM {#XLAM}
+```
+public static final int XLAM
+```
+
+
+addinMacro-enabled テンプレート xltm ファイルを表します。ファイル形式はサポートされていません。ファイルタイプの検出のみです。
+
+### XLSB {#XLSB}
+```
+public static final int XLSB
+```
+
+
+xlsb ファイルを表します。ファイル形式はサポートされていません。ファイルタイプの検出のみです。
+
+### XLSM {#XLSM}
+```
+public static final int XLSM
+```
+
+
+xlsm ファイル（マクロ有効）を表します。ファイル形式はサポートされていません。ファイルタイプの検出のみです。
+
+### XLSX {#XLSX}
+```
+public static final int XLSX
+```
+
+
+xlsx ファイルを表します。ファイル形式はサポートされていません。ファイルタイプの検出のみです。
+
+### XLTM {#XLTM}
+```
+public static final int XLTM
+```
+
+
+マクロ有効テンプレート xltm ファイルを表します。ファイル形式はサポートされていません。ファイルタイプの検出のみです。
+
+### XLTX {#XLTX}
+```
+public static final int XLTX
+```
+
+
+テンプレート xltx ファイルを表します。ファイル形式はサポートされていません。ファイルタイプの検出のみです。
+
+### XML {#XML}
+```
+public static final int XML
+```
+
+
+シンプルな XML ファイルを表します。ファイル形式はサポートされていません。ファイルタイプの検出のみです。
+
+### XPS {#XPS}
+```
+public static final int XPS
+```
+
+
+XPS ファイルを表します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/fileformatutil/_index.md
+++ b/japanese/java/com.aspose.diagram/fileformatutil/_index.md
@@ -1,0 +1,168 @@
+---
+title: FileFormatUtil
+second_title: Aspose.Diagram for Java API リファレンス
+description: ファイル形式列挙体を文字列またはファイル拡張子に変換し、逆変換するユーティリティ メソッドを提供します。
+type: docs
+weight: 152
+url: /ja/java/com.aspose.diagram/fileformatutil/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class FileFormatUtil
+```
+
+ファイル形式列挙体を文字列またはファイル拡張子に変換し、逆変換するユーティリティ メソッドを提供します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [FileFormatUtil()](#FileFormatUtil--) |  |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [detectFileFormat(InputStream stream)](#detectFileFormat-java.io.InputStream-) | ストリームに格納された Visio の形式に関する情報を検出し、返します。 |
+| [detectFileFormat(String filePath)](#detectFileFormat-java.lang.String-) | ファイルに格納された Visio の形式に関する情報を検出し、返します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FileFormatUtil() {#FileFormatUtil--}
+```
+public FileFormatUtil()
+```
+
+
+### detectFileFormat(InputStream stream) {#detectFileFormat-java.io.InputStream-}
+```
+public static FileFormatInfo detectFileFormat(InputStream stream)
+```
+
+
+ストリームに格納された Visio の形式に関する情報を検出し、返します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ストリーム | java.io.InputStream | ストリーム |
+
+**Returns:**
+[FileFormatInfo](../../com.aspose.diagram/fileformatinfo) - A [FileFormatInfo](../../com.aspose.diagram/fileformatinfo) object that contains the detected information.
+### detectFileFormat(String filePath) {#detectFileFormat-java.lang.String-}
+```
+public static FileFormatInfo detectFileFormat(String filePath)
+```
+
+
+ファイルに格納された Visio の形式に関する情報を検出し、返します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| filePath | java.lang.String | ファイルパス。 |
+
+**Returns:**
+[FileFormatInfo](../../com.aspose.diagram/fileformatinfo) - A [FileFormatInfo](../../com.aspose.diagram/fileformatinfo) object that contains the detected information.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/fill/_index.md
+++ b/japanese/java/com.aspose.diagram/fill/_index.md
@@ -1,0 +1,597 @@
+---
+title: 塗りつぶし
+second_title: Aspose.Diagram for Java API リファレンス
+description: シェイプとシェイプのドロップシャドウの現在の塗りつぶし書式設定値を含み、パターンの前景色と背景色を含みます。
+type: docs
+weight: 153
+url: /ja/java/com.aspose.diagram/fill/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Fill
+```
+
+シェイプとシェイプのドロップシャドウの現在の塗りつぶし書式設定値を含み、パターン、前景色、背景色が含まれます。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getFillBkgnd()](#getFillBkgnd--) | シェイプの塗りつぶしパターンの背景に使用される色を指定します。 |
+| [getFillBkgndTrans()](#getFillBkgndTrans--) | シェイプの塗りつぶしパターンの背景（塗り）色の透明度レベルを指定します。0（完全に不透明）から1（完全に透明）までです。 |
+| [getFillForegnd()](#getFillForegnd--) | シェイプの塗りつぶしパターンの前景（ストローク）に使用される色を指定します。 |
+| [getFillForegndTrans()](#getFillForegndTrans--) | シェイプの塗りつぶしパターンの前景（塗り）色の透明度レベルを指定します。0（完全に不透明）から1（完全に透明）までです。 |
+| [getFillPattern()](#getFillPattern--) | シェイプの塗りつぶしパターンを指定します。 |
+| [getGradientFill()](#getGradientFill--) | シェイプの現在のグラデーション塗りつぶし書式設定値を含みます。 |
+| [getShapeShdwBlur()](#getShapeShdwBlur--) | シェイプの影のぼかしサイズを指定します。 |
+| [getShapeShdwObliqueAngle()](#getShapeShdwObliqueAngle--) | シェイプの影の斜め方向の角度を指定します。 |
+| [getShapeShdwOffsetX()](#getShapeShdwOffsetX--) | シェイプの影がシェイプから水平方向にオフセットされる距離（ページ単位）を決定します。 |
+| [getShapeShdwOffsetY()](#getShapeShdwOffsetY--) | シェイプの影がシェイプから垂直方向にオフセットされる距離（ページ単位）を決定します。 |
+| [getShapeShdwScaleFactor()](#getShapeShdwScaleFactor--) | シェイプの影を拡大または縮小できる割合（パーセンテージ）を指定します。 |
+| [getShapeShdwShow()](#getShapeShdwShow--) | シェイプの影のタイプを指定します。 |
+| [getShapeShdwType()](#getShapeShdwType--) | シェイプの影のタイプを指定します。 |
+| [getShdwBkgnd()](#getShdwBkgnd--) | シェイプのドロップシャドウ塗りつぶしパターンの背景（塗り）に使用される色を指定します。 |
+| [getShdwBkgndTrans()](#getShdwBkgndTrans--) | シェイプのドロップシャドウ塗りつぶしパターンの背景（塗り）の透明度レベルを指定します。0.0（完全に不透明）から1.0（完全に透明）までです。 |
+| [getShdwForegnd()](#getShdwForegnd--) | シェイプのドロップシャドウ塗りつぶしパターンの前景（ストローク）に使用される色を指定します。 |
+| [getShdwForegndTrans()](#getShdwForegndTrans--) | シェイプのドロップシャドウ塗りつぶしパターンの前景（ストローク）の透明度レベルを指定します。0.0（完全に不透明）から1.0（完全に透明）までです。 |
+| [getShdwPattern()](#getShdwPattern--) | シェイプの影の塗りつぶしパターンを指定します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | このプロパティの説明については、[getDel()](../../com.aspose.diagram/fill\#getDel--)をご覧ください。 |
+| [setFillBkgnd(ColorValue value)](#setFillBkgnd-com.aspose.diagram.ColorValue-) | このプロパティの説明については、[getFillBkgnd()](../../com.aspose.diagram/fill\#getFillBkgnd--)をご覧ください。 |
+| [setFillBkgndTrans(DoubleValue value)](#setFillBkgndTrans-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getFillBkgndTrans()](../../com.aspose.diagram/fill\#getFillBkgndTrans--)をご覧ください。 |
+| [setFillForegnd(ColorValue value)](#setFillForegnd-com.aspose.diagram.ColorValue-) | このプロパティの説明については、[getFillForegnd()](../../com.aspose.diagram/fill\#getFillForegnd--)をご覧ください。 |
+| [setFillForegndTrans(DoubleValue value)](#setFillForegndTrans-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getFillForegndTrans()](../../com.aspose.diagram/fill\#getFillForegndTrans--)をご覧ください。 |
+| [setFillPattern(IntValue value)](#setFillPattern-com.aspose.diagram.IntValue-) | このプロパティの説明については、[getFillPattern()](../../com.aspose.diagram/fill\#getFillPattern--)をご覧ください。 |
+| [setShapeShdwBlur(DoubleValue value)](#setShapeShdwBlur-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getShapeShdwBlur()](../../com.aspose.diagram/fill\#getShapeShdwBlur--)をご覧ください。 |
+| [setShapeShdwObliqueAngle(DoubleValue value)](#setShapeShdwObliqueAngle-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getShapeShdwObliqueAngle()](../../com.aspose.diagram/fill\#getShapeShdwObliqueAngle--)をご覧ください。 |
+| [setShapeShdwOffsetX(DoubleValue value)](#setShapeShdwOffsetX-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getShapeShdwOffsetX()](../../com.aspose.diagram/fill\#getShapeShdwOffsetX--) をご覧ください。 |
+| [setShapeShdwOffsetY(DoubleValue value)](#setShapeShdwOffsetY-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getShapeShdwOffsetY()](../../com.aspose.diagram/fill\#getShapeShdwOffsetY--) をご覧ください。 |
+| [setShapeShdwScaleFactor(DoubleValue value)](#setShapeShdwScaleFactor-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getShapeShdwScaleFactor()](../../com.aspose.diagram/fill\#getShapeShdwScaleFactor--) をご覧ください。 |
+| [setShapeShdwShow(ShapeShdwShow value)](#setShapeShdwShow-com.aspose.diagram.ShapeShdwShow-) | このプロパティの説明については、[getShapeShdwShow()](../../com.aspose.diagram/fill\#getShapeShdwShow--) をご覧ください。 |
+| [setShapeShdwType(ShapeShdwType value)](#setShapeShdwType-com.aspose.diagram.ShapeShdwType-) | このプロパティの説明については、[getShapeShdwType()](../../com.aspose.diagram/fill\#getShapeShdwType--) をご覧ください。 |
+| [setShdwBkgnd(ColorValue value)](#setShdwBkgnd-com.aspose.diagram.ColorValue-) | このプロパティの説明については、[getShdwBkgnd()](../../com.aspose.diagram/fill\#getShdwBkgnd--) をご覧ください。 |
+| [setShdwBkgndTrans(DoubleValue value)](#setShdwBkgndTrans-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getShdwBkgndTrans()](../../com.aspose.diagram/fill\#getShdwBkgndTrans--) をご覧ください。 |
+| [setShdwForegnd(ColorValue value)](#setShdwForegnd-com.aspose.diagram.ColorValue-) | このプロパティの説明については、[getShdwForegnd()](../../com.aspose.diagram/fill\#getShdwForegnd--) をご覧ください。 |
+| [setShdwForegndTrans(DoubleValue value)](#setShdwForegndTrans-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getShdwForegndTrans()](../../com.aspose.diagram/fill\#getShdwForegndTrans--) をご覧ください。 |
+| [setShdwPattern(IntValue value)](#setShdwPattern-com.aspose.diagram.IntValue-) | このプロパティの説明については、[getShdwPattern()](../../com.aspose.diagram/fill\#getShdwPattern--) をご覧ください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getFillBkgnd() {#getFillBkgnd--}
+```
+public ColorValue getFillBkgnd()
+```
+
+
+シェイプの塗りつぶしパターンの背景に使用される色を指定します。
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getFillBkgndTrans() {#getFillBkgndTrans--}
+```
+public DoubleValue getFillBkgndTrans()
+```
+
+
+シェイプの塗りつぶしパターンの背景（塗り）色の透明度レベルを指定します。0（完全に不透明）から1（完全に透明）までです。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getFillForegnd() {#getFillForegnd--}
+```
+public ColorValue getFillForegnd()
+```
+
+
+シェイプの塗りつぶしパターンの前景（ストローク）に使用される色を指定します。
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getFillForegndTrans() {#getFillForegndTrans--}
+```
+public DoubleValue getFillForegndTrans()
+```
+
+
+シェイプの塗りつぶしパターンの前景（塗り）色の透明度レベルを指定します。0（完全に不透明）から1（完全に透明）までです。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getFillPattern() {#getFillPattern--}
+```
+public IntValue getFillPattern()
+```
+
+
+シェイプの塗りつぶしパターンを指定します。
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getGradientFill() {#getGradientFill--}
+```
+public GradientFill getGradientFill()
+```
+
+
+シェイプの現在のグラデーション塗りつぶし書式設定値を含みます。
+
+**Returns:**
+[GradientFill](../../com.aspose.diagram/gradientfill)
+### getShapeShdwBlur() {#getShapeShdwBlur--}
+```
+public DoubleValue getShapeShdwBlur()
+```
+
+
+シェイプの影のぼかしサイズを指定します。現在はぼかしを描画できませんが、vsdx からは解析できます。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShapeShdwObliqueAngle() {#getShapeShdwObliqueAngle--}
+```
+public DoubleValue getShapeShdwObliqueAngle()
+```
+
+
+シェイプの影の斜め方向の角度を指定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShapeShdwOffsetX() {#getShapeShdwOffsetX--}
+```
+public DoubleValue getShapeShdwOffsetX()
+```
+
+
+シェイプの影がシェイプから水平方向にオフセットされる距離（ページ単位）を決定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShapeShdwOffsetY() {#getShapeShdwOffsetY--}
+```
+public DoubleValue getShapeShdwOffsetY()
+```
+
+
+シェイプの影がシェイプから垂直方向にオフセットされる距離（ページ単位）を決定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShapeShdwScaleFactor() {#getShapeShdwScaleFactor--}
+```
+public DoubleValue getShapeShdwScaleFactor()
+```
+
+
+シェイプの影を拡大または縮小できる割合（パーセンテージ）を指定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShapeShdwShow() {#getShapeShdwShow--}
+```
+public ShapeShdwShow getShapeShdwShow()
+```
+
+
+シェイプの影のタイプを指定します。
+
+**Returns:**
+[ShapeShdwShow](../../com.aspose.diagram/shapeshdwshow)
+### getShapeShdwType() {#getShapeShdwType--}
+```
+public ShapeShdwType getShapeShdwType()
+```
+
+
+シェイプの影のタイプを指定します。
+
+**Returns:**
+[ShapeShdwType](../../com.aspose.diagram/shapeshdwtype)
+### getShdwBkgnd() {#getShdwBkgnd--}
+```
+public ColorValue getShdwBkgnd()
+```
+
+
+シェイプのドロップシャドウ塗りつぶしパターンの背景（塗り）に使用される色を指定します。
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getShdwBkgndTrans() {#getShdwBkgndTrans--}
+```
+public DoubleValue getShdwBkgndTrans()
+```
+
+
+シェイプのドロップシャドウ塗りつぶしパターンの背景（塗り）の透明度レベルを指定します。0.0（完全に不透明）から1.0（完全に透明）までです。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShdwForegnd() {#getShdwForegnd--}
+```
+public ColorValue getShdwForegnd()
+```
+
+
+シェイプのドロップシャドウ塗りつぶしパターンの前景（ストローク）に使用される色を指定します。
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getShdwForegndTrans() {#getShdwForegndTrans--}
+```
+public DoubleValue getShdwForegndTrans()
+```
+
+
+シェイプのドロップシャドウ塗りつぶしパターンの前景（ストローク）の透明度レベルを指定します。0.0（完全に不透明）から1.0（完全に透明）までです。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShdwPattern() {#getShdwPattern--}
+```
+public IntValue getShdwPattern()
+```
+
+
+シェイプの影の塗りつぶしパターンを指定します。
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+このプロパティの説明については、[getDel()](../../com.aspose.diagram/fill\#getDel--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setFillBkgnd(ColorValue value) {#setFillBkgnd-com.aspose.diagram.ColorValue-}
+```
+public void setFillBkgnd(ColorValue value)
+```
+
+
+このプロパティの説明については、[getFillBkgnd()](../../com.aspose.diagram/fill\#getFillBkgnd--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setFillBkgndTrans(DoubleValue value) {#setFillBkgndTrans-com.aspose.diagram.DoubleValue-}
+```
+public void setFillBkgndTrans(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getFillBkgndTrans()](../../com.aspose.diagram/fill\#getFillBkgndTrans--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setFillForegnd(ColorValue value) {#setFillForegnd-com.aspose.diagram.ColorValue-}
+```
+public void setFillForegnd(ColorValue value)
+```
+
+
+このプロパティの説明については、[getFillForegnd()](../../com.aspose.diagram/fill\#getFillForegnd--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setFillForegndTrans(DoubleValue value) {#setFillForegndTrans-com.aspose.diagram.DoubleValue-}
+```
+public void setFillForegndTrans(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getFillForegndTrans()](../../com.aspose.diagram/fill\#getFillForegndTrans--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setFillPattern(IntValue value) {#setFillPattern-com.aspose.diagram.IntValue-}
+```
+public void setFillPattern(IntValue value)
+```
+
+
+このプロパティの説明については、[getFillPattern()](../../com.aspose.diagram/fill\#getFillPattern--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setShapeShdwBlur(DoubleValue value) {#setShapeShdwBlur-com.aspose.diagram.DoubleValue-}
+```
+public void setShapeShdwBlur(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getShapeShdwBlur()](../../com.aspose.diagram/fill\#getShapeShdwBlur--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setShapeShdwObliqueAngle(DoubleValue value) {#setShapeShdwObliqueAngle-com.aspose.diagram.DoubleValue-}
+```
+public void setShapeShdwObliqueAngle(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getShapeShdwObliqueAngle()](../../com.aspose.diagram/fill\#getShapeShdwObliqueAngle--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setShapeShdwOffsetX(DoubleValue value) {#setShapeShdwOffsetX-com.aspose.diagram.DoubleValue-}
+```
+public void setShapeShdwOffsetX(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getShapeShdwOffsetX()](../../com.aspose.diagram/fill\#getShapeShdwOffsetX--) をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setShapeShdwOffsetY(DoubleValue value) {#setShapeShdwOffsetY-com.aspose.diagram.DoubleValue-}
+```
+public void setShapeShdwOffsetY(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getShapeShdwOffsetY()](../../com.aspose.diagram/fill\#getShapeShdwOffsetY--) をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setShapeShdwScaleFactor(DoubleValue value) {#setShapeShdwScaleFactor-com.aspose.diagram.DoubleValue-}
+```
+public void setShapeShdwScaleFactor(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getShapeShdwScaleFactor()](../../com.aspose.diagram/fill\#getShapeShdwScaleFactor--) をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setShapeShdwShow(ShapeShdwShow value) {#setShapeShdwShow-com.aspose.diagram.ShapeShdwShow-}
+```
+public void setShapeShdwShow(ShapeShdwShow value)
+```
+
+
+このプロパティの説明については、[getShapeShdwShow()](../../com.aspose.diagram/fill\#getShapeShdwShow--) をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [ShapeShdwShow](../../com.aspose.diagram/shapeshdwshow) |  |
+
+### setShapeShdwType(ShapeShdwType value) {#setShapeShdwType-com.aspose.diagram.ShapeShdwType-}
+```
+public void setShapeShdwType(ShapeShdwType value)
+```
+
+
+このプロパティの説明については、[getShapeShdwType()](../../com.aspose.diagram/fill\#getShapeShdwType--) をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [ShapeShdwType](../../com.aspose.diagram/shapeshdwtype) |  |
+
+### setShdwBkgnd(ColorValue value) {#setShdwBkgnd-com.aspose.diagram.ColorValue-}
+```
+public void setShdwBkgnd(ColorValue value)
+```
+
+
+このプロパティの説明については、[getShdwBkgnd()](../../com.aspose.diagram/fill\#getShdwBkgnd--) をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setShdwBkgndTrans(DoubleValue value) {#setShdwBkgndTrans-com.aspose.diagram.DoubleValue-}
+```
+public void setShdwBkgndTrans(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getShdwBkgndTrans()](../../com.aspose.diagram/fill\#getShdwBkgndTrans--) をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setShdwForegnd(ColorValue value) {#setShdwForegnd-com.aspose.diagram.ColorValue-}
+```
+public void setShdwForegnd(ColorValue value)
+```
+
+
+このプロパティの説明については、[getShdwForegnd()](../../com.aspose.diagram/fill\#getShdwForegnd--) をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setShdwForegndTrans(DoubleValue value) {#setShdwForegndTrans-com.aspose.diagram.DoubleValue-}
+```
+public void setShdwForegndTrans(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getShdwForegndTrans()](../../com.aspose.diagram/fill\#getShdwForegndTrans--) をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setShdwPattern(IntValue value) {#setShdwPattern-com.aspose.diagram.IntValue-}
+```
+public void setShdwPattern(IntValue value)
+```
+
+
+このプロパティの説明については、[getShdwPattern()](../../com.aspose.diagram/fill\#getShdwPattern--) をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/filltype/_index.md
+++ b/japanese/java/com.aspose.diagram/filltype/_index.md
@@ -1,0 +1,183 @@
+---
+title: FillType
+second_title: Aspose.Diagram for Java API リファレンス
+description: 塗りつぶし形式タイプ。
+type: docs
+weight: 154
+url: /ja/java/com.aspose.diagram/filltype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class FillType
+```
+
+塗りつぶし形式タイプ。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [AUTOMATIC](#AUTOMATIC) | 自動書式設定タイプを表します。 |
+| [GRADIENT](#GRADIENT) | グラデーション塗りつぶし形式。 |
+| [NONE](#NONE) | なしの書式設定タイプを表します。 |
+| [PATTERN](#PATTERN) | パターン塗りつぶし形式。 |
+| [SOLID](#SOLID) | 単色塗りつぶし形式。 |
+| [TEXTURE](#TEXTURE) | テクスチャ塗りつぶし形式。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AUTOMATIC {#AUTOMATIC}
+```
+public static final int AUTOMATIC
+```
+
+
+自動書式設定タイプを表します。
+
+### GRADIENT {#GRADIENT}
+```
+public static final int GRADIENT
+```
+
+
+グラデーション塗りつぶし形式。
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+なしの書式設定タイプを表します。
+
+### PATTERN {#PATTERN}
+```
+public static final int PATTERN
+```
+
+
+パターン塗りつぶし形式。
+
+### SOLID {#SOLID}
+```
+public static final int SOLID
+```
+
+
+単色塗りつぶし形式。
+
+### TEXTURE {#TEXTURE}
+```
+public static final int TEXTURE
+```
+
+
+テクスチャ塗りつぶし形式。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/fld/_index.md
+++ b/japanese/java/com.aspose.diagram/fld/_index.md
@@ -1,0 +1,155 @@
+---
+title: Fld
+second_title: Aspose.Diagram for Java API リファレンス
+description: 対応する Field 要素のテキスト フィールド挿入ポイントを示します。
+type: docs
+weight: 155
+url: /ja/java/com.aspose.diagram/fld/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.FormatTxt](../../com.aspose.diagram/formattxt)
+```
+public class Fld extends FormatTxt
+```
+
+対応する Field 要素のテキスト フィールド挿入ポイントを示します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Fld(int IX, Shape shape)](#Fld-int-com.aspose.diagram.Shape-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getValue()](#getValue--) | 値 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Fld(int IX, Shape shape) {#Fld-int-com.aspose.diagram.Shape-}
+```
+public Fld(int IX, Shape shape)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| IX | int | 要素 Field が親要素 Shape 内のゼロベースインデックスです。 |
+| shape | [Shape](../../com.aspose.diagram/shape) | シェイプ。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+値
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/floatpointnumcollection/_index.md
+++ b/japanese/java/com.aspose.diagram/floatpointnumcollection/_index.md
@@ -1,0 +1,231 @@
+---
+title: FloatPointNumCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: 倍精度ポイント数のコレクションを含みます。
+type: docs
+weight: 156
+url: /ja/java/com.aspose.diagram/floatpointnumcollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class FloatPointNumCollection extends Collection
+```
+
+倍精度ポイント数のコレクションを含みます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [FloatPointNumCollection()](#FloatPointNumCollection--) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(double number)](#add-double-) | コレクションに倍精度ポイント番号を追加します。 |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(double number)](#remove-double-) | コレクションから倍精度ポイント番号を削除します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FloatPointNumCollection() {#FloatPointNumCollection--}
+```
+public FloatPointNumCollection()
+```
+
+
+コンストラクタ。
+
+### add(double number) {#add-double-}
+```
+public int add(double number)
+```
+
+
+コレクションに倍精度ポイント番号を追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 数 | double |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public double get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+double -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(double number) {#remove-double-}
+```
+public void remove(double number)
+```
+
+
+コレクションから倍精度ポイント番号を削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 数 | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/folderfontsource/_index.md
+++ b/japanese/java/com.aspose.diagram/folderfontsource/_index.md
@@ -1,0 +1,177 @@
+---
+title: FolderFontSource
+second_title: Aspose.Diagram for Java API リファレンス
+description: TrueType フォント ファイルを含むフォルダーを表します。
+type: docs
+weight: 157
+url: /ja/java/com.aspose.diagram/folderfontsource/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.FontSourceBase](../../com.aspose.diagram/fontsourcebase)
+```
+public class FolderFontSource extends FontSourceBase
+```
+
+TrueType フォント ファイルを含むフォルダーを表します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [FolderFontSource(String folderPath, boolean scanSubfolders)](#FolderFontSource-java.lang.String-boolean-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFolderPath()](#getFolderPath--) | フォントフォルダーへのパス。 |
+| [getScanSubFolders()](#getScanSubFolders--) | サブフォルダーをスキャンするかどうかを決定します。 |
+| [getType()](#getType--) | フォントソースのタイプを返します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FolderFontSource(String folderPath, boolean scanSubfolders) {#FolderFontSource-java.lang.String-boolean-}
+```
+public FolderFontSource(String folderPath, boolean scanSubfolders)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| folderPath | java.lang.String | フォントフォルダーへのパス |
+| scanSubfolders | boolean | サブフォルダーをスキャンするかどうかを決定します。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFolderPath() {#getFolderPath--}
+```
+public String getFolderPath()
+```
+
+
+フォントフォルダーへのパス。
+
+**Returns:**
+java.lang.String
+### getScanSubFolders() {#getScanSubFolders--}
+```
+public boolean getScanSubFolders()
+```
+
+
+サブフォルダーをスキャンするかどうかを決定します。
+
+**Returns:**
+boolean
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+フォントソースのタイプを返します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/font/_index.md
+++ b/japanese/java/com.aspose.diagram/font/_index.md
@@ -1,0 +1,288 @@
+---
+title: フォント
+second_title: Aspose.Diagram for Java API リファレンス
+description: フォントに関する情報を含みます。
+type: docs
+weight: 158
+url: /ja/java/com.aspose.diagram/font/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Font
+```
+
+フォントに関する情報を含みます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Font()](#Font--) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCharSets()](#getCharSets--) | フォントがサポートする文字セット。 |
+| [getClass()](#getClass--) |  |
+| [getFlags()](#getFlags--) | 次の状態を示すフラグ：欠落フォント、デフォルトフォント、アジアフォント、複雑フォント、縦書きフォント、フォントタイプ。 |
+| [getID()](#getID--) | 親要素内の要素の ID。 |
+| [getName()](#getName--) | フォント名は UTF-16 Unicode 文字列です。 |
+| [getPanos()](#getPanos--) | フォントの Panose シグネチャ。 |
+| [getUnicodeRanges()](#getUnicodeRanges--) | フォントがサポートする Unicode 範囲。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCharSets(String value)](#setCharSets-java.lang.String-) | このプロパティの説明については、[getCharSets()](../../com.aspose.diagram/font\\#getCharSets--) を参照してください。 |
+| [setFlags(int value)](#setFlags-int-) | このプロパティの説明については、[getFlags()](../../com.aspose.diagram/font\\#getFlags--) を参照してください。 |
+| [setID(int value)](#setID-int-) | このプロパティの説明については、[getID()](../../com.aspose.diagram/font\\#getID--) を参照してください。 |
+| [setName(String value)](#setName-java.lang.String-) | このプロパティの説明については、[getName()](../../com.aspose.diagram/font\\#getName--) を参照してください。 |
+| [setPanos(String value)](#setPanos-java.lang.String-) | このプロパティの説明については、[getPanos()](../../com.aspose.diagram/font\\#getPanos--) を参照してください。 |
+| [setUnicodeRanges(String value)](#setUnicodeRanges-java.lang.String-) | このプロパティの説明については、[getUnicodeRanges()](../../com.aspose.diagram/font\\#getUnicodeRanges--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Font() {#Font--}
+```
+public Font()
+```
+
+
+コンストラクタ。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCharSets() {#getCharSets--}
+```
+public String getCharSets()
+```
+
+
+フォントがサポートする文字セット。
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFlags() {#getFlags--}
+```
+public int getFlags()
+```
+
+
+次の状態を示すフラグ：欠落フォント、デフォルトフォント、アジアフォント、複雑フォント、縦書きフォント、フォントタイプ。
+
+**Returns:**
+int
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+親要素内の要素の ID。
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+フォント名は UTF-16 Unicode 文字列です。
+
+**Returns:**
+java.lang.String
+### getPanos() {#getPanos--}
+```
+public String getPanos()
+```
+
+
+フォントの Panose シグネチャ。Panose は書体を視覚的特徴に基づいて分類するシステムです。
+
+**Returns:**
+java.lang.String
+### getUnicodeRanges() {#getUnicodeRanges--}
+```
+public String getUnicodeRanges()
+```
+
+
+フォントがサポートする Unicode 範囲。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCharSets(String value) {#setCharSets-java.lang.String-}
+```
+public void setCharSets(String value)
+```
+
+
+このプロパティの説明については、[getCharSets()](../../com.aspose.diagram/font\\#getCharSets--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setFlags(int value) {#setFlags-int-}
+```
+public void setFlags(int value)
+```
+
+
+このプロパティの説明については、[getFlags()](../../com.aspose.diagram/font\\#getFlags--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+このプロパティの説明については、[getID()](../../com.aspose.diagram/font\\#getID--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+このプロパティの説明については、[getName()](../../com.aspose.diagram/font\\#getName--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setPanos(String value) {#setPanos-java.lang.String-}
+```
+public void setPanos(String value)
+```
+
+
+このプロパティの説明については、[getPanos()](../../com.aspose.diagram/font\\#getPanos--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setUnicodeRanges(String value) {#setUnicodeRanges-java.lang.String-}
+```
+public void setUnicodeRanges(String value)
+```
+
+
+このプロパティの説明については、[getUnicodeRanges()](../../com.aspose.diagram/font\\#getUnicodeRanges--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/fontcollection/_index.md
+++ b/japanese/java/com.aspose.diagram/fontcollection/_index.md
@@ -1,0 +1,247 @@
+---
+title: FontCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: Font 要素のコレクションを含みます。
+type: docs
+weight: 159
+url: /ja/java/com.aspose.diagram/fontcollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class FontCollection extends Collection
+```
+
+Font 要素のコレクションを含みます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [FontCollection()](#FontCollection--) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(Font font)](#add-com.aspose.diagram.Font-) | Add the Font object in the collection. |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [getFont(int ID)](#getFont-int-) | 指定された ID の要素を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Font font)](#remove-com.aspose.diagram.Font-) | Remove the Font object from the collection. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FontCollection() {#FontCollection--}
+```
+public FontCollection()
+```
+
+
+コンストラクタ。
+
+### add(Font font) {#add-com.aspose.diagram.Font-}
+```
+public int add(Font font)
+```
+
+
+Add the Font object in the collection.
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| font | [Font](../../com.aspose.diagram/font) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Font get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[Font](../../com.aspose.diagram/font) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### getFont(int ID) {#getFont-int-}
+```
+public Font getFont(int ID)
+```
+
+
+指定された ID の要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ID | int | int 要素の親要素内の ID。 |
+
+**Returns:**
+[Font](../../com.aspose.diagram/font) - [Font](../../com.aspose.diagram/font)Font.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Font font) {#remove-com.aspose.diagram.Font-}
+```
+public void remove(Font font)
+```
+
+
+Remove the Font object from the collection.
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| font | [Font](../../com.aspose.diagram/font) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/fontconfigs/_index.md
+++ b/japanese/java/com.aspose.diagram/fontconfigs/_index.md
@@ -1,0 +1,272 @@
+---
+title: FontConfigs
+second_title: Aspose.Diagram for Java API リファレンス
+description: フォント設定を指定します。
+type: docs
+weight: 160
+url: /ja/java/com.aspose.diagram/fontconfigs/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class FontConfigs
+```
+
+フォント設定を指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [FontConfigs()](#FontConfigs--) |  |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDefaultFontName()](#getDefaultFontName--) | デフォルトのフォント名。 |
+| [getFontSources()](#getFontSources--) | ソースのリストを含む配列のコピーを取得します |
+| [getFontSubstitutes(String originalFontName)](#getFontSubstitutes-java.lang.String-) | 元のフォントが存在しない場合に使用されるフォント代替名を含む配列を返します。 |
+| [getPreferSystemFontSubstitutes()](#getPreferSystemFontSubstitutes--) | フォントが存在せず、そのフォントの代替が設定されていない場合に、システムフォント代替を優先するかどうかを示します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDefaultFontName(String value)](#setDefaultFontName-java.lang.String-) | このプロパティの説明については、[getDefaultFontName()](../../com.aspose.diagram/fontconfigs\#getDefaultFontName--) を参照してください |
+| [setFontFolder(String fontFolder, boolean recursive)](#setFontFolder-java.lang.String-boolean-) | フォントフォルダーを設定します |
+| [setFontFolders(String[] fontFolders, boolean recursive)](#setFontFolders-java.lang.String---boolean-) | フォントフォルダーを設定します |
+| [setFontSources(FontSourceBase[] sources)](#setFontSources-com.aspose.diagram.FontSourceBase---) | フォントソースを設定します。 |
+| [setFontSubstitutes(String originalFontName, String[] substituteFontNames)](#setFontSubstitutes-java.lang.String-java.lang.String---) | 指定された元フォント名のフォント代替名。 |
+| [setPreferSystemFontSubstitutes(boolean value)](#setPreferSystemFontSubstitutes-boolean-) | このプロパティの説明については、[getPreferSystemFontSubstitutes()](../../com.aspose.diagram/fontconfigs\#getPreferSystemFontSubstitutes--) を参照してください |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FontConfigs() {#FontConfigs--}
+```
+public FontConfigs()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultFontName() {#getDefaultFontName--}
+```
+public static String getDefaultFontName()
+```
+
+
+デフォルトのフォント名。
+
+**Returns:**
+java.lang.String
+### getFontSources() {#getFontSources--}
+```
+public static FontSourceBase[] getFontSources()
+```
+
+
+ソースのリストを含む配列のコピーを取得します
+
+**Returns:**
+com.aspose.diagram.FontSourceBase[] -
+### getFontSubstitutes(String originalFontName) {#getFontSubstitutes-java.lang.String-}
+```
+public static String[] getFontSubstitutes(String originalFontName)
+```
+
+
+元のフォントが存在しない場合に使用されるフォント代替名を含む配列を返します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| originalFontName | java.lang.String | originalFontName |
+
+**Returns:**
+java.lang.String[] - 元のフォントが存在しない場合に使用されるフォント代替名の配列。
+### getPreferSystemFontSubstitutes() {#getPreferSystemFontSubstitutes--}
+```
+public static boolean getPreferSystemFontSubstitutes()
+```
+
+
+フォントが存在せず、そのフォントの代替が設定されていない場合に、システムフォント代替を最初に使用するかどうかを示します。例: Ubuntu では、"Arial" フォントは通常 "Liberation Sans" に置き換えられます。デフォルト値は false です。
+
+**Returns:**
+boolean
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDefaultFontName(String value) {#setDefaultFontName-java.lang.String-}
+```
+public static void setDefaultFontName(String value)
+```
+
+
+このプロパティの説明については、[getDefaultFontName()](../../com.aspose.diagram/fontconfigs\#getDefaultFontName--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setFontFolder(String fontFolder, boolean recursive) {#setFontFolder-java.lang.String-boolean-}
+```
+public static void setFontFolder(String fontFolder, boolean recursive)
+```
+
+
+フォントフォルダーを設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| fontFolder | java.lang.String | TrueType フォントを含むフォルダー。 |
+| 再帰的 | boolean | サブフォルダーをスキャンするかどうかを決定します。 |
+
+### setFontFolders(String[] fontFolders, boolean recursive) {#setFontFolders-java.lang.String---boolean-}
+```
+public static void setFontFolders(String[] fontFolders, boolean recursive)
+```
+
+
+フォントフォルダーを設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| fontFolders | java.lang.String[] | TrueType フォントを含むフォルダー群。 |
+| 再帰的 | boolean | サブフォルダーをスキャンするかどうかを決定します。 |
+
+### setFontSources(FontSourceBase[] sources) {#setFontSources-com.aspose.diagram.FontSourceBase---}
+```
+public static void setFontSources(FontSourceBase[] sources)
+```
+
+
+フォントソースを設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| sources | [FontSourceBase\[\]](../../com.aspose.diagram/fontsourcebase) | TrueType フォントを含むソースの配列。 |
+
+### setFontSubstitutes(String originalFontName, String[] substituteFontNames) {#setFontSubstitutes-java.lang.String-java.lang.String---}
+```
+public static void setFontSubstitutes(String originalFontName, String[] substituteFontNames)
+```
+
+
+指定された元フォント名のフォント代替名。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| originalFontName | java.lang.String | 元のフォント名。 |
+| substituteFontNames | java.lang.String[] | 元のフォントが存在しない場合に使用されるフォント代替名のリスト。 |
+
+### setPreferSystemFontSubstitutes(boolean value) {#setPreferSystemFontSubstitutes-boolean-}
+```
+public static void setPreferSystemFontSubstitutes(boolean value)
+```
+
+
+このプロパティの説明については、[getPreferSystemFontSubstitutes()](../../com.aspose.diagram/fontconfigs\#getPreferSystemFontSubstitutes--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/fontsourcebase/_index.md
+++ b/japanese/java/com.aspose.diagram/fontsourcebase/_index.md
@@ -1,0 +1,147 @@
+---
+title: FontSourceBase
+second_title: Aspose.Diagram for Java API リファレンス
+description: これは、ユーザーがさまざまなフォント ソースを指定できるクラスの抽象基底クラスです。
+type: docs
+weight: 161
+url: /ja/java/com.aspose.diagram/fontsourcebase/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public abstract class FontSourceBase
+```
+
+これは、ユーザーがさまざまなフォント ソースを指定できるクラスの抽象基底クラスです。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [FontSourceBase()](#FontSourceBase--) |  |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getType()](#getType--) | フォントソースのタイプを返します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FontSourceBase() {#FontSourceBase--}
+```
+public FontSourceBase()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getType() {#getType--}
+```
+public abstract int getType()
+```
+
+
+フォントソースのタイプを返します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/fontsourcetype/_index.md
+++ b/japanese/java/com.aspose.diagram/fontsourcetype/_index.md
@@ -1,0 +1,156 @@
+---
+title: FontSourceType
+second_title: Aspose.Diagram for Java API リファレンス
+description: フォント ソースのタイプを指定します。
+type: docs
+weight: 162
+url: /ja/java/com.aspose.diagram/fontsourcetype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class FontSourceType
+```
+
+フォント ソースのタイプを指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [FONTS_FOLDER](#FONTS-FOLDER) | フォントファイルが格納されたフォルダーを表します。 |
+| [FONT_FILE](#FONT-FILE) | 単一のフォントファイルを表します。 |
+| [MEMORY_FONT](#MEMORY-FONT) | メモリ内の単一フォントを表します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FONTS_FOLDER {#FONTS-FOLDER}
+```
+public static final int FONTS_FOLDER
+```
+
+
+フォントファイルが格納されたフォルダーを表します。
+
+### FONT_FILE {#FONT-FILE}
+```
+public static final int FONT_FILE
+```
+
+
+単一のフォントファイルを表します。
+
+### MEMORY_FONT {#MEMORY-FONT}
+```
+public static final int MEMORY_FONT
+```
+
+
+メモリ内の単一フォントを表します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/foreign/_index.md
+++ b/japanese/java/com.aspose.diagram/foreign/_index.md
@@ -1,0 +1,205 @@
+---
+title: 外部
+second_title: Aspose.Diagram for Java API リファレンス
+description: Microsoft Visio ドキュメントで使用される別のプログラムからのオブジェクトの幅と高さを指定する要素を含みます。
+type: docs
+weight: 163
+url: /ja/java/com.aspose.diagram/foreign/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Foreign
+```
+
+Microsoft Visio ドキュメントで使用される他のプログラムからのオブジェクトの幅と高さを指定する要素を含みます。また、オブジェクトの画像が境界内でオフセットされる距離を指定する要素も含みます。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getImgHeight()](#getImgHeight--) | オブジェクトの境界内における画像の高さを決定します。 |
+| [getImgOffsetX()](#getImgOffsetX--) | オブジェクトの境界の原点から水平方向にオフセットされる距離を決定します。 |
+| [getImgOffsetY()](#getImgOffsetY--) | オブジェクトの境界の原点から垂直方向にオフセットされる距離を決定します。 |
+| [getImgWidth()](#getImgWidth--) | オブジェクトの境界内における画像の幅を決定します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | このプロパティの説明については、[getDel()](../../com.aspose.diagram/foreign\#getDel--)をご覧ください |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getImgHeight() {#getImgHeight--}
+```
+public DoubleValue getImgHeight()
+```
+
+
+オブジェクトの境界内にある画像の高さを決定します。デフォルトの数式は: F=\"Height\\*1\"です。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getImgOffsetX() {#getImgOffsetX--}
+```
+public DoubleValue getImgOffsetX()
+```
+
+
+オブジェクトの境界の原点から水平方向にオフセットされる距離を決定します。デフォルト値は 0 で、デフォルトの数式は F=\"ImgWidth\\*0\"です。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getImgOffsetY() {#getImgOffsetY--}
+```
+public DoubleValue getImgOffsetY()
+```
+
+
+オブジェクトの境界の原点から垂直方向にオフセットされる距離を決定します。デフォルト値は 0 で、デフォルトの数式は F=\"ImgHeight\\*0\"です。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getImgWidth() {#getImgWidth--}
+```
+public DoubleValue getImgWidth()
+```
+
+
+オブジェクトの境界内にある画像の幅を決定します。デフォルトの数式は: F=\"Width\\*1\"です。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+このプロパティの説明については、[getDel()](../../com.aspose.diagram/foreign\#getDel--)をご覧ください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/foreigndata/_index.md
+++ b/japanese/java/com.aspose.diagram/foreigndata/_index.md
@@ -1,0 +1,486 @@
+---
+title: ForeignData
+second_title: Aspose.Diagram for Java API リファレンス
+description: Windows メタファイルビットマップや OLE データなどの画像データを MIME マルチパーパスインターネットメール拡張 (MIME) でエンコードした BLOB を含みます。
+type: docs
+weight: 164
+url: /ja/java/com.aspose.diagram/foreigndata/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ForeignData
+```
+
+Windows メタファイル、ビットマップ、または OLE データなどの画像データの MIME (Multipurpose Internet Mail Extensions) エンコード BLOB を含みます。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCompressionLevel()](#getCompressionLevel--) | この属性は、外部データが DIB、JPG、PNG、TIFF、または GIF ファイルなどのラスタベースの外部オブジェクトである場合にのみ意味があります。 |
+| [getCompressionType()](#getCompressionType--) | この属性は、外部データが DIB、JPG、PNG、TIFF、または GIF ファイルなどのラスタベースの外部オブジェクトである場合にのみ意味があります。 |
+| [getExtentX()](#getExtentX--) | この属性は、外部データがメタファイルの場合にのみ意味があります。 |
+| [getExtentY()](#getExtentY--) | この属性は、外部データがメタファイルの場合にのみ意味があります。 |
+| [getForeignType()](#getForeignType--) | データ型。 |
+| [getImageData()](#getImageData--) | OLE オブジェクトの画像をバイト配列として表します。 |
+| [getMappingMode()](#getMappingMode--) | この属性は、外部データがメタファイルの場合にのみ意味があります。 |
+| [getObjectData()](#getObjectData--) | 埋め込み OLE オブジェクトデータをバイト配列として表します。 |
+| [getObjectHeight()](#getObjectHeight--) | この属性は、外部データが OLE2 埋め込みオブジェクトの場合にのみ意味があります。 |
+| [getObjectSourceFullName()](#getObjectSourceFullName--) | リンクされた OLE オブジェクトのソースファイルの完全な名前を返します。 |
+| [getObjectType()](#getObjectType--) | If the ForeignType attribute is "Object", the ForeignData element must also have an ObjectType attribute. |
+| [getObjectWidth()](#getObjectWidth--) | この属性は、外部データが OLE2 埋め込みオブジェクトの場合にのみ意味があります。 |
+| [getShowAsIcon()](#getShowAsIcon--) | この属性は、外部データが OLE2 埋め込みオブジェクトの場合にのみ意味があります。 |
+| [getValue()](#getValue--) | Windows メタファイル、ビットマップ、または OLE データなどの画像データの MIME (Multipurpose Internet Mail Extensions) エンコード BLOB を含みます。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCompressionLevel(double value)](#setCompressionLevel-double-) | このプロパティの説明については、[getCompressionLevel()](../../com.aspose.diagram/foreigndata\#getCompressionLevel--) を参照してください。 |
+| [setCompressionType(int value)](#setCompressionType-int-) | このプロパティの説明については、[getCompressionType()](../../com.aspose.diagram/foreigndata\#getCompressionType--) を参照してください。 |
+| [setExtentX(double value)](#setExtentX-double-) | このプロパティの説明については、[getExtentX()](../../com.aspose.diagram/foreigndata\#getExtentX--) を参照してください。 |
+| [setExtentY(double value)](#setExtentY-double-) | このプロパティの説明については、[getExtentY()](../../com.aspose.diagram/foreigndata\#getExtentY--) を参照してください。 |
+| [setForeignType(int value)](#setForeignType-int-) | このプロパティの説明については、[getForeignType()](../../com.aspose.diagram/foreigndata\#getForeignType--) を参照してください。 |
+| [setImageData(byte[] value)](#setImageData-byte---) | このプロパティの説明については、[getImageData()](../../com.aspose.diagram/foreigndata\#getImageData--) を参照してください。 |
+| [setMappingMode(int value)](#setMappingMode-int-) | このプロパティの説明については、[getMappingMode()](../../com.aspose.diagram/foreigndata\#getMappingMode--) を参照してください。 |
+| [setObjectData(byte[] value)](#setObjectData-byte---) | このプロパティの説明については、[getObjectData()](../../com.aspose.diagram/foreigndata\#getObjectData--) を参照してください。 |
+| [setObjectHeight(double value)](#setObjectHeight-double-) | このプロパティの説明については、[getObjectHeight()](../../com.aspose.diagram/foreigndata\#getObjectHeight--) を参照してください。 |
+| [setObjectSourceFullName(String value)](#setObjectSourceFullName-java.lang.String-) | このプロパティの説明については、[getObjectSourceFullName()](../../com.aspose.diagram/foreigndata\#getObjectSourceFullName--) を参照してください。 |
+| [setObjectType(int value)](#setObjectType-int-) | このプロパティの説明については、[getObjectType()](../../com.aspose.diagram/foreigndata\#getObjectType--) を参照してください。 |
+| [setObjectWidth(double value)](#setObjectWidth-double-) | このプロパティの説明については、[getObjectWidth()](../../com.aspose.diagram/foreigndata\#getObjectWidth--) を参照してください。 |
+| [setShowAsIcon(int value)](#setShowAsIcon-int-) | このプロパティの説明については、[getShowAsIcon()](../../com.aspose.diagram/foreigndata\#getShowAsIcon--) を参照してください。 |
+| [setValue(byte[] value)](#setValue-byte---) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/foreigndata\#getValue--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCompressionLevel() {#getCompressionLevel--}
+```
+public double getCompressionLevel()
+```
+
+
+この属性は、外部データが DIB、JPG、PNG、TIFF、または GIF ファイルなどのラスタベースの外部オブジェクトの場合にのみ意味があります。値はファイルに適用された圧縮レベルを示します。圧縮レベルはパーセントの百分の一で測定されます。
+
+**Returns:**
+double
+### getCompressionType() {#getCompressionType--}
+```
+public int getCompressionType()
+```
+
+
+この属性は、外部データが DIB、JPG、PNG、TIFF、または GIF ファイルなどのラスタベースの外部オブジェクトの場合にのみ意味があります。値はファイルに適用された圧縮タイプを示します。
+
+**Returns:**
+int
+### getExtentX() {#getExtentX--}
+```
+public double getExtentX()
+```
+
+
+この属性は、外部データがメタファイルの場合にのみ意味があります。値はメタファイルの水平範囲を示します。
+
+**Returns:**
+double
+### getExtentY() {#getExtentY--}
+```
+public double getExtentY()
+```
+
+
+この属性は、外部データがメタファイルの場合にのみ意味があります。値はメタファイルの垂直範囲を示します。
+
+**Returns:**
+double
+### getForeignType() {#getForeignType--}
+```
+public int getForeignType()
+```
+
+
+データ型。
+
+**Returns:**
+int
+### getImageData() {#getImageData--}
+```
+public byte[] getImageData()
+```
+
+
+OLE オブジェクトの画像をバイト配列として表します。
+
+**Returns:**
+byte[]
+### getMappingMode() {#getMappingMode--}
+```
+public int getMappingMode()
+```
+
+
+この属性は、外部データがメタファイルの場合にのみ意味があります。値はメタファイルのマッピングモードを示します。
+
+**Returns:**
+int
+### getObjectData() {#getObjectData--}
+```
+public byte[] getObjectData()
+```
+
+
+埋め込み OLE オブジェクトデータをバイト配列として表します。
+
+**Returns:**
+byte[]
+### getObjectHeight() {#getObjectHeight--}
+```
+public double getObjectHeight()
+```
+
+
+この属性は、外部データが OLE2 埋め込みオブジェクトの場合にのみ意味があります。値はページ単位でオブジェクトの高さを表します。
+
+**Returns:**
+double
+### getObjectSourceFullName() {#getObjectSourceFullName--}
+```
+public String getObjectSourceFullName()
+```
+
+
+リンクされた OLE オブジェクトのソースファイルの完全な名前を返します。ファイルタイプが OleFileType.Unknown の場合にのみ、ソース完全名の設定をサポートします。例：wav ファイル、avi ファイルなど。
+
+**Returns:**
+java.lang.String
+### getObjectType() {#getObjectType--}
+```
+public int getObjectType()
+```
+
+
+If the ForeignType attribute is "Object", the ForeignData element must also have an ObjectType attribute.
+
+**Returns:**
+int
+### getObjectWidth() {#getObjectWidth--}
+```
+public double getObjectWidth()
+```
+
+
+この属性は、外部データが OLE2 埋め込みオブジェクトの場合にのみ意味があります。値はページ単位でオブジェクトの幅を表します。
+
+**Returns:**
+double
+### getShowAsIcon() {#getShowAsIcon--}
+```
+public int getShowAsIcon()
+```
+
+
+この属性は、外部データが OLE2 埋め込みオブジェクトの場合にのみ意味があります。
+
+**Returns:**
+int
+### getValue() {#getValue--}
+```
+public byte[] getValue()
+```
+
+
+Windows メタファイル、ビットマップ、または OLE データなどの画像データの MIME (Multipurpose Internet Mail Extensions) エンコード BLOB を含みます。
+
+**Returns:**
+byte[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCompressionLevel(double value) {#setCompressionLevel-double-}
+```
+public void setCompressionLevel(double value)
+```
+
+
+このプロパティの説明については、[getCompressionLevel()](../../com.aspose.diagram/foreigndata\#getCompressionLevel--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double |  |
+
+### setCompressionType(int value) {#setCompressionType-int-}
+```
+public void setCompressionType(int value)
+```
+
+
+このプロパティの説明については、[getCompressionType()](../../com.aspose.diagram/foreigndata\#getCompressionType--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setExtentX(double value) {#setExtentX-double-}
+```
+public void setExtentX(double value)
+```
+
+
+このプロパティの説明については、[getExtentX()](../../com.aspose.diagram/foreigndata\#getExtentX--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double |  |
+
+### setExtentY(double value) {#setExtentY-double-}
+```
+public void setExtentY(double value)
+```
+
+
+このプロパティの説明については、[getExtentY()](../../com.aspose.diagram/foreigndata\#getExtentY--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double |  |
+
+### setForeignType(int value) {#setForeignType-int-}
+```
+public void setForeignType(int value)
+```
+
+
+このプロパティの説明については、[getForeignType()](../../com.aspose.diagram/foreigndata\#getForeignType--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setImageData(byte[] value) {#setImageData-byte---}
+```
+public void setImageData(byte[] value)
+```
+
+
+このプロパティの説明については、[getImageData()](../../com.aspose.diagram/foreigndata\#getImageData--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | byte[] |  |
+
+### setMappingMode(int value) {#setMappingMode-int-}
+```
+public void setMappingMode(int value)
+```
+
+
+このプロパティの説明については、[getMappingMode()](../../com.aspose.diagram/foreigndata\#getMappingMode--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setObjectData(byte[] value) {#setObjectData-byte---}
+```
+public void setObjectData(byte[] value)
+```
+
+
+このプロパティの説明については、[getObjectData()](../../com.aspose.diagram/foreigndata\#getObjectData--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | byte[] |  |
+
+### setObjectHeight(double value) {#setObjectHeight-double-}
+```
+public void setObjectHeight(double value)
+```
+
+
+このプロパティの説明については、[getObjectHeight()](../../com.aspose.diagram/foreigndata\#getObjectHeight--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double |  |
+
+### setObjectSourceFullName(String value) {#setObjectSourceFullName-java.lang.String-}
+```
+public void setObjectSourceFullName(String value)
+```
+
+
+このプロパティの説明については、[getObjectSourceFullName()](../../com.aspose.diagram/foreigndata\#getObjectSourceFullName--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setObjectType(int value) {#setObjectType-int-}
+```
+public void setObjectType(int value)
+```
+
+
+このプロパティの説明については、[getObjectType()](../../com.aspose.diagram/foreigndata\#getObjectType--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setObjectWidth(double value) {#setObjectWidth-double-}
+```
+public void setObjectWidth(double value)
+```
+
+
+このプロパティの説明については、[getObjectWidth()](../../com.aspose.diagram/foreigndata\#getObjectWidth--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double |  |
+
+### setShowAsIcon(int value) {#setShowAsIcon-int-}
+```
+public void setShowAsIcon(int value)
+```
+
+
+このプロパティの説明については、[getShowAsIcon()](../../com.aspose.diagram/foreigndata\#getShowAsIcon--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setValue(byte[] value) {#setValue-byte---}
+```
+public void setValue(byte[] value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/foreigndata\#getValue--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | byte[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/foreigntype/_index.md
+++ b/japanese/java/com.aspose.diagram/foreigntype/_index.md
@@ -1,0 +1,183 @@
+---
+title: ForeignType
+second_title: Aspose.Diagram for Java API リファレンス
+description: データ型。
+type: docs
+weight: 165
+url: /ja/java/com.aspose.diagram/foreigntype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ForeignType
+```
+
+データ型。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [BITMAP](#BITMAP) | Bitmap. |
+| [ENH_METAFILE](#ENH-METAFILE) | 拡張メタファイル。 |
+| [INK](#INK) | インク。 |
+| [METAFILE](#METAFILE) | メタファイル。 |
+| [OBJECT](#OBJECT) | オブジェクト。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BITMAP {#BITMAP}
+```
+public static final int BITMAP
+```
+
+
+Bitmap.
+
+### ENH_METAFILE {#ENH-METAFILE}
+```
+public static final int ENH_METAFILE
+```
+
+
+拡張メタファイル。
+
+### INK {#INK}
+```
+public static final int INK
+```
+
+
+インク。
+
+### METAFILE {#METAFILE}
+```
+public static final int METAFILE
+```
+
+
+メタファイル。
+
+### OBJECT {#OBJECT}
+```
+public static final int OBJECT
+```
+
+
+オブジェクト。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/formattxt/_index.md
+++ b/japanese/java/com.aspose.diagram/formattxt/_index.md
@@ -1,0 +1,147 @@
+---
+title: FormatTxt
+second_title: Aspose.Diagram for Java API リファレンス
+description: テキストの書式設定のための抽象クラス。
+type: docs
+weight: 166
+url: /ja/java/com.aspose.diagram/formattxt/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public abstract class FormatTxt
+```
+
+テキストの書式設定のための抽象クラス。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [FormatTxt()](#FormatTxt--) |  |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getValue()](#getValue--) | 値 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FormatTxt() {#FormatTxt--}
+```
+public FormatTxt()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getValue() {#getValue--}
+```
+public abstract String getValue()
+```
+
+
+値
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/formattxtcollection/_index.md
+++ b/japanese/java/com.aspose.diagram/formattxtcollection/_index.md
@@ -1,0 +1,243 @@
+---
+title: FormatTxtCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: シェイプのテキストを含む FormatTxt コレクション。
+type: docs
+weight: 167
+url: /ja/java/com.aspose.diagram/formattxtcollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class FormatTxtCollection extends Collection
+```
+
+シェイプのテキストを含む FormatTxt コレクション。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(FormatTxt item)](#add-com.aspose.diagram.FormatTxt-) | Add the FormatTxt object in the collection. |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [getText()](#getText--) | Contains the text of a shape with formating. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(FormatTxt item)](#remove-com.aspose.diagram.FormatTxt-) | Remove the FormatTxt object from the collection. |
+| [setWholeText(String text)](#setWholeText-java.lang.String-) | Set the text of a shape without formating. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(FormatTxt item) {#add-com.aspose.diagram.FormatTxt-}
+```
+public int add(FormatTxt item)
+```
+
+
+Add the FormatTxt object in the collection.
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [FormatTxt](../../com.aspose.diagram/formattxt) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public FormatTxt get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[FormatTxt](../../com.aspose.diagram/formattxt) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### getText() {#getText--}
+```
+public String getText()
+```
+
+
+Contains the text of a shape with formating.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(FormatTxt item) {#remove-com.aspose.diagram.FormatTxt-}
+```
+public void remove(FormatTxt item)
+```
+
+
+Remove the FormatTxt object from the collection.
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [FormatTxt](../../com.aspose.diagram/formattxt) |  |
+
+### setWholeText(String text) {#setWholeText-java.lang.String-}
+```
+public void setWholeText(String text)
+```
+
+
+Set the text of a shape without formating.
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| テキスト | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/frompartvalue/_index.md
+++ b/japanese/java/com.aspose.diagram/frompartvalue/_index.md
@@ -1,0 +1,264 @@
+---
+title: FromPartValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: 接続が開始されるシェイプの部分。
+type: docs
+weight: 168
+url: /ja/java/com.aspose.diagram/frompartvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class FromPartValue
+```
+
+接続が開始されるシェイプの部分。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [BEGIN_X_CELL](#BEGIN-X-CELL) | BeginX セル。 |
+| [BEGIN_X_OR_BEGIN_Y_POINT](#BEGIN-X-OR-BEGIN-Y-POINT) | BeginX/BeginY 点。 |
+| [BEGIN_Y_CELL](#BEGIN-Y-CELL) | BeginY セル。 |
+| [BOTTOM_EDGE](#BOTTOM-EDGE) | 下端。 |
+| [CENTER_EDGE](#CENTER-EDGE) | 中心エッジ。 |
+| [CONTROL_POINT](#CONTROL-POINT) | 制御点。 |
+| [END_X_CELL](#END-X-CELL) | EndX セル。 |
+| [END_X_OR_END_Y_POINT](#END-X-OR-END-Y-POINT) | EndX/EndY 点。 |
+| [END_Y_CELL](#END-Y-CELL) | EndY cell. |
+| [LEFT_EDGE](#LEFT-EDGE) | Left edge. |
+| [MIDDLE_EDGE](#MIDDLE-EDGE) | Middle Edge. |
+| [NONE](#NONE) | None. |
+| [RIGHT_EDGE](#RIGHT-EDGE) | Right Edge. |
+| [TOP_EDGE](#TOP-EDGE) | Top Edge. |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BEGIN_X_CELL {#BEGIN-X-CELL}
+```
+public static final int BEGIN_X_CELL
+```
+
+
+BeginX セル。
+
+### BEGIN_X_OR_BEGIN_Y_POINT {#BEGIN-X-OR-BEGIN-Y-POINT}
+```
+public static final int BEGIN_X_OR_BEGIN_Y_POINT
+```
+
+
+BeginX/BeginY 点。
+
+### BEGIN_Y_CELL {#BEGIN-Y-CELL}
+```
+public static final int BEGIN_Y_CELL
+```
+
+
+BeginY セル。
+
+### BOTTOM_EDGE {#BOTTOM-EDGE}
+```
+public static final int BOTTOM_EDGE
+```
+
+
+下端。
+
+### CENTER_EDGE {#CENTER-EDGE}
+```
+public static final int CENTER_EDGE
+```
+
+
+中心エッジ。
+
+### CONTROL_POINT {#CONTROL-POINT}
+```
+public static final int CONTROL_POINT
+```
+
+
+制御点。
+
+### END_X_CELL {#END-X-CELL}
+```
+public static final int END_X_CELL
+```
+
+
+EndX セル。
+
+### END_X_OR_END_Y_POINT {#END-X-OR-END-Y-POINT}
+```
+public static final int END_X_OR_END_Y_POINT
+```
+
+
+EndX/EndY 点。
+
+### END_Y_CELL {#END-Y-CELL}
+```
+public static final int END_Y_CELL
+```
+
+
+EndY cell.
+
+### LEFT_EDGE {#LEFT-EDGE}
+```
+public static final int LEFT_EDGE
+```
+
+
+Left edge.
+
+### MIDDLE_EDGE {#MIDDLE-EDGE}
+```
+public static final int MIDDLE_EDGE
+```
+
+
+Middle Edge.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+None.
+
+### RIGHT_EDGE {#RIGHT-EDGE}
+```
+public static final int RIGHT_EDGE
+```
+
+
+Right Edge.
+
+### TOP_EDGE {#TOP-EDGE}
+```
+public static final int TOP_EDGE
+```
+
+
+Top Edge.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/geom/_index.md
+++ b/japanese/java/com.aspose.diagram/geom/_index.md
@@ -1,0 +1,346 @@
+---
+title: Geom
+second_title: Aspose.Diagram for Java API リファレンス
+description: シェイプを構成する線と円弧の頂点座標を指定する要素を含みます。
+type: docs
+weight: 169
+url: /ja/java/com.aspose.diagram/geom/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Geom
+```
+
+形状を構成する線や弧の頂点座標を指定する要素を含みます。形状に複数のパスがある場合、各パスに対して Geom 要素が存在します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Geom()](#Geom--) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCoordinateCol()](#getCoordinateCol--) | 座標のコレクションです。 |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getIX()](#getIX--) | 親要素内の要素のゼロベースインデックスです。 |
+| [getNextCoordinateIX()](#getNextCoordinateIX--) | 次のシェイプの座標コレクションメンバーの IX 値を返します。 |
+| [getNoFill()](#getNoFill--) | パスを塗りつぶすかどうかを指定します。 |
+| [getNoLine()](#getNoLine--) | パスの境界線の周囲に線を描画するかどうかを指定します。 |
+| [getNoQuickDrag()](#getNoQuickDrag--) | ユーザーが Geometry セクションで定義された塗りつぶし領域をクリックしたときに、シェイプを選択またはドラッグできるかどうかを決定します。 |
+| [getNoShow()](#getNoShow--) | パスが描画ページに表示されるかどうかを指定します。 |
+| [getNoSnap()](#getNoSnap--) | 他のシェイプがパスにスナップするかどうかを指定します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | このプロパティの説明については、[getDel()](../../com.aspose.diagram/geom\#getDel--) を参照してください。 |
+| [setIX(int value)](#setIX-int-) | このプロパティの説明については、[getIX()](../../com.aspose.diagram/geom\#getIX--) を参照してください。 |
+| [setNoFill(BoolValue value)](#setNoFill-com.aspose.diagram.BoolValue-) | このプロパティの説明については、[getNoFill()](../../com.aspose.diagram/geom\#getNoFill--) を参照してください。 |
+| [setNoLine(BoolValue value)](#setNoLine-com.aspose.diagram.BoolValue-) | このプロパティの説明については、[getNoLine()](../../com.aspose.diagram/geom\#getNoLine--) を参照してください。 |
+| [setNoQuickDrag(BoolValue value)](#setNoQuickDrag-com.aspose.diagram.BoolValue-) | このプロパティの説明については、[getNoQuickDrag()](../../com.aspose.diagram/geom\#getNoQuickDrag--) を参照してください。 |
+| [setNoShow(BoolValue value)](#setNoShow-com.aspose.diagram.BoolValue-) | このプロパティの説明については、[getNoShow()](../../com.aspose.diagram/geom\#getNoShow--) を参照してください。 |
+| [setNoSnap(BoolValue value)](#setNoSnap-com.aspose.diagram.BoolValue-) | このプロパティの説明については、[getNoSnap()](../../com.aspose.diagram/geom\#getNoSnap--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Geom() {#Geom--}
+```
+public Geom()
+```
+
+
+コンストラクタ。
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCoordinateCol() {#getCoordinateCol--}
+```
+public CoordinateCollection getCoordinateCol()
+```
+
+
+座標のコレクションです。座標のシーケンスを示します。
+
+**Returns:**
+[CoordinateCollection](../../com.aspose.diagram/coordinatecollection)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+親要素内の要素のゼロベースインデックスです。
+
+**Returns:**
+int
+### getNextCoordinateIX() {#getNextCoordinateIX--}
+```
+public int getNextCoordinateIX()
+```
+
+
+次のシェイプの座標コレクションメンバーの IX 値を返します。
+
+**Returns:**
+int
+### getNoFill() {#getNoFill--}
+```
+public BoolValue getNoFill()
+```
+
+
+パスを塗りつぶすかどうかを指定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getNoLine() {#getNoLine--}
+```
+public BoolValue getNoLine()
+```
+
+
+パスの境界線の周囲に線を描画するかどうかを指定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getNoQuickDrag() {#getNoQuickDrag--}
+```
+public BoolValue getNoQuickDrag()
+```
+
+
+ユーザーが Geometry セクションで定義された塗りつぶし領域をクリックしたときに、シェイプを選択またはドラッグできるかどうかを決定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getNoShow() {#getNoShow--}
+```
+public BoolValue getNoShow()
+```
+
+
+パスが描画ページに表示されるかどうかを指定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getNoSnap() {#getNoSnap--}
+```
+public BoolValue getNoSnap()
+```
+
+
+他のシェイプがパスにスナップするかどうかを指定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+このプロパティの説明については、[getDel()](../../com.aspose.diagram/geom\#getDel--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+このプロパティの説明については、[getIX()](../../com.aspose.diagram/geom\#getIX--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setNoFill(BoolValue value) {#setNoFill-com.aspose.diagram.BoolValue-}
+```
+public void setNoFill(BoolValue value)
+```
+
+
+このプロパティの説明については、[getNoFill()](../../com.aspose.diagram/geom\#getNoFill--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setNoLine(BoolValue value) {#setNoLine-com.aspose.diagram.BoolValue-}
+```
+public void setNoLine(BoolValue value)
+```
+
+
+このプロパティの説明については、[getNoLine()](../../com.aspose.diagram/geom\#getNoLine--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setNoQuickDrag(BoolValue value) {#setNoQuickDrag-com.aspose.diagram.BoolValue-}
+```
+public void setNoQuickDrag(BoolValue value)
+```
+
+
+このプロパティの説明については、[getNoQuickDrag()](../../com.aspose.diagram/geom\#getNoQuickDrag--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setNoShow(BoolValue value) {#setNoShow-com.aspose.diagram.BoolValue-}
+```
+public void setNoShow(BoolValue value)
+```
+
+
+このプロパティの説明については、[getNoShow()](../../com.aspose.diagram/geom\#getNoShow--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setNoSnap(BoolValue value) {#setNoSnap-com.aspose.diagram.BoolValue-}
+```
+public void setNoSnap(BoolValue value)
+```
+
+
+このプロパティの説明については、[getNoSnap()](../../com.aspose.diagram/geom\#getNoSnap--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/geomcollection/_index.md
+++ b/japanese/java/com.aspose.diagram/geomcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: GeomCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: Geom コレクション。
+type: docs
+weight: 170
+url: /ja/java/com.aspose.diagram/geomcollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class GeomCollection extends Collection
+```
+
+Geom コレクション。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(Geom item)](#add-com.aspose.diagram.Geom-) | コレクションに Geom オブジェクトを追加します。 |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Geom item)](#remove-com.aspose.diagram.Geom-) | コレクションから Geom オブジェクトを削除します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Geom item) {#add-com.aspose.diagram.Geom-}
+```
+public int add(Geom item)
+```
+
+
+コレクションに Geom オブジェクトを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [Geom](../../com.aspose.diagram/geom) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Geom get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[Geom](../../com.aspose.diagram/geom) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Geom item) {#remove-com.aspose.diagram.Geom-}
+```
+public void remove(Geom item)
+```
+
+
+コレクションから Geom オブジェクトを削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [Geom](../../com.aspose.diagram/geom) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/gloweffect/_index.md
+++ b/japanese/java/com.aspose.diagram/gloweffect/_index.md
@@ -1,0 +1,150 @@
+---
+title: GlowEffect
+second_title: Aspose.Diagram for Java API リファレンス
+description: このクラスは、オブジェクトのエッジの外側にカラーのぼかしアウトラインを追加するグロー効果を指定します。
+type: docs
+weight: 171
+url: /ja/java/com.aspose.diagram/gloweffect/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class GlowEffect
+```
+
+このクラスは、オブジェクトのエッジの外側にカラーのぼかし輪郭が追加されるグロー効果を指定します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getSize()](#getSize--) | ポイント単位のグローの半径です。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setSize(double value)](#setSize-double-) | このプロパティの説明については、[getSize()](../../com.aspose.diagram/gloweffect\#getSize--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getSize() {#getSize--}
+```
+public double getSize()
+```
+
+
+ポイント単位のグローの半径です。
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setSize(double value) {#setSize-double-}
+```
+public void setSize(double value)
+```
+
+
+このプロパティの説明については、[getSize()](../../com.aspose.diagram/gloweffect\#getSize--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/gluedshapesflags/_index.md
+++ b/japanese/java/com.aspose.diagram/gluedshapesflags/_index.md
@@ -1,0 +1,183 @@
+---
+title: GluedShapesFlags
+second_title: Aspose.Diagram for Java API リファレンス
+description: Specifies constants that identify which shapes to return based on the dimensionality and directionality of the connection points that are glued to a particular shape passed to the Shape.GluedShapes method.
+type: docs
+weight: 176
+url: /ja/java/com.aspose.diagram/gluedshapesflags/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class GluedShapesFlags
+```
+
+特定のシェイプに接着された接続ポイントの次元性と方向性に基づいて、返すシェイプを識別する定数を指定します。これらは Shape.GluedShapes メソッドに渡されます。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [GLUED_SHAPES_ALL_1_D](#GLUED-SHAPES-ALL-1-D) | Return IDs of all 1-D shapes that are glued to this shape. |
+| [GLUED_SHAPES_ALL_2_D](#GLUED-SHAPES-ALL-2-D) | Return all 2-D shapes that are glued to this shape and all 2-D shapes to which this shape is glued. |
+| [GLUED_SHAPES_INCOMING_1_D](#GLUED-SHAPES-INCOMING-1-D) | Return IDs of 1-D shapes whose end points are glued to this shape. |
+| [GLUED_SHAPES_INCOMING_2_D](#GLUED-SHAPES-INCOMING-2-D) | If the source object is a 1-D shape, return IDs of 2-D shape to which the begin point is glued. |
+| [GLUED_SHAPES_OUTGOING_1_D](#GLUED-SHAPES-OUTGOING-1-D) | このシェイプに開始点が貼り付けられている1次元シェイプのIDを返します。 |
+| [GLUED_SHAPES_OUTGOING_2_D](#GLUED-SHAPES-OUTGOING-2-D) | ソースオブジェクトが1次元シェイプの場合、終了点が貼り付けられている2次元シェイプのIDを返します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GLUED_SHAPES_ALL_1_D {#GLUED-SHAPES-ALL-1-D}
+```
+public static final int GLUED_SHAPES_ALL_1_D
+```
+
+
+Return IDs of all 1-D shapes that are glued to this shape.
+
+### GLUED_SHAPES_ALL_2_D {#GLUED-SHAPES-ALL-2-D}
+```
+public static final int GLUED_SHAPES_ALL_2_D
+```
+
+
+Return all 2-D shapes that are glued to this shape and all 2-D shapes to which this shape is glued.
+
+### GLUED_SHAPES_INCOMING_1_D {#GLUED-SHAPES-INCOMING-1-D}
+```
+public static final int GLUED_SHAPES_INCOMING_1_D
+```
+
+
+Return IDs of 1-D shapes whose end points are glued to this shape.
+
+### GLUED_SHAPES_INCOMING_2_D {#GLUED-SHAPES-INCOMING-2-D}
+```
+public static final int GLUED_SHAPES_INCOMING_2_D
+```
+
+
+ソースオブジェクトが1次元シェイプの場合、開始点が貼り付けられている2次元シェイプのIDを返します。ソースオブジェクトが2次元シェイプの場合、このシェイプに貼り付けられている2次元シェイプのIDを返します。
+
+### GLUED_SHAPES_OUTGOING_1_D {#GLUED-SHAPES-OUTGOING-1-D}
+```
+public static final int GLUED_SHAPES_OUTGOING_1_D
+```
+
+
+このシェイプに開始点が貼り付けられている1次元シェイプのIDを返します。
+
+### GLUED_SHAPES_OUTGOING_2_D {#GLUED-SHAPES-OUTGOING-2-D}
+```
+public static final int GLUED_SHAPES_OUTGOING_2_D
+```
+
+
+ソースオブジェクトが1次元シェイプの場合、終了点が貼り付けられている2次元シェイプのIDを返します。ソースオブジェクトが2次元シェイプの場合、このシェイプが貼り付けられている2次元シェイプのIDを返します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/gluesettings/_index.md
+++ b/japanese/java/com.aspose.diagram/gluesettings/_index.md
@@ -1,0 +1,201 @@
+---
+title: GlueSettings
+second_title: Aspose.Diagram for Java API リファレンス
+description: ビット値は、特定の接着設定がオンかオフかを示します。
+type: docs
+weight: 172
+url: /ja/java/com.aspose.diagram/gluesettings/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class GlueSettings
+```
+
+The bit values indicate that a specific glue setting is on or off. The value may be a sum of the values:
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [CONNECTION_POINTS](#CONNECTION-POINTS) | 接続ポイントに接着します。 |
+| [DISABLED](#DISABLED) | Glue is disabled |
+| [GEOMETRY](#GEOMETRY) | ジオメトリに接着します。 |
+| [GUIDES](#GUIDES) | ガイドに接着します。 |
+| [HANDLES](#HANDLES) | ハンドルに接着します。 |
+| [NONE](#NONE) | 接着は有効ですが、他の接着設定は有効になっていません。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+| [VERTICES](#VERTICES) | 頂点に接着します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CONNECTION_POINTS {#CONNECTION-POINTS}
+```
+public static final int CONNECTION_POINTS
+```
+
+
+接続ポイントに接着します。
+
+### DISABLED {#DISABLED}
+```
+public static final int DISABLED
+```
+
+
+Glue is disabled
+
+### GEOMETRY {#GEOMETRY}
+```
+public static final int GEOMETRY
+```
+
+
+ジオメトリに接着します。
+
+### GUIDES {#GUIDES}
+```
+public static final int GUIDES
+```
+
+
+ガイドに接着します。
+
+### HANDLES {#HANDLES}
+```
+public static final int HANDLES
+```
+
+
+ハンドルに接着します。
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+接着は有効ですが、他の接着設定は有効になっていません。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### VERTICES {#VERTICES}
+```
+public static final int VERTICES
+```
+
+
+頂点に接着します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/gluesettingsvalue/_index.md
+++ b/japanese/java/com.aspose.diagram/gluesettingsvalue/_index.md
@@ -1,0 +1,201 @@
+---
+title: GlueSettingsValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: ドキュメントで接着が有効な場合に、シェイプが接着するオブジェクトを指定します。
+type: docs
+weight: 173
+url: /ja/java/com.aspose.diagram/gluesettingsvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class GlueSettingsValue
+```
+
+ドキュメントで接着が有効な場合に、シェイプが接着するオブジェクトを指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [GLUE_IS_DISABLED](#GLUE-IS-DISABLED) | 接着が無効です。 |
+| [GLUE_IS_ENABLED](#GLUE-IS-ENABLED) | 接着は有効ですが、他の接着設定は有効になっていません。 |
+| [GLUE_TO_CONNECTION_POINTS](#GLUE-TO-CONNECTION-POINTS) | 接続ポイントに接着します。 |
+| [GLUE_TO_GEOMETRY](#GLUE-TO-GEOMETRY) | ジオメトリに接着します。 |
+| [GLUE_TO_GUIDES](#GLUE-TO-GUIDES) | ガイドに接着します。 |
+| [GLUE_TO_HANDLES](#GLUE-TO-HANDLES) | ハンドルに接着します。 |
+| [GLUE_TO_VERTICES](#GLUE-TO-VERTICES) | 頂点に接着します。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GLUE_IS_DISABLED {#GLUE-IS-DISABLED}
+```
+public static final int GLUE_IS_DISABLED
+```
+
+
+接着が無効です。
+
+### GLUE_IS_ENABLED {#GLUE-IS-ENABLED}
+```
+public static final int GLUE_IS_ENABLED
+```
+
+
+接着は有効ですが、他の接着設定は有効になっていません。
+
+### GLUE_TO_CONNECTION_POINTS {#GLUE-TO-CONNECTION-POINTS}
+```
+public static final int GLUE_TO_CONNECTION_POINTS
+```
+
+
+接続ポイントに接着します。
+
+### GLUE_TO_GEOMETRY {#GLUE-TO-GEOMETRY}
+```
+public static final int GLUE_TO_GEOMETRY
+```
+
+
+ジオメトリに接着します。
+
+### GLUE_TO_GUIDES {#GLUE-TO-GUIDES}
+```
+public static final int GLUE_TO_GUIDES
+```
+
+
+ガイドに接着します。
+
+### GLUE_TO_HANDLES {#GLUE-TO-HANDLES}
+```
+public static final int GLUE_TO_HANDLES
+```
+
+
+ハンドルに接着します。
+
+### GLUE_TO_VERTICES {#GLUE-TO-VERTICES}
+```
+public static final int GLUE_TO_VERTICES
+```
+
+
+頂点に接着します。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/gluetype/_index.md
+++ b/japanese/java/com.aspose.diagram/gluetype/_index.md
@@ -1,0 +1,179 @@
+---
+title: GlueType
+second_title: Aspose.Diagram for Java API リファレンス
+description: シェイプに接続する際に、動的シェイプ間の接着が許可されているかどうかを指定します。
+type: docs
+weight: 174
+url: /ja/java/com.aspose.diagram/gluetype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class GlueType
+```
+
+シェイプに接続する際に、動的（シェイプ間）接着が許可されるかどうかを指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [GlueType(int value)](#GlueType-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | シェイプに接続する際に、動的（シェイプ間）接着が許可されるかどうかを指定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/gluetype\\#getValue--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GlueType(int value) {#GlueType-int-}
+```
+public GlueType(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+シェイプに接続する際に、動的（シェイプ間）接着が許可されるかどうかを指定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/gluetype\\#getValue--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/gluetypevalue/_index.md
+++ b/japanese/java/com.aspose.diagram/gluetypevalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: GlueTypeValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: シェイプに接続する際に、動的シェイプ間の接着が許可されているかどうかを指定します。
+type: docs
+weight: 175
+url: /ja/java/com.aspose.diagram/gluetypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class GlueTypeValue
+```
+
+シェイプに接続する際に、動的（シェイプ間）接着が許可されるかどうかを指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [ALLOW_DYNAMIC_GLUE](#ALLOW-DYNAMIC-GLUE) | 動的接着を許可します。 |
+| [ALLOW_DYNAMIC_GLUE_2002](#ALLOW-DYNAMIC-GLUE-2002) | 動的接着を許可します（Microsoft Visio 2002 では廃止）。 |
+| [ALLOW_DYNAMIC_GLUE_FOR_DYNAMIC_CONNECTOR](#ALLOW-DYNAMIC-GLUE-FOR-DYNAMIC-CONNECTOR) | デフォルト。 |
+| [NO_ALLOW_2_D_SHAPE](#NO-ALLOW-2-D-SHAPE) | この 2-D シェイプが動的接着で接続されることを許可しません。 |
+| [NO_ALLOW_DYNAMIC_GLUE](#NO-ALLOW-DYNAMIC-GLUE) | 動的接着を許可しません。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALLOW_DYNAMIC_GLUE {#ALLOW-DYNAMIC-GLUE}
+```
+public static final int ALLOW_DYNAMIC_GLUE
+```
+
+
+動的接着を許可します。
+
+### ALLOW_DYNAMIC_GLUE_2002 {#ALLOW-DYNAMIC-GLUE-2002}
+```
+public static final int ALLOW_DYNAMIC_GLUE_2002
+```
+
+
+動的接着を許可します（Microsoft Visio 2002 では廃止）。
+
+### ALLOW_DYNAMIC_GLUE_FOR_DYNAMIC_CONNECTOR {#ALLOW-DYNAMIC-GLUE-FOR-DYNAMIC-CONNECTOR}
+```
+public static final int ALLOW_DYNAMIC_GLUE_FOR_DYNAMIC_CONNECTOR
+```
+
+
+既定です。動的コネクタに対してのみ動的接着を許可し、それ以外は静的接着を使用します。
+
+### NO_ALLOW_2_D_SHAPE {#NO-ALLOW-2-D-SHAPE}
+```
+public static final int NO_ALLOW_2_D_SHAPE
+```
+
+
+この 2-D シェイプが動的接着で接続されることを許可しません。
+
+### NO_ALLOW_DYNAMIC_GLUE {#NO-ALLOW-DYNAMIC-GLUE}
+```
+public static final int NO_ALLOW_DYNAMIC_GLUE
+```
+
+
+動的接着を許可しません。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/gradientdirectiontype/_index.md
+++ b/japanese/java/com.aspose.diagram/gradientdirectiontype/_index.md
@@ -1,0 +1,183 @@
+---
+title: GradientDirectionType
+second_title: Aspose.Diagram for Java API リファレンス
+description: すべての方向タイプのグラデーションを表します。
+type: docs
+weight: 177
+url: /ja/java/com.aspose.diagram/gradientdirectiontype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class GradientDirectionType
+```
+
+すべての方向タイプのグラデーションを表します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [FROM_CENTER](#FROM-CENTER) | FromCenter |
+| [FROM_LOWER_LEFT_CORNER](#FROM-LOWER-LEFT-CORNER) | FromLowerLeftCorner |
+| [FROM_LOWER_RIGHT_CORNER](#FROM-LOWER-RIGHT-CORNER) | FromLowerRightCorner |
+| [FROM_UPPER_LEFT_CORNER](#FROM-UPPER-LEFT-CORNER) | FromUpperLeftCorner |
+| [FROM_UPPER_RIGHT_CORNER](#FROM-UPPER-RIGHT-CORNER) | FromUpperRightCorner |
+| [UNKNOWN](#UNKNOWN) | Unknown |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FROM_CENTER {#FROM-CENTER}
+```
+public static final int FROM_CENTER
+```
+
+
+FromCenter
+
+### FROM_LOWER_LEFT_CORNER {#FROM-LOWER-LEFT-CORNER}
+```
+public static final int FROM_LOWER_LEFT_CORNER
+```
+
+
+FromLowerLeftCorner
+
+### FROM_LOWER_RIGHT_CORNER {#FROM-LOWER-RIGHT-CORNER}
+```
+public static final int FROM_LOWER_RIGHT_CORNER
+```
+
+
+FromLowerRightCorner
+
+### FROM_UPPER_LEFT_CORNER {#FROM-UPPER-LEFT-CORNER}
+```
+public static final int FROM_UPPER_LEFT_CORNER
+```
+
+
+FromUpperLeftCorner
+
+### FROM_UPPER_RIGHT_CORNER {#FROM-UPPER-RIGHT-CORNER}
+```
+public static final int FROM_UPPER_RIGHT_CORNER
+```
+
+
+FromUpperRightCorner
+
+### UNKNOWN {#UNKNOWN}
+```
+public static final int UNKNOWN
+```
+
+
+Unknown
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/gradientfill/_index.md
+++ b/japanese/java/com.aspose.diagram/gradientfill/_index.md
@@ -1,0 +1,211 @@
+---
+title: GradientFill
+second_title: Aspose.Diagram for Java API リファレンス
+description: グラデーション塗りつぶしを表します。
+type: docs
+weight: 178
+url: /ja/java/com.aspose.diagram/gradientfill/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class GradientFill
+```
+
+グラデーション塗りつぶしを表します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getGradientAngle()](#getGradientAngle--) | 塗りつぶしカラーのグラデーションの向きを指定します。 |
+| [getGradientDir()](#getGradientDir--) | 塗りつぶしカラーのグラデーションのタイプを指定します。 |
+| [getGradientEnabled()](#getGradientEnabled--) | 塗りつぶしカラーのグラデーションが表示されるかどうかを指定します。 |
+| [getGradientStops()](#getGradientStops--) | グラデーションストップのコレクションを表します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setGradientAngle(DoubleValue value)](#setGradientAngle-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getGradientAngle()](../../com.aspose.diagram/gradientfill\#getGradientAngle--) を参照してください。 |
+| [setGradientDir(IntValue value)](#setGradientDir-com.aspose.diagram.IntValue-) | このプロパティの説明については、[getGradientDir()](../../com.aspose.diagram/gradientfill\#getGradientDir--) を参照してください。 |
+| [setGradientEnabled(BoolValue value)](#setGradientEnabled-com.aspose.diagram.BoolValue-) | このプロパティの説明については、[getGradientEnabled()](../../com.aspose.diagram/gradientfill\#getGradientEnabled--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getGradientAngle() {#getGradientAngle--}
+```
+public DoubleValue getGradientAngle()
+```
+
+
+塗りつぶしカラーのグラデーションの向きを指定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getGradientDir() {#getGradientDir--}
+```
+public IntValue getGradientDir()
+```
+
+
+塗りつぶしカラーのグラデーションのタイプを指定します。
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getGradientEnabled() {#getGradientEnabled--}
+```
+public BoolValue getGradientEnabled()
+```
+
+
+塗りつぶしカラーのグラデーションが表示されるかどうかを指定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getGradientStops() {#getGradientStops--}
+```
+public GradientStopCollection getGradientStops()
+```
+
+
+グラデーションストップのコレクションを表します。
+
+**Returns:**
+[GradientStopCollection](../../com.aspose.diagram/gradientstopcollection)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setGradientAngle(DoubleValue value) {#setGradientAngle-com.aspose.diagram.DoubleValue-}
+```
+public void setGradientAngle(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getGradientAngle()](../../com.aspose.diagram/gradientfill\#getGradientAngle--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setGradientDir(IntValue value) {#setGradientDir-com.aspose.diagram.IntValue-}
+```
+public void setGradientDir(IntValue value)
+```
+
+
+このプロパティの説明については、[getGradientDir()](../../com.aspose.diagram/gradientfill\#getGradientDir--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setGradientEnabled(BoolValue value) {#setGradientEnabled-com.aspose.diagram.BoolValue-}
+```
+public void setGradientEnabled(BoolValue value)
+```
+
+
+このプロパティの説明については、[getGradientEnabled()](../../com.aspose.diagram/gradientfill\#getGradientEnabled--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/gradientfilldir/_index.md
+++ b/japanese/java/com.aspose.diagram/gradientfilldir/_index.md
@@ -1,0 +1,255 @@
+---
+title: GradientFillDir
+second_title: Aspose.Diagram for Java API リファレンス
+description: シェイプの塗りつぶしカラーグラデーションのタイプを指定します。
+type: docs
+weight: 179
+url: /ja/java/com.aspose.diagram/gradientfilldir/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class GradientFillDir
+```
+
+シェイプの塗りつぶしカラーグラデーションのタイプを指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [LINEAR](#LINEAR) | 線形の塗りつぶしカラーグラデーションを指定します。 |
+| [PATH](#PATH) | シェイプの塗りつぶしカラーグラデーションがパスモードであることを指定します |
+| [RADIAL_FROM_BOTTOM_LEFT](#RADIAL-FROM-BOTTOM-LEFT) | シェイプの左下隅から放射モードで塗りつぶしカラーグラデーションを指定します |
+| [RADIAL_FROM_BOTTOM_RIGHT](#RADIAL-FROM-BOTTOM-RIGHT) | シェイプの右下隅から放射モードで塗りつぶしカラーグラデーションを指定します |
+| [RADIAL_FROM_CENTER](#RADIAL-FROM-CENTER) | シェイプの中心から放射モードで塗りつぶしカラーグラデーションを指定します。 |
+| [RADIAL_FROM_CENTER_BOTTOM](#RADIAL-FROM-CENTER-BOTTOM) | シェイプの下端の中心から放射モードで塗りつぶしカラーグラデーションを指定します。 |
+| [RADIAL_FROM_CENTER_TOP](#RADIAL-FROM-CENTER-TOP) | シェイプの上端の中心から放射モードで塗りつぶしカラーグラデーションを指定します |
+| [RADIAL_FROM_TOP_LEFT](#RADIAL-FROM-TOP-LEFT) | シェイプの左上隅から放射モードで塗りつぶしカラーグラデーションを指定します |
+| [RADIAL_FROM_TOP_RIGHT](#RADIAL-FROM-TOP-RIGHT) | シェイプの右上隅から放射モードで塗りつぶしカラーグラデーションを指定します |
+| [RECTANGLE_FROM_BOTTOM_LEFT](#RECTANGLE-FROM-BOTTOM-LEFT) | シェイプの左下隅から矩形モードで塗りつぶしカラーグラデーションを指定します |
+| [RECTANGLE_FROM_BOTTOM_RIGHT](#RECTANGLE-FROM-BOTTOM-RIGHT) | シェイプの右下隅から矩形モードで塗りつぶしカラーグラデーションを指定します |
+| [RECTANGLE_FROM_CENTER](#RECTANGLE-FROM-CENTER) | シェイプの中心から矩形モードで塗りつぶしカラーグラデーションを指定します。 |
+| [RECTANGLE_FROM_TOP_LEFT](#RECTANGLE-FROM-TOP-LEFT) | シェイプの左上隅から矩形モードで塗りつぶしカラーグラデーションを指定します |
+| [RECTANGLE_FROM_TOP_RIGHT](#RECTANGLE-FROM-TOP-RIGHT) | シェイプの右上隅から矩形モードで塗りつぶしカラーグラデーションを指定します |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LINEAR {#LINEAR}
+```
+public static final int LINEAR
+```
+
+
+線形の塗りつぶしカラーグラデーションを指定します。
+
+### PATH {#PATH}
+```
+public static final int PATH
+```
+
+
+シェイプの塗りつぶしカラーグラデーションがパスモードであることを指定します
+
+### RADIAL_FROM_BOTTOM_LEFT {#RADIAL-FROM-BOTTOM-LEFT}
+```
+public static final int RADIAL_FROM_BOTTOM_LEFT
+```
+
+
+シェイプの左下隅から放射モードで塗りつぶしカラーグラデーションを指定します
+
+### RADIAL_FROM_BOTTOM_RIGHT {#RADIAL-FROM-BOTTOM-RIGHT}
+```
+public static final int RADIAL_FROM_BOTTOM_RIGHT
+```
+
+
+シェイプの右下隅から放射モードで塗りつぶしカラーグラデーションを指定します
+
+### RADIAL_FROM_CENTER {#RADIAL-FROM-CENTER}
+```
+public static final int RADIAL_FROM_CENTER
+```
+
+
+シェイプの中心から放射モードで塗りつぶしカラーグラデーションを指定します。
+
+### RADIAL_FROM_CENTER_BOTTOM {#RADIAL-FROM-CENTER-BOTTOM}
+```
+public static final int RADIAL_FROM_CENTER_BOTTOM
+```
+
+
+シェイプの下端の中心から放射モードで塗りつぶしカラーグラデーションを指定します。
+
+### RADIAL_FROM_CENTER_TOP {#RADIAL-FROM-CENTER-TOP}
+```
+public static final int RADIAL_FROM_CENTER_TOP
+```
+
+
+シェイプの上端の中心から放射モードで塗りつぶしカラーグラデーションを指定します
+
+### RADIAL_FROM_TOP_LEFT {#RADIAL-FROM-TOP-LEFT}
+```
+public static final int RADIAL_FROM_TOP_LEFT
+```
+
+
+シェイプの左上隅から放射モードで塗りつぶしカラーグラデーションを指定します
+
+### RADIAL_FROM_TOP_RIGHT {#RADIAL-FROM-TOP-RIGHT}
+```
+public static final int RADIAL_FROM_TOP_RIGHT
+```
+
+
+シェイプの右上隅から放射モードで塗りつぶしカラーグラデーションを指定します
+
+### RECTANGLE_FROM_BOTTOM_LEFT {#RECTANGLE-FROM-BOTTOM-LEFT}
+```
+public static final int RECTANGLE_FROM_BOTTOM_LEFT
+```
+
+
+シェイプの左下隅から矩形モードで塗りつぶしカラーグラデーションを指定します
+
+### RECTANGLE_FROM_BOTTOM_RIGHT {#RECTANGLE-FROM-BOTTOM-RIGHT}
+```
+public static final int RECTANGLE_FROM_BOTTOM_RIGHT
+```
+
+
+シェイプの右下隅から矩形モードで塗りつぶしカラーグラデーションを指定します
+
+### RECTANGLE_FROM_CENTER {#RECTANGLE-FROM-CENTER}
+```
+public static final int RECTANGLE_FROM_CENTER
+```
+
+
+シェイプの中心から矩形モードで塗りつぶしカラーグラデーションを指定します。
+
+### RECTANGLE_FROM_TOP_LEFT {#RECTANGLE-FROM-TOP-LEFT}
+```
+public static final int RECTANGLE_FROM_TOP_LEFT
+```
+
+
+シェイプの左上隅から矩形モードで塗りつぶしカラーグラデーションを指定します
+
+### RECTANGLE_FROM_TOP_RIGHT {#RECTANGLE-FROM-TOP-RIGHT}
+```
+public static final int RECTANGLE_FROM_TOP_RIGHT
+```
+
+
+シェイプの右上隅から矩形モードで塗りつぶしカラーグラデーションを指定します
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/gradientfilltype/_index.md
+++ b/japanese/java/com.aspose.diagram/gradientfilltype/_index.md
@@ -1,0 +1,165 @@
+---
+title: GradientFillType
+second_title: Aspose.Diagram for Java API リファレンス
+description: すべてのグラデーション塗りつぶしタイプを表します。
+type: docs
+weight: 180
+url: /ja/java/com.aspose.diagram/gradientfilltype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class GradientFillType
+```
+
+すべてのグラデーション塗りつぶしタイプを表します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [LINEAR](#LINEAR) | Linear |
+| [PATH](#PATH) | Path |
+| [RADIAL](#RADIAL) | 放射状 |
+| [RECTANGLE](#RECTANGLE) | 長方形 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LINEAR {#LINEAR}
+```
+public static final int LINEAR
+```
+
+
+Linear
+
+### PATH {#PATH}
+```
+public static final int PATH
+```
+
+
+Path
+
+### RADIAL {#RADIAL}
+```
+public static final int RADIAL
+```
+
+
+放射状
+
+### RECTANGLE {#RECTANGLE}
+```
+public static final int RECTANGLE
+```
+
+
+長方形
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/gradientstop/_index.md
+++ b/japanese/java/com.aspose.diagram/gradientstop/_index.md
@@ -1,0 +1,222 @@
+---
+title: GradientStop
+second_title: Aspose.Diagram for Java API リファレンス
+description: グラデーションストップを表します。
+type: docs
+weight: 181
+url: /ja/java/com.aspose.diagram/gradientstop/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class GradientStop
+```
+
+グラデーションストップを表します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [GradientStop()](#GradientStop--) |  |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getColor()](#getColor--) | このグラデーションストップの色を取得します。 |
+| [getPosition()](#getPosition--) | ストップの位置。 |
+| [getTransparency()](#getTransparency--) | 領域の透明度を 0.0（不透明）から 1.0（透明）までの値で取得または設定します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setColor(ColorValue value)](#setColor-com.aspose.diagram.ColorValue-) | このプロパティの説明については、[getColor()](../../com.aspose.diagram/gradientstop\#getColor--) を参照してください。 |
+| [setPosition(DoubleValue value)](#setPosition-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getPosition()](../../com.aspose.diagram/gradientstop\#getPosition--) を参照してください。 |
+| [setTransparency(DoubleValue value)](#setTransparency-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getTransparency()](../../com.aspose.diagram/gradientstop\#getTransparency--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GradientStop() {#GradientStop--}
+```
+public GradientStop()
+```
+
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColor() {#getColor--}
+```
+public ColorValue getColor()
+```
+
+
+このグラデーションストップの色を取得します。
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getPosition() {#getPosition--}
+```
+public DoubleValue getPosition()
+```
+
+
+ストップの位置。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTransparency() {#getTransparency--}
+```
+public DoubleValue getTransparency()
+```
+
+
+領域の透明度を 0.0（不透明）から 1.0（透明）までの値で取得または設定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setColor(ColorValue value) {#setColor-com.aspose.diagram.ColorValue-}
+```
+public void setColor(ColorValue value)
+```
+
+
+このプロパティの説明については、[getColor()](../../com.aspose.diagram/gradientstop\#getColor--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setPosition(DoubleValue value) {#setPosition-com.aspose.diagram.DoubleValue-}
+```
+public void setPosition(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getPosition()](../../com.aspose.diagram/gradientstop\#getPosition--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTransparency(DoubleValue value) {#setTransparency-com.aspose.diagram.DoubleValue-}
+```
+public void setTransparency(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getTransparency()](../../com.aspose.diagram/gradientstop\#getTransparency--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/gradientstopcollection/_index.md
+++ b/japanese/java/com.aspose.diagram/gradientstopcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: GradientStopCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: グラデーションストップのコレクションを表します。
+type: docs
+weight: 182
+url: /ja/java/com.aspose.diagram/gradientstopcollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class GradientStopCollection extends Collection
+```
+
+グラデーションストップのコレクションを表します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(DoubleValue position, ColorValue color)](#add-com.aspose.diagram.DoubleValue-com.aspose.diagram.ColorValue-) | Add a gradient stop. |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gets the gradient stop by the index. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [set(int index, GradientStop value)](#set-int-com.aspose.diagram.GradientStop-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(DoubleValue position, ColorValue color) {#add-com.aspose.diagram.DoubleValue-com.aspose.diagram.ColorValue-}
+```
+public void add(DoubleValue position, ColorValue color)
+```
+
+
+Add a gradient stop.
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| position | [DoubleValue](../../com.aspose.diagram/doublevalue) | The position of the stop,in unit of percentage. |
+| color | [ColorValue](../../com.aspose.diagram/colorvalue) | The color of the stop. |
+
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public GradientStop get(int index)
+```
+
+
+Gets the gradient stop by the index.
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | The index. |
+
+**Returns:**
+[GradientStop](../../com.aspose.diagram/gradientstop) - The gradient stop.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### set(int index, GradientStop value) {#set-int-com.aspose.diagram.GradientStop-}
+```
+public void set(int index, GradientStop value)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+| value | [GradientStop](../../com.aspose.diagram/gradientstop) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/gradientstyletype/_index.md
+++ b/japanese/java/com.aspose.diagram/gradientstyletype/_index.md
@@ -1,0 +1,192 @@
+---
+title: GradientStyleType
+second_title: Aspose.Diagram for Java API リファレンス
+description: グラデーションシェーディングスタイルを表します。
+type: docs
+weight: 183
+url: /ja/java/com.aspose.diagram/gradientstyletype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class GradientStyleType
+```
+
+グラデーションシェーディングスタイルを表します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [DIAGONAL_DOWN](#DIAGONAL-DOWN) | 対角下方向のシェーディングスタイル |
+| [DIAGONAL_UP](#DIAGONAL-UP) | 対角上方向のシェーディングスタイル |
+| [FROM_CENTER](#FROM-CENTER) | 中心からのシェーディングスタイル |
+| [FROM_CORNER](#FROM-CORNER) | コーナーからのシェーディングスタイル |
+| [HORIZONTAL](#HORIZONTAL) | 水平シェーディングスタイル |
+| [UNKNOWN](#UNKNOWN) | 不明なシェーディングスタイル。テンプレートファイル内のシェーディングスタイル（GradientStyleType のメンバーではないもの）のみ対象です。 |
+| [VERTICAL](#VERTICAL) | 垂直シェーディングスタイル |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DIAGONAL_DOWN {#DIAGONAL-DOWN}
+```
+public static final int DIAGONAL_DOWN
+```
+
+
+対角下方向のシェーディングスタイル
+
+### DIAGONAL_UP {#DIAGONAL-UP}
+```
+public static final int DIAGONAL_UP
+```
+
+
+対角上方向のシェーディングスタイル
+
+### FROM_CENTER {#FROM-CENTER}
+```
+public static final int FROM_CENTER
+```
+
+
+中心からのシェーディングスタイル
+
+### FROM_CORNER {#FROM-CORNER}
+```
+public static final int FROM_CORNER
+```
+
+
+コーナーからのシェーディングスタイル
+
+### HORIZONTAL {#HORIZONTAL}
+```
+public static final int HORIZONTAL
+```
+
+
+水平シェーディングスタイル
+
+### UNKNOWN {#UNKNOWN}
+```
+public static final int UNKNOWN
+```
+
+
+不明なシェーディングスタイル。テンプレートファイル内のシェーディングスタイル（GradientStyleType のメンバーではないもの）のみ対象です。
+
+### VERTICAL {#VERTICAL}
+```
+public static final int VERTICAL
+```
+
+
+垂直シェーディングスタイル
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/griddensity/_index.md
+++ b/japanese/java/com.aspose.diagram/griddensity/_index.md
@@ -1,0 +1,179 @@
+---
+title: GridDensity
+second_title: Aspose.Diagram for Java API リファレンス
+description: ページで使用する水平/垂直グリッドのタイプを指定します。
+type: docs
+weight: 184
+url: /ja/java/com.aspose.diagram/griddensity/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class GridDensity
+```
+
+ページで使用する水平/垂直グリッドのタイプを指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [GridDensity(int value)](#GridDensity-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | ページで使用する水平/垂直グリッドのタイプを指定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/griddensity\#getValue--) をご覧ください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GridDensity(int value) {#GridDensity-int-}
+```
+public GridDensity(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+ページで使用する水平/垂直グリッドのタイプを指定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/griddensity\#getValue--) をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/griddensityvalue/_index.md
+++ b/japanese/java/com.aspose.diagram/griddensityvalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: GridDensityValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: ページで使用する水平/垂直グリッドのタイプを指定します。
+type: docs
+weight: 185
+url: /ja/java/com.aspose.diagram/griddensityvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class GridDensityValue
+```
+
+ページで使用する水平/垂直グリッドのタイプを指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [COARSE](#COARSE) | 粗い。 |
+| [FINE](#FINE) | 細かい |
+| [FIXED](#FIXED) | 固定。 |
+| [NORMAL](#NORMAL) | 標準。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### COARSE {#COARSE}
+```
+public static final int COARSE
+```
+
+
+粗い。
+
+### FINE {#FINE}
+```
+public static final int FINE
+```
+
+
+細かい
+
+### FIXED {#FIXED}
+```
+public static final int FIXED
+```
+
+
+固定。
+
+### NORMAL {#NORMAL}
+```
+public static final int NORMAL
+```
+
+
+標準。デフォルト。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/group/_index.md
+++ b/japanese/java/com.aspose.diagram/group/_index.md
@@ -1,0 +1,216 @@
+---
+title: Group
+second_title: Aspose.Diagram for Java API リファレンス
+description: Contains elements that control how you add shapes to a group move members of a group and select groups.
+type: docs
+weight: 186
+url: /ja/java/com.aspose.diagram/group/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Group
+```
+
+グループにシェイプを追加する方法、グループのメンバーを移動する方法、グループを選択する方法を制御する要素を含みます。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getDisplayMode()](#getDisplayMode--) | Group 要素に含まれる場合、DisplayMode 要素はグループ シェイプとそのメンバーの表示方法を指定します。 |
+| [getDontMoveChildren()](#getDontMoveChildren--) | Specifies whether you can drag shapes in a group by using the mouse. |
+| [getSelectMode()](#getSelectMode--) | ユーザーがグループ シェイプとそのメンバーを選択する方法を指定します。 |
+| [hashCode()](#hashCode--) |  |
+| [isDropTarget()](#isDropTarget--) | Specifies whether the group allows a shape to be added to it when the shape is dropped on the group. |
+| [isSnapTarget()](#isSnapTarget--) | Specifies whether snapping to a group or to shapes within the group is enabled. |
+| [isTextEditTarget()](#isTextEditTarget--) | Specifies how to assign text to a group. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | For the description of this property, please see [getDel()](../../com.aspose.diagram/group\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getDisplayMode() {#getDisplayMode--}
+```
+public DisplayMode getDisplayMode()
+```
+
+
+Group 要素に含まれる場合、DisplayMode 要素はグループ シェイプとそのメンバーの表示方法を指定します。
+
+**Returns:**
+[DisplayMode](../../com.aspose.diagram/displaymode)
+### getDontMoveChildren() {#getDontMoveChildren--}
+```
+public BoolValue getDontMoveChildren()
+```
+
+
+Specifies whether you can drag shapes in a group by using the mouse.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getSelectMode() {#getSelectMode--}
+```
+public SelectMode getSelectMode()
+```
+
+
+ユーザーがグループ シェイプとそのメンバーを選択する方法を指定します。
+
+**Returns:**
+[SelectMode](../../com.aspose.diagram/selectmode)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isDropTarget() {#isDropTarget--}
+```
+public BoolValue isDropTarget()
+```
+
+
+Specifies whether the group allows a shape to be added to it when the shape is dropped on the group.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### isSnapTarget() {#isSnapTarget--}
+```
+public BoolValue isSnapTarget()
+```
+
+
+Specifies whether snapping to a group or to shapes within the group is enabled.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### isTextEditTarget() {#isTextEditTarget--}
+```
+public BoolValue isTextEditTarget()
+```
+
+
+Specifies how to assign text to a group.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+For the description of this property, please see [getDel()](../../com.aspose.diagram/group\#getDel--)
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/headerfooter/_index.md
+++ b/japanese/java/com.aspose.diagram/headerfooter/_index.md
@@ -1,0 +1,361 @@
+---
+title: HeaderFooter
+second_title: Aspose.Diagram for Java API リファレンス
+description: 文書のヘッダーとフッターの要素を含みます。
+type: docs
+weight: 188
+url: /ja/java/com.aspose.diagram/headerfooter/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class HeaderFooter
+```
+
+ドキュメントのヘッダーとフッターの要素を含みます。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFooterCenter()](#getFooterCenter--) | 文書のフッターの中央部分に表示されるテキスト文字列を含みます。 |
+| [getFooterLeft()](#getFooterLeft--) | 文書のフッターの左側部分に表示されるテキスト文字列を含みます。 |
+| [getFooterMargin()](#getFooterMargin--) | 文書のフッターの余白を指定します。 |
+| [getFooterRight()](#getFooterRight--) | 文書のフッターの右側部分に表示されるテキスト文字列を含みます。 |
+| [getHeaderCenter()](#getHeaderCenter--) | 文書のヘッダーの中央部分に表示されるテキスト文字列を含みます。 |
+| [getHeaderFooterColor()](#getHeaderFooterColor--) | ヘッダーとフッターのテキスト色のRGB値です。 |
+| [getHeaderFooterFont()](#getHeaderFooterFont--) | ヘッダーとフッターのテキストに使用されるフォントを指定します。 |
+| [getHeaderLeft()](#getHeaderLeft--) | 文書のヘッダーの左側部分に表示されるテキスト文字列を含みます。 |
+| [getHeaderMargin()](#getHeaderMargin--) | 文書のフッターの余白を指定します。 |
+| [getHeaderRight()](#getHeaderRight--) | 文書のヘッダーの右側部分に表示されるテキスト文字列を含みます。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setFooterCenter(String value)](#setFooterCenter-java.lang.String-) | このプロパティの説明については、[getFooterCenter()](../../com.aspose.diagram/headerfooter\#getFooterCenter--)をご覧ください。 |
+| [setFooterLeft(String value)](#setFooterLeft-java.lang.String-) | このプロパティの説明については、[getFooterLeft()](../../com.aspose.diagram/headerfooter\#getFooterLeft--)をご覧ください。 |
+| [setFooterMargin(Margin value)](#setFooterMargin-com.aspose.diagram.Margin-) | このプロパティの説明については、[getFooterMargin()](../../com.aspose.diagram/headerfooter\#getFooterMargin--)をご覧ください。 |
+| [setFooterRight(String value)](#setFooterRight-java.lang.String-) | このプロパティの説明については、[getFooterRight()](../../com.aspose.diagram/headerfooter\#getFooterRight--)をご覧ください。 |
+| [setHeaderCenter(String value)](#setHeaderCenter-java.lang.String-) | このプロパティの説明については、[getHeaderCenter()](../../com.aspose.diagram/headerfooter\#getHeaderCenter--)をご覧ください。 |
+| [setHeaderFooterColor(Color value)](#setHeaderFooterColor-com.aspose.diagram.Color-) | このプロパティの説明については、[getHeaderFooterColor()](../../com.aspose.diagram/headerfooter\#getHeaderFooterColor--)をご覧ください。 |
+| [setHeaderLeft(String value)](#setHeaderLeft-java.lang.String-) | このプロパティの説明については、[getHeaderLeft()](../../com.aspose.diagram/headerfooter\#getHeaderLeft--)をご覧ください。 |
+| [setHeaderMargin(Margin value)](#setHeaderMargin-com.aspose.diagram.Margin-) | このプロパティの説明については、[getHeaderMargin()](../../com.aspose.diagram/headerfooter\#getHeaderMargin--)をご覧ください。 |
+| [setHeaderRight(String value)](#setHeaderRight-java.lang.String-) | このプロパティの説明については、[getHeaderRight()](../../com.aspose.diagram/headerfooter\#getHeaderRight--)をご覧ください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFooterCenter() {#getFooterCenter--}
+```
+public String getFooterCenter()
+```
+
+
+文書のフッターの中央部分に表示されるテキスト文字列を含みます。
+
+**Returns:**
+java.lang.String
+### getFooterLeft() {#getFooterLeft--}
+```
+public String getFooterLeft()
+```
+
+
+文書のフッターの左側部分に表示されるテキスト文字列を含みます。
+
+**Returns:**
+java.lang.String
+### getFooterMargin() {#getFooterMargin--}
+```
+public Margin getFooterMargin()
+```
+
+
+文書のフッターの余白を指定します。
+
+**Returns:**
+[Margin](../../com.aspose.diagram/margin)
+### getFooterRight() {#getFooterRight--}
+```
+public String getFooterRight()
+```
+
+
+文書のフッターの右側部分に表示されるテキスト文字列を含みます。
+
+**Returns:**
+java.lang.String
+### getHeaderCenter() {#getHeaderCenter--}
+```
+public String getHeaderCenter()
+```
+
+
+文書のヘッダーの中央部分に表示されるテキスト文字列を含みます。
+
+**Returns:**
+java.lang.String
+### getHeaderFooterColor() {#getHeaderFooterColor--}
+```
+public Color getHeaderFooterColor()
+```
+
+
+ヘッダーとフッターのテキスト色のRGB値です。
+
+**Returns:**
+[Color](../../com.aspose.diagram/color)
+### getHeaderFooterFont() {#getHeaderFooterFont--}
+```
+public HeaderFooterFont getHeaderFooterFont()
+```
+
+
+ヘッダーとフッターのテキストに使用されるフォントを指定します。
+
+**Returns:**
+[HeaderFooterFont](../../com.aspose.diagram/headerfooterfont)
+### getHeaderLeft() {#getHeaderLeft--}
+```
+public String getHeaderLeft()
+```
+
+
+文書のヘッダーの左側部分に表示されるテキスト文字列を含みます。
+
+**Returns:**
+java.lang.String
+### getHeaderMargin() {#getHeaderMargin--}
+```
+public Margin getHeaderMargin()
+```
+
+
+文書のフッターの余白を指定します。
+
+**Returns:**
+[Margin](../../com.aspose.diagram/margin)
+### getHeaderRight() {#getHeaderRight--}
+```
+public String getHeaderRight()
+```
+
+
+文書のヘッダーの右側部分に表示されるテキスト文字列を含みます。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setFooterCenter(String value) {#setFooterCenter-java.lang.String-}
+```
+public void setFooterCenter(String value)
+```
+
+
+このプロパティの説明については、[getFooterCenter()](../../com.aspose.diagram/headerfooter\#getFooterCenter--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setFooterLeft(String value) {#setFooterLeft-java.lang.String-}
+```
+public void setFooterLeft(String value)
+```
+
+
+このプロパティの説明については、[getFooterLeft()](../../com.aspose.diagram/headerfooter\#getFooterLeft--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setFooterMargin(Margin value) {#setFooterMargin-com.aspose.diagram.Margin-}
+```
+public void setFooterMargin(Margin value)
+```
+
+
+このプロパティの説明については、[getFooterMargin()](../../com.aspose.diagram/headerfooter\#getFooterMargin--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [Margin](../../com.aspose.diagram/margin) |  |
+
+### setFooterRight(String value) {#setFooterRight-java.lang.String-}
+```
+public void setFooterRight(String value)
+```
+
+
+このプロパティの説明については、[getFooterRight()](../../com.aspose.diagram/headerfooter\#getFooterRight--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setHeaderCenter(String value) {#setHeaderCenter-java.lang.String-}
+```
+public void setHeaderCenter(String value)
+```
+
+
+このプロパティの説明については、[getHeaderCenter()](../../com.aspose.diagram/headerfooter\#getHeaderCenter--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setHeaderFooterColor(Color value) {#setHeaderFooterColor-com.aspose.diagram.Color-}
+```
+public void setHeaderFooterColor(Color value)
+```
+
+
+このプロパティの説明については、[getHeaderFooterColor()](../../com.aspose.diagram/headerfooter\#getHeaderFooterColor--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [Color](../../com.aspose.diagram/color) |  |
+
+### setHeaderLeft(String value) {#setHeaderLeft-java.lang.String-}
+```
+public void setHeaderLeft(String value)
+```
+
+
+このプロパティの説明については、[getHeaderLeft()](../../com.aspose.diagram/headerfooter\#getHeaderLeft--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setHeaderMargin(Margin value) {#setHeaderMargin-com.aspose.diagram.Margin-}
+```
+public void setHeaderMargin(Margin value)
+```
+
+
+このプロパティの説明については、[getHeaderMargin()](../../com.aspose.diagram/headerfooter\#getHeaderMargin--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [Margin](../../com.aspose.diagram/margin) |  |
+
+### setHeaderRight(String value) {#setHeaderRight-java.lang.String-}
+```
+public void setHeaderRight(String value)
+```
+
+
+このプロパティの説明については、[getHeaderRight()](../../com.aspose.diagram/headerfooter\#getHeaderRight--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/headerfooterfont/_index.md
+++ b/japanese/java/com.aspose.diagram/headerfooterfont/_index.md
@@ -1,0 +1,475 @@
+---
+title: HeaderFooterFont
+second_title: Aspose.Diagram for Java API リファレンス
+description: ヘッダーとフッターのテキストに使用されるフォントを指定します。
+type: docs
+weight: 189
+url: /ja/java/com.aspose.diagram/headerfooterfont/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class HeaderFooterFont
+```
+
+ヘッダーとフッターのテキストに使用されるフォントを指定します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCharSet()](#getCharSet--) | Specifies the character set of the font. |
+| [getClass()](#getClass--) |  |
+| [getClipPrecision()](#getClipPrecision--) | Specifies the clipping precision of the font. |
+| [getEscapement()](#getEscapement--) | Specifies the escapement attribute of the font. |
+| [getFaceName()](#getFaceName--) | Specifies the type face name attribute of the font. |
+| [getHeight()](#getHeight--) | Specifies the height of the font. |
+| [getItalic()](#getItalic--) | Specifies the weight of the font. |
+| [getOrientation()](#getOrientation--) | Specifies the orientation of the font. |
+| [getOutPrecision()](#getOutPrecision--) | Specifies the output precision attribute of the font. |
+| [getPitchAndFamily()](#getPitchAndFamily--) | Specifies the pitch and family of the font. |
+| [getQuality()](#getQuality--) | Specifies the output quality of the font. |
+| [getStrikeOut()](#getStrikeOut--) | Specifies whether the font is a strikeout font. |
+| [getUnderline()](#getUnderline--) | Specifies whether the font is underlined. |
+| [getWeight()](#getWeight--) | Specifies the weight of the font. |
+| [getWidth()](#getWidth--) | Specifies the width of the font. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCharSet(long value)](#setCharSet-long-) | For the description of this property, please see \{@link HeaderFooterFont\#(getCharSet() & 0xFFFFFFFFL)\} |
+| [setClipPrecision(long value)](#setClipPrecision-long-) | For the description of this property, please see \{@link HeaderFooterFont\#(getClipPrecision() & 0xFFFFFFFFL)\} |
+| [setEscapement(int value)](#setEscapement-int-) | For the description of this property, please see [getEscapement()](../../com.aspose.diagram/headerfooterfont\#getEscapement--) |
+| [setFaceName(String value)](#setFaceName-java.lang.String-) | For the description of this property, please see [getFaceName()](../../com.aspose.diagram/headerfooterfont\#getFaceName--) |
+| [setHeight(int value)](#setHeight-int-) | For the description of this property, please see [getHeight()](../../com.aspose.diagram/headerfooterfont\#getHeight--) |
+| [setItalic(int value)](#setItalic-int-) | このプロパティの説明については、[getItalic()](../../com.aspose.diagram/headerfooterfont\#getItalic--) を参照してください。 |
+| [setOrientation(int value)](#setOrientation-int-) | このプロパティの説明については、[getOrientation()](../../com.aspose.diagram/headerfooterfont\#getOrientation--) を参照してください。 |
+| [setOutPrecision(long value)](#setOutPrecision-long-) | このプロパティの説明については、\{@link HeaderFooterFont\#(getOutPrecision() & 0xFFFFFFFFL)\} を参照してください。 |
+| [setPitchAndFamily(long value)](#setPitchAndFamily-long-) | このプロパティの説明については、\{@link HeaderFooterFont\#(getPitchAndFamily() & 0xFFFFFFFFL)\} を参照してください。 |
+| [setQuality(long value)](#setQuality-long-) | このプロパティの説明については、\{@link HeaderFooterFont\#(getQuality() & 0xFFFFFFFFL)\} を参照してください。 |
+| [setStrikeOut(int value)](#setStrikeOut-int-) | このプロパティの説明については、[getStrikeOut()](../../com.aspose.diagram/headerfooterfont\#getStrikeOut--) を参照してください。 |
+| [setUnderline(int value)](#setUnderline-int-) | このプロパティの説明については、[getUnderline()](../../com.aspose.diagram/headerfooterfont\#getUnderline--) を参照してください。 |
+| [setWeight(int value)](#setWeight-int-) | このプロパティの説明については、[getWeight()](../../com.aspose.diagram/headerfooterfont\#getWeight--) を参照してください。 |
+| [setWidth(int value)](#setWidth-int-) | このプロパティの説明については、[getWidth()](../../com.aspose.diagram/headerfooterfont\#getWidth--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCharSet() {#getCharSet--}
+```
+public long getCharSet()
+```
+
+
+フォントの文字セットを指定します。GDI LOGFONT の lfCharSet フィールドに相当します。
+
+**Returns:**
+long
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getClipPrecision() {#getClipPrecision--}
+```
+public long getClipPrecision()
+```
+
+
+フォントのクリッピング精度を指定します。GDI LOGFONT の lfClipPrecision フィールドに相当します。
+
+**Returns:**
+long
+### getEscapement() {#getEscapement--}
+```
+public int getEscapement()
+```
+
+
+フォントのエスケープ属性を指定します。GDI LOGFONT の lfEscapement フィールドに相当します。
+
+**Returns:**
+int
+### getFaceName() {#getFaceName--}
+```
+public String getFaceName()
+```
+
+
+フォントの書体名属性を指定します。GDI LOGFONT の lfFaceName フィールドに相当します。
+
+**Returns:**
+java.lang.String
+### getHeight() {#getHeight--}
+```
+public int getHeight()
+```
+
+
+フォントの高さを指定します。GDI LOGFONT の lfHeight フィールドに相当します。
+
+**Returns:**
+int
+### getItalic() {#getItalic--}
+```
+public int getItalic()
+```
+
+
+フォントの太さを指定します。GDI LOGFONT の lfWeight フィールドに相当します。
+
+**Returns:**
+int
+### getOrientation() {#getOrientation--}
+```
+public int getOrientation()
+```
+
+
+フォントの向きを指定します。GDI LOGFONT の lfOrientation フィールドに相当します。
+
+**Returns:**
+int
+### getOutPrecision() {#getOutPrecision--}
+```
+public long getOutPrecision()
+```
+
+
+フォントの出力精度属性を指定します。GDI LOGFONT の lfOutPrecision フィールドに相当します。
+
+**Returns:**
+long
+### getPitchAndFamily() {#getPitchAndFamily--}
+```
+public long getPitchAndFamily()
+```
+
+
+フォントのピッチとファミリを指定します。GDI LOGFONT の lfPitchAndFamily フィールドに相当します。
+
+**Returns:**
+long
+### getQuality() {#getQuality--}
+```
+public long getQuality()
+```
+
+
+フォントの出力品質を指定します。GDI LOGFONT の lfQuality フィールドに相当します。
+
+**Returns:**
+long
+### getStrikeOut() {#getStrikeOut--}
+```
+public int getStrikeOut()
+```
+
+
+フォントが取り消し線かどうかを指定します。GDI LOGFONT の lfStrikeOut フィールドに相当します。
+
+**Returns:**
+int
+### getUnderline() {#getUnderline--}
+```
+public int getUnderline()
+```
+
+
+フォントが下線かどうかを指定します。GDI LOGFONT の lfUnderline フィールドに相当します。
+
+**Returns:**
+int
+### getWeight() {#getWeight--}
+```
+public int getWeight()
+```
+
+
+フォントの太さを指定します。GDI LOGFONT の lfWeight フィールドに相当します。
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public int getWidth()
+```
+
+
+フォントの幅を指定します。GDI LOGFONT の lfWidth フィールドに相当します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCharSet(long value) {#setCharSet-long-}
+```
+public void setCharSet(long value)
+```
+
+
+For the description of this property, please see \{@link HeaderFooterFont\#(getCharSet() & 0xFFFFFFFFL)\}
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | long |  |
+
+### setClipPrecision(long value) {#setClipPrecision-long-}
+```
+public void setClipPrecision(long value)
+```
+
+
+For the description of this property, please see \{@link HeaderFooterFont\#(getClipPrecision() & 0xFFFFFFFFL)\}
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | long |  |
+
+### setEscapement(int value) {#setEscapement-int-}
+```
+public void setEscapement(int value)
+```
+
+
+For the description of this property, please see [getEscapement()](../../com.aspose.diagram/headerfooterfont\#getEscapement--)
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setFaceName(String value) {#setFaceName-java.lang.String-}
+```
+public void setFaceName(String value)
+```
+
+
+For the description of this property, please see [getFaceName()](../../com.aspose.diagram/headerfooterfont\#getFaceName--)
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setHeight(int value) {#setHeight-int-}
+```
+public void setHeight(int value)
+```
+
+
+For the description of this property, please see [getHeight()](../../com.aspose.diagram/headerfooterfont\#getHeight--)
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setItalic(int value) {#setItalic-int-}
+```
+public void setItalic(int value)
+```
+
+
+このプロパティの説明については、[getItalic()](../../com.aspose.diagram/headerfooterfont\#getItalic--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setOrientation(int value) {#setOrientation-int-}
+```
+public void setOrientation(int value)
+```
+
+
+このプロパティの説明については、[getOrientation()](../../com.aspose.diagram/headerfooterfont\#getOrientation--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setOutPrecision(long value) {#setOutPrecision-long-}
+```
+public void setOutPrecision(long value)
+```
+
+
+このプロパティの説明については、\{@link HeaderFooterFont\#(getOutPrecision() & 0xFFFFFFFFL)\} を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | long |  |
+
+### setPitchAndFamily(long value) {#setPitchAndFamily-long-}
+```
+public void setPitchAndFamily(long value)
+```
+
+
+このプロパティの説明については、\{@link HeaderFooterFont\#(getPitchAndFamily() & 0xFFFFFFFFL)\} を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | long |  |
+
+### setQuality(long value) {#setQuality-long-}
+```
+public void setQuality(long value)
+```
+
+
+このプロパティの説明については、\{@link HeaderFooterFont\#(getQuality() & 0xFFFFFFFFL)\} を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | long |  |
+
+### setStrikeOut(int value) {#setStrikeOut-int-}
+```
+public void setStrikeOut(int value)
+```
+
+
+このプロパティの説明については、[getStrikeOut()](../../com.aspose.diagram/headerfooterfont\#getStrikeOut--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setUnderline(int value) {#setUnderline-int-}
+```
+public void setUnderline(int value)
+```
+
+
+このプロパティの説明については、[getUnderline()](../../com.aspose.diagram/headerfooterfont\#getUnderline--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setWeight(int value) {#setWeight-int-}
+```
+public void setWeight(int value)
+```
+
+
+このプロパティの説明については、[getWeight()](../../com.aspose.diagram/headerfooterfont\#getWeight--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setWidth(int value) {#setWidth-int-}
+```
+public void setWidth(int value)
+```
+
+
+このプロパティの説明については、[getWidth()](../../com.aspose.diagram/headerfooterfont\#getWidth--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/help/_index.md
+++ b/japanese/java/com.aspose.diagram/help/_index.md
@@ -1,0 +1,172 @@
+---
+title: ヘルプ
+second_title: Aspose.Diagram for Java API リファレンス
+description: Shape 要素のヘルプファイルトピックと著作権情報を指定する要素を含みます。
+type: docs
+weight: 190
+url: /ja/java/com.aspose.diagram/help/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Help
+```
+
+Shape 要素のヘルプファイルトピックと著作権情報を指定する要素を含みます。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCopyright()](#getCopyright--) | 人が読める著作権表記を表す文字列を含みます。 |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getHelpTopic()](#getHelpTopic--) | Shape 要素のヘルプトピック ID を指定します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | このプロパティの説明については、[getDel()](../../com.aspose.diagram/help\#getDel--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCopyright() {#getCopyright--}
+```
+public Str2Value getCopyright()
+```
+
+
+人が読める著作権表記を表す文字列を含みます。
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getHelpTopic() {#getHelpTopic--}
+```
+public Str2Value getHelpTopic()
+```
+
+
+Shape 要素のヘルプトピック ID を指定します。
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+このプロパティの説明については、[getDel()](../../com.aspose.diagram/help\#getDel--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/horzalign/_index.md
+++ b/japanese/java/com.aspose.diagram/horzalign/_index.md
@@ -1,0 +1,179 @@
+---
+title: HorzAlign
+second_title: Aspose.Diagram for Java API リファレンス
+description: シェイプのテキストブロック内のテキストの水平揃えを指定します。
+type: docs
+weight: 191
+url: /ja/java/com.aspose.diagram/horzalign/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class HorzAlign
+```
+
+シェイプのテキストブロック内のテキストの水平揃えを指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [HorzAlign(int value)](#HorzAlign-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | シェイプのテキストブロック内のテキストの水平揃えを指定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/horzalign\#getValue--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### HorzAlign(int value) {#HorzAlign-int-}
+```
+public HorzAlign(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+シェイプのテキストブロック内のテキストの水平揃えを指定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/horzalign\#getValue--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/horzalignvalue/_index.md
+++ b/japanese/java/com.aspose.diagram/horzalignvalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: HorzAlignValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: シェイプのテキストブロック内のテキストの水平揃えを指定します。
+type: docs
+weight: 192
+url: /ja/java/com.aspose.diagram/horzalignvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class HorzAlignValue
+```
+
+シェイプのテキストブロック内のテキストの水平揃えを指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [CENTER](#CENTER) | 中央。 |
+| [FORCE_JUSTIFY](#FORCE-JUSTIFY) | 強制的に両端揃えにします。 |
+| [JUSTIFY](#JUSTIFY) | 両端揃え。 |
+| [LEFT_ALIGN](#LEFT-ALIGN) | 左揃え。 |
+| [RIGHT_ALIGN](#RIGHT-ALIGN) | 右揃え。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CENTER {#CENTER}
+```
+public static final int CENTER
+```
+
+
+中央。
+
+### FORCE_JUSTIFY {#FORCE-JUSTIFY}
+```
+public static final int FORCE_JUSTIFY
+```
+
+
+強制的に両端揃えにします。
+
+### JUSTIFY {#JUSTIFY}
+```
+public static final int JUSTIFY
+```
+
+
+両端揃え。
+
+### LEFT_ALIGN {#LEFT-ALIGN}
+```
+public static final int LEFT_ALIGN
+```
+
+
+左揃え。
+
+### RIGHT_ALIGN {#RIGHT-ALIGN}
+```
+public static final int RIGHT_ALIGN
+```
+
+
+右揃え。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/htmlsaveoptions/_index.md
+++ b/japanese/java/com.aspose.diagram/htmlsaveoptions/_index.md
@@ -1,0 +1,629 @@
+---
+title: HTMLSaveOptions
+second_title: Aspose.Diagram for Java API リファレンス
+description: ダイアグラムページを HTML にレンダリングする際に、追加オプションを指定できます。
+type: docs
+weight: 187
+url: /ja/java/com.aspose.diagram/htmlsaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.SaveOptions](../../com.aspose.diagram/saveoptions), [com.aspose.diagram.RenderingSaveOptions](../../com.aspose.diagram/renderingsaveoptions)
+```
+public class HTMLSaveOptions extends RenderingSaveOptions
+```
+
+ダイアグラムページを HTML にレンダリングする際に、追加オプションを指定できます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [HTMLSaveOptions()](#HTMLSaveOptions--) | このクラスの新しいインスタンスを初期化します。このインスタンスは Aspose.Diagram.SaveFileFormat 形式でドキュメントを保存するために使用できます。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | 指定された保存形式に適したクラスの保存オプションオブジェクトを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDefaultFont()](#getDefaultFont--) | 図内の文字が Unicode で、正しいフォント値が設定されていない、またはフォントがローカルにインストールされていない場合、pdf、画像、または XPS でブロックとして表示されることがあります。 |
+| [getEmfRenderSetting()](#getEmfRenderSetting--) | Emf メタファイルのレンダリング設定です。 |
+| [getEnlargePage()](#getEnlargePage--) | ページを拡大するかどうかを指定します。 |
+| [getExportGuideShapes()](#getExportGuideShapes--) | ガイドシェイプをエクスポートするかどうかを定義します。 |
+| [getExportHiddenPage()](#getExportHiddenPage--) | 非表示ページをエクスポートするかどうかを定義します。 |
+| [getPageCount()](#getPageCount--) | HTML にレンダリングするページ数。 |
+| [getPageIndex()](#getPageIndex--) | レンダリングする最初のページの 0 ベースインデックス。 |
+| [getPageSize()](#getPageSize--) | 生成された画像のページサイズ。 |
+| [getResolution()](#getResolution--) | 生成された HTML の解像度（dpi 単位）。 |
+| [getSaveAsSingleFile()](#getSaveAsSingleFile--) | HTML を単一ファイルとして保存するかどうかを示します。 |
+| [getSaveForegroundPagesOnly()](#getSaveForegroundPagesOnly--) | すべてのページを画像として保存するか、前景のみを保存するかを指定します。 |
+| [getSaveFormat()](#getSaveFormat--) | この保存オプションオブジェクトが使用された場合、レンダリングされた図ページが保存される形式を指定します。 |
+| [getSaveTitle()](#getSaveTitle--) | タイトルをエクスポートするかどうかを定義します。 |
+| [getSaveToolBar()](#getSaveToolBar--) | ツールバーを保存するかどうかを指定します。デフォルト値は true です。 |
+| [getShapes()](#getShapes--) | レンダリングするシェイプ。 |
+| [getStreamProvider()](#getStreamProvider--) | オブジェクトをエクスポートするための IStreamProvider。 |
+| [getTitle()](#getTitle--) | HTML にレンダリングする図のタイトル。 |
+| [getWarningCallback()](#getWarningCallback--) | 警告コールバック。 |
+| [hashCode()](#hashCode--) |  |
+| [isExportComments()](#isExportComments--) | コメントをエクスポートするかどうかを定義します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | このプロパティの説明については、[getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--) を参照してください。 |
+| [setEmfRenderSetting(int value)](#setEmfRenderSetting-int-) | このプロパティの説明については、[getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--) を参照してください。 |
+| [setEnlargePage(boolean value)](#setEnlargePage-boolean-) | このプロパティの説明については、[getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--) を参照してください。 |
+| [setExportComments(boolean value)](#setExportComments-boolean-) | このプロパティの説明については、[isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--) を参照してください。 |
+| [setExportGuideShapes(boolean value)](#setExportGuideShapes-boolean-) | このプロパティの説明については、[getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--) を参照してください。 |
+| [setExportHiddenPage(boolean value)](#setExportHiddenPage-boolean-) | このプロパティの説明については、[getExportHiddenPage()](../../com.aspose.diagram/htmlsaveoptions\#getExportHiddenPage--) を参照してください。 |
+| [setPageCount(int value)](#setPageCount-int-) | このプロパティの説明については、[getPageCount()](../../com.aspose.diagram/htmlsaveoptions\#getPageCount--) を参照してください。 |
+| [setPageIndex(int value)](#setPageIndex-int-) | このプロパティの説明については、[getPageIndex()](../../com.aspose.diagram/htmlsaveoptions\#getPageIndex--) を参照してください。 |
+| [setPageSize(PageSize value)](#setPageSize-com.aspose.diagram.PageSize-) | このプロパティの説明については、[getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--) を参照してください。 |
+| [setResolution(int value)](#setResolution-int-) | このプロパティの説明については、[getResolution()](../../com.aspose.diagram/htmlsaveoptions\#getResolution--) を参照してください。 |
+| [setSaveAsSingleFile(boolean value)](#setSaveAsSingleFile-boolean-) | このプロパティの説明については、[getSaveAsSingleFile()](../../com.aspose.diagram/htmlsaveoptions\#getSaveAsSingleFile--) を参照してください。 |
+| [setSaveForegroundPagesOnly(boolean value)](#setSaveForegroundPagesOnly-boolean-) | このプロパティの説明については、[getSaveForegroundPagesOnly()](../../com.aspose.diagram/htmlsaveoptions\#getSaveForegroundPagesOnly--) を参照してください。 |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | このプロパティの説明については、[getSaveFormat()](../../com.aspose.diagram/htmlsaveoptions\#getSaveFormat--) を参照してください。 |
+| [setSaveTitle(boolean value)](#setSaveTitle-boolean-) | このプロパティの説明については、[getSaveTitle()](../../com.aspose.diagram/htmlsaveoptions\#getSaveTitle--) を参照してください。 |
+| [setSaveToolBar(boolean value)](#setSaveToolBar-boolean-) | このプロパティの説明については、[getSaveToolBar()](../../com.aspose.diagram/htmlsaveoptions\#getSaveToolBar--) を参照してください。 |
+| [setShapes(ShapeCollection value)](#setShapes-com.aspose.diagram.ShapeCollection-) | このプロパティの説明については、[getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--) を参照してください。 |
+| [setStreamProvider(IStreamProvider value)](#setStreamProvider-com.aspose.diagram.IStreamProvider-) | このプロパティの説明については、[getStreamProvider()](../../com.aspose.diagram/htmlsaveoptions\#getStreamProvider--) を参照してください。 |
+| [setTitle(String value)](#setTitle-java.lang.String-) | このプロパティの説明については、[getTitle()](../../com.aspose.diagram/htmlsaveoptions\#getTitle--) を参照してください。 |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### HTMLSaveOptions() {#HTMLSaveOptions--}
+```
+public HTMLSaveOptions()
+```
+
+
+このクラスの新しいインスタンスを初期化します。このインスタンスは Aspose.Diagram.SaveFileFormat 形式でドキュメントを保存するために使用できます。
+
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+指定された保存形式に適したクラスの保存オプションオブジェクトを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| saveFormat | int | 保存オプションオブジェクトを作成するための Aspose.Diagram.SaveFileFormat です。 |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+ダイアグラム内の文字が Unicode で、正しいフォントが設定されていない、またはフォントがローカルにインストールされていない場合、PDF、画像、または XPS で文字がブロックとして表示されることがあります。MingLiu や MS Gothic などの DefaultFont を設定して、これらの文字を表示してください。
+
+**Returns:**
+java.lang.String
+### getEmfRenderSetting() {#getEmfRenderSetting--}
+```
+public int getEmfRenderSetting()
+```
+
+
+Emf メタファイルのレンダリング設定です。\"EMF+ Dual\" と識別される EMF メタファイルは、EMF+ レコードと EMF レコードの両方を含むことができます。画像のレンダリングには、どちらのレコードタイプも使用でき、EMF+ レコードのみ、または EMF レコードのみを使用することもできます。EmfPlusPrefer が設定されている場合は EMF+ レコードが解析され、設定されていない場合は EMF レコードのみが解析されます。デフォルト値は EmfOnly です。
+
+**Returns:**
+int
+### getEnlargePage() {#getEnlargePage--}
+```
+public boolean getEnlargePage()
+```
+
+
+ページを拡大するかどうかを指定します。true の場合はページを拡大し、false の場合は拡大しません。デフォルト値は true です。
+
+**Returns:**
+boolean
+### getExportGuideShapes() {#getExportGuideShapes--}
+```
+public boolean getExportGuideShapes()
+```
+
+
+ガイドシェイプをエクスポートするかどうかを定義します。デフォルト値は true です。
+
+**Returns:**
+boolean
+### getExportHiddenPage() {#getExportHiddenPage--}
+```
+public boolean getExportHiddenPage()
+```
+
+
+非表示ページをエクスポートするかどうかを定義します。デフォルト値は true です。
+
+**Returns:**
+boolean
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+HTML でレンダリングするページ数です。デフォルトは MaxValue で、これはダイアグラムのすべてのページがレンダリングされることを意味します。
+
+**Returns:**
+int
+### getPageIndex() {#getPageIndex--}
+```
+public int getPageIndex()
+```
+
+
+レンダリングする最初のページの 0 ベースインデックスです。デフォルトは 0 です。
+
+**Returns:**
+int
+### getPageSize() {#getPageSize--}
+```
+public PageSize getPageSize()
+```
+
+
+生成された画像のページサイズです。 [PageSize](../../com.aspose.diagram/pagesize) または null にできます。デフォルト値は null です。PageSize が null の場合、生成された画像のページサイズはソース図から取得されます。
+
+**Returns:**
+[PageSize](../../com.aspose.diagram/pagesize)
+### getResolution() {#getResolution--}
+```
+public int getResolution()
+```
+
+
+生成された HTML の解像度（dpi）です。このプロパティは HTML に保存する場合にのみ効果があります。デフォルト値は 96 です。
+
+**Returns:**
+int
+### getSaveAsSingleFile() {#getSaveAsSingleFile--}
+```
+public boolean getSaveAsSingleFile()
+```
+
+
+HTML を単一ファイルとして保存するかどうかを示します。デフォルト値は false です。複数ページがある場合、これらのページとその他のリソースは別々のファイルに保存する必要があります。シナリオによっては、転送の便利さのために結果ファイルを1つだけ取得したい場合があります。その場合、ユーザーはこのプロパティを true に設定できます。
+
+**Returns:**
+boolean
+### getSaveForegroundPagesOnly() {#getSaveForegroundPagesOnly--}
+```
+public boolean getSaveForegroundPagesOnly()
+```
+
+
+すべてのページを画像として保存するか、前景のみを保存するかを指定します。true の場合、前景ページのみがレンダリングされます（背景が存在すれば含む）。false の場合、前景ページがレンダリングされた後、空の背景ページが続きます。PageCount が 1 より大きい場合にのみ true を返すことができます。デフォルト値は false です。
+
+**Returns:**
+boolean
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+この保存オプションオブジェクトが使用される場合、レンダリングされた図ページが保存される形式を指定します。Aspose.Diagram.SaveFileFormat のみ使用できます。
+
+**Returns:**
+int
+### getSaveTitle() {#getSaveTitle--}
+```
+public boolean getSaveTitle()
+```
+
+
+タイトルをエクスポートするかどうかを定義します。デフォルト値は true です。
+
+**Returns:**
+boolean
+### getSaveToolBar() {#getSaveToolBar--}
+```
+public boolean getSaveToolBar()
+```
+
+
+ツールバーを保存するかどうかを指定します。デフォルト値は true です。
+
+**Returns:**
+boolean
+### getShapes() {#getShapes--}
+```
+public ShapeCollection getShapes()
+```
+
+
+レンダリングするシェイプです。デフォルトのカウントは 0 です。
+
+**Returns:**
+[ShapeCollection](../../com.aspose.diagram/shapecollection)
+### getStreamProvider() {#getStreamProvider--}
+```
+public IStreamProvider getStreamProvider()
+```
+
+
+オブジェクトをエクスポートするための IStreamProvider。
+
+**Returns:**
+[IStreamProvider](../../com.aspose.diagram/istreamprovider)
+### getTitle() {#getTitle--}
+```
+public String getTitle()
+```
+
+
+HTML にレンダリングする図のタイトルです。Title が null の場合、Diagram.DocumentProperties.Title [DocumentProperties](../../com.aspose.diagram/documentproperties) がタイトルとして使用されます。Diagram.DocumentProperties.Title が null または空の場合、Diagram のファイル名がタイトルとして使用されます。
+
+**Returns:**
+java.lang.String
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+警告コールバック。
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExportComments() {#isExportComments--}
+```
+public boolean isExportComments()
+```
+
+
+コメントをエクスポートするかどうかを定義します。デフォルト値は false です。
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+このプロパティの説明については、[getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setEmfRenderSetting(int value) {#setEmfRenderSetting-int-}
+```
+public void setEmfRenderSetting(int value)
+```
+
+
+このプロパティの説明については、[getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setEnlargePage(boolean value) {#setEnlargePage-boolean-}
+```
+public void setEnlargePage(boolean value)
+```
+
+
+このプロパティの説明については、[getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setExportComments(boolean value) {#setExportComments-boolean-}
+```
+public void setExportComments(boolean value)
+```
+
+
+このプロパティの説明については、[isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setExportGuideShapes(boolean value) {#setExportGuideShapes-boolean-}
+```
+public void setExportGuideShapes(boolean value)
+```
+
+
+このプロパティの説明については、[getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setExportHiddenPage(boolean value) {#setExportHiddenPage-boolean-}
+```
+public void setExportHiddenPage(boolean value)
+```
+
+
+このプロパティの説明については、[getExportHiddenPage()](../../com.aspose.diagram/htmlsaveoptions\#getExportHiddenPage--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setPageCount(int value) {#setPageCount-int-}
+```
+public void setPageCount(int value)
+```
+
+
+このプロパティの説明については、[getPageCount()](../../com.aspose.diagram/htmlsaveoptions\#getPageCount--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setPageIndex(int value) {#setPageIndex-int-}
+```
+public void setPageIndex(int value)
+```
+
+
+このプロパティの説明については、[getPageIndex()](../../com.aspose.diagram/htmlsaveoptions\#getPageIndex--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setPageSize(PageSize value) {#setPageSize-com.aspose.diagram.PageSize-}
+```
+public void setPageSize(PageSize value)
+```
+
+
+このプロパティの説明については、[getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [PageSize](../../com.aspose.diagram/pagesize) |  |
+
+### setResolution(int value) {#setResolution-int-}
+```
+public void setResolution(int value)
+```
+
+
+このプロパティの説明については、[getResolution()](../../com.aspose.diagram/htmlsaveoptions\#getResolution--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setSaveAsSingleFile(boolean value) {#setSaveAsSingleFile-boolean-}
+```
+public void setSaveAsSingleFile(boolean value)
+```
+
+
+このプロパティの説明については、[getSaveAsSingleFile()](../../com.aspose.diagram/htmlsaveoptions\#getSaveAsSingleFile--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setSaveForegroundPagesOnly(boolean value) {#setSaveForegroundPagesOnly-boolean-}
+```
+public void setSaveForegroundPagesOnly(boolean value)
+```
+
+
+このプロパティの説明については、[getSaveForegroundPagesOnly()](../../com.aspose.diagram/htmlsaveoptions\#getSaveForegroundPagesOnly--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+このプロパティの説明については、[getSaveFormat()](../../com.aspose.diagram/htmlsaveoptions\#getSaveFormat--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setSaveTitle(boolean value) {#setSaveTitle-boolean-}
+```
+public void setSaveTitle(boolean value)
+```
+
+
+このプロパティの説明については、[getSaveTitle()](../../com.aspose.diagram/htmlsaveoptions\#getSaveTitle--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setSaveToolBar(boolean value) {#setSaveToolBar-boolean-}
+```
+public void setSaveToolBar(boolean value)
+```
+
+
+このプロパティの説明については、[getSaveToolBar()](../../com.aspose.diagram/htmlsaveoptions\#getSaveToolBar--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setShapes(ShapeCollection value) {#setShapes-com.aspose.diagram.ShapeCollection-}
+```
+public void setShapes(ShapeCollection value)
+```
+
+
+このプロパティの説明については、[getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [ShapeCollection](../../com.aspose.diagram/shapecollection) |  |
+
+### setStreamProvider(IStreamProvider value) {#setStreamProvider-com.aspose.diagram.IStreamProvider-}
+```
+public void setStreamProvider(IStreamProvider value)
+```
+
+
+このプロパティの説明については、[getStreamProvider()](../../com.aspose.diagram/htmlsaveoptions\#getStreamProvider--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [IStreamProvider](../../com.aspose.diagram/istreamprovider) |  |
+
+### setTitle(String value) {#setTitle-java.lang.String-}
+```
+public void setTitle(String value)
+```
+
+
+このプロパティの説明については、[getTitle()](../../com.aspose.diagram/htmlsaveoptions\#getTitle--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/hyperlink/_index.md
+++ b/japanese/java/com.aspose.diagram/hyperlink/_index.md
@@ -1,0 +1,348 @@
+---
+title: Hyperlink
+second_title: Aspose.Diagram for Java API リファレンス
+description: シェイプまたは描画ページと別の描画ページ、別のファイル、またはウェブサイト間で複数のジャンプを作成するための要素を含みます。
+type: docs
+weight: 193
+url: /ja/java/com.aspose.diagram/hyperlink/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Hyperlink
+```
+
+シェイプまたは描画ページと別の描画ページ、別のファイル、または Web サイト間で複数のジャンプを作成するための要素を含みます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Hyperlink()](#Hyperlink--) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAddress()](#getAddress--) | ジャンプ先の URL アドレス、DOS ファイル名、または UNC パスを指定します。 |
+| [getClass()](#getClass--) |  |
+| [getDefault()](#getDefault--) | シェイプまたはページのデフォルトハイパーリンクを指定します。 |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getDescription()](#getDescription--) | Description 要素はハイパーリンクを説明するテキスト文字列を含みます。 |
+| [getExtraInfo()](#getExtraInfo--) | URL の解決に使用される情報（画像マップの座標など）を含みます。 |
+| [getFrame()](#getFrame--) | Microsoft Visio がコンテナ アプリケーションでアクティブ ドキュメントとして開かれているときにターゲットとするフレーム名を含みます。 |
+| [getID()](#getID--) | 要素の親要素内における一意の ID。 |
+| [getInvisible()](#getInvisible--) | Invisible 要素は、シェイプまたはページのショートカット メニューにハイパーリンクが表示されるかどうかを示します。 |
+| [getName()](#getName--) | 要素の名前。 |
+| [getNameU()](#getNameU--) | 要素のユニバーサル名。 |
+| [getNewWindow()](#getNewWindow--) | ハイパーリンクでウェブページや別の Visio ドキュメントを開く際に、Microsoft Visio が新しい場所にウィンドウを開くかどうかを指定します。 |
+| [getSortKey()](#getSortKey--) | Invisible 要素は、シェイプまたはページのショートカット メニューにハイパーリンクが表示されるかどうかを示します。 |
+| [getSubAddress()](#getSubAddress--) | リンク先のドキュメント内の位置を指定します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | このプロパティの説明については、[getDel()](../../com.aspose.diagram/hyperlink\#getDel--) を参照してください。 |
+| [setID(int value)](#setID-int-) | このプロパティの説明については、[getID()](../../com.aspose.diagram/hyperlink\#getID--) を参照してください。 |
+| [setName(String value)](#setName-java.lang.String-) | このプロパティの説明については、[getName()](../../com.aspose.diagram/hyperlink\#getName--) を参照してください。 |
+| [setNameU(String value)](#setNameU-java.lang.String-) | このプロパティの説明については、[getNameU()](../../com.aspose.diagram/hyperlink\#getNameU--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Hyperlink() {#Hyperlink--}
+```
+public Hyperlink()
+```
+
+
+コンストラクタ。
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAddress() {#getAddress--}
+```
+public Str2Value getAddress()
+```
+
+
+ジャンプ先の URL アドレス、DOS ファイル名、または UNC パスを指定します。
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefault() {#getDefault--}
+```
+public BoolValue getDefault()
+```
+
+
+シェイプまたはページのデフォルトハイパーリンクを指定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getDescription() {#getDescription--}
+```
+public Str2Value getDescription()
+```
+
+
+Description 要素はハイパーリンクを説明するテキスト文字列を含みます。
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getExtraInfo() {#getExtraInfo--}
+```
+public Str2Value getExtraInfo()
+```
+
+
+URL の解決に使用される情報（画像マップの座標など）を含みます。例えば、x=41 y=7 は画像マップの座標を指定します。
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getFrame() {#getFrame--}
+```
+public Str2Value getFrame()
+```
+
+
+Microsoft Visio がコンテナ アプリケーションでアクティブ ドキュメントとして開かれているときにターゲットとするフレーム名を含みます。デフォルトは空文字列です。
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+要素の親要素内における一意の ID。
+
+**Returns:**
+int
+### getInvisible() {#getInvisible--}
+```
+public BoolValue getInvisible()
+```
+
+
+Invisible 要素は、シェイプまたはページのショートカット メニューにハイパーリンクが表示されるかどうかを示します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素の名前。
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+要素のユニバーサル名。
+
+**Returns:**
+java.lang.String
+### getNewWindow() {#getNewWindow--}
+```
+public BoolValue getNewWindow()
+```
+
+
+ハイパーリンクでウェブページや別の Visio ドキュメントを開く際に、Microsoft Visio が新しい場所にウィンドウを開くかどうかを指定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getSortKey() {#getSortKey--}
+```
+public Str2Value getSortKey()
+```
+
+
+Invisible 要素は、シェイプまたはページのショートカット メニューにハイパーリンクが表示されるかどうかを示します。
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getSubAddress() {#getSubAddress--}
+```
+public Str2Value getSubAddress()
+```
+
+
+リンク先のドキュメント内の位置を指定します。
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+このプロパティの説明については、[getDel()](../../com.aspose.diagram/hyperlink\#getDel--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+このプロパティの説明については、[getID()](../../com.aspose.diagram/hyperlink\#getID--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+このプロパティの説明については、[getName()](../../com.aspose.diagram/hyperlink\#getName--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+このプロパティの説明については、[getNameU()](../../com.aspose.diagram/hyperlink\#getNameU--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/hyperlinkcollection/_index.md
+++ b/japanese/java/com.aspose.diagram/hyperlinkcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: HyperlinkCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: ハイパーリンク コレクション。
+type: docs
+weight: 194
+url: /ja/java/com.aspose.diagram/hyperlinkcollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class HyperlinkCollection extends Collection
+```
+
+ハイパーリンク コレクション。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(Hyperlink item)](#add-com.aspose.diagram.Hyperlink-) | コレクションに Hyperlink オブジェクトを追加します。 |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Hyperlink item)](#remove-com.aspose.diagram.Hyperlink-) | コレクションから Hyperlink オブジェクトを削除します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Hyperlink item) {#add-com.aspose.diagram.Hyperlink-}
+```
+public int add(Hyperlink item)
+```
+
+
+コレクションに Hyperlink オブジェクトを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [Hyperlink](../../com.aspose.diagram/hyperlink) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Hyperlink get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[Hyperlink](../../com.aspose.diagram/hyperlink) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Hyperlink item) {#remove-com.aspose.diagram.Hyperlink-}
+```
+public void remove(Hyperlink item)
+```
+
+
+コレクションから Hyperlink オブジェクトを削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [Hyperlink](../../com.aspose.diagram/hyperlink) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/iconsizevalue/_index.md
+++ b/japanese/java/com.aspose.diagram/iconsizevalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: IconSizeValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: オプションの int。
+type: docs
+weight: 195
+url: /ja/java/com.aspose.diagram/iconsizevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class IconSizeValue
+```
+
+オプションの int。要素のアイコンのサイズ。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [DOUBLE](#DOUBLE) | Double。 |
+| [NORMAL](#NORMAL) | 標準。 |
+| [TALL](#TALL) | 高い。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+| [WIDE](#WIDE) | 広い。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DOUBLE {#DOUBLE}
+```
+public static final int DOUBLE
+```
+
+
+Double。
+
+### NORMAL {#NORMAL}
+```
+public static final int NORMAL
+```
+
+
+標準。
+
+### TALL {#TALL}
+```
+public static final int TALL
+```
+
+
+高い。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### WIDE {#WIDE}
+```
+public static final int WIDE
+```
+
+
+広い。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/image/_index.md
+++ b/japanese/java/com.aspose.diagram/image/_index.md
@@ -1,0 +1,227 @@
+---
+title: Image
+second_title: Aspose.Diagram for Java API リファレンス
+description: Contains the gamma brightness contrast blur sharpen denoise and transparency values for a bitmap.
+type: docs
+weight: 196
+url: /ja/java/com.aspose.diagram/image/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Image
+```
+
+ビットマップのガンマ、明るさ、コントラスト、ぼかし、シャープ、ノイズ除去、透明度の値を含みます。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBlur()](#getBlur--) | Blurs or softens a bitmap image. |
+| [getBrightness()](#getBrightness--) | Adjusts the brightness of a bitmap image. |
+| [getClass()](#getClass--) |  |
+| [getContrast()](#getContrast--) | Specifies the contrast of a bitmap image. |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getDenoise()](#getDenoise--) | Removes noise (pixels that have randomly distributed color levels) from a bitmap image. |
+| [getGamma()](#getGamma--) | Adjusts or corrects the intensity of an image for a particular output device, such as a monitor or scanner. |
+| [getSharpen()](#getSharpen--) | Specifies the amount to sharpen a bitmap image. |
+| [getTransparency()](#getTransparency--) | Specifies the transparency level for a layer color, from 0 (opaque) to 1 (completely transparent). |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | For the description of this property, please see [getDel()](../../com.aspose.diagram/image\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBlur() {#getBlur--}
+```
+public DoubleValue getBlur()
+```
+
+
+Blurs or softens a bitmap image. The Blur element contains a value between 0 and 1; the default value is 0.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBrightness() {#getBrightness--}
+```
+public DoubleValue getBrightness()
+```
+
+
+Adjusts the brightness of a bitmap image. The Brightness element contains a value between 0 and 1; the default value is 0.5.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getContrast() {#getContrast--}
+```
+public DoubleValue getContrast()
+```
+
+
+Specifies the contrast of a bitmap image. The Contrast element contains a value between 0 and 1.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getDenoise() {#getDenoise--}
+```
+public DoubleValue getDenoise()
+```
+
+
+Removes noise (pixels that have randomly distributed color levels) from a bitmap image.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getGamma() {#getGamma--}
+```
+public DoubleValue getGamma()
+```
+
+
+Adjusts or corrects the intensity of an image for a particular output device, such as a monitor or scanner. The default value is 1 (no correction.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getSharpen() {#getSharpen--}
+```
+public DoubleValue getSharpen()
+```
+
+
+Specifies the amount to sharpen a bitmap image. Sharpening an image focuses it by increasing the contrast of adjacent pixels.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTransparency() {#getTransparency--}
+```
+public DoubleValue getTransparency()
+```
+
+
+Specifies the transparency level for a layer color, from 0 (opaque) to 1 (completely transparent).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+For the description of this property, please see [getDel()](../../com.aspose.diagram/image\#getDel--)
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/imageactivexcontrol/_index.md
+++ b/japanese/java/com.aspose.diagram/imageactivexcontrol/_index.md
@@ -1,0 +1,597 @@
+---
+title: ImageActiveXControl
+second_title: Aspose.Diagram for Java API リファレンス
+description: 画像コントロールを表します。
+type: docs
+weight: 197
+url: /ja/java/com.aspose.diagram/imageactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class ImageActiveXControl extends ActiveXControl
+```
+
+画像コントロールを表します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBackOleColor()](#getBackOleColor--) | 背景の OLE カラー。 |
+| [getBorderOleColor()](#getBorderOleColor--) | 背景の OLE カラー。 |
+| [getBorderStyle()](#getBorderStyle--) | コントロールで使用される境界線の種類。 |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | コントロールのバイナリ データ。 |
+| [getForeOleColor()](#getForeOleColor--) | 前景の OLE カラー。 |
+| [getHeight()](#getHeight--) | ポイント単位のコントロールの高さ。 |
+| [getIMEMode()](#getIMEMode--) | コントロールがフォーカスを受け取る際の Input Method Editor のデフォルト実行時モード。 |
+| [getMouseIcon()](#getMouseIcon--) | コントロールのマウスポインタとして表示するカスタムアイコンです。 |
+| [getMousePointer()](#getMousePointer--) | コントロールのマウスポインタとして表示されるアイコンの種類です。 |
+| [getPicture()](#getPicture--) | 画像のデータです。 |
+| [getPictureAlignment()](#getPictureAlignment--) | フォームまたは画像内の画像の配置です。 |
+| [getPictureSizeMode()](#getPictureSizeMode--) | 画像の表示方法です。 |
+| [getSpecialEffect()](#getSpecialEffect--) | コントロールの特殊効果です。 |
+| [getType()](#getType--) | ActiveX コントロールのタイプを取得します。 |
+| [getWidth()](#getWidth--) | ポイント単位のコントロールの幅です。 |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | コントロールが全内容を表示するために自動的にサイズ変更されるかどうかを示します。 |
+| [isEnabled()](#isEnabled--) | コントロールがフォーカスを受け取り、ユーザー生成イベントに応答できるかどうかを示します。 |
+| [isLocked()](#isLocked--) | コントロール内のデータが編集ロックされているかどうかを示します。 |
+| [isTiled()](#isTiled--) | 画像が背景全体にタイル状に配置されるかどうかを示します。 |
+| [isTransparent()](#isTransparent--) | コントロールが透明かどうかを示します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | このプロパティの説明については、[isAutoSize()](../../com.aspose.diagram/imageactivexcontrol\\#isAutoSize--) を参照してください。 |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | このプロパティの説明については、[getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) を参照してください |
+| [setBorderOleColor(int value)](#setBorderOleColor-int-) | このプロパティの説明については、[getBorderOleColor()](../../com.aspose.diagram/imageactivexcontrol\\#getBorderOleColor--) を参照してください。 |
+| [setBorderStyle(int value)](#setBorderStyle-int-) | このプロパティの説明については、[getBorderStyle()](../../com.aspose.diagram/imageactivexcontrol\\#getBorderStyle--) を参照してください。 |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | このプロパティの説明については、[isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) を参照してください |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | このプロパティの説明については、[getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) を参照してください |
+| [setHeight(double value)](#setHeight-double-) | このプロパティの説明については、[getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) を参照してください |
+| [setIMEMode(int value)](#setIMEMode-int-) | このプロパティの説明については、[getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) を参照してください |
+| [setLocked(boolean value)](#setLocked-boolean-) | このプロパティの説明については、[isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) を参照してください |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | このプロパティの説明については、[getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) を参照してください |
+| [setMousePointer(int value)](#setMousePointer-int-) | このプロパティの説明については、[getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) を参照してください |
+| [setPicture(byte[] value)](#setPicture-byte---) | このプロパティの説明については、[getPicture()](../../com.aspose.diagram/imageactivexcontrol\\#getPicture--) を参照してください。 |
+| [setPictureAlignment(int value)](#setPictureAlignment-int-) | このプロパティの説明については、[getPictureAlignment()](../../com.aspose.diagram/imageactivexcontrol\#getPictureAlignment--) を参照してください。 |
+| [setPictureSizeMode(int value)](#setPictureSizeMode-int-) | このプロパティの説明については、[getPictureSizeMode()](../../com.aspose.diagram/imageactivexcontrol\#getPictureSizeMode--) を参照してください。 |
+| [setSpecialEffect(int value)](#setSpecialEffect-int-) | このプロパティの説明については、[getSpecialEffect()](../../com.aspose.diagram/imageactivexcontrol\#getSpecialEffect--) を参照してください。 |
+| [setTiled(boolean value)](#setTiled-boolean-) | このプロパティの説明については、[isTiled()](../../com.aspose.diagram/imageactivexcontrol\#isTiled--) を参照してください。 |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | このプロパティの説明については、[isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) を参照してください |
+| [setWidth(double value)](#setWidth-double-) | このプロパティの説明については、[getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) を参照してください |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+背景の OLE カラー。
+
+**Returns:**
+int
+### getBorderOleColor() {#getBorderOleColor--}
+```
+public int getBorderOleColor()
+```
+
+
+背景の OLE カラー。
+
+**Returns:**
+int
+### getBorderStyle() {#getBorderStyle--}
+```
+public int getBorderStyle()
+```
+
+
+コントロールで使用される境界線の種類。
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+コントロールのバイナリ データ。
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+前景の OLE カラーです。Image コントロールには適用されません。
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+ポイント単位のコントロールの高さ。
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+コントロールがフォーカスを受け取る際の Input Method Editor のデフォルト実行時モード。
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+コントロールのマウスポインタとして表示するカスタムアイコンです。
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+コントロールのマウスポインタとして表示されるアイコンの種類です。
+
+**Returns:**
+int
+### getPicture() {#getPicture--}
+```
+public byte[] getPicture()
+```
+
+
+画像のデータです。
+
+**Returns:**
+byte[]
+### getPictureAlignment() {#getPictureAlignment--}
+```
+public int getPictureAlignment()
+```
+
+
+フォームまたは画像内の画像の配置です。
+
+**Returns:**
+int
+### getPictureSizeMode() {#getPictureSizeMode--}
+```
+public int getPictureSizeMode()
+```
+
+
+画像の表示方法です。
+
+**Returns:**
+int
+### getSpecialEffect() {#getSpecialEffect--}
+```
+public int getSpecialEffect()
+```
+
+
+コントロールの特殊効果です。
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+ActiveX コントロールのタイプを取得します。
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+ポイント単位のコントロールの幅です。
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+コントロールが全内容を表示するために自動的にサイズ変更されるかどうかを示します。
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+コントロールがフォーカスを受け取り、ユーザー生成イベントに応答できるかどうかを示します。
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+コントロール内のデータが編集ロックされているかどうかを示します。
+
+**Returns:**
+boolean
+### isTiled() {#isTiled--}
+```
+public boolean isTiled()
+```
+
+
+画像が背景全体にタイル状に配置されるかどうかを示します。
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+コントロールが透明かどうかを示します。
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+このプロパティの説明については、[isAutoSize()](../../com.aspose.diagram/imageactivexcontrol\\#isAutoSize--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+このプロパティの説明については、[getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setBorderOleColor(int value) {#setBorderOleColor-int-}
+```
+public void setBorderOleColor(int value)
+```
+
+
+このプロパティの説明については、[getBorderOleColor()](../../com.aspose.diagram/imageactivexcontrol\\#getBorderOleColor--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setBorderStyle(int value) {#setBorderStyle-int-}
+```
+public void setBorderStyle(int value)
+```
+
+
+このプロパティの説明については、[getBorderStyle()](../../com.aspose.diagram/imageactivexcontrol\\#getBorderStyle--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+このプロパティの説明については、[isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+このプロパティの説明については、[getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+このプロパティの説明については、[getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+このプロパティの説明については、[getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+このプロパティの説明については、[isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+このプロパティの説明については、[getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+このプロパティの説明については、[getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setPicture(byte[] value) {#setPicture-byte---}
+```
+public void setPicture(byte[] value)
+```
+
+
+このプロパティの説明については、[getPicture()](../../com.aspose.diagram/imageactivexcontrol\\#getPicture--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | byte[] |  |
+
+### setPictureAlignment(int value) {#setPictureAlignment-int-}
+```
+public void setPictureAlignment(int value)
+```
+
+
+このプロパティの説明については、[getPictureAlignment()](../../com.aspose.diagram/imageactivexcontrol\#getPictureAlignment--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setPictureSizeMode(int value) {#setPictureSizeMode-int-}
+```
+public void setPictureSizeMode(int value)
+```
+
+
+このプロパティの説明については、[getPictureSizeMode()](../../com.aspose.diagram/imageactivexcontrol\#getPictureSizeMode--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setSpecialEffect(int value) {#setSpecialEffect-int-}
+```
+public void setSpecialEffect(int value)
+```
+
+
+このプロパティの説明については、[getSpecialEffect()](../../com.aspose.diagram/imageactivexcontrol\#getSpecialEffect--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setTiled(boolean value) {#setTiled-boolean-}
+```
+public void setTiled(boolean value)
+```
+
+
+このプロパティの説明については、[isTiled()](../../com.aspose.diagram/imageactivexcontrol\#isTiled--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+このプロパティの説明については、[isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+このプロパティの説明については、[getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/imagecolormode/_index.md
+++ b/japanese/java/com.aspose.diagram/imagecolormode/_index.md
@@ -1,0 +1,156 @@
+---
+title: ImageColorMode
+second_title: Aspose.Diagram for Java API リファレンス
+description: ドキュメントページの生成画像のカラーモードを指定します。
+type: docs
+weight: 198
+url: /ja/java/com.aspose.diagram/imagecolormode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ImageColorMode
+```
+
+ドキュメントページの生成画像のカラーモードを指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [BLACK_AND_WHITE](#BLACK-AND-WHITE) | ドキュメントのページは白黒画像としてレンダリングされます。 |
+| [GRAYSCALE](#GRAYSCALE) | ドキュメントのページはグレースケール画像としてレンダリングされます。 |
+| [NONE](#NONE) | ドキュメントのページはカラー画像としてレンダリングされます。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BLACK_AND_WHITE {#BLACK-AND-WHITE}
+```
+public static final int BLACK_AND_WHITE
+```
+
+
+ドキュメントのページは白黒画像としてレンダリングされます。
+
+### GRAYSCALE {#GRAYSCALE}
+```
+public static final int GRAYSCALE
+```
+
+
+ドキュメントのページはグレースケール画像としてレンダリングされます。
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+ドキュメントのページはカラー画像としてレンダリングされます。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/imageformat/_index.md
+++ b/japanese/java/com.aspose.diagram/imageformat/_index.md
@@ -1,0 +1,273 @@
+---
+title: ImageFormat
+second_title: Aspose.Diagram for Java API リファレンス
+description: 画像のファイル形式を指定します。
+type: docs
+weight: 199
+url: /ja/java/com.aspose.diagram/imageformat/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ImageFormat
+```
+
+画像のファイル形式を指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [ImageFormat()](#ImageFormat--) |  |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object obj)](#equals-java.lang.Object-) | 指定されたオブジェクトがこの ImageFormat オブジェクトと等価な ImageFormat オブジェクトであるかどうかを示す値を返します。 |
+| [getBmp()](#getBmp--) | ビットマップ (BMP) 画像形式を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getEmf()](#getEmf--) | 拡張メタファイル (EMF) 画像形式を取得します。 |
+| [getExif()](#getExif--) | 交換可能画像ファイル (Exif) 形式を取得します。 |
+| [getGif()](#getGif--) | Graphics Interchange Format (GIF) 画像形式を取得します。 |
+| [getIcon()](#getIcon--) | Windows アイコン画像形式を取得します。 |
+| [getImageFormatFromSuffixName(String name)](#getImageFormatFromSuffixName-java.lang.String-) | 拡張子名に応じて画像形式を取得します |
+| [getJpeg()](#getJpeg--) | Joint Photographic Experts Group (JPEG) 画像形式を取得します。 |
+| [getMemoryBmp()](#getMemoryBmp--) | メモリビットマップ画像形式を取得します。 |
+| [getName()](#getName--) | この ImageFormat インスタンスの文字列名を取得します |
+| [getPng()](#getPng--) | W3C Portable Network Graphics (PNG) 画像形式を取得します。 |
+| [getTiff()](#getTiff--) | Tagged Image File Format (TIFF) 画像形式を取得します。 |
+| [getWmf()](#getWmf--) | Windows メタファイル (WMF) 画像形式を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ImageFormat() {#ImageFormat--}
+```
+public ImageFormat()
+```
+
+
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+指定されたオブジェクトがこの ImageFormat オブジェクトと等価な ImageFormat オブジェクトであるかどうかを示す値を返します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| obj | java.lang.Object | テスト対象のオブジェクト。 |
+
+**Returns:**
+boolean - o がこの ImageFormat オブジェクトと等価な ImageFormat オブジェクトである場合は true、そうでない場合は false。
+### getBmp() {#getBmp--}
+```
+public static ImageFormat getBmp()
+```
+
+
+ビットマップ (BMP) 画像形式を取得します。
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the bitmap image format.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getEmf() {#getEmf--}
+```
+public static ImageFormat getEmf()
+```
+
+
+拡張メタファイル (EMF) 画像形式を取得します。
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the enhanced metafile image format.
+### getExif() {#getExif--}
+```
+public static ImageFormat getExif()
+```
+
+
+交換可能画像ファイル (Exif) 形式を取得します。
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the Exif format.
+### getGif() {#getGif--}
+```
+public static ImageFormat getGif()
+```
+
+
+Graphics Interchange Format (GIF) 画像形式を取得します。
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the GIF image format.
+### getIcon() {#getIcon--}
+```
+public static ImageFormat getIcon()
+```
+
+
+Windows アイコン画像形式を取得します。
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the Windows icon image format.
+### getImageFormatFromSuffixName(String name) {#getImageFormatFromSuffixName-java.lang.String-}
+```
+public static ImageFormat getImageFormatFromSuffixName(String name)
+```
+
+
+拡張子名に応じて画像形式を取得します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String | サフィックス名 |
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - >An ImageFormat object according to the suffix name.
+### getJpeg() {#getJpeg--}
+```
+public static ImageFormat getJpeg()
+```
+
+
+Joint Photographic Experts Group (JPEG) 画像形式を取得します。
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the JPEG image format.
+### getMemoryBmp() {#getMemoryBmp--}
+```
+public static ImageFormat getMemoryBmp()
+```
+
+
+メモリビットマップ画像形式を取得します。
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the memory bitmap image format.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+この ImageFormat インスタンスの文字列名を取得します
+
+**Returns:**
+java.lang.String - この ImageFormat インスタンスの文字列名
+### getPng() {#getPng--}
+```
+public static ImageFormat getPng()
+```
+
+
+W3C Portable Network Graphics (PNG) 画像形式を取得します。
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the PNG image format.
+### getTiff() {#getTiff--}
+```
+public static ImageFormat getTiff()
+```
+
+
+Tagged Image File Format (TIFF) 画像形式を取得します。
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the TIFF image format.
+### getWmf() {#getWmf--}
+```
+public static ImageFormat getWmf()
+```
+
+
+Windows メタファイル (WMF) 画像形式を取得します。
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the Windows metafile image format.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/imagesaveoptions/_index.md
+++ b/japanese/java/com.aspose.diagram/imagesaveoptions/_index.md
@@ -1,0 +1,809 @@
+---
+title: ImageSaveOptions
+second_title: Aspose.Diagram for Java API リファレンス
+description: ダイアグラムページを画像にレンダリングする際に、追加オプションを指定できます。
+type: docs
+weight: 200
+url: /ja/java/com.aspose.diagram/imagesaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.SaveOptions](../../com.aspose.diagram/saveoptions), [com.aspose.diagram.RenderingSaveOptions](../../com.aspose.diagram/renderingsaveoptions)
+```
+public class ImageSaveOptions extends RenderingSaveOptions
+```
+
+ダイアグラムページを画像にレンダリングする際に、追加オプションを指定できます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [ImageSaveOptions(int saveFormat)](#ImageSaveOptions-int-) | このクラスの新しいインスタンスを初期化します。このインスタンスは、Aspose.Diagram.SaveFileFormat、Aspose.Diagram.SaveFileFormat、Aspose.Diagram.SaveFileFormat、Aspose.Diagram.SaveFileFormat、または Aspose.Diagram.SaveFileFormat 形式でレンダリングされた画像を保存するために使用できます。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | 指定された保存形式に適したクラスの保存オプションオブジェクトを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCompositingQuality()](#getCompositingQuality--) | 合成時に使用する品質レベルを指定します。 |
+| [getContentZoom()](#getContentZoom--) | このパラメーターはスケールに似ていますが、生成された画像サイズには影響しません。 |
+| [getDefaultFont()](#getDefaultFont--) | 図内の文字が Unicode で、正しいフォント値が設定されていない、またはフォントがローカルにインストールされていない場合、pdf、画像、または XPS でブロックとして表示されることがあります。 |
+| [getEmfRenderSetting()](#getEmfRenderSetting--) | Emf メタファイルのレンダリング設定です。 |
+| [getEnlargePage()](#getEnlargePage--) | ページを拡大するかどうかを指定します。 |
+| [getExportGuideShapes()](#getExportGuideShapes--) | ガイドシェイプをエクスポートするかどうかを定義します。 |
+| [getExportHiddenPage()](#getExportHiddenPage--) | 非表示ページをエクスポートするかどうかを定義します。 |
+| [getImageBrightness()](#getImageBrightness--) | 生成された画像の明るさ。 |
+| [getImageColorMode()](#getImageColorMode--) | 生成された画像のカラーモード。 |
+| [getImageContrast()](#getImageContrast--) | 生成された画像のコントラスト。 |
+| [getInterpolationMode()](#getInterpolationMode--) | 画像が拡大縮小または回転される際に使用されるアルゴリズムを指定します。 |
+| [getJpegQuality()](#getJpegQuality--) | 生成された JPEG 画像の品質を決定する値。 |
+| [getPageCount()](#getPageCount--) | マルチページTIFFファイルに保存する際にレンダリングするページ数です。 |
+| [getPageIndex()](#getPageIndex--) | レンダリングする最初のページの 0 ベースインデックス。 |
+| [getPageSize()](#getPageSize--) | 生成された画像のページサイズ。 |
+| [getPixelOffsetMode()](#getPixelOffsetMode--) | レンダリング中にピクセルがどのようにオフセットされるかを指定する値です。 |
+| [getResolution()](#getResolution--) | 生成された画像の解像度（ドット毎インチ）です。 |
+| [getSameAsPdfConversionArea()](#getSameAsPdfConversionArea--) | 保存領域がPDFと同じかどうかを指定します。 |
+| [getSaveForegroundPagesOnly()](#getSaveForegroundPagesOnly--) | すべてのページを画像として保存するか、前景のみを保存するかを指定します。 |
+| [getSaveFormat()](#getSaveFormat--) | この保存オプションオブジェクトが使用された場合、レンダリングされた図ページが保存される形式を指定します。 |
+| [getScale()](#getScale--) | 生成された画像のズーム倍率です。 |
+| [getShapes()](#getShapes--) | レンダリングするシェイプ。 |
+| [getSmoothingMode()](#getSmoothingMode--) | 線や曲線、塗りつぶし領域のエッジに平滑化（アンチエイリアス）が適用されるかどうかを指定します。 |
+| [getTiffCompression()](#getTiffCompression--) | 生成された画像をTIFF形式で保存する際に適用する圧縮タイプです。 |
+| [getWarningCallback()](#getWarningCallback--) | 警告コールバック。 |
+| [hashCode()](#hashCode--) |  |
+| [isExportComments()](#isExportComments--) | コメントをエクスポートするかどうかを定義します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCompositingQuality(int value)](#setCompositingQuality-int-) | このプロパティの説明については、[getCompositingQuality()](../../com.aspose.diagram/imagesaveoptions\#getCompositingQuality--) をご参照ください。 |
+| [setContentZoom(float value)](#setContentZoom-float-) | このプロパティの説明については、[getContentZoom()](../../com.aspose.diagram/imagesaveoptions\#getContentZoom--) をご参照ください。 |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | このプロパティの説明については、[getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--) を参照してください。 |
+| [setEmfRenderSetting(int value)](#setEmfRenderSetting-int-) | このプロパティの説明については、[getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--) を参照してください。 |
+| [setEnlargePage(boolean value)](#setEnlargePage-boolean-) | このプロパティの説明については、[getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--) を参照してください。 |
+| [setExportComments(boolean value)](#setExportComments-boolean-) | このプロパティの説明については、[isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--) を参照してください。 |
+| [setExportGuideShapes(boolean value)](#setExportGuideShapes-boolean-) | このプロパティの説明については、[getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--) を参照してください。 |
+| [setExportHiddenPage(boolean value)](#setExportHiddenPage-boolean-) | このプロパティの説明については、[getExportHiddenPage()](../../com.aspose.diagram/imagesaveoptions\#getExportHiddenPage--) をご参照ください。 |
+| [setImageBrightness(float value)](#setImageBrightness-float-) | このプロパティの説明については、[getImageBrightness()](../../com.aspose.diagram/imagesaveoptions\#getImageBrightness--) をご参照ください。 |
+| [setImageColorMode(int value)](#setImageColorMode-int-) | このプロパティの説明については、[getImageColorMode()](../../com.aspose.diagram/imagesaveoptions\#getImageColorMode--) をご参照ください。 |
+| [setImageContrast(float value)](#setImageContrast-float-) | このプロパティの説明については、[getImageContrast()](../../com.aspose.diagram/imagesaveoptions\#getImageContrast--) をご参照ください。 |
+| [setInterpolationMode(int value)](#setInterpolationMode-int-) | このプロパティの説明については、[getInterpolationMode()](../../com.aspose.diagram/imagesaveoptions\#getInterpolationMode--) をご参照ください。 |
+| [setJpegQuality(int value)](#setJpegQuality-int-) | このプロパティの説明については、[getJpegQuality()](../../com.aspose.diagram/imagesaveoptions\#getJpegQuality--) をご参照ください。 |
+| [setPageCount(int value)](#setPageCount-int-) | このプロパティの説明については、[getPageCount()](../../com.aspose.diagram/imagesaveoptions\#getPageCount--) をご参照ください。 |
+| [setPageIndex(int value)](#setPageIndex-int-) | このプロパティの説明については、[getPageIndex()](../../com.aspose.diagram/imagesaveoptions\#getPageIndex--) をご参照ください。 |
+| [setPageSize(PageSize value)](#setPageSize-com.aspose.diagram.PageSize-) | このプロパティの説明については、[getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--) を参照してください。 |
+| [setPixelOffsetMode(int value)](#setPixelOffsetMode-int-) | このプロパティの説明については、[getPixelOffsetMode()](../../com.aspose.diagram/imagesaveoptions\#getPixelOffsetMode--) をご参照ください。 |
+| [setResolution(float value)](#setResolution-float-) | このプロパティの説明については、[getResolution()](../../com.aspose.diagram/imagesaveoptions\#getResolution--) をご参照ください。 |
+| [setSameAsPdfConversionArea(boolean value)](#setSameAsPdfConversionArea-boolean-) | このプロパティの説明については、[getSameAsPdfConversionArea()](../../com.aspose.diagram/imagesaveoptions\#getSameAsPdfConversionArea--) をご参照ください。 |
+| [setSaveForegroundPagesOnly(boolean value)](#setSaveForegroundPagesOnly-boolean-) | このプロパティの説明については、[getSaveForegroundPagesOnly()](../../com.aspose.diagram/imagesaveoptions\#getSaveForegroundPagesOnly--) をご参照ください。 |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | このプロパティの説明については、[getSaveFormat()](../../com.aspose.diagram/imagesaveoptions\#getSaveFormat--) をご参照ください。 |
+| [setScale(float value)](#setScale-float-) | このプロパティの説明については、[getScale()](../../com.aspose.diagram/imagesaveoptions\#getScale--) をご参照ください。 |
+| [setShapes(ShapeCollection value)](#setShapes-com.aspose.diagram.ShapeCollection-) | このプロパティの説明については、[getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--) を参照してください。 |
+| [setSmoothingMode(int value)](#setSmoothingMode-int-) | このプロパティの説明については、[getSmoothingMode()](../../com.aspose.diagram/imagesaveoptions\#getSmoothingMode--) をご参照ください。 |
+| [setTiffCompression(int value)](#setTiffCompression-int-) | このプロパティの説明については、[getTiffCompression()](../../com.aspose.diagram/imagesaveoptions\#getTiffCompression--) をご参照ください。 |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ImageSaveOptions(int saveFormat) {#ImageSaveOptions-int-}
+```
+public ImageSaveOptions(int saveFormat)
+```
+
+
+このクラスの新しいインスタンスを初期化します。このインスタンスは、Aspose.Diagram.SaveFileFormat、Aspose.Diagram.SaveFileFormat、Aspose.Diagram.SaveFileFormat、Aspose.Diagram.SaveFileFormat、または Aspose.Diagram.SaveFileFormat 形式でレンダリングされた画像を保存するために使用できます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| saveFormat | int | Aspose.Diagram.SaveFileFormat、Aspose.Diagram.SaveFileFormat、Aspose.Diagram.SaveFileFormat、Aspose.Diagram.SaveFileFormat、または Aspose.Diagram.SaveFileFormat にできます。 |
+
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+指定された保存形式に適したクラスの保存オプションオブジェクトを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| saveFormat | int | 保存オプションオブジェクトを作成するための Aspose.Diagram.SaveFileFormat です。 |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCompositingQuality() {#getCompositingQuality--}
+```
+public int getCompositingQuality()
+```
+
+
+合成時に使用する品質レベルを指定します。このプロパティはラスタ画像形式で保存する場合にのみ有効です。デフォルト値は Aspose.Diagram.Saving.CompositingQuality です。
+
+**Returns:**
+int
+### getContentZoom() {#getContentZoom--}
+```
+public float getContentZoom()
+```
+
+
+このパラメータはスケールに似ていますが、生成される画像サイズには影響しません。デフォルト値は 1.0 です。値は 0 より大きくなければなりません。
+
+**Returns:**
+float
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+ダイアグラム内の文字が Unicode で、正しいフォントが設定されていない、またはフォントがローカルにインストールされていない場合、PDF、画像、または XPS で文字がブロックとして表示されることがあります。MingLiu や MS Gothic などの DefaultFont を設定して、これらの文字を表示してください。
+
+**Returns:**
+java.lang.String
+### getEmfRenderSetting() {#getEmfRenderSetting--}
+```
+public int getEmfRenderSetting()
+```
+
+
+Emf メタファイルのレンダリング設定です。\"EMF+ Dual\" と識別される EMF メタファイルは、EMF+ レコードと EMF レコードの両方を含むことができます。画像のレンダリングには、どちらのレコードタイプも使用でき、EMF+ レコードのみ、または EMF レコードのみを使用することもできます。EmfPlusPrefer が設定されている場合は EMF+ レコードが解析され、設定されていない場合は EMF レコードのみが解析されます。デフォルト値は EmfOnly です。
+
+**Returns:**
+int
+### getEnlargePage() {#getEnlargePage--}
+```
+public boolean getEnlargePage()
+```
+
+
+ページを拡大するかどうかを指定します。true の場合はページを拡大し、false の場合は拡大しません。デフォルト値は true です。
+
+**Returns:**
+boolean
+### getExportGuideShapes() {#getExportGuideShapes--}
+```
+public boolean getExportGuideShapes()
+```
+
+
+ガイドシェイプをエクスポートするかどうかを定義します。デフォルト値は true です。
+
+**Returns:**
+boolean
+### getExportHiddenPage() {#getExportHiddenPage--}
+```
+public boolean getExportHiddenPage()
+```
+
+
+非表示ページをエクスポートするかどうかを定義します。デフォルト値は true です。
+
+**Returns:**
+boolean
+### getImageBrightness() {#getImageBrightness--}
+```
+public float getImageBrightness()
+```
+
+
+生成された画像の明るさです。このプロパティはラスタ画像形式で保存する場合にのみ有効です。デフォルト値は 0.5 です。値は 0 から 1 の範囲でなければなりません。
+
+**Returns:**
+float
+### getImageColorMode() {#getImageColorMode--}
+```
+public int getImageColorMode()
+```
+
+
+生成された画像のカラーモードです。このプロパティはラスタ画像形式で保存する場合にのみ有効です。デフォルト値は Aspose.Diagram.Saving.ImageColorMode です。
+
+**Returns:**
+int
+### getImageContrast() {#getImageContrast--}
+```
+public float getImageContrast()
+```
+
+
+生成された画像のコントラストです。このプロパティはラスタ画像形式で保存する場合にのみ有効です。デフォルト値は 0.5 です。値は 0 から 1 の範囲でなければなりません。
+
+**Returns:**
+float
+### getInterpolationMode() {#getInterpolationMode--}
+```
+public int getInterpolationMode()
+```
+
+
+画像が拡大縮小または回転される際に使用されるアルゴリズムを指定します。このプロパティはラスタ画像形式で保存する場合にのみ有効です。デフォルト値は Aspose.Diagram.Saving.InterpolationMode です。
+
+**Returns:**
+int
+### getJpegQuality() {#getJpegQuality--}
+```
+public int getJpegQuality()
+```
+
+
+生成された JPEG 画像の品質を決定する値です。JPEG で保存する場合にのみ有効です。このプロパティを使用して JPEG 形式で保存する際の画像品質を取得または設定します。値は 0 から 100 の範囲で、0 は最低品質で最大圧縮、100 は最高品質で最小圧縮を意味します。デフォルト値は 95 です。
+
+**Returns:**
+int
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+マルチページ TIFF ファイルに保存する際にレンダリングするページ数です。デフォルトは MaxValue で、これは図のすべてのページがレンダリングされることを意味します。
+
+**Returns:**
+int
+### getPageIndex() {#getPageIndex--}
+```
+public int getPageIndex()
+```
+
+
+レンダリングする最初のページの 0 ベースインデックスです。デフォルトは 0 です。
+
+**Returns:**
+int
+### getPageSize() {#getPageSize--}
+```
+public PageSize getPageSize()
+```
+
+
+生成された画像のページサイズです。 [PageSize](../../com.aspose.diagram/pagesize) または null にできます。デフォルト値は null です。PageSize が null の場合、生成された画像のページサイズはソース図から取得されます。
+
+**Returns:**
+[PageSize](../../com.aspose.diagram/pagesize)
+### getPixelOffsetMode() {#getPixelOffsetMode--}
+```
+public int getPixelOffsetMode()
+```
+
+
+レンダリング中のピクセルオフセット方法を指定する値です。このプロパティはラスタ画像形式で保存する場合にのみ有効です。デフォルト値は Aspose.Diagram.Saving.PixelOffsetMode です。
+
+**Returns:**
+int
+### getResolution() {#getResolution--}
+```
+public float getResolution()
+```
+
+
+生成された画像の解像度（dpi）です。このプロパティはラスタ画像形式で保存する場合にのみ有効です。デフォルト値は 96 です。
+
+**Returns:**
+float
+### getSameAsPdfConversionArea() {#getSameAsPdfConversionArea--}
+```
+public boolean getSameAsPdfConversionArea()
+```
+
+
+保存領域が PDF と同じかどうかを指定します。true の場合、レンダリング領域は PDF と同じになります。false の場合、レンダリング領域はデフォルトになります。デフォルト値は false です。
+
+**Returns:**
+boolean
+### getSaveForegroundPagesOnly() {#getSaveForegroundPagesOnly--}
+```
+public boolean getSaveForegroundPagesOnly()
+```
+
+
+すべてのページを画像として保存するか、前景のみを保存するかを指定します。true の場合、前景ページのみがレンダリングされます（背景が存在すれば含む）。false の場合、前景ページがレンダリングされた後、空の背景ページが続きます。PageCount が 1 より大きい場合にのみ true を返すことができます。デフォルト値は false です。
+
+**Returns:**
+boolean
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+この保存オプションオブジェクトが使用される場合、レンダリングされた図ページが保存される形式を指定します。Aspose.Diagram.SaveFileFormat、Aspose.Diagram.SaveFileFormat、Aspose.Diagram.SaveFileFormat、Aspose.Diagram.SaveFileFormat、または Aspose.Diagram.SaveFileFormat のいずれかを指定できます。
+
+**Returns:**
+int
+### getScale() {#getScale--}
+```
+public float getScale()
+```
+
+
+生成された画像のズーム倍率です。デフォルト値は 1.0 です。値は 0 より大きくなければなりません。
+
+**Returns:**
+float
+### getShapes() {#getShapes--}
+```
+public ShapeCollection getShapes()
+```
+
+
+レンダリングするシェイプです。デフォルトのカウントは 0 です。
+
+**Returns:**
+[ShapeCollection](../../com.aspose.diagram/shapecollection)
+### getSmoothingMode() {#getSmoothingMode--}
+```
+public int getSmoothingMode()
+```
+
+
+線や曲線、塗りつぶし領域のエッジにスムージング（アンチエイリアス）が適用されるかどうかを指定します。このプロパティはラスタ画像形式で保存する場合にのみ有効です。デフォルト値は Aspose.Diagram.Saving.SmoothingMode です。
+
+**Returns:**
+int
+### getTiffCompression() {#getTiffCompression--}
+```
+public int getTiffCompression()
+```
+
+
+生成された画像を TIFF 形式で保存する際に適用する圧縮タイプです。TIFF で保存する場合にのみ有効です。デフォルト値は Aspose.Diagram.Saving.TiffCompression です。
+
+**Returns:**
+int
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+警告コールバック。
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExportComments() {#isExportComments--}
+```
+public boolean isExportComments()
+```
+
+
+コメントをエクスポートするかどうかを定義します。デフォルト値は false です。
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCompositingQuality(int value) {#setCompositingQuality-int-}
+```
+public void setCompositingQuality(int value)
+```
+
+
+このプロパティの説明については、[getCompositingQuality()](../../com.aspose.diagram/imagesaveoptions\#getCompositingQuality--) をご参照ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setContentZoom(float value) {#setContentZoom-float-}
+```
+public void setContentZoom(float value)
+```
+
+
+このプロパティの説明については、[getContentZoom()](../../com.aspose.diagram/imagesaveoptions\#getContentZoom--) をご参照ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | float |  |
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+このプロパティの説明については、[getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setEmfRenderSetting(int value) {#setEmfRenderSetting-int-}
+```
+public void setEmfRenderSetting(int value)
+```
+
+
+このプロパティの説明については、[getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setEnlargePage(boolean value) {#setEnlargePage-boolean-}
+```
+public void setEnlargePage(boolean value)
+```
+
+
+このプロパティの説明については、[getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setExportComments(boolean value) {#setExportComments-boolean-}
+```
+public void setExportComments(boolean value)
+```
+
+
+このプロパティの説明については、[isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setExportGuideShapes(boolean value) {#setExportGuideShapes-boolean-}
+```
+public void setExportGuideShapes(boolean value)
+```
+
+
+このプロパティの説明については、[getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setExportHiddenPage(boolean value) {#setExportHiddenPage-boolean-}
+```
+public void setExportHiddenPage(boolean value)
+```
+
+
+このプロパティの説明については、[getExportHiddenPage()](../../com.aspose.diagram/imagesaveoptions\#getExportHiddenPage--) をご参照ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setImageBrightness(float value) {#setImageBrightness-float-}
+```
+public void setImageBrightness(float value)
+```
+
+
+このプロパティの説明については、[getImageBrightness()](../../com.aspose.diagram/imagesaveoptions\#getImageBrightness--) をご参照ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | float |  |
+
+### setImageColorMode(int value) {#setImageColorMode-int-}
+```
+public void setImageColorMode(int value)
+```
+
+
+このプロパティの説明については、[getImageColorMode()](../../com.aspose.diagram/imagesaveoptions\#getImageColorMode--) をご参照ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setImageContrast(float value) {#setImageContrast-float-}
+```
+public void setImageContrast(float value)
+```
+
+
+このプロパティの説明については、[getImageContrast()](../../com.aspose.diagram/imagesaveoptions\#getImageContrast--) をご参照ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | float |  |
+
+### setInterpolationMode(int value) {#setInterpolationMode-int-}
+```
+public void setInterpolationMode(int value)
+```
+
+
+このプロパティの説明については、[getInterpolationMode()](../../com.aspose.diagram/imagesaveoptions\#getInterpolationMode--) をご参照ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setJpegQuality(int value) {#setJpegQuality-int-}
+```
+public void setJpegQuality(int value)
+```
+
+
+このプロパティの説明については、[getJpegQuality()](../../com.aspose.diagram/imagesaveoptions\#getJpegQuality--) をご参照ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setPageCount(int value) {#setPageCount-int-}
+```
+public void setPageCount(int value)
+```
+
+
+このプロパティの説明については、[getPageCount()](../../com.aspose.diagram/imagesaveoptions\#getPageCount--) をご参照ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setPageIndex(int value) {#setPageIndex-int-}
+```
+public void setPageIndex(int value)
+```
+
+
+このプロパティの説明については、[getPageIndex()](../../com.aspose.diagram/imagesaveoptions\#getPageIndex--) をご参照ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setPageSize(PageSize value) {#setPageSize-com.aspose.diagram.PageSize-}
+```
+public void setPageSize(PageSize value)
+```
+
+
+このプロパティの説明については、[getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [PageSize](../../com.aspose.diagram/pagesize) |  |
+
+### setPixelOffsetMode(int value) {#setPixelOffsetMode-int-}
+```
+public void setPixelOffsetMode(int value)
+```
+
+
+このプロパティの説明については、[getPixelOffsetMode()](../../com.aspose.diagram/imagesaveoptions\#getPixelOffsetMode--) をご参照ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setResolution(float value) {#setResolution-float-}
+```
+public void setResolution(float value)
+```
+
+
+このプロパティの説明については、[getResolution()](../../com.aspose.diagram/imagesaveoptions\#getResolution--) をご参照ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | float |  |
+
+### setSameAsPdfConversionArea(boolean value) {#setSameAsPdfConversionArea-boolean-}
+```
+public void setSameAsPdfConversionArea(boolean value)
+```
+
+
+このプロパティの説明については、[getSameAsPdfConversionArea()](../../com.aspose.diagram/imagesaveoptions\#getSameAsPdfConversionArea--) をご参照ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setSaveForegroundPagesOnly(boolean value) {#setSaveForegroundPagesOnly-boolean-}
+```
+public void setSaveForegroundPagesOnly(boolean value)
+```
+
+
+このプロパティの説明については、[getSaveForegroundPagesOnly()](../../com.aspose.diagram/imagesaveoptions\#getSaveForegroundPagesOnly--) をご参照ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+このプロパティの説明については、[getSaveFormat()](../../com.aspose.diagram/imagesaveoptions\#getSaveFormat--) をご参照ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setScale(float value) {#setScale-float-}
+```
+public void setScale(float value)
+```
+
+
+このプロパティの説明については、[getScale()](../../com.aspose.diagram/imagesaveoptions\#getScale--) をご参照ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | float |  |
+
+### setShapes(ShapeCollection value) {#setShapes-com.aspose.diagram.ShapeCollection-}
+```
+public void setShapes(ShapeCollection value)
+```
+
+
+このプロパティの説明については、[getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [ShapeCollection](../../com.aspose.diagram/shapecollection) |  |
+
+### setSmoothingMode(int value) {#setSmoothingMode-int-}
+```
+public void setSmoothingMode(int value)
+```
+
+
+このプロパティの説明については、[getSmoothingMode()](../../com.aspose.diagram/imagesaveoptions\#getSmoothingMode--) をご参照ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setTiffCompression(int value) {#setTiffCompression-int-}
+```
+public void setTiffCompression(int value)
+```
+
+
+このプロパティの説明については、[getTiffCompression()](../../com.aspose.diagram/imagesaveoptions\#getTiffCompression--) をご参照ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/individualfontconfigs/_index.md
+++ b/japanese/java/com.aspose.diagram/individualfontconfigs/_index.md
@@ -1,0 +1,193 @@
+---
+title: IndividualFontConfigs
+second_title: Aspose.Diagram for Java API リファレンス
+description: 各オブジェクトのフォント設定。
+type: docs
+weight: 201
+url: /ja/java/com.aspose.diagram/individualfontconfigs/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class IndividualFontConfigs
+```
+
+各[Diagram](../../com.aspose.diagram/diagram)オブジェクトのフォント設定。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [IndividualFontConfigs()](#IndividualFontConfigs--) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFontSources()](#getFontSources--) | ソースのリストを含む配列のコピーを取得します |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setFontFolder(String fontFolder, boolean recursive)](#setFontFolder-java.lang.String-boolean-) | フォントフォルダーを設定します |
+| [setFontFolders(String[] fontFolders, boolean recursive)](#setFontFolders-java.lang.String---boolean-) | フォントフォルダーを設定します |
+| [setFontSources(FontSourceBase[] sources)](#setFontSources-com.aspose.diagram.FontSourceBase---) | フォントソースを設定します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### IndividualFontConfigs() {#IndividualFontConfigs--}
+```
+public IndividualFontConfigs()
+```
+
+
+コンストラクタ。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFontSources() {#getFontSources--}
+```
+public FontSourceBase[] getFontSources()
+```
+
+
+ソースのリストを含む配列のコピーを取得します
+
+**Returns:**
+com.aspose.diagram.FontSourceBase[] -
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setFontFolder(String fontFolder, boolean recursive) {#setFontFolder-java.lang.String-boolean-}
+```
+public void setFontFolder(String fontFolder, boolean recursive)
+```
+
+
+フォントフォルダーを設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| fontFolder | java.lang.String | TrueType フォントを含むフォルダー。 |
+| 再帰的 | boolean | サブフォルダーをスキャンするかどうかを決定します。 |
+
+### setFontFolders(String[] fontFolders, boolean recursive) {#setFontFolders-java.lang.String---boolean-}
+```
+public void setFontFolders(String[] fontFolders, boolean recursive)
+```
+
+
+フォントフォルダーを設定します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| fontFolders | java.lang.String[] | TrueType フォントを含むフォルダー群。 |
+| 再帰的 | boolean | サブフォルダーをスキャンするかどうかを決定します。 |
+
+### setFontSources(FontSourceBase[] sources) {#setFontSources-com.aspose.diagram.FontSourceBase---}
+```
+public void setFontSources(FontSourceBase[] sources)
+```
+
+
+フォントソースを設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| sources | [FontSourceBase\[\]](../../com.aspose.diagram/fontsourcebase) | TrueType フォントを含むソースの配列。 |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/infiniteline/_index.md
+++ b/japanese/java/com.aspose.diagram/infiniteline/_index.md
@@ -1,0 +1,299 @@
+---
+title: InfiniteLine
+second_title: Aspose.Diagram for Java API リファレンス
+description: 無限直線上の2点の x および y 座標を指定する要素を含みます。
+type: docs
+weight: 202
+url: /ja/java/com.aspose.diagram/infiniteline/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class InfiniteLine extends Coordinate
+```
+
+無限直線上の 2 点の x 座標と y 座標を指定する要素を含みます。X と Y 要素は最初の点の x 座標と y 座標を指定し、A と B 要素は2 番目の点の x 座標と y 座標を指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [InfiniteLine()](#InfiniteLine--) | [InfiniteLine](../../com.aspose.diagram/infiniteline) クラスのインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | 無限直線上の点の x 座標で、y 座標は B 要素で表されます。 |
+| [getB()](#getB--) | 無限直線上の点の y 座標で、x 座標は A 要素で表されます。 |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getIX()](#getIX--) | 親要素内の要素のゼロベースインデックスです。 |
+| [getX()](#getX--) | 無限直線上の点の x 座標です。 |
+| [getY()](#getY--) | 無限直線上の点の y 座標です。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getA()](../../com.aspose.diagram/infiniteline\#getA--) を参照してください。 |
+| [setB(DoubleValue value)](#setB-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getB()](../../com.aspose.diagram/infiniteline\#getB--) を参照してください。 |
+| [setDel(int value)](#setDel-int-) | このプロパティの説明については、[getDel()](../../com.aspose.diagram/infiniteline\#getDel--) を参照してください。 |
+| [setIX(int value)](#setIX-int-) | このプロパティの説明については、[getIX()](../../com.aspose.diagram/infiniteline\#getIX--) を参照してください。 |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getX()](../../com.aspose.diagram/infiniteline\#getX--) を参照してください。 |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getY()](../../com.aspose.diagram/infiniteline\#getY--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### InfiniteLine() {#InfiniteLine--}
+```
+public InfiniteLine()
+```
+
+
+[InfiniteLine](../../com.aspose.diagram/infiniteline) クラスのインスタンスを作成します。
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+無限直線上の点の x 座標で、y 座標は B 要素で表されます。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getB() {#getB--}
+```
+public DoubleValue getB()
+```
+
+
+無限直線上の点の y 座標で、x 座標は A 要素で表されます。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+親要素内の要素のゼロベースインデックスです。
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+無限直線上の点の x 座標です。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+無限直線上の点の y 座標です。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getA()](../../com.aspose.diagram/infiniteline\#getA--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setB(DoubleValue value) {#setB-com.aspose.diagram.DoubleValue-}
+```
+public void setB(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getB()](../../com.aspose.diagram/infiniteline\#getB--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+このプロパティの説明については、[getDel()](../../com.aspose.diagram/infiniteline\#getDel--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+このプロパティの説明については、[getIX()](../../com.aspose.diagram/infiniteline\#getIX--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getX()](../../com.aspose.diagram/infiniteline\#getX--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getY()](../../com.aspose.diagram/infiniteline\#getY--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/infinitelinecollection/_index.md
+++ b/japanese/java/com.aspose.diagram/infinitelinecollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: InfiniteLineCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: InfiniteLine コレクション。
+type: docs
+weight: 203
+url: /ja/java/com.aspose.diagram/infinitelinecollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class InfiniteLineCollection extends Collection
+```
+
+InfiniteLine コレクション。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public InfiniteLine get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[InfiniteLine](../../com.aspose.diagram/infiniteline) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/inputmethodeditormode/_index.md
+++ b/japanese/java/com.aspose.diagram/inputmethodeditormode/_index.md
@@ -1,0 +1,246 @@
+---
+title: InputMethodEditorMode
+second_title: Aspose.Diagram for Java API リファレンス
+description: Input Method Editor のデフォルト実行時モードを表します。
+type: docs
+weight: 204
+url: /ja/java/com.aspose.diagram/inputmethodeditormode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class InputMethodEditorMode
+```
+
+Input Method Editor のデフォルト実行時モードを表します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [ALPHA](#ALPHA) | 半角英数字モードでIMEがオンです。 |
+| [ALPHA_FULL](#ALPHA-FULL) | 全角英数字モードでIMEがオンです。 |
+| [DISABLE](#DISABLE) | IMEがオフです。ユーザーはキーボードでIMEをオンにできません。 |
+| [HANGUL](#HANGUL) | 半角ハングルモードでIMEがオンです。 |
+| [HANGUL_FULL](#HANGUL-FULL) | 全角ハングルモードでIMEがオンです。 |
+| [HANZI](#HANZI) | 半角漢字モードでIMEがオンです。 |
+| [HANZI_FULL](#HANZI-FULL) | 全角漢字モードでIMEがオンです。 |
+| [HIRAGANA](#HIRAGANA) | 全角ひらがなモードでIMEがオンです。 |
+| [KATAKANA](#KATAKANA) | 全角カタカナモードでIMEがオンです。 |
+| [KATAKANA_HALF](#KATAKANA-HALF) | 半角カタカナモードでIMEがオンです。 |
+| [NO_CONTROL](#NO-CONTROL) | IMEを制御しません。 |
+| [OFF](#OFF) | IMEがオフです。 |
+| [ON](#ON) | IMEがオンです。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALPHA {#ALPHA}
+```
+public static final int ALPHA
+```
+
+
+半角英数字モードでIMEがオンです。
+
+### ALPHA_FULL {#ALPHA-FULL}
+```
+public static final int ALPHA_FULL
+```
+
+
+全角英数字モードでIMEがオンです。
+
+### DISABLE {#DISABLE}
+```
+public static final int DISABLE
+```
+
+
+IMEがオフです。ユーザーはキーボードでIMEをオンにできません。
+
+### HANGUL {#HANGUL}
+```
+public static final int HANGUL
+```
+
+
+半角ハングルモードでIMEがオンです。
+
+### HANGUL_FULL {#HANGUL-FULL}
+```
+public static final int HANGUL_FULL
+```
+
+
+全角ハングルモードでIMEがオンです。
+
+### HANZI {#HANZI}
+```
+public static final int HANZI
+```
+
+
+半角漢字モードでIMEがオンです。
+
+### HANZI_FULL {#HANZI-FULL}
+```
+public static final int HANZI_FULL
+```
+
+
+全角漢字モードでIMEがオンです。
+
+### HIRAGANA {#HIRAGANA}
+```
+public static final int HIRAGANA
+```
+
+
+全角ひらがなモードでIMEがオンです。
+
+### KATAKANA {#KATAKANA}
+```
+public static final int KATAKANA
+```
+
+
+全角カタカナモードでIMEがオンです。
+
+### KATAKANA_HALF {#KATAKANA-HALF}
+```
+public static final int KATAKANA_HALF
+```
+
+
+半角カタカナモードでIMEがオンです。
+
+### NO_CONTROL {#NO-CONTROL}
+```
+public static final int NO_CONTROL
+```
+
+
+IMEを制御しません。
+
+### OFF {#OFF}
+```
+public static final int OFF
+```
+
+
+IMEがオフです。英語モード。
+
+### ON {#ON}
+```
+public static final int ON
+```
+
+
+IMEがオンです。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/interpolationmode/_index.md
+++ b/japanese/java/com.aspose.diagram/interpolationmode/_index.md
@@ -1,0 +1,210 @@
+---
+title: InterpolationMode
+second_title: Aspose.Diagram for Java API リファレンス
+description: InterpolationMode 列挙体は、画像が拡大縮小または回転される際に使用されるアルゴリズムを指定します。
+type: docs
+weight: 206
+url: /ja/java/com.aspose.diagram/interpolationmode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class InterpolationMode
+```
+
+InterpolationMode 列挙体は、画像が拡大縮小または回転される際に使用されるアルゴリズムを指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [BICUBIC](#BICUBIC) | バイキュービック補間を指定します。 |
+| [BILINEAR](#BILINEAR) | 双一次補間を指定します。 |
+| [DEFAULT](#DEFAULT) | デフォルトモードを指定します。 |
+| [HIGH](#HIGH) | 高品質の補間を指定します。 |
+| [HIGH_QUALITY_BICUBIC](#HIGH-QUALITY-BICUBIC) | 高品質のバイキュービック補間を指定します。 |
+| [HIGH_QUALITY_BILINEAR](#HIGH-QUALITY-BILINEAR) | 高品質の双一次補間を指定します。 |
+| [INVALID](#INVALID) | QualityMode 列挙体の Invalid 要素に相当します。 |
+| [LOW](#LOW) | 低品質の補間を指定します。 |
+| [NEAREST_NEIGHBOR](#NEAREST-NEIGHBOR) | 最近傍補間を指定します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BICUBIC {#BICUBIC}
+```
+public static final int BICUBIC
+```
+
+
+バイキュービック補間を指定します。事前フィルタリングは行われません。このモードは画像を元のサイズの 25％ 未満に縮小する場合には適していません。
+
+### BILINEAR {#BILINEAR}
+```
+public static final int BILINEAR
+```
+
+
+双一次補間を指定します。事前フィルタリングは行われません。このモードは画像を元のサイズの 50％ 未満に縮小する場合には適していません。
+
+### DEFAULT {#DEFAULT}
+```
+public static final int DEFAULT
+```
+
+
+デフォルトモードを指定します。
+
+### HIGH {#HIGH}
+```
+public static final int HIGH
+```
+
+
+高品質の補間を指定します。
+
+### HIGH_QUALITY_BICUBIC {#HIGH-QUALITY-BICUBIC}
+```
+public static final int HIGH_QUALITY_BICUBIC
+```
+
+
+高品質のバイキュービック補間を指定します。高品質な縮小を保証するために事前フィルタリングが実行されます。このモードは最高品質の変換画像を生成します。
+
+### HIGH_QUALITY_BILINEAR {#HIGH-QUALITY-BILINEAR}
+```
+public static final int HIGH_QUALITY_BILINEAR
+```
+
+
+高品質の双一次補間を指定します。高品質な縮小を保証するために事前フィルタリングが実行されます。
+
+### INVALID {#INVALID}
+```
+public static final int INVALID
+```
+
+
+QualityMode 列挙体の Invalid 要素に相当します。
+
+### LOW {#LOW}
+```
+public static final int LOW
+```
+
+
+低品質の補間を指定します。
+
+### NEAREST_NEIGHBOR {#NEAREST-NEIGHBOR}
+```
+public static final int NEAREST_NEIGHBOR
+```
+
+
+最近傍補間を指定します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/interruptmonitor/_index.md
+++ b/japanese/java/com.aspose.diagram/interruptmonitor/_index.md
@@ -1,0 +1,156 @@
+---
+title: InterruptMonitor
+second_title: Aspose.Diagram for Java API リファレンス
+description: 割り込みに関するすべての演算子を表します。
+type: docs
+weight: 207
+url: /ja/java/com.aspose.diagram/interruptmonitor/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.AbstractInterruptMonitor](../../com.aspose.diagram/abstractinterruptmonitor)
+```
+public class InterruptMonitor extends AbstractInterruptMonitor
+```
+
+割り込みに関するすべての演算子を表します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [InterruptMonitor()](#InterruptMonitor--) |  |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [interrupt()](#interrupt--) | Interrupt the current operator. |
+| [isInterruptionRequested()](#isInterruptionRequested--) | Mark the monitor as requesting interruption |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### InterruptMonitor() {#InterruptMonitor--}
+```
+public InterruptMonitor()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### interrupt() {#interrupt--}
+```
+public void interrupt()
+```
+
+
+Interrupt the current operator.
+
+### isInterruptionRequested() {#isInterruptionRequested--}
+```
+public boolean isInterruptionRequested()
+```
+
+
+Mark the monitor as requesting interruption
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/intvalue/_index.md
+++ b/japanese/java/com.aspose.diagram/intvalue/_index.md
@@ -1,0 +1,230 @@
+---
+title: IntValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: 整数値
+type: docs
+weight: 205
+url: /ja/java/com.aspose.diagram/intvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class IntValue
+```
+
+整数値
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [IntValue(int value, int unit)](#IntValue-int-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性。 |
+| [getValue()](#getValue--) | 整数値。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [isThemed()](#isThemed--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setThemed(boolean value)](#setThemed-boolean-) | このプロパティの説明については、[isThemed()](../../com.aspose.diagram/intvalue\#isThemed--) を参照してください。 |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | このプロパティの説明については、[getUfe()](../../com.aspose.diagram/intvalue\#getUfe--) を参照してください。 |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/intvalue\#getValue--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### IntValue(int value, int unit) {#IntValue-int-int-}
+```
+public IntValue(int value, int unit)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+| 単位 | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+整数値。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### isThemed() {#isThemed--}
+```
+public boolean isThemed()
+```
+
+
+
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setThemed(boolean value) {#setThemed-boolean-}
+```
+public void setThemed(boolean value)
+```
+
+
+このプロパティの説明については、[isThemed()](../../com.aspose.diagram/intvalue\#isThemed--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+このプロパティの説明については、[getUfe()](../../com.aspose.diagram/intvalue\#getUfe--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/intvalue\#getValue--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/ipagesavingcallback/_index.md
+++ b/japanese/java/com.aspose.diagram/ipagesavingcallback/_index.md
@@ -1,0 +1,45 @@
+---
+title: IPageSavingCallback
+second_title: Aspose.Diagram for Java API リファレンス
+description: ページ保存プロセスの進行状況を制御/表示します。
+type: docs
+weight: 456
+url: /ja/java/com.aspose.diagram/ipagesavingcallback/
+---
+```
+public interface IPageSavingCallback
+```
+
+ページ保存プロセスの進行状況を制御/表示します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [pageEndSaving(PageEndSavingArgs args)](#pageEndSaving-com.aspose.diagram.PageEndSavingArgs-) | Control/Indicate a page ends to be output. |
+| [pageStartSaving(PageStartSavingArgs args)](#pageStartSaving-com.aspose.diagram.PageStartSavingArgs-) | Control/Indicate a page starts to be output. |
+### pageEndSaving(PageEndSavingArgs args) {#pageEndSaving-com.aspose.diagram.PageEndSavingArgs-}
+```
+public abstract void pageEndSaving(PageEndSavingArgs args)
+```
+
+
+Control/Indicate a page ends to be output.
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| args | [PageEndSavingArgs](../../com.aspose.diagram/pageendsavingargs) | ページの情報が保存プロセスを終了します。 |
+
+### pageStartSaving(PageStartSavingArgs args) {#pageStartSaving-com.aspose.diagram.PageStartSavingArgs-}
+```
+public abstract void pageStartSaving(PageStartSavingArgs args)
+```
+
+
+Control/Indicate a page starts to be output.
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| args | [PageStartSavingArgs](../../com.aspose.diagram/pagestartsavingargs) | ページの保存プロセス開始に関する情報です。 |
+

--- a/japanese/java/com.aspose.diagram/issue/_index.md
+++ b/japanese/java/com.aspose.diagram/issue/_index.md
@@ -1,0 +1,210 @@
+---
+title: Issue
+second_title: Aspose.Diagram for Java API リファレンス
+description: ドキュメント内の単一の検証問題を表します。
+type: docs
+weight: 208
+url: /ja/java/com.aspose.diagram/issue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Issue
+```
+
+ドキュメント内の単一の検証問題を表します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Issue()](#Issue--) | コンストラクタ |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getID()](#getID--) | 検証問題の一意の識別子を指定します。 |
+| [getIgnored()](#getIgnored--) | 検証問題が現在無視されているかどうかを指定します。 |
+| [getIssueTarget()](#getIssueTarget--) | 親検証問題の対象に応じて、親検証問題が関連付けられるページ、またはページとシェイプの両方を指定します。 |
+| [getRuleInfo()](#getRuleInfo--) | 親の検証問題が関連する検証ルールに関する情報を指定します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setID(long value)](#setID-long-) | このプロパティの説明については、[getID()](../../com.aspose.diagram/issue\#getID--) をご覧ください。 |
+| [setIgnored(int value)](#setIgnored-int-) | このプロパティの説明については、[getIgnored()](../../com.aspose.diagram/issue\#getIgnored--) をご覧ください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Issue() {#Issue--}
+```
+public Issue()
+```
+
+
+コンストラクタ
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getID() {#getID--}
+```
+public long getID()
+```
+
+
+検証問題の一意の識別子を指定します。
+
+**Returns:**
+long
+### getIgnored() {#getIgnored--}
+```
+public int getIgnored()
+```
+
+
+検証問題が現在無視されているかどうかを指定します。デフォルトは False です。
+
+**Returns:**
+int
+### getIssueTarget() {#getIssueTarget--}
+```
+public IssueTarget getIssueTarget()
+```
+
+
+親検証問題の対象に応じて、ページ、またはページとシェイプの両方を指定します。親検証問題の対象がドキュメントの場合、IssueTarget はページもシェイプも指定しません。
+
+**Returns:**
+[IssueTarget](../../com.aspose.diagram/issuetarget)
+### getRuleInfo() {#getRuleInfo--}
+```
+public RuleInfo getRuleInfo()
+```
+
+
+親の検証問題が関連する検証ルールに関する情報を指定します。
+
+**Returns:**
+[RuleInfo](../../com.aspose.diagram/ruleinfo)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setID(long value) {#setID-long-}
+```
+public void setID(long value)
+```
+
+
+このプロパティの説明については、[getID()](../../com.aspose.diagram/issue\#getID--) をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | long |  |
+
+### setIgnored(int value) {#setIgnored-int-}
+```
+public void setIgnored(int value)
+```
+
+
+このプロパティの説明については、[getIgnored()](../../com.aspose.diagram/issue\#getIgnored--) をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/issuecollection/_index.md
+++ b/japanese/java/com.aspose.diagram/issuecollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: IssueCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: Issue コレクション。
+type: docs
+weight: 209
+url: /ja/java/com.aspose.diagram/issuecollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class IssueCollection extends Collection
+```
+
+Issue コレクション。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(Issue issue)](#add-com.aspose.diagram.Issue-) | コレクションに問題を追加します。 |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Issue issue)](#remove-com.aspose.diagram.Issue-) | コレクションから問題を削除します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Issue issue) {#add-com.aspose.diagram.Issue-}
+```
+public int add(Issue issue)
+```
+
+
+コレクションに問題を追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| issue | [Issue](../../com.aspose.diagram/issue) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Issue get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[Issue](../../com.aspose.diagram/issue) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Issue issue) {#remove-com.aspose.diagram.Issue-}
+```
+public void remove(Issue issue)
+```
+
+
+コレクションから問題を削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| issue | [Issue](../../com.aspose.diagram/issue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/issuetarget/_index.md
+++ b/japanese/java/com.aspose.diagram/issuetarget/_index.md
@@ -1,0 +1,194 @@
+---
+title: IssueTarget
+second_title: Aspose.Diagram for Java API リファレンス
+description: 親検証問題の対象に応じて、ページ、またはページとシェイプの両方を指定します。
+type: docs
+weight: 210
+url: /ja/java/com.aspose.diagram/issuetarget/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class IssueTarget
+```
+
+親検証問題の対象に応じて、ページ、またはページとシェイプの両方を指定します。親検証問題の対象がドキュメントの場合、IssueTarget はページもシェイプも指定しません。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [IssueTarget(long pageID, long shapeID)](#IssueTarget-long-long-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getPageId()](#getPageId--) | 親検証問題に関連付けられたページの一意識別子を指定します。 |
+| [getShapeId()](#getShapeId--) | 親検証問題に関連付けられたシェイプの一意識別子を指定します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setPageId(long value)](#setPageId-long-) | このプロパティの説明については、[getPageId()](../../com.aspose.diagram/issuetarget\\#getPageId--) を参照してください。 |
+| [setShapeId(long value)](#setShapeId-long-) | このプロパティの説明については、[getShapeId()](../../com.aspose.diagram/issuetarget\\#getShapeId--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### IssueTarget(long pageID, long shapeID) {#IssueTarget-long-long-}
+```
+public IssueTarget(long pageID, long shapeID)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| pageID | long |  |
+| shapeID | long |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getPageId() {#getPageId--}
+```
+public long getPageId()
+```
+
+
+親検証問題に関連付けられたページの一意識別子を指定します。対象がドキュメントの場合、PageID の値は 0xFFFFFFFF にできます。
+
+**Returns:**
+long
+### getShapeId() {#getShapeId--}
+```
+public long getShapeId()
+```
+
+
+親検証問題に関連付けられたシェイプの一意識別子を指定します。対象がドキュメントまたはページの場合、ShapeID の値は 0xFFFFFFFF にできます。
+
+**Returns:**
+long
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setPageId(long value) {#setPageId-long-}
+```
+public void setPageId(long value)
+```
+
+
+このプロパティの説明については、[getPageId()](../../com.aspose.diagram/issuetarget\\#getPageId--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | long |  |
+
+### setShapeId(long value) {#setShapeId-long-}
+```
+public void setShapeId(long value)
+```
+
+
+このプロパティの説明については、[getShapeId()](../../com.aspose.diagram/issuetarget\\#getShapeId--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | long |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/istreamprovider/_index.md
+++ b/japanese/java/com.aspose.diagram/istreamprovider/_index.md
@@ -1,0 +1,45 @@
+---
+title: IStreamProvider
+second_title: Aspose.Diagram for Java API リファレンス
+description: エクスポートされたストリームプロバイダーを表します。
+type: docs
+weight: 457
+url: /ja/java/com.aspose.diagram/istreamprovider/
+---
+```
+public interface IStreamProvider
+```
+
+エクスポートされたストリームプロバイダーを表します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [closeStream(StreamProviderOptions options)](#closeStream-com.aspose.diagram.StreamProviderOptions-) | ストリームを閉じます。 |
+| [initStream(StreamProviderOptions options)](#initStream-com.aspose.diagram.StreamProviderOptions-) | ストリームを取得します。 |
+### closeStream(StreamProviderOptions options) {#closeStream-com.aspose.diagram.StreamProviderOptions-}
+```
+public abstract void closeStream(StreamProviderOptions options)
+```
+
+
+ストリームを閉じます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| options | [StreamProviderOptions](../../com.aspose.diagram/streamprovideroptions) |  |
+
+### initStream(StreamProviderOptions options) {#initStream-com.aspose.diagram.StreamProviderOptions-}
+```
+public abstract void initStream(StreamProviderOptions options)
+```
+
+
+ストリームを取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| options | [StreamProviderOptions](../../com.aspose.diagram/streamprovideroptions) |  |
+

--- a/japanese/java/com.aspose.diagram/iwarningcallback/_index.md
+++ b/japanese/java/com.aspose.diagram/iwarningcallback/_index.md
@@ -1,0 +1,31 @@
+---
+title: IWarningCallback
+second_title: Aspose.Diagram for Java API リファレンス
+description: 警告のコールバックインターフェイスです。
+type: docs
+weight: 458
+url: /ja/java/com.aspose.diagram/iwarningcallback/
+---
+```
+public interface IWarningCallback
+```
+
+警告のコールバックインターフェイスです。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [warning(WarningInfo warningInfo)](#warning-com.aspose.diagram.WarningInfo-) | 私たちのコールバックは "Warning" メソッドを実装するだけで構いません。 |
+### warning(WarningInfo warningInfo) {#warning-com.aspose.diagram.WarningInfo-}
+```
+public abstract void warning(WarningInfo warningInfo)
+```
+
+
+私たちのコールバックは "Warning" メソッドを実装するだけで構いません。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| warningInfo | [WarningInfo](../../com.aspose.diagram/warninginfo) | 警告情報 |
+

--- a/japanese/java/com.aspose.diagram/labelactivexcontrol/_index.md
+++ b/japanese/java/com.aspose.diagram/labelactivexcontrol/_index.md
@@ -1,0 +1,622 @@
+---
+title: LabelActiveXControl
+second_title: Aspose.Diagram for Java API リファレンス
+description: ラベル ActiveX コントロールを表します。
+type: docs
+weight: 211
+url: /ja/java/com.aspose.diagram/labelactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class LabelActiveXControl extends ActiveXControl
+```
+
+ラベル ActiveX コントロールを表します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAccelerator()](#getAccelerator--) | コントロールのアクセラレータキーです。 |
+| [getBackOleColor()](#getBackOleColor--) | 背景の OLE カラー。 |
+| [getBorderOleColor()](#getBorderOleColor--) | 背景の OLE カラー。 |
+| [getBorderStyle()](#getBorderStyle--) | コントロールで使用される境界線の種類。 |
+| [getCaption()](#getCaption--) | コントロール上に表示される説明テキストです。 |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | コントロールのバイナリ データ。 |
+| [getForeOleColor()](#getForeOleColor--) | 前景の OLE カラー。 |
+| [getHeight()](#getHeight--) | ポイント単位のコントロールの高さ。 |
+| [getIMEMode()](#getIMEMode--) | コントロールがフォーカスを受け取る際の Input Method Editor のデフォルト実行時モード。 |
+| [getMouseIcon()](#getMouseIcon--) | コントロールのマウスポインタとして表示するカスタムアイコンです。 |
+| [getMousePointer()](#getMousePointer--) | コントロールのマウスポインタとして表示されるアイコンの種類です。 |
+| [getPicture()](#getPicture--) | 画像のデータです。 |
+| [getPicturePosition()](#getPicturePosition--) | コントロールのキャプションに対する画像の位置。 |
+| [getSpecialEffect()](#getSpecialEffect--) | コントロールの特殊効果です。 |
+| [getType()](#getType--) | ActiveX コントロールのタイプを取得します。 |
+| [getWidth()](#getWidth--) | ポイント単位のコントロールの幅です。 |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | コントロールが全内容を表示するために自動的にサイズ変更されるかどうかを示します。 |
+| [isEnabled()](#isEnabled--) | コントロールがフォーカスを受け取り、ユーザー生成イベントに応答できるかどうかを示します。 |
+| [isLocked()](#isLocked--) | コントロール内のデータが編集ロックされているかどうかを示します。 |
+| [isTransparent()](#isTransparent--) | コントロールが透明かどうかを示します。 |
+| [isWordWrapped()](#isWordWrapped--) | コントロールの内容が行末で自動的に折り返されるかどうかを示します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAccelerator(char value)](#setAccelerator-char-) | このプロパティの説明については、[getAccelerator()](../../com.aspose.diagram/labelactivexcontrol\#getAccelerator--) を参照してください。 |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | このプロパティの説明については、[isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) を参照してください |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | このプロパティの説明については、[getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) を参照してください |
+| [setBorderOleColor(int value)](#setBorderOleColor-int-) | このプロパティの説明については、[getBorderOleColor()](../../com.aspose.diagram/labelactivexcontrol\#getBorderOleColor--) を参照してください。 |
+| [setBorderStyle(int value)](#setBorderStyle-int-) | このプロパティの説明については、[getBorderStyle()](../../com.aspose.diagram/labelactivexcontrol\#getBorderStyle--) を参照してください。 |
+| [setCaption(String value)](#setCaption-java.lang.String-) | このプロパティの説明については、[getCaption()](../../com.aspose.diagram/labelactivexcontrol\#getCaption--) を参照してください。 |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | このプロパティの説明については、[isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) を参照してください |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | このプロパティの説明については、[getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) を参照してください |
+| [setHeight(double value)](#setHeight-double-) | このプロパティの説明については、[getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) を参照してください |
+| [setIMEMode(int value)](#setIMEMode-int-) | このプロパティの説明については、[getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) を参照してください |
+| [setLocked(boolean value)](#setLocked-boolean-) | このプロパティの説明については、[isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) を参照してください |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | このプロパティの説明については、[getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) を参照してください |
+| [setMousePointer(int value)](#setMousePointer-int-) | このプロパティの説明については、[getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) を参照してください |
+| [setPicture(byte[] value)](#setPicture-byte---) | このプロパティの説明については、[getPicture()](../../com.aspose.diagram/labelactivexcontrol\#getPicture--) を参照してください。 |
+| [setPicturePosition(int value)](#setPicturePosition-int-) | このプロパティの説明については、[getPicturePosition()](../../com.aspose.diagram/labelactivexcontrol\#getPicturePosition--) を参照してください。 |
+| [setSpecialEffect(int value)](#setSpecialEffect-int-) | このプロパティの説明については、[getSpecialEffect()](../../com.aspose.diagram/labelactivexcontrol\#getSpecialEffect--) を参照してください。 |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | このプロパティの説明については、[isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) を参照してください |
+| [setWidth(double value)](#setWidth-double-) | このプロパティの説明については、[getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) を参照してください |
+| [setWordWrapped(boolean value)](#setWordWrapped-boolean-) | このプロパティの説明については、[isWordWrapped()](../../com.aspose.diagram/labelactivexcontrol\#isWordWrapped--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAccelerator() {#getAccelerator--}
+```
+public char getAccelerator()
+```
+
+
+コントロールのアクセラレータキーです。
+
+**Returns:**
+char
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+背景の OLE カラー。
+
+**Returns:**
+int
+### getBorderOleColor() {#getBorderOleColor--}
+```
+public int getBorderOleColor()
+```
+
+
+背景の OLE カラー。
+
+**Returns:**
+int
+### getBorderStyle() {#getBorderStyle--}
+```
+public int getBorderStyle()
+```
+
+
+コントロールで使用される境界線の種類。
+
+**Returns:**
+int
+### getCaption() {#getCaption--}
+```
+public String getCaption()
+```
+
+
+コントロール上に表示される説明テキストです。
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+コントロールのバイナリ データ。
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+前景の OLE カラーです。Image コントロールには適用されません。
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+ポイント単位のコントロールの高さ。
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+コントロールがフォーカスを受け取る際の Input Method Editor のデフォルト実行時モード。
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+コントロールのマウスポインタとして表示するカスタムアイコンです。
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+コントロールのマウスポインタとして表示されるアイコンの種類です。
+
+**Returns:**
+int
+### getPicture() {#getPicture--}
+```
+public byte[] getPicture()
+```
+
+
+画像のデータです。
+
+**Returns:**
+byte[]
+### getPicturePosition() {#getPicturePosition--}
+```
+public int getPicturePosition()
+```
+
+
+コントロールのキャプションに対する画像の位置。
+
+**Returns:**
+int
+### getSpecialEffect() {#getSpecialEffect--}
+```
+public int getSpecialEffect()
+```
+
+
+コントロールの特殊効果です。
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+ActiveX コントロールのタイプを取得します。
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+ポイント単位のコントロールの幅です。
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+コントロールが全内容を表示するために自動的にサイズ変更されるかどうかを示します。
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+コントロールがフォーカスを受け取り、ユーザー生成イベントに応答できるかどうかを示します。
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+コントロール内のデータが編集ロックされているかどうかを示します。
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+コントロールが透明かどうかを示します。
+
+**Returns:**
+boolean
+### isWordWrapped() {#isWordWrapped--}
+```
+public boolean isWordWrapped()
+```
+
+
+コントロールの内容が行末で自動的に折り返されるかどうかを示します。
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAccelerator(char value) {#setAccelerator-char-}
+```
+public void setAccelerator(char value)
+```
+
+
+このプロパティの説明については、[getAccelerator()](../../com.aspose.diagram/labelactivexcontrol\#getAccelerator--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | char |  |
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+このプロパティの説明については、[isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+このプロパティの説明については、[getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setBorderOleColor(int value) {#setBorderOleColor-int-}
+```
+public void setBorderOleColor(int value)
+```
+
+
+このプロパティの説明については、[getBorderOleColor()](../../com.aspose.diagram/labelactivexcontrol\#getBorderOleColor--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setBorderStyle(int value) {#setBorderStyle-int-}
+```
+public void setBorderStyle(int value)
+```
+
+
+このプロパティの説明については、[getBorderStyle()](../../com.aspose.diagram/labelactivexcontrol\#getBorderStyle--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setCaption(String value) {#setCaption-java.lang.String-}
+```
+public void setCaption(String value)
+```
+
+
+このプロパティの説明については、[getCaption()](../../com.aspose.diagram/labelactivexcontrol\#getCaption--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+このプロパティの説明については、[isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+このプロパティの説明については、[getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+このプロパティの説明については、[getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+このプロパティの説明については、[getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+このプロパティの説明については、[isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+このプロパティの説明については、[getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+このプロパティの説明については、[getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setPicture(byte[] value) {#setPicture-byte---}
+```
+public void setPicture(byte[] value)
+```
+
+
+このプロパティの説明については、[getPicture()](../../com.aspose.diagram/labelactivexcontrol\#getPicture--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | byte[] |  |
+
+### setPicturePosition(int value) {#setPicturePosition-int-}
+```
+public void setPicturePosition(int value)
+```
+
+
+このプロパティの説明については、[getPicturePosition()](../../com.aspose.diagram/labelactivexcontrol\#getPicturePosition--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setSpecialEffect(int value) {#setSpecialEffect-int-}
+```
+public void setSpecialEffect(int value)
+```
+
+
+このプロパティの説明については、[getSpecialEffect()](../../com.aspose.diagram/labelactivexcontrol\#getSpecialEffect--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+このプロパティの説明については、[isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+このプロパティの説明については、[getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double |  |
+
+### setWordWrapped(boolean value) {#setWordWrapped-boolean-}
+```
+public void setWordWrapped(boolean value)
+```
+
+
+このプロパティの説明については、[isWordWrapped()](../../com.aspose.diagram/labelactivexcontrol\#isWordWrapped--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/layer/_index.md
+++ b/japanese/java/com.aspose.diagram/layer/_index.md
@@ -1,0 +1,334 @@
+---
+title: Layer
+second_title: Aspose.Diagram for Java API リファレンス
+description: ページ用の単一レイヤーとそのプロパティを定義する要素を含みます。
+type: docs
+weight: 212
+url: /ja/java/com.aspose.diagram/layer/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Layer
+```
+
+ページ用の単一レイヤーとそのプロパティを定義する要素を含みます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Layer()](#Layer--) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getActive()](#getActive--) | レイヤーがアクティブかどうかを指定します。 |
+| [getClass()](#getClass--) |  |
+| [getColor()](#getColor--) | レイヤーの表示に使用されるカラーテーブル内の色のインデックス、またはカラーテーブルにないカスタムカラーを指定する RGB 値（例: \#ff9900）。 |
+| [getColorTrans()](#getColorTrans--) | レイヤーまたはシェイプのテキストカラーの透明度を決定します。0（完全に不透明）から 1（完全に透明）までの範囲です。 |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getGlue()](#getGlue--) | レイヤーに属するシェイプを接着できるかどうかを指定します。 |
+| [getIX()](#getIX--) | 親要素内の要素のゼロベースインデックスです。 |
+| [getLock()](#getLock--) | レイヤーに属するシェイプが選択または編集できないようにロックされているかどうかを指定します。 |
+| [getName()](#getName--) | Name 要素はレイヤーの名前を指定します。 |
+| [getNameUniv()](#getNameUniv--) | レイヤーのユニバーサル名を指定します。 |
+| [getPrint()](#getPrint--) | 図面が印刷される際に、レイヤーに属するシェイプが印刷されるかどうかを指定します。 |
+| [getSnap()](#getSnap--) | 他のシェイプがレイヤーに割り当てられたシェイプにスナップできるかどうかを指定します。 |
+| [getStatus()](#getStatus--) | レイヤーがドキュメントに対して有効なレイヤーかどうかを指定します。 |
+| [getVisible()](#getVisible--) | レイヤーに属するシェイプが図面ページ上で表示されるかどうかを指定します。 |
+| [hashCode()](#hashCode--) |  |
+| [isColorChecked()](#isColorChecked--) | 要素がローカルでチェックされたかどうかを示すフラグです。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setColorChecked(int value)](#setColorChecked-int-) | このプロパティの説明については、[isColorChecked()](../../com.aspose.diagram/layer\#isColorChecked--) を参照してください。 |
+| [setDel(int value)](#setDel-int-) | このプロパティの説明については、[getDel()](../../com.aspose.diagram/layer\#getDel--) を参照してください。 |
+| [setIX(int value)](#setIX-int-) | このプロパティの説明については、[getIX()](../../com.aspose.diagram/layer\#getIX--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Layer() {#Layer--}
+```
+public Layer()
+```
+
+
+コンストラクタ。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getActive() {#getActive--}
+```
+public BoolValue getActive()
+```
+
+
+レイヤーがアクティブかどうかを指定します。事前にレイヤーに割り当てられていないシェイプは、図面ページにドロップされたときにアクティブなレイヤーに割り当てられます。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColor() {#getColor--}
+```
+public ColorValue getColor()
+```
+
+
+レイヤーの表示に使用されるカラーテーブル内の色のインデックス、またはカラーテーブルにないカスタムカラーを指定する RGB 値（例: \#ff9900）。
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getColorTrans() {#getColorTrans--}
+```
+public DoubleValue getColorTrans()
+```
+
+
+レイヤーまたはシェイプのテキストカラーの透明度を決定します。0（完全に不透明）から 1（完全に透明）までの範囲です。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getGlue() {#getGlue--}
+```
+public BoolValue getGlue()
+```
+
+
+レイヤーに属するシェイプを接着できるかどうかを指定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+親要素内の要素のゼロベースインデックスです。
+
+**Returns:**
+int
+### getLock() {#getLock--}
+```
+public BoolValue getLock()
+```
+
+
+レイヤーに属するシェイプが選択または編集できないようにロックされているかどうかを指定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getName() {#getName--}
+```
+public Str2Value getName()
+```
+
+
+Name 要素はレイヤーの名前を指定します。
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getNameUniv() {#getNameUniv--}
+```
+public Str2Value getNameUniv()
+```
+
+
+レイヤーのユニバーサル名を指定します。
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getPrint() {#getPrint--}
+```
+public BoolValue getPrint()
+```
+
+
+図面が印刷される際に、レイヤーに属するシェイプが印刷されるかどうかを指定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getSnap() {#getSnap--}
+```
+public BoolValue getSnap()
+```
+
+
+他のシェイプがレイヤーに割り当てられたシェイプにスナップできるかどうかを指定します。レイヤーに割り当てられたシェイプは他のシェイプにスナップできますが、他のシェイプはそれらにスナップできません。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getStatus() {#getStatus--}
+```
+public BoolValue getStatus()
+```
+
+
+レイヤーがドキュメントに対して有効なレイヤーかどうかを指定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getVisible() {#getVisible--}
+```
+public BoolValue getVisible()
+```
+
+
+レイヤーに属するシェイプが図面ページ上で表示されるかどうかを指定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isColorChecked() {#isColorChecked--}
+```
+public int isColorChecked()
+```
+
+
+要素がローカルでチェックされたかどうかを示すフラグです。値が 1 の場合、要素がローカルでチェックされたことを示します。
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setColorChecked(int value) {#setColorChecked-int-}
+```
+public void setColorChecked(int value)
+```
+
+
+このプロパティの説明については、[isColorChecked()](../../com.aspose.diagram/layer\#isColorChecked--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+このプロパティの説明については、[getDel()](../../com.aspose.diagram/layer\#getDel--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+このプロパティの説明については、[getIX()](../../com.aspose.diagram/layer\#getIX--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/layercollection/_index.md
+++ b/japanese/java/com.aspose.diagram/layercollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: LayerCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: Layer コレクション。
+type: docs
+weight: 213
+url: /ja/java/com.aspose.diagram/layercollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class LayerCollection extends Collection
+```
+
+Layer コレクション。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(Layer item)](#add-com.aspose.diagram.Layer-) | Add the Layer object in the collection. |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Layer item)](#remove-com.aspose.diagram.Layer-) | Remove the Layer object from the collection. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Layer item) {#add-com.aspose.diagram.Layer-}
+```
+public int add(Layer item)
+```
+
+
+Add the Layer object in the collection.
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [Layer](../../com.aspose.diagram/layer) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Layer get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[Layer](../../com.aspose.diagram/layer) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Layer item) {#remove-com.aspose.diagram.Layer-}
+```
+public void remove(Layer item)
+```
+
+
+Remove the Layer object from the collection.
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [Layer](../../com.aspose.diagram/layer) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/layermem/_index.md
+++ b/japanese/java/com.aspose.diagram/layermem/_index.md
@@ -1,0 +1,161 @@
+---
+title: LayerMem
+second_title: Aspose.Diagram for Java API リファレンス
+description: シェイプが割り当てられる各レイヤーを指定する LayerMember 要素を含みます。
+type: docs
+weight: 214
+url: /ja/java/com.aspose.diagram/layermem/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LayerMem
+```
+
+LayerMember 要素を含み、シェイプが割り当てられる各レイヤーを指定します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getLayerMember()](#getLayerMember--) | シェイプが割り当てられるレイヤーまたはレイヤー群を指定します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | このプロパティの説明については、[getDel()](../../com.aspose.diagram/layermem\\#getDel--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getLayerMember() {#getLayerMember--}
+```
+public Str2Value getLayerMember()
+```
+
+
+シェイプが割り当てられるレイヤーまたはレイヤー群を指定します。レイヤーの割り当ては、ページのレイヤーのゼロベースインデックスに基づいて指定されます。シェイプが複数のレイヤーに割り当てられる場合、各レイヤーインデックスはセミコロンで区切られます。
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+このプロパティの説明については、[getDel()](../../com.aspose.diagram/layermem\\#getDel--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/layout/_index.md
+++ b/japanese/java/com.aspose.diagram/layout/_index.md
@@ -1,0 +1,362 @@
+---
+title: レイアウト
+second_title: Aspose.Diagram for Java API リファレンス
+description: シェイプの配置とコネクタのルーティング設定を制御する要素を含みます。
+type: docs
+weight: 215
+url: /ja/java/com.aspose.diagram/layout/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Layout
+```
+
+シェイプの配置とコネクタのルーティング設定を制御する要素を含みます。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getConFixedCode()](#getConFixedCode--) | コネクタが再ルーティングするタイミングを決定します。 |
+| [getConLineJumpCode()](#getConLineJumpCode--) | 2つのコネクタが交差したときにコネクタがジャンプするかどうかを決定します、 |
+| [getConLineJumpDirX()](#getConLineJumpDirX--) | 動的コネクタの水平セグメントで発生するラインジャンプの方向を決定します。 |
+| [getConLineJumpDirY()](#getConLineJumpDirY--) | 動的コネクタの垂直セグメントで発生するラインジャンプの方向を決定します。 |
+| [getConLineJumpStyle()](#getConLineJumpStyle--) | 動的コネクタ上のラインジャンプのスタイルを決定します。 |
+| [getConLineRouteExt()](#getConLineRouteExt--) | コネクタの外観を決定します。 |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getDisplayLevel()](#getDisplayLevel--) | シェイプの表示レベルバンド（Z オーダー グループ化の相対範囲）を決定します。 |
+| [getRelationships()](#getRelationships--) | コンテナ、リスト、コールアウト、およびシェイプ間の関係を保存します。 |
+| [getShapeFixedCode()](#getShapeFixedCode--) | 配置可能なシェイプの配置動作を指定します。 |
+| [getShapePermeablePlace()](#getShapePermeablePlace--) | ユーザーが [Lay Out Shapes]（Shapes メニュー）を選択したときに、配置可能なシェイプを別のシェイプの上に配置できるかどうかを指定します。 |
+| [getShapePermeableX()](#getShapePermeableX--) | コネクタがシェイプを横方向に通過できるかどうかを指定します。 |
+| [getShapePermeableY()](#getShapePermeableY--) | コネクタがシェイプを縦方向に通過できるかどうかを指定します。 |
+| [getShapePlaceFlip()](#getShapePlaceFlip--) | ユーザーが「Lay Out Shapes」（シェイプ メニュー）を選択したときに、配置可能なシェイプがページ上で反転または回転する方法を指定します。 |
+| [getShapePlaceStyle()](#getShapePlaceStyle--) | 子要素の配置スタイルを決定します。 |
+| [getShapePlowCode()](#getShapePlowCode--) | 描画ページ上で別の配置可能なシェイプを対象シェイプの近くにドラッグしたときに、対象シェイプが離れるかどうかを指定します。 |
+| [getShapeRouteStyle()](#getShapeRouteStyle--) | 描画ページ上のコネクタのルーティング スタイルと方向を指定します。 |
+| [getShapeSplit()](#getShapeSplit--) | このシェイプが分割可能なシェイプを分割できるかどうかを決定します。 |
+| [getShapeSplittable()](#getShapeSplittable--) | この 1 次元シェイプが分割できるかどうかを決定します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | このプロパティの説明については、[getDel()](../../com.aspose.diagram/layout\#getDel--) を参照してください |
+| [setShapePlaceStyle(ShapePlaceStyle value)](#setShapePlaceStyle-com.aspose.diagram.ShapePlaceStyle-) | このプロパティの説明については、[getShapePlaceStyle()](../../com.aspose.diagram/layout\#getShapePlaceStyle--) を参照してください |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConFixedCode() {#getConFixedCode--}
+```
+public ConFixedCode getConFixedCode()
+```
+
+
+コネクタが再ルーティングするタイミングを決定します。
+
+**Returns:**
+[ConFixedCode](../../com.aspose.diagram/confixedcode)
+### getConLineJumpCode() {#getConLineJumpCode--}
+```
+public ConLineJumpCode getConLineJumpCode()
+```
+
+
+2つのコネクタが交差したときにコネクタがジャンプするかどうかを決定します、
+
+**Returns:**
+[ConLineJumpCode](../../com.aspose.diagram/conlinejumpcode)
+### getConLineJumpDirX() {#getConLineJumpDirX--}
+```
+public ConLineJumpDirX getConLineJumpDirX()
+```
+
+
+動的コネクタの水平セグメントで発生するラインジャンプの方向を決定します。
+
+**Returns:**
+[ConLineJumpDirX](../../com.aspose.diagram/conlinejumpdirx)
+### getConLineJumpDirY() {#getConLineJumpDirY--}
+```
+public ConLineJumpDirY getConLineJumpDirY()
+```
+
+
+動的コネクタの垂直セグメントで発生するラインジャンプの方向を決定します。
+
+**Returns:**
+[ConLineJumpDirY](../../com.aspose.diagram/conlinejumpdiry)
+### getConLineJumpStyle() {#getConLineJumpStyle--}
+```
+public ConLineJumpStyle getConLineJumpStyle()
+```
+
+
+動的コネクタ上のラインジャンプのスタイルを決定します。
+
+**Returns:**
+[ConLineJumpStyle](../../com.aspose.diagram/conlinejumpstyle)
+### getConLineRouteExt() {#getConLineRouteExt--}
+```
+public ConLineRouteExt getConLineRouteExt()
+```
+
+
+コネクタの外観を決定します。
+
+**Returns:**
+[ConLineRouteExt](../../com.aspose.diagram/conlinerouteext)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getDisplayLevel() {#getDisplayLevel--}
+```
+public IntValue getDisplayLevel()
+```
+
+
+シェイプの表示レベルバンド（Z オーダー グループ化の相対範囲）を決定します。
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getRelationships() {#getRelationships--}
+```
+public BoolValue getRelationships()
+```
+
+
+コンテナ、リスト、コールアウト、およびシェイプ間の関係を保存します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getShapeFixedCode() {#getShapeFixedCode--}
+```
+public ShapeFixedCode getShapeFixedCode()
+```
+
+
+配置可能なシェイプの配置動作を指定します。
+
+**Returns:**
+[ShapeFixedCode](../../com.aspose.diagram/shapefixedcode)
+### getShapePermeablePlace() {#getShapePermeablePlace--}
+```
+public BoolValue getShapePermeablePlace()
+```
+
+
+ユーザーが [Lay Out Shapes]（Shapes メニュー）を選択したときに、配置可能なシェイプを別のシェイプの上に配置できるかどうかを指定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getShapePermeableX() {#getShapePermeableX--}
+```
+public BoolValue getShapePermeableX()
+```
+
+
+コネクタがシェイプを横方向に通過できるかどうかを指定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getShapePermeableY() {#getShapePermeableY--}
+```
+public BoolValue getShapePermeableY()
+```
+
+
+コネクタがシェイプを縦方向に通過できるかどうかを指定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getShapePlaceFlip() {#getShapePlaceFlip--}
+```
+public ShapePlaceFlip getShapePlaceFlip()
+```
+
+
+ユーザーが「Lay Out Shapes」（シェイプ メニュー）を選択したときに、配置可能なシェイプがページ上で反転または回転する方法を指定します。
+
+**Returns:**
+[ShapePlaceFlip](../../com.aspose.diagram/shapeplaceflip)
+### getShapePlaceStyle() {#getShapePlaceStyle--}
+```
+public ShapePlaceStyle getShapePlaceStyle()
+```
+
+
+子要素の配置スタイルを決定します。
+
+**Returns:**
+[ShapePlaceStyle](../../com.aspose.diagram/shapeplacestyle)
+### getShapePlowCode() {#getShapePlowCode--}
+```
+public ShapePlowCode getShapePlowCode()
+```
+
+
+描画ページ上で別の配置可能なシェイプを対象シェイプの近くにドラッグしたときに、対象シェイプが離れるかどうかを指定します。
+
+**Returns:**
+[ShapePlowCode](../../com.aspose.diagram/shapeplowcode)
+### getShapeRouteStyle() {#getShapeRouteStyle--}
+```
+public ShapeRouteStyle getShapeRouteStyle()
+```
+
+
+描画ページ上のコネクタのルーティング スタイルと方向を指定します。
+
+**Returns:**
+[ShapeRouteStyle](../../com.aspose.diagram/shaperoutestyle)
+### getShapeSplit() {#getShapeSplit--}
+```
+public BoolValue getShapeSplit()
+```
+
+
+このシェイプが分割可能なシェイプを分割できるかどうかを決定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getShapeSplittable() {#getShapeSplittable--}
+```
+public BoolValue getShapeSplittable()
+```
+
+
+この 1 次元シェイプが分割できるかどうかを決定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+このプロパティの説明については、[getDel()](../../com.aspose.diagram/layout\#getDel--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setShapePlaceStyle(ShapePlaceStyle value) {#setShapePlaceStyle-com.aspose.diagram.ShapePlaceStyle-}
+```
+public void setShapePlaceStyle(ShapePlaceStyle value)
+```
+
+
+このプロパティの説明については、[getShapePlaceStyle()](../../com.aspose.diagram/layout\#getShapePlaceStyle--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [ShapePlaceStyle](../../com.aspose.diagram/shapeplacestyle) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/layoutdirection/_index.md
+++ b/japanese/java/com.aspose.diagram/layoutdirection/_index.md
@@ -1,0 +1,201 @@
+---
+title: LayoutDirection
+second_title: Aspose.Diagram for Java API リファレンス
+description: レイアウトの方向を設定するために使用されます。
+type: docs
+weight: 216
+url: /ja/java/com.aspose.diagram/layoutdirection/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LayoutDirection
+```
+
+レイアウトの方向を設定するために使用されます。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [BOTTOM_TO_TOP](#BOTTOM-TO-TOP) | シェイプを下から上へ配置します。 |
+| [DOWN_THEN_LEFT](#DOWN-THEN-LEFT) | シェイプをまず下に、次に左へ配置します。 |
+| [DOWN_THEN_RIGHT](#DOWN-THEN-RIGHT) | シェイプをまず下に、次に右へ配置します。 |
+| [LEFT_THEN_DOWN](#LEFT-THEN-DOWN) | シェイプをまず左に、次に下へ配置します。 |
+| [LEFT_TO_RIGHT](#LEFT-TO-RIGHT) | シェイプを左から右へ配置します。 |
+| [RIGHT_THEN_DOWN](#RIGHT-THEN-DOWN) | シェイプをまず右に、次に下へ配置します。 |
+| [RIGHT_TO_LEFT](#RIGHT-TO-LEFT) | シェイプを右から左へ配置します。 |
+| [TOP_TO_BOTTOM](#TOP-TO-BOTTOM) | シェイプを上から下へ配置します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOTTOM_TO_TOP {#BOTTOM-TO-TOP}
+```
+public static final int BOTTOM_TO_TOP
+```
+
+
+シェイプを下から上へ配置します。Flowchart スタイルが選択された場合にのみ意味があります。
+
+### DOWN_THEN_LEFT {#DOWN-THEN-LEFT}
+```
+public static final int DOWN_THEN_LEFT
+```
+
+
+シェイプをまず下に、次に左へ配置します。CompactTree スタイルが選択された場合にのみ意味があります。
+
+### DOWN_THEN_RIGHT {#DOWN-THEN-RIGHT}
+```
+public static final int DOWN_THEN_RIGHT
+```
+
+
+シェイプをまず下に、次に右へ配置します。CompactTree スタイルが選択された場合にのみ意味があります。
+
+### LEFT_THEN_DOWN {#LEFT-THEN-DOWN}
+```
+public static final int LEFT_THEN_DOWN
+```
+
+
+シェイプをまず左に、次に下へ配置します。CompactTree スタイルが選択された場合にのみ意味があります。
+
+### LEFT_TO_RIGHT {#LEFT-TO-RIGHT}
+```
+public static final int LEFT_TO_RIGHT
+```
+
+
+左から右へシェイプを配置します。フローチャートスタイルが選択されている場合にのみ意味があります。
+
+### RIGHT_THEN_DOWN {#RIGHT-THEN-DOWN}
+```
+public static final int RIGHT_THEN_DOWN
+```
+
+
+シェイプをまず右に、次に下に配置します。コンパクトツリースタイルが選択されている場合にのみ意味があります。
+
+### RIGHT_TO_LEFT {#RIGHT-TO-LEFT}
+```
+public static final int RIGHT_TO_LEFT
+```
+
+
+右から左へシェイプを配置します。フローチャートスタイルが選択されている場合にのみ意味があります。
+
+### TOP_TO_BOTTOM {#TOP-TO-BOTTOM}
+```
+public static final int TOP_TO_BOTTOM
+```
+
+
+上から下へシェイプを配置します。フローチャートスタイルが選択されている場合にのみ意味があります。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/layoutoptions/_index.md
+++ b/japanese/java/com.aspose.diagram/layoutoptions/_index.md
@@ -1,0 +1,238 @@
+---
+title: LayoutOptions
+second_title: Aspose.Diagram for Java API リファレンス
+description: ページの再レイアウトを実行するための、シェイプのレイアウトスタイルと追加オプションを指定するために使用されます。
+type: docs
+weight: 217
+url: /ja/java/com.aspose.diagram/layoutoptions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LayoutOptions
+```
+
+ページ（複数ページ）の再レイアウトを実行するために、シェイプのレイアウトのスタイルと追加オプションを指定するために使用されます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [LayoutOptions()](#LayoutOptions--) | LayoutOptions の新しいインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDirection()](#getDirection--) | シェイプのレイアウト方向を設定するために使用されます。 |
+| [getEnlargePage()](#getEnlargePage--) | 描画に合わせてページを拡大する必要があるかどうかを定義します。 |
+| [getLayoutStyle()](#getLayoutStyle--) | レイアウトのスタイルを指定するために使用されます。 |
+| [getSpaceShapes()](#getSpaceShapes--) | シェイプ間の間隔をインチで定義します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDirection(int value)](#setDirection-int-) | このプロパティの説明については、[getDirection()](../../com.aspose.diagram/layoutoptions\#getDirection--) を参照してください。 |
+| [setEnlargePage(boolean value)](#setEnlargePage-boolean-) | このプロパティの説明については、[getEnlargePage()](../../com.aspose.diagram/layoutoptions\#getEnlargePage--) を参照してください。 |
+| [setLayoutStyle(int value)](#setLayoutStyle-int-) | このプロパティの説明については、[getLayoutStyle()](../../com.aspose.diagram/layoutoptions\#getLayoutStyle--) を参照してください。 |
+| [setSpaceShapes(float value)](#setSpaceShapes-float-) | このプロパティの説明については、[getSpaceShapes()](../../com.aspose.diagram/layoutoptions\#getSpaceShapes--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LayoutOptions() {#LayoutOptions--}
+```
+public LayoutOptions()
+```
+
+
+LayoutOptions の新しいインスタンスを初期化します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDirection() {#getDirection--}
+```
+public int getDirection()
+```
+
+
+シェイプのレイアウト方向を設定するために使用されます。デフォルト値は TopToBottom です。
+
+**Returns:**
+int
+### getEnlargePage() {#getEnlargePage--}
+```
+public boolean getEnlargePage()
+```
+
+
+描画に合わせてページを拡大する必要があるかどうかを定義します。デフォルト値は false です。
+
+**Returns:**
+boolean
+### getLayoutStyle() {#getLayoutStyle--}
+```
+public int getLayoutStyle()
+```
+
+
+レイアウトのスタイルを指定するために使用されます。デフォルト値は FlowChart です。
+
+**Returns:**
+int
+### getSpaceShapes() {#getSpaceShapes--}
+```
+public float getSpaceShapes()
+```
+
+
+シェイプ間の間隔をインチで定義します。デフォルト値は 0.3 インチ（約 7.5 mm）です。
+
+**Returns:**
+float
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDirection(int value) {#setDirection-int-}
+```
+public void setDirection(int value)
+```
+
+
+このプロパティの説明については、[getDirection()](../../com.aspose.diagram/layoutoptions\#getDirection--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setEnlargePage(boolean value) {#setEnlargePage-boolean-}
+```
+public void setEnlargePage(boolean value)
+```
+
+
+このプロパティの説明については、[getEnlargePage()](../../com.aspose.diagram/layoutoptions\#getEnlargePage--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setLayoutStyle(int value) {#setLayoutStyle-int-}
+```
+public void setLayoutStyle(int value)
+```
+
+
+このプロパティの説明については、[getLayoutStyle()](../../com.aspose.diagram/layoutoptions\#getLayoutStyle--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setSpaceShapes(float value) {#setSpaceShapes-float-}
+```
+public void setSpaceShapes(float value)
+```
+
+
+このプロパティの説明については、[getSpaceShapes()](../../com.aspose.diagram/layoutoptions\#getSpaceShapes--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | float |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/layoutstyle/_index.md
+++ b/japanese/java/com.aspose.diagram/layoutstyle/_index.md
@@ -1,0 +1,165 @@
+---
+title: LayoutStyle
+second_title: Aspose.Diagram for Java API リファレンス
+description: レイアウトのスタイルを指定するために使用されます。
+type: docs
+weight: 218
+url: /ja/java/com.aspose.diagram/layoutstyle/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LayoutStyle
+```
+
+レイアウトのスタイルを指定するために使用されます。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [CIRCULAR](#CIRCULAR) | Circular style. |
+| [COMPACT_TREE](#COMPACT-TREE) | Tree style. |
+| [FLOW_CHART](#FLOW-CHART) | Flowchart style. |
+| [RADIAL](#RADIAL) | Radial style. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CIRCULAR {#CIRCULAR}
+```
+public static final int CIRCULAR
+```
+
+
+Circular style.
+
+### COMPACT_TREE {#COMPACT-TREE}
+```
+public static final int COMPACT_TREE
+```
+
+
+Tree style.
+
+### FLOW_CHART {#FLOW-CHART}
+```
+public static final int FLOW_CHART
+```
+
+
+Flowchart style.
+
+### RADIAL {#RADIAL}
+```
+public static final int RADIAL
+```
+
+
+Radial style.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/license/_index.md
+++ b/japanese/java/com.aspose.diagram/license/_index.md
@@ -1,0 +1,188 @@
+---
+title: ライセンス
+second_title: Aspose.Diagram for Java API リファレンス
+description: コンポーネントのライセンスを取得するためのメソッドを提供します。
+type: docs
+weight: 219
+url: /ja/java/com.aspose.diagram/license/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class License
+```
+
+コンポーネントのライセンスを取得するためのメソッドを提供します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [License()](#License--) | このクラスの新しいインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setLicense(InputStream stream)](#setLicense-java.io.InputStream-) | コンポーネントにライセンスを付与します。 |
+| [setLicense(String licenseName)](#setLicense-java.lang.String-) | コンポーネントにライセンスを付与します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### License() {#License--}
+```
+public License()
+```
+
+
+このクラスの新しいインスタンスを初期化します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setLicense(InputStream stream) {#setLicense-java.io.InputStream-}
+```
+public void setLicense(InputStream stream)
+```
+
+
+コンポーネントにライセンスを付与します。
+
+このメソッドを使用して、ストリームからライセンスをロードします。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ストリーム | java.io.InputStream | ライセンスを含むストリームです。 |
+
+### setLicense(String licenseName) {#setLicense-java.lang.String-}
+```
+public void setLicense(String licenseName)
+```
+
+
+コンポーネントにライセンスを付与します。
+
+次の場所でライセンスを検索します：
+
+1. 明示的なパス。
+
+2. コンポーネント アセンブリのフォルダー。
+
+3. クライアントの呼び出しアセンブリのフォルダー。
+
+4. エントリ アセンブリのフォルダー。
+
+5. クライアントの呼び出しアセンブリに埋め込まれたリソース。
+
+**Note:**On the .NET Compact Framework, tries to find the license only in these locations:
+
+1. 明示的なパス。
+
+2. クライアントの呼び出しアセンブリに埋め込まれたリソース。
+
+2. コンポーネント JAR ファイルのフォルダー。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| licenseName | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/lightrigdirectiontype/_index.md
+++ b/japanese/java/com.aspose.diagram/lightrigdirectiontype/_index.md
@@ -1,0 +1,201 @@
+---
+title: LightRigDirectionType
+second_title: Aspose.Diagram for Java API リファレンス
+description: ライトリグ方向タイプを表します。
+type: docs
+weight: 220
+url: /ja/java/com.aspose.diagram/lightrigdirectiontype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LightRigDirectionType
+```
+
+ライトリグ方向タイプを表します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [BOTTOM](#BOTTOM) | 下 |
+| [BOTTOM_LEFT](#BOTTOM-LEFT) | 左下。 |
+| [BOTTOM_RIGHT](#BOTTOM-RIGHT) | 右下。 |
+| [LEFT](#LEFT) | 左。 |
+| [RIGHT](#RIGHT) | 右。 |
+| [TOP](#TOP) | 上。 |
+| [TOP_LEFT](#TOP-LEFT) | 左上。 |
+| [TOP_RIGHT](#TOP-RIGHT) | 右上。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOTTOM {#BOTTOM}
+```
+public static final int BOTTOM
+```
+
+
+下
+
+### BOTTOM_LEFT {#BOTTOM-LEFT}
+```
+public static final int BOTTOM_LEFT
+```
+
+
+左下。
+
+### BOTTOM_RIGHT {#BOTTOM-RIGHT}
+```
+public static final int BOTTOM_RIGHT
+```
+
+
+右下。
+
+### LEFT {#LEFT}
+```
+public static final int LEFT
+```
+
+
+左。
+
+### RIGHT {#RIGHT}
+```
+public static final int RIGHT
+```
+
+
+右。
+
+### TOP {#TOP}
+```
+public static final int TOP
+```
+
+
+上。
+
+### TOP_LEFT {#TOP-LEFT}
+```
+public static final int TOP_LEFT
+```
+
+
+左上。
+
+### TOP_RIGHT {#TOP-RIGHT}
+```
+public static final int TOP_RIGHT
+```
+
+
+右上。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/line/_index.md
+++ b/japanese/java/com.aspose.diagram/line/_index.md
@@ -1,0 +1,447 @@
+---
+title: Line
+second_title: Aspose.Diagram for Java API リファレンス
+description: シェイプに関する一般的な位置情報を指定する要素を含みます。
+type: docs
+weight: 221
+url: /ja/java/com.aspose.diagram/line/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Line
+```
+
+シェイプに関する一般的な位置情報を指定する要素を含みます。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBeginArrow()](#getBeginArrow--) | 線の最初の頂点に矢じりまたはその他の線端形式があるかどうかを示します。 |
+| [getBeginArrowSize()](#getBeginArrowSize--) | 線の始点における矢じりのサイズを決定します。 |
+| [getClass()](#getClass--) |  |
+| [getCompoundType()](#getCompoundType--) | 図形の線のCompoundTypeを指定します。 |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getEndArrow()](#getEndArrow--) | 線の最後の頂点に矢じりまたはその他の線端形式があるかどうかを示します。 |
+| [getEndArrowSize()](#getEndArrowSize--) | 線の終点における矢じりのサイズを指定します。 |
+| [getGradientLine()](#getGradientLine--) | 図形の現在のグラデーション線書式設定値を含みます |
+| [getLineCap()](#getLineCap--) | 線が丸みのある端か四角い端かを指定します。 |
+| [getLineColor()](#getLineColor--) | 図形の線の色を指定します。 |
+| [getLineColorTrans()](#getLineColorTrans--) | 図形の線の色の透明度レベルを指定します。0（不透明）から1（完全に透明）までです。 |
+| [getLinePattern()](#getLinePattern--) | 図形の線パターンを指定します |
+| [getLineWeight()](#getLineWeight--) | 図形の線の太さを指定します。 |
+| [getRounding()](#getRounding--) | パスの連続する2つのセグメントが接続する箇所に適用される丸みアークの半径を指定します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setBeginArrow(IntValue value)](#setBeginArrow-com.aspose.diagram.IntValue-) | このプロパティの説明については、[getBeginArrow()](../../com.aspose.diagram/line\#getBeginArrow--) を参照してください |
+| [setBeginArrowSize(ArrowSize value)](#setBeginArrowSize-com.aspose.diagram.ArrowSize-) | このプロパティの説明については、[getBeginArrowSize()](../../com.aspose.diagram/line\#getBeginArrowSize--) を参照してください |
+| [setCompoundType(CompoundType value)](#setCompoundType-com.aspose.diagram.CompoundType-) | このプロパティの説明については、[getCompoundType()](../../com.aspose.diagram/line\#getCompoundType--) を参照してください |
+| [setDel(int value)](#setDel-int-) | このプロパティの説明については、[getDel()](../../com.aspose.diagram/line\#getDel--) を参照してください |
+| [setEndArrow(IntValue value)](#setEndArrow-com.aspose.diagram.IntValue-) | このプロパティの説明については、[getEndArrow()](../../com.aspose.diagram/line\#getEndArrow--) を参照してください |
+| [setEndArrowSize(ArrowSize value)](#setEndArrowSize-com.aspose.diagram.ArrowSize-) | このプロパティの説明については、[getEndArrowSize()](../../com.aspose.diagram/line\#getEndArrowSize--) を参照してください |
+| [setLineCap(BoolValue value)](#setLineCap-com.aspose.diagram.BoolValue-) | このプロパティの説明については、[getLineCap()](../../com.aspose.diagram/line\#getLineCap--) を参照してください |
+| [setLineColor(ColorValue value)](#setLineColor-com.aspose.diagram.ColorValue-) | このプロパティの説明については、[getLineColor()](../../com.aspose.diagram/line\#getLineColor--) を参照してください |
+| [setLineColorTrans(DoubleValue value)](#setLineColorTrans-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getLineColorTrans()](../../com.aspose.diagram/line\#getLineColorTrans--) を参照してください |
+| [setLinePattern(IntValue value)](#setLinePattern-com.aspose.diagram.IntValue-) | このプロパティの説明については、[getLinePattern()](../../com.aspose.diagram/line\#getLinePattern--) を参照してください |
+| [setLineWeight(DoubleValue value)](#setLineWeight-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getLineWeight()](../../com.aspose.diagram/line\#getLineWeight--) を参照してください |
+| [setRounding(DoubleValue value)](#setRounding-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getRounding()](../../com.aspose.diagram/line\#getRounding--) を参照してください |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBeginArrow() {#getBeginArrow--}
+```
+public IntValue getBeginArrow()
+```
+
+
+線の最初の頂点に矢じりまたはその他の線端形式があるかどうかを示します。0 から 45 の数値、またはカスタム線端の名前を使用した USE 関数を入力してください。
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getBeginArrowSize() {#getBeginArrowSize--}
+```
+public ArrowSize getBeginArrowSize()
+```
+
+
+線の始点にある矢じりのサイズを決定します。0 から 6 の数値を入力してください。
+
+**Returns:**
+[ArrowSize](../../com.aspose.diagram/arrowsize)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCompoundType() {#getCompoundType--}
+```
+public CompoundType getCompoundType()
+```
+
+
+図形の線のCompoundTypeを指定します。
+
+**Returns:**
+[CompoundType](../../com.aspose.diagram/compoundtype)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getEndArrow() {#getEndArrow--}
+```
+public IntValue getEndArrow()
+```
+
+
+線の最後の頂点に矢じりまたはその他の線端形式があるかどうかを示します。
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getEndArrowSize() {#getEndArrowSize--}
+```
+public ArrowSize getEndArrowSize()
+```
+
+
+線の終点における矢じりのサイズを指定します。
+
+**Returns:**
+[ArrowSize](../../com.aspose.diagram/arrowsize)
+### getGradientLine() {#getGradientLine--}
+```
+public GradientFill getGradientLine()
+```
+
+
+図形の現在のグラデーション線書式設定値を含みます
+
+**Returns:**
+[GradientFill](../../com.aspose.diagram/gradientfill)
+### getLineCap() {#getLineCap--}
+```
+public BoolValue getLineCap()
+```
+
+
+線が丸みのある端か四角い端かを指定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLineColor() {#getLineColor--}
+```
+public ColorValue getLineColor()
+```
+
+
+図形の線の色を指定します。
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getLineColorTrans() {#getLineColorTrans--}
+```
+public DoubleValue getLineColorTrans()
+```
+
+
+図形の線の色の透明度レベルを指定します。0（不透明）から 1（完全に透明）までです。デフォルトは 0 です。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLinePattern() {#getLinePattern--}
+```
+public IntValue getLinePattern()
+```
+
+
+図形の線パターンを指定します
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getLineWeight() {#getLineWeight--}
+```
+public DoubleValue getLineWeight()
+```
+
+
+図形の線幅を指定します。線幅は図面のスケールに依存しません。図面が拡大縮小されても、線幅は変わりません。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getRounding() {#getRounding--}
+```
+public DoubleValue getRounding()
+```
+
+
+パスの連続する2つのセグメントが接続する箇所に適用される丸み弧の半径を指定します。例えば、矩形に丸みを持たせる際に使用できます。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setBeginArrow(IntValue value) {#setBeginArrow-com.aspose.diagram.IntValue-}
+```
+public void setBeginArrow(IntValue value)
+```
+
+
+このプロパティの説明については、[getBeginArrow()](../../com.aspose.diagram/line\#getBeginArrow--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setBeginArrowSize(ArrowSize value) {#setBeginArrowSize-com.aspose.diagram.ArrowSize-}
+```
+public void setBeginArrowSize(ArrowSize value)
+```
+
+
+このプロパティの説明については、[getBeginArrowSize()](../../com.aspose.diagram/line\#getBeginArrowSize--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [ArrowSize](../../com.aspose.diagram/arrowsize) |  |
+
+### setCompoundType(CompoundType value) {#setCompoundType-com.aspose.diagram.CompoundType-}
+```
+public void setCompoundType(CompoundType value)
+```
+
+
+このプロパティの説明については、[getCompoundType()](../../com.aspose.diagram/line\#getCompoundType--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [CompoundType](../../com.aspose.diagram/compoundtype) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+このプロパティの説明については、[getDel()](../../com.aspose.diagram/line\#getDel--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setEndArrow(IntValue value) {#setEndArrow-com.aspose.diagram.IntValue-}
+```
+public void setEndArrow(IntValue value)
+```
+
+
+このプロパティの説明については、[getEndArrow()](../../com.aspose.diagram/line\#getEndArrow--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setEndArrowSize(ArrowSize value) {#setEndArrowSize-com.aspose.diagram.ArrowSize-}
+```
+public void setEndArrowSize(ArrowSize value)
+```
+
+
+このプロパティの説明については、[getEndArrowSize()](../../com.aspose.diagram/line\#getEndArrowSize--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [ArrowSize](../../com.aspose.diagram/arrowsize) |  |
+
+### setLineCap(BoolValue value) {#setLineCap-com.aspose.diagram.BoolValue-}
+```
+public void setLineCap(BoolValue value)
+```
+
+
+このプロパティの説明については、[getLineCap()](../../com.aspose.diagram/line\#getLineCap--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setLineColor(ColorValue value) {#setLineColor-com.aspose.diagram.ColorValue-}
+```
+public void setLineColor(ColorValue value)
+```
+
+
+このプロパティの説明については、[getLineColor()](../../com.aspose.diagram/line\#getLineColor--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setLineColorTrans(DoubleValue value) {#setLineColorTrans-com.aspose.diagram.DoubleValue-}
+```
+public void setLineColorTrans(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getLineColorTrans()](../../com.aspose.diagram/line\#getLineColorTrans--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setLinePattern(IntValue value) {#setLinePattern-com.aspose.diagram.IntValue-}
+```
+public void setLinePattern(IntValue value)
+```
+
+
+このプロパティの説明については、[getLinePattern()](../../com.aspose.diagram/line\#getLinePattern--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setLineWeight(DoubleValue value) {#setLineWeight-com.aspose.diagram.DoubleValue-}
+```
+public void setLineWeight(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getLineWeight()](../../com.aspose.diagram/line\#getLineWeight--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setRounding(DoubleValue value) {#setRounding-com.aspose.diagram.DoubleValue-}
+```
+public void setRounding(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getRounding()](../../com.aspose.diagram/line\#getRounding--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/lineadjustfrom/_index.md
+++ b/japanese/java/com.aspose.diagram/lineadjustfrom/_index.md
@@ -1,0 +1,179 @@
+---
+title: LineAdjustFrom
+second_title: Aspose.Diagram for Java API リファレンス
+description: 動的コネクタが互いに重なる場合に、どのコネクタを間隔を空けるかを指定します。
+type: docs
+weight: 222
+url: /ja/java/com.aspose.diagram/lineadjustfrom/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LineAdjustFrom
+```
+
+動的コネクタが互いに重なる場合に、どのコネクタを間隔を空けるかを指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [LineAdjustFrom(int value)](#LineAdjustFrom-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | 動的コネクタが互いに重なる場合に、どのコネクタを間隔を空けるかを指定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | For the description of this property, please see [getValue()](../../com.aspose.diagram/lineadjustfrom\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LineAdjustFrom(int value) {#LineAdjustFrom-int-}
+```
+public LineAdjustFrom(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+動的コネクタが互いに重なる場合に、どのコネクタを間隔を空けるかを指定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+For the description of this property, please see [getValue()](../../com.aspose.diagram/lineadjustfrom\#getValue--)
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/lineadjustfromvalue/_index.md
+++ b/japanese/java/com.aspose.diagram/lineadjustfromvalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: LineAdjustFromValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: 動的コネクタが互いに重なる場合に、どのコネクタを間隔を空けるかを指定します。
+type: docs
+weight: 223
+url: /ja/java/com.aspose.diagram/lineadjustfromvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LineAdjustFromValue
+```
+
+動的コネクタが互いに重なる場合に、どのコネクタを間隔を空けるかを指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [ALL_LINES](#ALL-LINES) | すべての線。 |
+| [NO_LINES](#NO-LINES) | 線なし。 |
+| [ROUTING_STYLE_DEFAULT](#ROUTING-STYLE-DEFAULT) | ルーティング スタイルのデフォルトです。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+| [UNRELATED_LINES](#UNRELATED-LINES) | 無関係な行です。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALL_LINES {#ALL-LINES}
+```
+public static final int ALL_LINES
+```
+
+
+すべての線。
+
+### NO_LINES {#NO-LINES}
+```
+public static final int NO_LINES
+```
+
+
+線なし。
+
+### ROUTING_STYLE_DEFAULT {#ROUTING-STYLE-DEFAULT}
+```
+public static final int ROUTING_STYLE_DEFAULT
+```
+
+
+ルーティング スタイルのデフォルトです。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### UNRELATED_LINES {#UNRELATED-LINES}
+```
+public static final int UNRELATED_LINES
+```
+
+
+無関係な行です。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/lineadjustto/_index.md
+++ b/japanese/java/com.aspose.diagram/lineadjustto/_index.md
@@ -1,0 +1,179 @@
+---
+title: LineAdjustTo
+second_title: Aspose.Diagram for Java API リファレンス
+description: 動的コネクタが互いに重なる場合に、どのコネクタを重ねて配置するかを指定します。
+type: docs
+weight: 224
+url: /ja/java/com.aspose.diagram/lineadjustto/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LineAdjustTo
+```
+
+動的コネクタが互いに重なる場合に、どのコネクタを重ねて配置するかを指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [LineAdjustTo(int value)](#LineAdjustTo-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | 動的コネクタが互いに重なる場合に、どのコネクタを重ねて配置するかを指定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/lineadjustto\#getValue--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LineAdjustTo(int value) {#LineAdjustTo-int-}
+```
+public LineAdjustTo(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+動的コネクタが互いに重なる場合に、どのコネクタを重ねて配置するかを指定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/lineadjustto\#getValue--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/lineadjusttovalue/_index.md
+++ b/japanese/java/com.aspose.diagram/lineadjusttovalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: LineAdjustToValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: 動的コネクタが互いに重なる場合に、どのコネクタを重ねて配置するかを指定します。
+type: docs
+weight: 225
+url: /ja/java/com.aspose.diagram/lineadjusttovalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LineAdjustToValue
+```
+
+動的コネクタが互いに重なる場合に、どのコネクタを重ねて配置するかを指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [ALL_LINES_CLOSE](#ALL-LINES-CLOSE) | 互いに近いすべての線。 |
+| [NO_LINES](#NO-LINES) | 線なし。 |
+| [RELATEDLINES](#RELATEDLINES) | 関連する線。 |
+| [ROUTING_STYLE_DEFAULT](#ROUTING-STYLE-DEFAULT) | ルーティング スタイルのデフォルトです。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALL_LINES_CLOSE {#ALL-LINES-CLOSE}
+```
+public static final int ALL_LINES_CLOSE
+```
+
+
+互いに近いすべての線。
+
+### NO_LINES {#NO-LINES}
+```
+public static final int NO_LINES
+```
+
+
+線なし。
+
+### RELATEDLINES {#RELATEDLINES}
+```
+public static final int RELATEDLINES
+```
+
+
+関連する線。
+
+### ROUTING_STYLE_DEFAULT {#ROUTING-STYLE-DEFAULT}
+```
+public static final int ROUTING_STYLE_DEFAULT
+```
+
+
+ルーティング スタイルのデフォルトです。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/linejumpcode/_index.md
+++ b/japanese/java/com.aspose.diagram/linejumpcode/_index.md
@@ -1,0 +1,179 @@
+---
+title: LineJumpCode
+second_title: Aspose.Diagram for Java API リファレンス
+description: ジャンプを追加したい動的コネクタを決定します。
+type: docs
+weight: 226
+url: /ja/java/com.aspose.diagram/linejumpcode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LineJumpCode
+```
+
+ジャンプを追加したい動的コネクタを決定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [LineJumpCode(int value)](#LineJumpCode-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | ジャンプを追加したい動的コネクタを決定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | For the description of this property, please see [getValue()](../../com.aspose.diagram/linejumpcode\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LineJumpCode(int value) {#LineJumpCode-int-}
+```
+public LineJumpCode(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+ジャンプを追加したい動的コネクタを決定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+For the description of this property, please see [getValue()](../../com.aspose.diagram/linejumpcode\#getValue--)
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/linejumpcodevalue/_index.md
+++ b/japanese/java/com.aspose.diagram/linejumpcodevalue/_index.md
@@ -1,0 +1,192 @@
+---
+title: LineJumpCodeValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: ジャンプを追加したい動的コネクタを決定します。
+type: docs
+weight: 227
+url: /ja/java/com.aspose.diagram/linejumpcodevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LineJumpCodeValue
+```
+
+ジャンプを追加したい動的コネクタを決定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [FIRST_DISPLAYED_LINE](#FIRST-DISPLAYED-LINE) | 最初に表示される線（表示順序で下部のシェイプ）。 |
+| [HORIZONTAL_LINES](#HORIZONTAL-LINES) | 水平線。 |
+| [LAST_DISPLAYED_LINE](#LAST-DISPLAYED-LINE) | 最後に表示される線（表示順序で上部のシェイプ）。 |
+| [LAST_ROUTED_LINE](#LAST-ROUTED-LINE) | 最後にルーティングされた線。 |
+| [NONE](#NONE) | None. |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+| [VERTICAL_LINES](#VERTICAL-LINES) | 垂直線。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FIRST_DISPLAYED_LINE {#FIRST-DISPLAYED-LINE}
+```
+public static final int FIRST_DISPLAYED_LINE
+```
+
+
+最初に表示される線（表示順序で下部のシェイプ）。
+
+### HORIZONTAL_LINES {#HORIZONTAL-LINES}
+```
+public static final int HORIZONTAL_LINES
+```
+
+
+水平線。
+
+### LAST_DISPLAYED_LINE {#LAST-DISPLAYED-LINE}
+```
+public static final int LAST_DISPLAYED_LINE
+```
+
+
+最後に表示される線（表示順序で上部のシェイプ）。
+
+### LAST_ROUTED_LINE {#LAST-ROUTED-LINE}
+```
+public static final int LAST_ROUTED_LINE
+```
+
+
+最後にルーティングされた線。
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+None.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### VERTICAL_LINES {#VERTICAL-LINES}
+```
+public static final int VERTICAL_LINES
+```
+
+
+垂直線。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/linejumpstyle/_index.md
+++ b/japanese/java/com.aspose.diagram/linejumpstyle/_index.md
@@ -1,0 +1,179 @@
+---
+title: LineJumpStyle
+second_title: Aspose.Diagram for Java API リファレンス
+description: 描画ページ上のすべてのコネクタで、ローカルのラインジャンプスタイルが設定されていないもののラインジャンプスタイルを指定します。
+type: docs
+weight: 228
+url: /ja/java/com.aspose.diagram/linejumpstyle/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LineJumpStyle
+```
+
+ローカルのラインジャンプスタイルが設定されていない描画ページ上のすべてのコネクタのラインジャンプスタイルを指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [LineJumpStyle(int value)](#LineJumpStyle-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | ローカルのラインジャンプスタイルが設定されていない描画ページ上のすべてのコネクタのラインジャンプスタイルを指定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/linejumpstyle\#getValue--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LineJumpStyle(int value) {#LineJumpStyle-int-}
+```
+public LineJumpStyle(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+ローカルのラインジャンプスタイルが設定されていない描画ページ上のすべてのコネクタのラインジャンプスタイルを指定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/linejumpstyle\#getValue--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/linejumpstylevalue/_index.md
+++ b/japanese/java/com.aspose.diagram/linejumpstylevalue/_index.md
@@ -1,0 +1,228 @@
+---
+title: LineJumpStyleValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: 描画ページ上のすべてのコネクタで、ローカルのラインジャンプスタイルが設定されていないもののラインジャンプスタイルを指定します。
+type: docs
+weight: 229
+url: /ja/java/com.aspose.diagram/linejumpstylevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LineJumpStyleValue
+```
+
+ローカルのラインジャンプスタイルが設定されていない描画ページ上のすべてのコネクタのラインジャンプスタイルを指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [ARC](#ARC) | 弧。 |
+| [DEFAULT](#DEFAULT) | デフォルト。 |
+| [GAP](#GAP) | ギャップ。 |
+| [SIDES_2](#SIDES-2) | 2 辺。 |
+| [SIDES_3](#SIDES-3) | 3 辺。 |
+| [SIDES_4](#SIDES-4) | 4 辺。 |
+| [SIDES_5](#SIDES-5) | 5 辺。 |
+| [SIDES_6](#SIDES-6) | 6 辺。 |
+| [SIDES_7](#SIDES-7) | 7 辺。 |
+| [SQUARE](#SQUARE) | 正方形。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ARC {#ARC}
+```
+public static final int ARC
+```
+
+
+弧。
+
+### DEFAULT {#DEFAULT}
+```
+public static final int DEFAULT
+```
+
+
+デフォルト。
+
+### GAP {#GAP}
+```
+public static final int GAP
+```
+
+
+ギャップ。
+
+### SIDES_2 {#SIDES-2}
+```
+public static final int SIDES_2
+```
+
+
+2 辺。
+
+### SIDES_3 {#SIDES-3}
+```
+public static final int SIDES_3
+```
+
+
+3 辺。
+
+### SIDES_4 {#SIDES-4}
+```
+public static final int SIDES_4
+```
+
+
+4 辺。
+
+### SIDES_5 {#SIDES-5}
+```
+public static final int SIDES_5
+```
+
+
+5 辺。
+
+### SIDES_6 {#SIDES-6}
+```
+public static final int SIDES_6
+```
+
+
+6 辺。
+
+### SIDES_7 {#SIDES-7}
+```
+public static final int SIDES_7
+```
+
+
+7 辺。
+
+### SQUARE {#SQUARE}
+```
+public static final int SQUARE
+```
+
+
+正方形。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/linerouteext/_index.md
+++ b/japanese/java/com.aspose.diagram/linerouteext/_index.md
@@ -1,0 +1,179 @@
+---
+title: LineRouteExt
+second_title: Aspose.Diagram for Java API リファレンス
+description: ページ上のすべてのコネクタのデフォルト外観を指定します。
+type: docs
+weight: 230
+url: /ja/java/com.aspose.diagram/linerouteext/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LineRouteExt
+```
+
+ページ上のすべてのコネクタのデフォルト外観を指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [LineRouteExt(int value)](#LineRouteExt-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | ページ上のすべてのコネクタのデフォルト外観を指定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/linerouteext\#getValue--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LineRouteExt(int value) {#LineRouteExt-int-}
+```
+public LineRouteExt(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+ページ上のすべてのコネクタのデフォルト外観を指定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/linerouteext\#getValue--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/linerouteextvalue/_index.md
+++ b/japanese/java/com.aspose.diagram/linerouteextvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: LineRouteExtValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: ページ上のすべてのコネクタのデフォルト外観を指定します。
+type: docs
+weight: 231
+url: /ja/java/com.aspose.diagram/linerouteextvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LineRouteExtValue
+```
+
+ページ上のすべてのコネクタのデフォルト外観を指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [CURVED](#CURVED) | 曲線。 |
+| [DEFAULT](#DEFAULT) | デフォルト。 |
+| [STRAIGHT](#STRAIGHT) | Straight. |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CURVED {#CURVED}
+```
+public static final int CURVED
+```
+
+
+曲線。
+
+### DEFAULT {#DEFAULT}
+```
+public static final int DEFAULT
+```
+
+
+デフォルト。
+
+### STRAIGHT {#STRAIGHT}
+```
+public static final int STRAIGHT
+```
+
+
+Straight.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/lineto/_index.md
+++ b/japanese/java/com.aspose.diagram/lineto/_index.md
@@ -1,0 +1,249 @@
+---
+title: LineTo
+second_title: Aspose.Diagram for Java API リファレンス
+description: 直線セグメントの終点頂点の x および y 座標を含みます。
+type: docs
+weight: 232
+url: /ja/java/com.aspose.diagram/lineto/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class LineTo extends Coordinate
+```
+
+直線セグメントの終点の x および y 座標を含みます。これらの座標はそれぞれ X 要素と Y 要素に格納されています。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [LineTo()](#LineTo--) | [LineTo](../../com.aspose.diagram/lineto) クラスのインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getIX()](#getIX--) | 親要素内の要素のゼロベースインデックスです。 |
+| [getX()](#getX--) | 直線セグメントの終点頂点の x 座標。 |
+| [getY()](#getY--) | 直線セグメントの終点頂点の y 座標。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | このプロパティの説明については、[getDel()](../../com.aspose.diagram/lineto\#getDel--) を参照してください。 |
+| [setIX(int value)](#setIX-int-) | このプロパティの説明については、[getIX()](../../com.aspose.diagram/lineto\#getIX--) を参照してください。 |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getX()](../../com.aspose.diagram/lineto\#getX--) を参照してください。 |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getY()](../../com.aspose.diagram/lineto\#getY--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LineTo() {#LineTo--}
+```
+public LineTo()
+```
+
+
+[LineTo](../../com.aspose.diagram/lineto) クラスのインスタンスを作成します。
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+親要素内の要素のゼロベースインデックスです。
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+直線セグメントの終点頂点の x 座標。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+直線セグメントの終点頂点の y 座標。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+このプロパティの説明については、[getDel()](../../com.aspose.diagram/lineto\#getDel--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+このプロパティの説明については、[getIX()](../../com.aspose.diagram/lineto\#getIX--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getX()](../../com.aspose.diagram/lineto\#getX--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getY()](../../com.aspose.diagram/lineto\#getY--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/linetocollection/_index.md
+++ b/japanese/java/com.aspose.diagram/linetocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: LineToCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: LineTo コレクション。
+type: docs
+weight: 233
+url: /ja/java/com.aspose.diagram/linetocollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class LineToCollection extends Collection
+```
+
+LineTo コレクション。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public LineTo get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[LineTo](../../com.aspose.diagram/lineto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/listboxactivexcontrol/_index.md
+++ b/japanese/java/com.aspose.diagram/listboxactivexcontrol/_index.md
@@ -1,0 +1,772 @@
+---
+title: ListBoxActiveXControl
+second_title: Aspose.Diagram for Java API リファレンス
+description: ListBox ActiveX コントロールを表します。
+type: docs
+weight: 234
+url: /ja/java/com.aspose.diagram/listboxactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class ListBoxActiveXControl extends ActiveXControl
+```
+
+ListBox ActiveX コントロールを表します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBackOleColor()](#getBackOleColor--) | 背景の OLE カラー。 |
+| [getBorderOleColor()](#getBorderOleColor--) | 背景の OLE カラー。 |
+| [getBorderStyle()](#getBorderStyle--) | コントロールで使用される境界線の種類。 |
+| [getBoundColumn()](#getBoundColumn--) | ComboBox または ListBox の Value プロパティが MultiSelect プロパティの値 (fmMultiSelectSingle) のときにどのように決定されるかを表します。 |
+| [getClass()](#getClass--) |  |
+| [getColumnCount()](#getColumnCount--) | ComboBox または ListBox に表示する列数を表します。 |
+| [getColumnWidths()](#getColumnWidths--) | 列の幅。 |
+| [getData()](#getData--) | コントロールのバイナリ データ。 |
+| [getForeOleColor()](#getForeOleColor--) | 前景の OLE カラー。 |
+| [getHeight()](#getHeight--) | ポイント単位のコントロールの高さ。 |
+| [getIMEMode()](#getIMEMode--) | コントロールがフォーカスを受け取る際の Input Method Editor のデフォルト実行時モード。 |
+| [getIntegralHeight()](#getIntegralHeight--) | コントロールが部分的な行を表示せず、完全な行のみを表示するかどうかを示します。 |
+| [getListStyle()](#getListStyle--) | 視覚的な外観です。 |
+| [getListWidth()](#getListWidth--) | ポイント単位の幅です。 |
+| [getMatchEntry()](#getMatchEntry--) | ユーザーが入力する際に ListBox または ComboBox がリストを検索する方法を示します。 |
+| [getMouseIcon()](#getMouseIcon--) | コントロールのマウスポインタとして表示するカスタムアイコンです。 |
+| [getMousePointer()](#getMousePointer--) | コントロールのマウスポインタとして表示されるアイコンの種類です。 |
+| [getScrollBars()](#getScrollBars--) | コントロールに垂直スクロールバー、水平スクロールバー、両方、またはどちらもないかを示します。 |
+| [getShowColumnHeads()](#getShowColumnHeads--) | 列見出しが表示されるかどうかを示します。 |
+| [getSpecialEffect()](#getSpecialEffect--) | コントロールの特殊効果です。 |
+| [getTextColumn()](#getTextColumn--) | ユーザーに表示する ComboBox または ListBox の列を表します。 |
+| [getType()](#getType--) | ActiveX コントロールのタイプを取得します。 |
+| [getValue()](#getValue--) | コントロールの値です。 |
+| [getWidth()](#getWidth--) | ポイント単位のコントロールの幅です。 |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | コントロールが全内容を表示するために自動的にサイズ変更されるかどうかを示します。 |
+| [isEnabled()](#isEnabled--) | コントロールがフォーカスを受け取り、ユーザー生成イベントに応答できるかどうかを示します。 |
+| [isLocked()](#isLocked--) | コントロール内のデータが編集ロックされているかどうかを示します。 |
+| [isTransparent()](#isTransparent--) | コントロールが透明かどうかを示します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | このプロパティの説明については、[isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) を参照してください |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | このプロパティの説明については、[getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) を参照してください |
+| [setBorderOleColor(int value)](#setBorderOleColor-int-) | このプロパティの説明については、[getBorderOleColor()](../../com.aspose.diagram/listboxactivexcontrol\#getBorderOleColor--)をご覧ください。 |
+| [setBorderStyle(int value)](#setBorderStyle-int-) | このプロパティの説明については、[getBorderStyle()](../../com.aspose.diagram/listboxactivexcontrol\#getBorderStyle--)をご覧ください。 |
+| [setBoundColumn(int value)](#setBoundColumn-int-) | このプロパティの説明については、[getBoundColumn()](../../com.aspose.diagram/listboxactivexcontrol\#getBoundColumn--)をご覧ください。 |
+| [setColumnCount(int value)](#setColumnCount-int-) | このプロパティの説明については、[getColumnCount()](../../com.aspose.diagram/listboxactivexcontrol\#getColumnCount--)をご覧ください。 |
+| [setColumnWidths(double value)](#setColumnWidths-double-) | このプロパティの説明については、[getColumnWidths()](../../com.aspose.diagram/listboxactivexcontrol\#getColumnWidths--)をご覧ください。 |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | このプロパティの説明については、[isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) を参照してください |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | このプロパティの説明については、[getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) を参照してください |
+| [setHeight(double value)](#setHeight-double-) | このプロパティの説明については、[getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) を参照してください |
+| [setIMEMode(int value)](#setIMEMode-int-) | このプロパティの説明については、[getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) を参照してください |
+| [setIntegralHeight(boolean value)](#setIntegralHeight-boolean-) | このプロパティの説明については、[getIntegralHeight()](../../com.aspose.diagram/listboxactivexcontrol\#getIntegralHeight--)をご覧ください。 |
+| [setListStyle(int value)](#setListStyle-int-) | このプロパティの説明については、[getListStyle()](../../com.aspose.diagram/listboxactivexcontrol\#getListStyle--) を参照してください |
+| [setListWidth(double value)](#setListWidth-double-) | このプロパティの説明については、[getListWidth()](../../com.aspose.diagram/listboxactivexcontrol\#getListWidth--) を参照してください |
+| [setLocked(boolean value)](#setLocked-boolean-) | このプロパティの説明については、[isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) を参照してください |
+| [setMatchEntry(int value)](#setMatchEntry-int-) | このプロパティの説明については、[getMatchEntry()](../../com.aspose.diagram/listboxactivexcontrol\#getMatchEntry--) を参照してください |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | このプロパティの説明については、[getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) を参照してください |
+| [setMousePointer(int value)](#setMousePointer-int-) | このプロパティの説明については、[getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) を参照してください |
+| [setScrollBars(int value)](#setScrollBars-int-) | このプロパティの説明については、[getScrollBars()](../../com.aspose.diagram/listboxactivexcontrol\#getScrollBars--) を参照してください |
+| [setShowColumnHeads(boolean value)](#setShowColumnHeads-boolean-) | このプロパティの説明については、[getShowColumnHeads()](../../com.aspose.diagram/listboxactivexcontrol\#getShowColumnHeads--) を参照してください |
+| [setSpecialEffect(int value)](#setSpecialEffect-int-) | このプロパティの説明については、[getSpecialEffect()](../../com.aspose.diagram/listboxactivexcontrol\#getSpecialEffect--) を参照してください |
+| [setTextColumn(int value)](#setTextColumn-int-) | このプロパティの説明については、[getTextColumn()](../../com.aspose.diagram/listboxactivexcontrol\#getTextColumn--) を参照してください |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | このプロパティの説明については、[isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) を参照してください |
+| [setValue(String value)](#setValue-java.lang.String-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/listboxactivexcontrol\#getValue--) を参照してください |
+| [setWidth(double value)](#setWidth-double-) | このプロパティの説明については、[getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) を参照してください |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+背景の OLE カラー。
+
+**Returns:**
+int
+### getBorderOleColor() {#getBorderOleColor--}
+```
+public int getBorderOleColor()
+```
+
+
+背景の OLE カラー。
+
+**Returns:**
+int
+### getBorderStyle() {#getBorderStyle--}
+```
+public int getBorderStyle()
+```
+
+
+コントロールで使用される境界線の種類。
+
+**Returns:**
+int
+### getBoundColumn() {#getBoundColumn--}
+```
+public int getBoundColumn()
+```
+
+
+ComboBox または ListBox の Value プロパティが MultiSelect プロパティの値 (fmMultiSelectSingle) のときにどのように決定されるかを表します。
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColumnCount() {#getColumnCount--}
+```
+public int getColumnCount()
+```
+
+
+ComboBox または ListBox に表示する列数を表します。
+
+**Returns:**
+int
+### getColumnWidths() {#getColumnWidths--}
+```
+public double getColumnWidths()
+```
+
+
+列の幅。
+
+**Returns:**
+double
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+コントロールのバイナリ データ。
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+前景の OLE カラーです。Image コントロールには適用されません。
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+ポイント単位のコントロールの高さ。
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+コントロールがフォーカスを受け取る際の Input Method Editor のデフォルト実行時モード。
+
+**Returns:**
+int
+### getIntegralHeight() {#getIntegralHeight--}
+```
+public boolean getIntegralHeight()
+```
+
+
+コントロールが部分的な行を表示せず、完全な行のみを表示するかどうかを示します。
+
+**Returns:**
+boolean
+### getListStyle() {#getListStyle--}
+```
+public int getListStyle()
+```
+
+
+視覚的な外観です。
+
+**Returns:**
+int
+### getListWidth() {#getListWidth--}
+```
+public double getListWidth()
+```
+
+
+ポイント単位の幅です。
+
+**Returns:**
+double
+### getMatchEntry() {#getMatchEntry--}
+```
+public int getMatchEntry()
+```
+
+
+ユーザーが入力する際に ListBox または ComboBox がリストを検索する方法を示します。
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+コントロールのマウスポインタとして表示するカスタムアイコンです。
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+コントロールのマウスポインタとして表示されるアイコンの種類です。
+
+**Returns:**
+int
+### getScrollBars() {#getScrollBars--}
+```
+public int getScrollBars()
+```
+
+
+コントロールに垂直スクロールバー、水平スクロールバー、両方、またはどちらもないかを示します。
+
+**Returns:**
+int
+### getShowColumnHeads() {#getShowColumnHeads--}
+```
+public boolean getShowColumnHeads()
+```
+
+
+列見出しが表示されるかどうかを示します。
+
+**Returns:**
+boolean
+### getSpecialEffect() {#getSpecialEffect--}
+```
+public int getSpecialEffect()
+```
+
+
+コントロールの特殊効果です。
+
+**Returns:**
+int
+### getTextColumn() {#getTextColumn--}
+```
+public int getTextColumn()
+```
+
+
+ユーザーに表示する ComboBox または ListBox の列を表します。
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+ActiveX コントロールのタイプを取得します。
+
+**Returns:**
+int
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+コントロールの値です。
+
+**Returns:**
+java.lang.String
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+ポイント単位のコントロールの幅です。
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+コントロールが全内容を表示するために自動的にサイズ変更されるかどうかを示します。
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+コントロールがフォーカスを受け取り、ユーザー生成イベントに応答できるかどうかを示します。
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+コントロール内のデータが編集ロックされているかどうかを示します。
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+コントロールが透明かどうかを示します。
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+このプロパティの説明については、[isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+このプロパティの説明については、[getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setBorderOleColor(int value) {#setBorderOleColor-int-}
+```
+public void setBorderOleColor(int value)
+```
+
+
+このプロパティの説明については、[getBorderOleColor()](../../com.aspose.diagram/listboxactivexcontrol\#getBorderOleColor--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setBorderStyle(int value) {#setBorderStyle-int-}
+```
+public void setBorderStyle(int value)
+```
+
+
+このプロパティの説明については、[getBorderStyle()](../../com.aspose.diagram/listboxactivexcontrol\#getBorderStyle--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setBoundColumn(int value) {#setBoundColumn-int-}
+```
+public void setBoundColumn(int value)
+```
+
+
+このプロパティの説明については、[getBoundColumn()](../../com.aspose.diagram/listboxactivexcontrol\#getBoundColumn--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setColumnCount(int value) {#setColumnCount-int-}
+```
+public void setColumnCount(int value)
+```
+
+
+このプロパティの説明については、[getColumnCount()](../../com.aspose.diagram/listboxactivexcontrol\#getColumnCount--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setColumnWidths(double value) {#setColumnWidths-double-}
+```
+public void setColumnWidths(double value)
+```
+
+
+このプロパティの説明については、[getColumnWidths()](../../com.aspose.diagram/listboxactivexcontrol\#getColumnWidths--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+このプロパティの説明については、[isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+このプロパティの説明については、[getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+このプロパティの説明については、[getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+このプロパティの説明については、[getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setIntegralHeight(boolean value) {#setIntegralHeight-boolean-}
+```
+public void setIntegralHeight(boolean value)
+```
+
+
+このプロパティの説明については、[getIntegralHeight()](../../com.aspose.diagram/listboxactivexcontrol\#getIntegralHeight--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setListStyle(int value) {#setListStyle-int-}
+```
+public void setListStyle(int value)
+```
+
+
+このプロパティの説明については、[getListStyle()](../../com.aspose.diagram/listboxactivexcontrol\#getListStyle--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setListWidth(double value) {#setListWidth-double-}
+```
+public void setListWidth(double value)
+```
+
+
+このプロパティの説明については、[getListWidth()](../../com.aspose.diagram/listboxactivexcontrol\#getListWidth--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+このプロパティの説明については、[isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setMatchEntry(int value) {#setMatchEntry-int-}
+```
+public void setMatchEntry(int value)
+```
+
+
+このプロパティの説明については、[getMatchEntry()](../../com.aspose.diagram/listboxactivexcontrol\#getMatchEntry--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+このプロパティの説明については、[getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+このプロパティの説明については、[getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setScrollBars(int value) {#setScrollBars-int-}
+```
+public void setScrollBars(int value)
+```
+
+
+このプロパティの説明については、[getScrollBars()](../../com.aspose.diagram/listboxactivexcontrol\#getScrollBars--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setShowColumnHeads(boolean value) {#setShowColumnHeads-boolean-}
+```
+public void setShowColumnHeads(boolean value)
+```
+
+
+このプロパティの説明については、[getShowColumnHeads()](../../com.aspose.diagram/listboxactivexcontrol\#getShowColumnHeads--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setSpecialEffect(int value) {#setSpecialEffect-int-}
+```
+public void setSpecialEffect(int value)
+```
+
+
+このプロパティの説明については、[getSpecialEffect()](../../com.aspose.diagram/listboxactivexcontrol\#getSpecialEffect--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setTextColumn(int value) {#setTextColumn-int-}
+```
+public void setTextColumn(int value)
+```
+
+
+このプロパティの説明については、[getTextColumn()](../../com.aspose.diagram/listboxactivexcontrol\#getTextColumn--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+このプロパティの説明については、[isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setValue(String value) {#setValue-java.lang.String-}
+```
+public void setValue(String value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/listboxactivexcontrol\#getValue--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+このプロパティの説明については、[getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/loadfileformat/_index.md
+++ b/japanese/java/com.aspose.diagram/loadfileformat/_index.md
@@ -1,0 +1,246 @@
+---
+title: LoadFileFormat
+second_title: Aspose.Diagram for Java API リファレンス
+description: 図面形式選択の読み込み用列挙体。
+type: docs
+weight: 235
+url: /ja/java/com.aspose.diagram/loadfileformat/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LoadFileFormat
+```
+
+図面形式選択の読み込み用列挙体。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [VDW](#VDW) | MS Visio Vdw Web 描画形式。 |
+| [VDX](#VDX) | MS Visio VDX XML 形式。 |
+| [VSD](#VSD) | MS Visio Vsd バイナリ形式。 |
+| [VSDM](#VSDM) | MS Visio Vsdm ファイル形式（マクロを有効にします）。 |
+| [VSDX](#VSDX) | MS Visio 2013 Vsdx ファイル形式。 |
+| [VSS](#VSS) | MS Visio Vss バイナリステンシル形式。 |
+| [VSSM](#VSSM) | MS Visio Vssm ファイル形式（マクロを有効にします）。 |
+| [VSSX](#VSSX) | MS Visio 2013 Vssx ファイル形式。 |
+| [VST](#VST) | MS Visio Vst バイナリテンプレート形式。 |
+| [VSTM](#VSTM) | MS Visio Vstm ファイル形式（マクロを有効にします）。 |
+| [VSTX](#VSTX) | MS Visio 2013 Vstx テンプレートファイル形式。 |
+| [VSX](#VSX) | MS Visio Vsx xml ステンシル形式。 |
+| [VTX](#VTX) | MS Visio Vtx XML テンプレート形式。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### VDW {#VDW}
+```
+public static final int VDW
+```
+
+
+MS Visio Vdw Web 描画形式。
+
+### VDX {#VDX}
+```
+public static final int VDX
+```
+
+
+MS Visio VDX XML 形式。
+
+### VSD {#VSD}
+```
+public static final int VSD
+```
+
+
+MS Visio Vsd バイナリ形式。
+
+### VSDM {#VSDM}
+```
+public static final int VSDM
+```
+
+
+MS Visio Vsdm ファイル形式（マクロを有効にします）。
+
+### VSDX {#VSDX}
+```
+public static final int VSDX
+```
+
+
+MS Visio 2013 Vsdx ファイル形式。
+
+### VSS {#VSS}
+```
+public static final int VSS
+```
+
+
+MS Visio Vss バイナリステンシル形式。
+
+### VSSM {#VSSM}
+```
+public static final int VSSM
+```
+
+
+MS Visio Vssm ファイル形式（マクロを有効にします）。
+
+### VSSX {#VSSX}
+```
+public static final int VSSX
+```
+
+
+MS Visio 2013 Vssx ファイル形式。
+
+### VST {#VST}
+```
+public static final int VST
+```
+
+
+MS Visio Vst バイナリテンプレート形式。
+
+### VSTM {#VSTM}
+```
+public static final int VSTM
+```
+
+
+MS Visio Vstm ファイル形式（マクロを有効にします）。
+
+### VSTX {#VSTX}
+```
+public static final int VSTX
+```
+
+
+MS Visio 2013 Vstx テンプレートファイル形式。
+
+### VSX {#VSX}
+```
+public static final int VSX
+```
+
+
+MS Visio Vsx xml ステンシル形式。
+
+### VTX {#VTX}
+```
+public static final int VTX
+```
+
+
+MS Visio Vtx XML テンプレート形式。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/loadoptions/_index.md
+++ b/japanese/java/com.aspose.diagram/loadoptions/_index.md
@@ -1,0 +1,252 @@
+---
+title: LoadOptions
+second_title: Aspose.Diagram for Java API リファレンス
+description: Diagram オブジェクトに図面を読み込む際に追加オプションを指定できます。
+type: docs
+weight: 236
+url: /ja/java/com.aspose.diagram/loadoptions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LoadOptions
+```
+
+Diagram オブジェクトに図面を読み込む際に追加オプションを指定できます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [LoadOptions()](#LoadOptions--) | このクラスの新しいインスタンスをデフォルト値で初期化します。 |
+| [LoadOptions(int format)](#LoadOptions-int-) | 指定された形式でこのクラスの新しいインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getInterruptMonitor()](#getInterruptMonitor--) | 割り込みモニター。 |
+| [getLoadFormat()](#getLoadFormat--) | ロードする図の形式を指定します。 |
+| [getLocale()](#getLocale--) | ファイルがロードされた時点で図に使用されるロケール。 |
+| [getPages()](#getPages--) | ロードするページのインデックスを指定します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setInterruptMonitor(AbstractInterruptMonitor value)](#setInterruptMonitor-com.aspose.diagram.AbstractInterruptMonitor-) | このプロパティの説明については、[getInterruptMonitor()](../../com.aspose.diagram/loadoptions\#getInterruptMonitor--) をご覧ください。 |
+| [setLoadFormat(int value)](#setLoadFormat-int-) | このプロパティの説明については、[getLoadFormat()](../../com.aspose.diagram/loadoptions\#getLoadFormat--) をご覧ください。 |
+| [setLocale(Locale value)](#setLocale-java.util.Locale-) | このプロパティの説明については、[getLocale()](../../com.aspose.diagram/loadoptions\#getLocale--) をご覧ください。 |
+| [setPages(ArrayList value)](#setPages-java.util.ArrayList-) | このプロパティの説明については、[getPages()](../../com.aspose.diagram/loadoptions\#getPages--) をご覧ください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LoadOptions() {#LoadOptions--}
+```
+public LoadOptions()
+```
+
+
+このクラスの新しいインスタンスをデフォルト値で初期化します。デフォルトのファイル形式は Aspose.Diagram.LoadFileFormat に設定されています。
+
+### LoadOptions(int format) {#LoadOptions-int-}
+```
+public LoadOptions(int format)
+```
+
+
+指定された形式でこのクラスの新しいインスタンスを初期化します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| フォーマット | int | Aspose.Diagram.LoadFileFormat ロード ファイル形式。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getInterruptMonitor() {#getInterruptMonitor--}
+```
+public AbstractInterruptMonitor getInterruptMonitor()
+```
+
+
+割り込みモニター。
+
+**Returns:**
+[AbstractInterruptMonitor](../../com.aspose.diagram/abstractinterruptmonitor)
+### getLoadFormat() {#getLoadFormat--}
+```
+public int getLoadFormat()
+```
+
+
+ロードされる図の形式を指定します。デフォルトは Aspose.Diagram.LoadFileFormat です。Aspose.Diagram.LoadFileFormat の読み取り/書き込み。
+
+**Returns:**
+int
+### getLocale() {#getLocale--}
+```
+public Locale getLocale()
+```
+
+
+ファイルがロードされた時点で図に使用されるロケール。
+
+**Returns:**
+java.util.Locale
+### getPages() {#getPages--}
+```
+public ArrayList getPages()
+```
+
+
+ロードするページのインデックスを指定します。
+
+**Returns:**
+java.util.ArrayList
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setInterruptMonitor(AbstractInterruptMonitor value) {#setInterruptMonitor-com.aspose.diagram.AbstractInterruptMonitor-}
+```
+public void setInterruptMonitor(AbstractInterruptMonitor value)
+```
+
+
+このプロパティの説明については、[getInterruptMonitor()](../../com.aspose.diagram/loadoptions\#getInterruptMonitor--) をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [AbstractInterruptMonitor](../../com.aspose.diagram/abstractinterruptmonitor) |  |
+
+### setLoadFormat(int value) {#setLoadFormat-int-}
+```
+public void setLoadFormat(int value)
+```
+
+
+このプロパティの説明については、[getLoadFormat()](../../com.aspose.diagram/loadoptions\#getLoadFormat--) をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setLocale(Locale value) {#setLocale-java.util.Locale-}
+```
+public void setLocale(Locale value)
+```
+
+
+このプロパティの説明については、[getLocale()](../../com.aspose.diagram/loadoptions\#getLocale--) をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.util.Locale |  |
+
+### setPages(ArrayList value) {#setPages-java.util.ArrayList-}
+```
+public void setPages(ArrayList value)
+```
+
+
+このプロパティの説明については、[getPages()](../../com.aspose.diagram/loadoptions\#getPages--) をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.util.ArrayList |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/localizefont/_index.md
+++ b/japanese/java/com.aspose.diagram/localizefont/_index.md
@@ -1,0 +1,204 @@
+---
+title: LocalizeFont
+second_title: Aspose.Diagram for Java API リファレンス
+description: シェイプテキストを別の言語にローカライズ（翻訳）すべきかどうかを指定します。
+type: docs
+weight: 237
+url: /ja/java/com.aspose.diagram/localizefont/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LocalizeFont
+```
+
+シェイプテキストをローカライズ（別の言語に翻訳）するかどうかを指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [LocalizeFont(int value)](#LocalizeFont-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | シェイプテキストをローカライズ（別の言語に翻訳）するかどうかを指定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | このプロパティの説明については、[getUfe()](../../com.aspose.diagram/localizefont\#getUfe--) を参照してください。 |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/localizefont\#getValue--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LocalizeFont(int value) {#LocalizeFont-int-}
+```
+public LocalizeFont(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+シェイプテキストをローカライズ（別の言語に翻訳）するかどうかを指定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+このプロパティの説明については、[getUfe()](../../com.aspose.diagram/localizefont\#getUfe--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/localizefont\#getValue--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/localizefontvalue/_index.md
+++ b/japanese/java/com.aspose.diagram/localizefontvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: LocalizeFontValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: シェイプテキストを別の言語にローカライズ（翻訳）すべきかどうかを指定します。
+type: docs
+weight: 238
+url: /ja/java/com.aspose.diagram/localizefontvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LocalizeFontValue
+```
+
+シェイプテキストをローカライズ（別の言語に翻訳）するかどうかを指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [ALWAYS_LOCALIZE_FONT](#ALWAYS-LOCALIZE-FONT) | 常にフォントをローカライズします。 |
+| [LOCALIZE_FONT_ONLY_ARIAL_SYMBOL](#LOCALIZE-FONT-ONLY-ARIAL-SYMBOL) | フォントが Arial または Symbol（デフォルト）の場合のみローカライズします。 |
+| [NEVER_LOCALIZE_FONT](#NEVER-LOCALIZE-FONT) | フォントをローカライズしません。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALWAYS_LOCALIZE_FONT {#ALWAYS-LOCALIZE-FONT}
+```
+public static final int ALWAYS_LOCALIZE_FONT
+```
+
+
+常にフォントをローカライズします。
+
+### LOCALIZE_FONT_ONLY_ARIAL_SYMBOL {#LOCALIZE-FONT-ONLY-ARIAL-SYMBOL}
+```
+public static final int LOCALIZE_FONT_ONLY_ARIAL_SYMBOL
+```
+
+
+フォントが Arial または Symbol（デフォルト）の場合のみローカライズします。
+
+### NEVER_LOCALIZE_FONT {#NEVER-LOCALIZE-FONT}
+```
+public static final int NEVER_LOCALIZE_FONT
+```
+
+
+フォントをローカライズしません。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/margin/_index.md
+++ b/japanese/java/com.aspose.diagram/margin/_index.md
@@ -1,0 +1,194 @@
+---
+title: Margin
+second_title: Aspose.Diagram for Java API リファレンス
+description: 余白を指定します。
+type: docs
+weight: 239
+url: /ja/java/com.aspose.diagram/margin/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Margin
+```
+
+余白を指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Margin(double value, int unit)](#Margin-double-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUnit()](#getUnit--) | 単位を表します。 |
+| [getValue()](#getValue--) | 余白を指定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUnit(int value)](#setUnit-int-) | このプロパティの説明については、[getUnit()](../../com.aspose.diagram/margin\#getUnit--) を参照してください。 |
+| [setValue(double value)](#setValue-double-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/margin\#getValue--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Margin(double value, int unit) {#Margin-double-int-}
+```
+public Margin(double value, int unit)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double |  |
+| 単位 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUnit() {#getUnit--}
+```
+public int getUnit()
+```
+
+
+単位を表します。デフォルトは DP です。
+
+**Returns:**
+int
+### getValue() {#getValue--}
+```
+public double getValue()
+```
+
+
+余白を指定します。
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUnit(int value) {#setUnit-int-}
+```
+public void setUnit(int value)
+```
+
+
+このプロパティの説明については、[getUnit()](../../com.aspose.diagram/margin\#getUnit--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setValue(double value) {#setValue-double-}
+```
+public void setValue(double value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/margin\#getValue--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/master/_index.md
+++ b/japanese/java/com.aspose.diagram/master/_index.md
@@ -1,0 +1,516 @@
+---
+title: Master
+second_title: Aspose.Diagram for Java API リファレンス
+description: ドキュメントのマスターを定義する要素を含みます。
+type: docs
+weight: 240
+url: /ja/java/com.aspose.diagram/master/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Master
+```
+
+ドキュメントの master を定義する要素を含みます。master とは、ステンシル上の形状で、図面作成時に繰り返し使用するものです。ステンシルから形状を図面ページへドラッグすると、その形状は master のインスタンスとなり、master のローカルコピーがドキュメントに含まれます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Master()](#Master--) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [dispose()](#dispose--) | アンマネージド リソースの解放、リリース、またはリセットに関連するアプリケーション定義のタスクを実行します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAlignName()](#getAlignName--) | ステンシルウィンドウ内の master のテキストが左揃え、右揃え、または中央揃えかどうかを指定します。 |
+| [getBaseID()](#getBaseID--) | ドキュメント間で master を識別する GUID（グローバル一意識別子）。 |
+| [getClass()](#getClass--) |  |
+| [getConnects()](#getConnects--) | 図面内の 2 つの形状間の各接続について Connect 要素を含みます。 |
+| [getHidden()](#getHidden--) | ユーザーインターフェイスで master が非表示かどうかを指定します。 |
+| [getID()](#getID--) | 要素の親要素内における一意の ID。 |
+| [getIcon()](#getIcon--) | ドキュメント内の Master または MasterShortcut 要素に対する MIME（Multipurpose Internet Mail Extensions）エンコードされたバイナリアイコン（.ico 形式）を指定します。 |
+| [getIconSize()](#getIconSize--) | 要素のアイコンのサイズ。 |
+| [getIconUpdate()](#getIconUpdate--) | アイコンが master 自体から自動的に生成されるかどうかを指定します。 |
+| [getMatchByName()](#getMatchByName--) | MatchByName 属性は、master のインスタンスが図面ページにドロップされたときに、Microsoft Visio がドキュメントの master が既に存在するかどうかを判断する方法を決定します。 |
+| [getName()](#getName--) | 要素の名前。 |
+| [getNameU()](#getNameU--) | 要素のユニバーサル名。 |
+| [getPageSheet()](#getPageSheet--) | ページまたはマスター要素のページシートを定義する要素を含みます。 |
+| [getPatternFlags()](#getPatternFlags--) | PatternFlags 属性は、マスターがカスタム パターンとして動作するかどうかを決定します。 |
+| [getPrompt()](#getPrompt--) | ステータスバーとツールチップが要素に対してプロンプトを表示します。 |
+| [getShapes()](#getShapes--) | Shape オブジェクトのコレクション。 |
+| [getUniqueID()](#getUniqueID--) | ドキュメント内でマスターを識別する GUID。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAlignName(int value)](#setAlignName-int-) | このプロパティの説明については、[getAlignName()](../../com.aspose.diagram/master\#getAlignName--) を参照してください。 |
+| [setBaseID(UUID value)](#setBaseID-java.util.UUID-) | このプロパティの説明については、[getBaseID()](../../com.aspose.diagram/master\#getBaseID--) を参照してください。 |
+| [setHidden(int value)](#setHidden-int-) | このプロパティの説明については、[getHidden()](../../com.aspose.diagram/master\#getHidden--) を参照してください。 |
+| [setID(int value)](#setID-int-) | このプロパティの説明については、[getID()](../../com.aspose.diagram/master\#getID--) を参照してください。 |
+| [setIcon(byte[] value)](#setIcon-byte---) | このプロパティの説明については、[getIcon()](../../com.aspose.diagram/master\#getIcon--) を参照してください。 |
+| [setIconSize(int value)](#setIconSize-int-) | このプロパティの説明については、[getIconSize()](../../com.aspose.diagram/master\#getIconSize--) を参照してください。 |
+| [setIconUpdate(int value)](#setIconUpdate-int-) | このプロパティの説明については、[getIconUpdate()](../../com.aspose.diagram/master\#getIconUpdate--) を参照してください。 |
+| [setMatchByName(int value)](#setMatchByName-int-) | このプロパティの説明については、[getMatchByName()](../../com.aspose.diagram/master\#getMatchByName--) を参照してください。 |
+| [setName(String value)](#setName-java.lang.String-) | このプロパティの説明については、[getName()](../../com.aspose.diagram/master\#getName--) を参照してください。 |
+| [setNameU(String value)](#setNameU-java.lang.String-) | このプロパティの説明については、[getNameU()](../../com.aspose.diagram/master\#getNameU--) を参照してください。 |
+| [setPatternFlags(int value)](#setPatternFlags-int-) | このプロパティの説明については、[getPatternFlags()](../../com.aspose.diagram/master\#getPatternFlags--) を参照してください。 |
+| [setPrompt(String value)](#setPrompt-java.lang.String-) | このプロパティの説明については、[getPrompt()](../../com.aspose.diagram/master\#getPrompt--) を参照してください。 |
+| [setUniqueID(UUID value)](#setUniqueID-java.util.UUID-) | このプロパティの説明については、[getUniqueID()](../../com.aspose.diagram/master\#getUniqueID--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Master() {#Master--}
+```
+public Master()
+```
+
+
+コンストラクタ。
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### dispose() {#dispose--}
+```
+public void dispose()
+```
+
+
+アンマネージド リソースの解放、リリース、またはリセットに関連するアプリケーション定義のタスクを実行します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAlignName() {#getAlignName--}
+```
+public int getAlignName()
+```
+
+
+ステンシルウィンドウ内の master のテキストが左揃え、右揃え、または中央揃えかどうかを指定します。
+
+**Returns:**
+int
+### getBaseID() {#getBaseID--}
+```
+public UUID getBaseID()
+```
+
+
+ドキュメント間で master を識別する GUID（グローバル一意識別子）。
+
+**Returns:**
+java.util.UUID
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConnects() {#getConnects--}
+```
+public ConnectCollection getConnects()
+```
+
+
+図面内の 2 つの形状間の各接続について Connect 要素を含みます。
+
+**Returns:**
+[ConnectCollection](../../com.aspose.diagram/connectcollection)
+### getHidden() {#getHidden--}
+```
+public int getHidden()
+```
+
+
+ユーザーインターフェイスで master が非表示かどうかを指定します。
+
+**Returns:**
+int
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+要素の親要素内における一意の ID。
+
+**Returns:**
+int
+### getIcon() {#getIcon--}
+```
+public byte[] getIcon()
+```
+
+
+ドキュメント内の Master または MasterShortcut 要素に対する MIME（Multipurpose Internet Mail Extensions）エンコードされたバイナリアイコン（.ico 形式）を指定します。
+
+**Returns:**
+byte[]
+### getIconSize() {#getIconSize--}
+```
+public int getIconSize()
+```
+
+
+要素のアイコンのサイズ。
+
+**Returns:**
+int
+### getIconUpdate() {#getIconUpdate--}
+```
+public int getIconUpdate()
+```
+
+
+アイコンが master 自体から自動的に生成されるかどうかを指定します。
+
+**Returns:**
+int
+### getMatchByName() {#getMatchByName--}
+```
+public int getMatchByName()
+```
+
+
+MatchByName 属性は、Microsoft Visio が描画ページにマスターのインスタンスをドロップしたときに、ドキュメント マスターがすでに存在するかどうかを判断する方法を決定します。これにより、スタンドアロン ステンシル ファイルからインスタンスがドラッグされた場合でも、ドキュメント マスターへの変更がマスターの新しいインスタンスに適用されます。
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素の名前。
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+要素のユニバーサル名。
+
+**Returns:**
+java.lang.String
+### getPageSheet() {#getPageSheet--}
+```
+public PageSheet getPageSheet()
+```
+
+
+ページまたはマスター要素のページシートを定義する要素を含みます。
+
+**Returns:**
+[PageSheet](../../com.aspose.diagram/pagesheet)
+### getPatternFlags() {#getPatternFlags--}
+```
+public int getPatternFlags()
+```
+
+
+PatternFlags 属性は、マスターがカスタム パターンとして動作するかどうかを決定します。
+
+**Returns:**
+int
+### getPrompt() {#getPrompt--}
+```
+public String getPrompt()
+```
+
+
+ステータスバーとツールチップが要素に対してプロンプトを表示します。
+
+**Returns:**
+java.lang.String
+### getShapes() {#getShapes--}
+```
+public ShapeCollection getShapes()
+```
+
+
+Shape オブジェクトのコレクション。
+
+**Returns:**
+[ShapeCollection](../../com.aspose.diagram/shapecollection)
+### getUniqueID() {#getUniqueID--}
+```
+public UUID getUniqueID()
+```
+
+
+ドキュメント内でマスターを識別する GUID。
+
+**Returns:**
+java.util.UUID
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAlignName(int value) {#setAlignName-int-}
+```
+public void setAlignName(int value)
+```
+
+
+このプロパティの説明については、[getAlignName()](../../com.aspose.diagram/master\#getAlignName--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setBaseID(UUID value) {#setBaseID-java.util.UUID-}
+```
+public void setBaseID(UUID value)
+```
+
+
+このプロパティの説明については、[getBaseID()](../../com.aspose.diagram/master\#getBaseID--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.util.UUID |  |
+
+### setHidden(int value) {#setHidden-int-}
+```
+public void setHidden(int value)
+```
+
+
+このプロパティの説明については、[getHidden()](../../com.aspose.diagram/master\#getHidden--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+このプロパティの説明については、[getID()](../../com.aspose.diagram/master\#getID--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setIcon(byte[] value) {#setIcon-byte---}
+```
+public void setIcon(byte[] value)
+```
+
+
+このプロパティの説明については、[getIcon()](../../com.aspose.diagram/master\#getIcon--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | byte[] |  |
+
+### setIconSize(int value) {#setIconSize-int-}
+```
+public void setIconSize(int value)
+```
+
+
+このプロパティの説明については、[getIconSize()](../../com.aspose.diagram/master\#getIconSize--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setIconUpdate(int value) {#setIconUpdate-int-}
+```
+public void setIconUpdate(int value)
+```
+
+
+このプロパティの説明については、[getIconUpdate()](../../com.aspose.diagram/master\#getIconUpdate--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setMatchByName(int value) {#setMatchByName-int-}
+```
+public void setMatchByName(int value)
+```
+
+
+このプロパティの説明については、[getMatchByName()](../../com.aspose.diagram/master\#getMatchByName--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+このプロパティの説明については、[getName()](../../com.aspose.diagram/master\#getName--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+このプロパティの説明については、[getNameU()](../../com.aspose.diagram/master\#getNameU--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setPatternFlags(int value) {#setPatternFlags-int-}
+```
+public void setPatternFlags(int value)
+```
+
+
+このプロパティの説明については、[getPatternFlags()](../../com.aspose.diagram/master\#getPatternFlags--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setPrompt(String value) {#setPrompt-java.lang.String-}
+```
+public void setPrompt(String value)
+```
+
+
+このプロパティの説明については、[getPrompt()](../../com.aspose.diagram/master\#getPrompt--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setUniqueID(UUID value) {#setUniqueID-java.util.UUID-}
+```
+public void setUniqueID(UUID value)
+```
+
+
+このプロパティの説明については、[getUniqueID()](../../com.aspose.diagram/master\#getUniqueID--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.util.UUID |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/mastercollection/_index.md
+++ b/japanese/java/com.aspose.diagram/mastercollection/_index.md
@@ -1,0 +1,304 @@
+---
+title: MasterCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: マスター コレクション。
+type: docs
+weight: 241
+url: /ja/java/com.aspose.diagram/mastercollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class MasterCollection extends Collection
+```
+
+マスター コレクション。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(Master master)](#add-com.aspose.diagram.Master-) | コレクションに Master オブジェクトを追加します。 |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [getMaster(int ID)](#getMaster-int-) | 指定された ID の要素を取得します。 |
+| [getMasterByName(String name)](#getMasterByName-java.lang.String-) | 名前で master を取得します。 |
+| [getMasterShortcuts()](#getMasterShortcuts--) | MasterShortcut コレクション。 |
+| [getMaxRelID()](#getMaxRelID--) | コレクション内の最大 rel ID を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [isExist(String name)](#isExist-java.lang.String-) | コレクションに master が存在するかどうか。 |
+| [isExistRelId(String relID)](#isExistRelId-java.lang.String-) | コレクションに master の rel ID が存在するかどうか。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Master master)](#remove-com.aspose.diagram.Master-) | コレクションから Master オブジェクトを削除します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Master master) {#add-com.aspose.diagram.Master-}
+```
+public int add(Master master)
+```
+
+
+コレクションに Master オブジェクトを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| master | [Master](../../com.aspose.diagram/master) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Master get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[Master](../../com.aspose.diagram/master) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### getMaster(int ID) {#getMaster-int-}
+```
+public Master getMaster(int ID)
+```
+
+
+指定された ID の要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ID | int |  |
+
+**Returns:**
+[Master](../../com.aspose.diagram/master) - 
+### getMasterByName(String name) {#getMasterByName-java.lang.String-}
+```
+public Master getMasterByName(String name)
+```
+
+
+名前で master を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String |  |
+
+**Returns:**
+[Master](../../com.aspose.diagram/master) - 
+### getMasterShortcuts() {#getMasterShortcuts--}
+```
+public MasterShortcutCollection getMasterShortcuts()
+```
+
+
+MasterShortcut コレクション。
+
+**Returns:**
+[MasterShortcutCollection](../../com.aspose.diagram/mastershortcutcollection)
+### getMaxRelID() {#getMaxRelID--}
+```
+public int getMaxRelID()
+```
+
+
+コレクション内の最大 rel ID を取得します。
+
+**Returns:**
+int -
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### isExist(String name) {#isExist-java.lang.String-}
+```
+public boolean isExist(String name)
+```
+
+
+コレクションに master が存在するかどうか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String |  |
+
+**Returns:**
+boolean -
+### isExistRelId(String relID) {#isExistRelId-java.lang.String-}
+```
+public boolean isExistRelId(String relID)
+```
+
+
+コレクションに master の rel ID が存在するかどうか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| relID | java.lang.String |  |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Master master) {#remove-com.aspose.diagram.Master-}
+```
+public void remove(Master master)
+```
+
+
+コレクションから Master オブジェクトを削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| master | [Master](../../com.aspose.diagram/master) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/mastershortcut/_index.md
+++ b/japanese/java/com.aspose.diagram/mastershortcut/_index.md
@@ -1,0 +1,388 @@
+---
+title: MasterShortcut
+second_title: Aspose.Diagram for Java API リファレンス
+description: ドキュメントで定義されたマスターショートカットを指定します。
+type: docs
+weight: 242
+url: /ja/java/com.aspose.diagram/mastershortcut/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class MasterShortcut
+```
+
+ドキュメントで定義されたマスターショートカットを指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [MasterShortcut()](#MasterShortcut--) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAlignName()](#getAlignName--) | ステンシルウィンドウ内の要素のテキストが左、右、または中央に揃えられるかを指定します。 |
+| [getClass()](#getClass--) |  |
+| [getID()](#getID--) | 要素の親要素内における一意の ID。 |
+| [getIcon()](#getIcon--) | ドキュメント内の Master または MasterShortcut 要素に対する MIME（Multipurpose Internet Mail Extensions）エンコードされたバイナリアイコン（.ico 形式）を指定します。 |
+| [getIconSize()](#getIconSize--) | 要素のアイコンのサイズ。 |
+| [getName()](#getName--) | 要素の名前。 |
+| [getNameU()](#getNameU--) | 要素のユニバーサル名。 |
+| [getPatternFlags()](#getPatternFlags--) | マスターがカスタムパターンとして動作するかどうかを決定します。 |
+| [getPrompt()](#getPrompt--) | ステータスバーとツールチップが要素に対してプロンプトを表示します。 |
+| [getShortcutHelp()](#getShortcutHelp--) | 要素のヘルプ文字列です。 |
+| [getShortcutURL()](#getShortcutURL--) | MasterShortcut 要素への URL です。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAlignName(int value)](#setAlignName-int-) | このプロパティの説明については、[getAlignName()](../../com.aspose.diagram/mastershortcut\#getAlignName--) を参照してください。 |
+| [setID(int value)](#setID-int-) | このプロパティの説明については、[getID()](../../com.aspose.diagram/mastershortcut\#getID--) を参照してください。 |
+| [setIcon(byte[] value)](#setIcon-byte---) | このプロパティの説明については、[getIcon()](../../com.aspose.diagram/mastershortcut\#getIcon--) を参照してください。 |
+| [setIconSize(int value)](#setIconSize-int-) | このプロパティの説明については、[getIconSize()](../../com.aspose.diagram/mastershortcut\#getIconSize--) を参照してください。 |
+| [setName(String value)](#setName-java.lang.String-) | このプロパティの説明については、[getName()](../../com.aspose.diagram/mastershortcut\#getName--) を参照してください。 |
+| [setNameU(String value)](#setNameU-java.lang.String-) | このプロパティの説明については、[getNameU()](../../com.aspose.diagram/mastershortcut\#getNameU--) を参照してください。 |
+| [setPatternFlags(int value)](#setPatternFlags-int-) | このプロパティの説明については、[getPatternFlags()](../../com.aspose.diagram/mastershortcut\#getPatternFlags--) を参照してください。 |
+| [setPrompt(String value)](#setPrompt-java.lang.String-) | このプロパティの説明については、[getPrompt()](../../com.aspose.diagram/mastershortcut\#getPrompt--) を参照してください。 |
+| [setShortcutHelp(String value)](#setShortcutHelp-java.lang.String-) | このプロパティの説明については、[getShortcutHelp()](../../com.aspose.diagram/mastershortcut\#getShortcutHelp--) を参照してください。 |
+| [setShortcutURL(String value)](#setShortcutURL-java.lang.String-) | このプロパティの説明については、[getShortcutURL()](../../com.aspose.diagram/mastershortcut\#getShortcutURL--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### MasterShortcut() {#MasterShortcut--}
+```
+public MasterShortcut()
+```
+
+
+コンストラクタ。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAlignName() {#getAlignName--}
+```
+public int getAlignName()
+```
+
+
+ステンシルウィンドウ内の要素のテキストが左、右、または中央に揃えられるかを指定します。
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+要素の親要素内における一意の ID。
+
+**Returns:**
+int
+### getIcon() {#getIcon--}
+```
+public byte[] getIcon()
+```
+
+
+ドキュメント内の Master または MasterShortcut 要素に対する MIME（Multipurpose Internet Mail Extensions）エンコードされたバイナリアイコン（.ico 形式）を指定します。
+
+**Returns:**
+byte[]
+### getIconSize() {#getIconSize--}
+```
+public int getIconSize()
+```
+
+
+要素のアイコンのサイズ。
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素の名前。
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+要素のユニバーサル名。
+
+**Returns:**
+java.lang.String
+### getPatternFlags() {#getPatternFlags--}
+```
+public int getPatternFlags()
+```
+
+
+マスターがカスタムパターンとして動作するかどうかを決定します。
+
+**Returns:**
+int
+### getPrompt() {#getPrompt--}
+```
+public String getPrompt()
+```
+
+
+ステータスバーとツールチップが要素に対してプロンプトを表示します。
+
+**Returns:**
+java.lang.String
+### getShortcutHelp() {#getShortcutHelp--}
+```
+public String getShortcutHelp()
+```
+
+
+要素のヘルプ文字列です。
+
+**Returns:**
+java.lang.String
+### getShortcutURL() {#getShortcutURL--}
+```
+public String getShortcutURL()
+```
+
+
+MasterShortcut 要素への URL です。この属性が存在する場合、この MasterShortcut 要素はショートカットです。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAlignName(int value) {#setAlignName-int-}
+```
+public void setAlignName(int value)
+```
+
+
+このプロパティの説明については、[getAlignName()](../../com.aspose.diagram/mastershortcut\#getAlignName--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+このプロパティの説明については、[getID()](../../com.aspose.diagram/mastershortcut\#getID--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setIcon(byte[] value) {#setIcon-byte---}
+```
+public void setIcon(byte[] value)
+```
+
+
+このプロパティの説明については、[getIcon()](../../com.aspose.diagram/mastershortcut\#getIcon--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | byte[] |  |
+
+### setIconSize(int value) {#setIconSize-int-}
+```
+public void setIconSize(int value)
+```
+
+
+このプロパティの説明については、[getIconSize()](../../com.aspose.diagram/mastershortcut\#getIconSize--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+このプロパティの説明については、[getName()](../../com.aspose.diagram/mastershortcut\#getName--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+このプロパティの説明については、[getNameU()](../../com.aspose.diagram/mastershortcut\#getNameU--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setPatternFlags(int value) {#setPatternFlags-int-}
+```
+public void setPatternFlags(int value)
+```
+
+
+このプロパティの説明については、[getPatternFlags()](../../com.aspose.diagram/mastershortcut\#getPatternFlags--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setPrompt(String value) {#setPrompt-java.lang.String-}
+```
+public void setPrompt(String value)
+```
+
+
+このプロパティの説明については、[getPrompt()](../../com.aspose.diagram/mastershortcut\#getPrompt--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setShortcutHelp(String value) {#setShortcutHelp-java.lang.String-}
+```
+public void setShortcutHelp(String value)
+```
+
+
+このプロパティの説明については、[getShortcutHelp()](../../com.aspose.diagram/mastershortcut\#getShortcutHelp--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setShortcutURL(String value) {#setShortcutURL-java.lang.String-}
+```
+public void setShortcutURL(String value)
+```
+
+
+このプロパティの説明については、[getShortcutURL()](../../com.aspose.diagram/mastershortcut\#getShortcutURL--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/mastershortcutcollection/_index.md
+++ b/japanese/java/com.aspose.diagram/mastershortcutcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: MasterShortcutCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: MasterShortcut コレクション。
+type: docs
+weight: 243
+url: /ja/java/com.aspose.diagram/mastershortcutcollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class MasterShortcutCollection extends Collection
+```
+
+MasterShortcut コレクション。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(MasterShortcut masterShortcut)](#add-com.aspose.diagram.MasterShortcut-) | コレクションに Master オブジェクトを追加します。 |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(MasterShortcut masterShortcut)](#remove-com.aspose.diagram.MasterShortcut-) | コレクションから MasterShortcut オブジェクトを削除します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(MasterShortcut masterShortcut) {#add-com.aspose.diagram.MasterShortcut-}
+```
+public int add(MasterShortcut masterShortcut)
+```
+
+
+コレクションに Master オブジェクトを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| masterShortcut | [MasterShortcut](../../com.aspose.diagram/mastershortcut) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public MasterShortcut get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[MasterShortcut](../../com.aspose.diagram/mastershortcut) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(MasterShortcut masterShortcut) {#remove-com.aspose.diagram.MasterShortcut-}
+```
+public void remove(MasterShortcut masterShortcut)
+```
+
+
+コレクションから MasterShortcut オブジェクトを削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| masterShortcut | [MasterShortcut](../../com.aspose.diagram/mastershortcut) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/measureconst/_index.md
+++ b/japanese/java/com.aspose.diagram/measureconst/_index.md
@@ -1,0 +1,561 @@
+---
+title: MeasureConst
+second_title: Aspose.Diagram for Java API リファレンス
+description: 測定単位。
+type: docs
+weight: 244
+url: /ja/java/com.aspose.diagram/measureconst/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class MeasureConst
+```
+
+測定単位。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [AC](#AC) | Acre. |
+| [AD](#AD) | Degrees. |
+| [AM](#AM) | Minutes. |
+| [AS](#AS) | Seconds. |
+| [BOOL](#BOOL) | ブール値。 |
+| [C](#C) | Ciceros. |
+| [CM](#CM) | Centimetres. |
+| [COLOR](#COLOR) | A color value. |
+| [CY](#CY) | Currency. |
+| [C_D](#C-D) | Ciceros/didits. |
+| [D](#D) | Didots. |
+| [DA](#DA) | Default angle units. |
+| [DATE](#DATE) | Date and time. |
+| [DE](#DE) | Default duration units. |
+| [DEG](#DEG) | Fractional degree. |
+| [DL](#DL) | Default length units. |
+| [DP](#DP) | Default page units. |
+| [DT](#DT) | Default type units. |
+| [ED](#ED) | Elapsed days. |
+| [EH](#EH) | Elapsed hours. |
+| [EM](#EM) | Elapsed minutes. |
+| [ES](#ES) | Elapsed seconds. |
+| [EW](#EW) | Elapsed weeks. |
+| [FT](#FT) | Feet. |
+| [F_I](#F-I) | Feet/inch. |
+| [GUID](#GUID) | A global unique identifier. |
+| [HA](#HA) | Hectare. |
+| [IN](#IN) | Inches. |
+| [IN_F](#IN-F) | Inches fractional. |
+| [KM](#KM) | Kilometres. |
+| [M](#M) | Metres. |
+| [MI](#MI) | Miles. |
+| [MI_F](#MI-F) | Milest fractional. |
+| [MM](#MM) | Milimetres. |
+| [MULTIDIM](#MULTIDIM) | Multidimential value. |
+| [NM](#NM) | Nautical miles. |
+| [NUM](#NUM) | Number. |
+| [NURBS](#NURBS) | Nurbs curve data. |
+| [P](#P) | Picas. |
+| [PER](#PER) | Percent. |
+| [PNT](#PNT) | 2-D coordinate. |
+| [POLYLINE](#POLYLINE) | Polyline point data. |
+| [PT](#PT) | Points. |
+| [P_PT](#P-PT) | Picas/points. |
+| [RAD](#RAD) | Radians. |
+| [STR](#STR) | 文字列。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+| [YD](#YD) | Yards. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AC {#AC}
+```
+public static final int AC
+```
+
+
+Acre.
+
+### AD {#AD}
+```
+public static final int AD
+```
+
+
+Degrees.
+
+### AM {#AM}
+```
+public static final int AM
+```
+
+
+Minutes.
+
+### AS {#AS}
+```
+public static final int AS
+```
+
+
+Seconds.
+
+### BOOL {#BOOL}
+```
+public static final int BOOL
+```
+
+
+ブール値。
+
+### C {#C}
+```
+public static final int C
+```
+
+
+Ciceros.
+
+### CM {#CM}
+```
+public static final int CM
+```
+
+
+Centimetres.
+
+### COLOR {#COLOR}
+```
+public static final int COLOR
+```
+
+
+A color value.
+
+### CY {#CY}
+```
+public static final int CY
+```
+
+
+Currency.
+
+### C_D {#C-D}
+```
+public static final int C_D
+```
+
+
+Ciceros/didits.
+
+### D {#D}
+```
+public static final int D
+```
+
+
+Didots.
+
+### DA {#DA}
+```
+public static final int DA
+```
+
+
+Default angle units.
+
+### DATE {#DATE}
+```
+public static final int DATE
+```
+
+
+Date and time.
+
+### DE {#DE}
+```
+public static final int DE
+```
+
+
+Default duration units.
+
+### DEG {#DEG}
+```
+public static final int DEG
+```
+
+
+Fractional degree.
+
+### DL {#DL}
+```
+public static final int DL
+```
+
+
+Default length units.
+
+### DP {#DP}
+```
+public static final int DP
+```
+
+
+Default page units.
+
+### DT {#DT}
+```
+public static final int DT
+```
+
+
+Default type units.
+
+### ED {#ED}
+```
+public static final int ED
+```
+
+
+Elapsed days.
+
+### EH {#EH}
+```
+public static final int EH
+```
+
+
+Elapsed hours.
+
+### EM {#EM}
+```
+public static final int EM
+```
+
+
+Elapsed minutes.
+
+### ES {#ES}
+```
+public static final int ES
+```
+
+
+Elapsed seconds.
+
+### EW {#EW}
+```
+public static final int EW
+```
+
+
+Elapsed weeks.
+
+### FT {#FT}
+```
+public static final int FT
+```
+
+
+Feet.
+
+### F_I {#F-I}
+```
+public static final int F_I
+```
+
+
+Feet/inch.
+
+### GUID {#GUID}
+```
+public static final int GUID
+```
+
+
+A global unique identifier.
+
+### HA {#HA}
+```
+public static final int HA
+```
+
+
+Hectare.
+
+### IN {#IN}
+```
+public static final int IN
+```
+
+
+Inches.
+
+### IN_F {#IN-F}
+```
+public static final int IN_F
+```
+
+
+Inches fractional.
+
+### KM {#KM}
+```
+public static final int KM
+```
+
+
+Kilometres.
+
+### M {#M}
+```
+public static final int M
+```
+
+
+Metres.
+
+### MI {#MI}
+```
+public static final int MI
+```
+
+
+Miles.
+
+### MI_F {#MI-F}
+```
+public static final int MI_F
+```
+
+
+Milest fractional.
+
+### MM {#MM}
+```
+public static final int MM
+```
+
+
+Milimetres.
+
+### MULTIDIM {#MULTIDIM}
+```
+public static final int MULTIDIM
+```
+
+
+Multidimential value.
+
+### NM {#NM}
+```
+public static final int NM
+```
+
+
+Nautical miles.
+
+### NUM {#NUM}
+```
+public static final int NUM
+```
+
+
+Number.
+
+### NURBS {#NURBS}
+```
+public static final int NURBS
+```
+
+
+Nurbs curve data.
+
+### P {#P}
+```
+public static final int P
+```
+
+
+Picas.
+
+### PER {#PER}
+```
+public static final int PER
+```
+
+
+Percent.
+
+### PNT {#PNT}
+```
+public static final int PNT
+```
+
+
+2-D coordinate.
+
+### POLYLINE {#POLYLINE}
+```
+public static final int POLYLINE
+```
+
+
+Polyline point data.
+
+### PT {#PT}
+```
+public static final int PT
+```
+
+
+Points.
+
+### P_PT {#P-PT}
+```
+public static final int P_PT
+```
+
+
+Picas/points.
+
+### RAD {#RAD}
+```
+public static final int RAD
+```
+
+
+Radians.
+
+### STR {#STR}
+```
+public static final int STR
+```
+
+
+文字列。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### YD {#YD}
+```
+public static final int YD
+```
+
+
+Yards.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/memoryfontsource/_index.md
+++ b/japanese/java/com.aspose.diagram/memoryfontsource/_index.md
@@ -1,0 +1,165 @@
+---
+title: MemoryFontSource
+second_title: Aspose.Diagram for Java API リファレンス
+description: メモリに格納された単一の TrueType フォントファイルを表します。
+type: docs
+weight: 245
+url: /ja/java/com.aspose.diagram/memoryfontsource/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.FontSourceBase](../../com.aspose.diagram/fontsourcebase)
+```
+public class MemoryFontSource extends FontSourceBase
+```
+
+メモリに格納された単一の TrueType フォントファイルを表します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [MemoryFontSource(byte[] fontData)](#MemoryFontSource-byte---) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFontData()](#getFontData--) | Binary font data. |
+| [getType()](#getType--) | フォントソースのタイプを返します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### MemoryFontSource(byte[] fontData) {#MemoryFontSource-byte---}
+```
+public MemoryFontSource(byte[] fontData)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| fontData | byte[] | Binary font data. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFontData() {#getFontData--}
+```
+public byte[] getFontData()
+```
+
+
+Binary font data.
+
+**Returns:**
+byte[]
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+フォントソースのタイプを返します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/milestonehelper/_index.md
+++ b/japanese/java/com.aspose.diagram/milestonehelper/_index.md
@@ -1,0 +1,278 @@
+---
+title: MilestoneHelper
+second_title: Aspose.Diagram for Java API リファレンス
+description: マイルストーン シェイプのプロパティを設定する MilestoneHelper。
+type: docs
+weight: 246
+url: /ja/java/com.aspose.diagram/milestonehelper/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class MilestoneHelper
+```
+
+マイルストーン シェイプのプロパティを設定する MilestoneHelper。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [MilestoneHelper(Shape shape)](#MilestoneHelper-com.aspose.diagram.Shape-) |  |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMilestoneDate()](#getMilestoneDate--) | マイルストーン日付 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [refreshMilestone(Shape timeline)](#refreshMilestone-com.aspose.diagram.Shape-) | マイルストーンを更新 |
+| [setAutoUpdate(boolean value)](#setAutoUpdate-boolean-) | タイムライン上でマーカー（マイルストーン、間隔）が移動される際にデータを更新するかどうか |
+|  | [setDateFormat(int value)](#setDateFormat-int-) | シェイプの DateFormat /// |
+
+| ----------------------- | ------------------------------- |
+| **Value**\u9286\u20ac | **Format String**\u9286\u20ac |
+| 0                       | dddd, yyyy-M-d                  |
+| 1                       | yyyy-MM-dd                      |
+| 2                       | yy-MMM-d                        |
+| 3                       | yyyy/M/d                        |
+| 4                       | yy-MMM.                         | |
+| [setDateFormatString(String value)](#setDateFormatString-java.lang.String-) | シェイプの DateFormat 文字列 |
+| [setMilestoneDate(DateTime value)](#setMilestoneDate-com.aspose.diagram.DateTime-) |  |
+| [setType(int value)](#setType-int-) | シェイプのタイプ |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### MilestoneHelper(Shape shape) {#MilestoneHelper-com.aspose.diagram.Shape-}
+```
+public MilestoneHelper(Shape shape)
+```
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| shape | [Shape](../../com.aspose.diagram/shape) |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMilestoneDate() {#getMilestoneDate--}
+```
+public DateTime getMilestoneDate()
+```
+
+
+マイルストーン日付
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### refreshMilestone(Shape timeline) {#refreshMilestone-com.aspose.diagram.Shape-}
+```
+public void refreshMilestone(Shape timeline)
+```
+
+
+マイルストーンを更新
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| timeline | [Shape](../../com.aspose.diagram/shape) |  |
+
+### setAutoUpdate(boolean value) {#setAutoUpdate-boolean-}
+```
+public void setAutoUpdate(boolean value)
+```
+
+
+タイムライン上でマーカー（マイルストーン、間隔）が移動される際にデータを更新するかどうか
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setDateFormat(int value) {#setDateFormat-int-}
+```
+public void setDateFormat(int value)
+```
+
+
+シェイプの DateFormat ///
+
+| ----------------------- | ------------------------------- |
+| **Value**\u9286\u20ac | **Format String**\u9286\u20ac |
+| 0                       | dddd, yyyy-M-d                  |
+| 1                       | yyyy-MM-dd                      |
+| 2                       | yy-MMM-d                        |
+| 3                       | yyyy/M/d                        |
+| 4                       | yy-MMM.-d                       |
+| 5                       | d MMMM yyyy                     |
+| 6                       | yy-M                            |
+| 7                       | MMM-yy                          |
+| 8                       | MMMM d, yyyy                    |
+| 9                       | MMM d, yyyy                     |
+| 10                      | M-d-yy                          |
+| 11                      | M-d                             |
+| 12                      | d MMMM, yyyy                    |
+| 13                      | d MMM, yyyy                     |
+| 14                      | d-M-yy                          |
+| 15                      | d-M                             |
+| 16                      | yy-M-d                          |
+| 17                      | yyyy-M-d                        |
+| 18                      | M-yy                            |
+| 19                      | M-yyyy                          |
+| 20                      | MMMM yyyy                       |
+| 21                      | MMMM yy                         |
+| 22                      | MMM yyyy                        |
+| 23                      | MMM yy                          |
+| 24                      | yy                              |
+| 25                      | yyyy                            |
+| 26                      | d                               |
+| 27                      | MMMM                            |
+| 28                      | MMM                             |
+| 29                      | M                               |
+| 30                      | MM/dd/yyyy                      |
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setDateFormatString(String value) {#setDateFormatString-java.lang.String-}
+```
+public void setDateFormatString(String value)
+```
+
+
+シェイプの DateFormat 文字列
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setMilestoneDate(DateTime value) {#setMilestoneDate-com.aspose.diagram.DateTime-}
+```
+public void setMilestoneDate(DateTime value)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setType(int value) {#setType-int-}
+```
+public void setType(int value)
+```
+
+
+シェイプのタイプ
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/misc/_index.md
+++ b/japanese/java/com.aspose.diagram/misc/_index.md
@@ -1,0 +1,381 @@
+---
+title: Misc
+second_title: Aspose.Diagram for Java API リファレンス
+description: 選択のハイライトや表示を制御する要素など、シェイプとグループのさまざまな要素を含みます。
+type: docs
+weight: 247
+url: /ja/java/com.aspose.diagram/misc/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Misc
+```
+
+選択ハイライトや表示を制御する要素など、シェイプやグループのさまざまな要素を含みます。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBegTrigger()](#getBegTrigger--) | Microsoft Visio が生成したトリガー式を含みます。この式は、別のシェイプへの接続を維持するために 1 次元シェイプの開始点を移動させるかどうかを判断します。 |
+| [getCalendar()](#getCalendar--) | カスタム プロパティ、テキスト フィールド、要素の数式に使用されるカレンダーを決定します。 |
+| [getClass()](#getClass--) |  |
+| [getComment()](#getComment--) | シェイプのコメントテキストを文字列形式で含みます。 |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getDropOnPageScale()](#getDropOnPageScale--) | シェイプが描画ページにドロップされたときに拡大縮小される割合を決定します。 |
+| [getDynFeedback()](#getDynFeedback--) | コネクタをドラッグするときにユーザーに提供されるビジュアルフィードバックのタイプを指定します。 |
+| [getEndTrigger()](#getEndTrigger--) | Microsoft Visio が生成したトリガー式を含みます。 |
+| [getGlueType()](#getGlueType--) | シェイプに接続するときに、動的（シェイプ間）グルーが許可されているかどうかを指定します。 |
+| [getHideText()](#getHideText--) | シェイプのテキストを非表示にします。 |
+| [getLangID()](#getLangID--) | セルの数式、テキスト、カスタムプロパティ、またはコメントが入力された言語のロケール ID (LCID) を示します。 |
+| [getLocalizeMerge()](#getLocalizeMerge--) | シェイプがドキュメント間でコピーされる際に、ローカライズ（LangID 要素がリセットされるかどうか）が行われるかどうかを決定します。 |
+| [getNoAlignBox()](#getNoAlignBox--) | シェイプが選択されたときに選択矩形を表示するかどうかを指定します。 |
+| [getNoCtlHandles()](#getNoCtlHandles--) | シェイプが選択されたときにコントロールハンドルを表示するかどうかを指定します。 |
+| [getNoLiveDynamics()](#getNoLiveDynamics--) | ユーザーが操作する際にシェイプが動的にサイズ変更または回転するかどうかを指定します。 |
+| [getNoObjHandles()](#getNoObjHandles--) | シェイプが選択されたときに選択ハンドルを表示するかどうかを指定します。 |
+| [getNonPrinting()](#getNonPrinting--) | 選択されたシェイプを印刷できるかどうかを指定します。 |
+| [getObjType()](#getObjType--) | Microsoft Visio を使用して描画ページ上にシェイプを配置する際、オブジェクトが配置可能かルーティング可能かを指定します。 |
+| [getShapeKeywords()](#getShapeKeywords--) | カスタム マスター シェイプに割り当てられた検索キーワードを含みます。 |
+| [getUpdateAlignBox()](#getUpdateAlignBox--) | コントロールハンドルが移動するたびにシェイプの選択矩形を再計算するかどうかを指定します。 |
+| [getWalkPreference()](#getWalkPreference--) | 形状が曖昧な位置に移動したとき、動的接着を使用して、1 次元形状の端点が接着された形状上の水平または垂直の接続点に移動するかどうかを指定します。 |
+| [hashCode()](#hashCode--) |  |
+| [isDropSource()](#isDropSource--) | シェイプをグループ上にドロップしてグループに追加できるかどうかを指定します。 |
+| [isReplaceLockShapeData()](#isReplaceLockShapeData--) | シェイプ置換操作中に、マスターシェイプの指定セルの値が置換されるシェイプの値（ローカル値を含む）を上書きするかどうかを示します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | このプロパティの説明については、[getDel()](../../com.aspose.diagram/misc\#getDel--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBegTrigger() {#getBegTrigger--}
+```
+public DoubleValue getBegTrigger()
+```
+
+
+Microsoft Visio が生成したトリガー式を含みます。この式は、別のシェイプへの接続を維持するために 1 次元シェイプの開始点を移動させるかどうかを判断します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getCalendar() {#getCalendar--}
+```
+public Calendar getCalendar()
+```
+
+
+カスタム プロパティ、テキスト フィールド、要素の数式に使用されるカレンダーを決定します。
+
+**Returns:**
+[Calendar](../../com.aspose.diagram/calendar)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getComment() {#getComment--}
+```
+public Str2Value getComment()
+```
+
+
+シェイプのコメントテキストを文字列形式で含みます。
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getDropOnPageScale() {#getDropOnPageScale--}
+```
+public DoubleValue getDropOnPageScale()
+```
+
+
+シェイプが描画ページにドロップされたときに拡大縮小される割合を決定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDynFeedback() {#getDynFeedback--}
+```
+public DynFeedback getDynFeedback()
+```
+
+
+コネクタをドラッグするときにユーザーに提供されるビジュアルフィードバックのタイプを指定します。
+
+**Returns:**
+[DynFeedback](../../com.aspose.diagram/dynfeedback)
+### getEndTrigger() {#getEndTrigger--}
+```
+public DoubleValue getEndTrigger()
+```
+
+
+Microsoft Visio が生成したトリガー式を含みます。このトリガー式は、別のシェイプへの接続を維持するために 1 次元シェイプの終点を移動させるかどうかを判断します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getGlueType() {#getGlueType--}
+```
+public GlueType getGlueType()
+```
+
+
+シェイプに接続するときに、動的（シェイプ間）グルーが許可されているかどうかを指定します。
+
+**Returns:**
+[GlueType](../../com.aspose.diagram/gluetype)
+### getHideText() {#getHideText--}
+```
+public BoolValue getHideText()
+```
+
+
+シェイプのテキストを非表示にします。テキストブロック内のテキストを表示したり、プロパティを編集したり、スタイルを適用したりできますが、HideText 要素を 0 に指定するまで変更は反映されません。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLangID() {#getLangID--}
+```
+public IntValue getLangID()
+```
+
+
+セルの数式、テキスト、カスタムプロパティ、またはコメントが入力された言語のロケール ID (LCID) を示します。
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getLocalizeMerge() {#getLocalizeMerge--}
+```
+public BoolValue getLocalizeMerge()
+```
+
+
+シェイプがドキュメント間でコピーされる際に、ローカライズ（LangID 要素がリセットされるかどうか）が行われるかどうかを決定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getNoAlignBox() {#getNoAlignBox--}
+```
+public BoolValue getNoAlignBox()
+```
+
+
+シェイプが選択されたときに選択矩形を表示するかどうかを指定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getNoCtlHandles() {#getNoCtlHandles--}
+```
+public BoolValue getNoCtlHandles()
+```
+
+
+シェイプが選択されたときにコントロールハンドルを表示するかどうかを指定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getNoLiveDynamics() {#getNoLiveDynamics--}
+```
+public BoolValue getNoLiveDynamics()
+```
+
+
+ユーザーが操作する際にシェイプが動的にサイズ変更または回転するかどうかを指定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getNoObjHandles() {#getNoObjHandles--}
+```
+public BoolValue getNoObjHandles()
+```
+
+
+シェイプが選択されたときに選択ハンドルを表示するかどうかを指定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getNonPrinting() {#getNonPrinting--}
+```
+public BoolValue getNonPrinting()
+```
+
+
+選択されたシェイプを印刷できるかどうかを指定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getObjType() {#getObjType--}
+```
+public ObjType getObjType()
+```
+
+
+Microsoft Visio を使用して描画ページ上にシェイプを配置する際、オブジェクトが配置可能かルーティング可能かを指定します。
+
+**Returns:**
+[ObjType](../../com.aspose.diagram/objtype)
+### getShapeKeywords() {#getShapeKeywords--}
+```
+public Str2Value getShapeKeywords()
+```
+
+
+カスタム マスター シェイプに割り当てられた検索キーワードを含みます。
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getUpdateAlignBox() {#getUpdateAlignBox--}
+```
+public BoolValue getUpdateAlignBox()
+```
+
+
+コントロールハンドルが移動するたびにシェイプの選択矩形を再計算するかどうかを指定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getWalkPreference() {#getWalkPreference--}
+```
+public WalkPreference getWalkPreference()
+```
+
+
+形状が曖昧な位置に移動したとき、動的接着を使用して、1 次元形状の端点が接着された形状上の水平または垂直の接続点に移動するかどうかを指定します。
+
+**Returns:**
+[WalkPreference](../../com.aspose.diagram/walkpreference)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isDropSource() {#isDropSource--}
+```
+public BoolValue isDropSource()
+```
+
+
+シェイプをグループ上にドロップしてグループに追加できるかどうかを指定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### isReplaceLockShapeData() {#isReplaceLockShapeData--}
+```
+public BoolValue isReplaceLockShapeData()
+```
+
+
+シェイプ置換操作中に、マスターシェイプの指定セルの値が置換されるシェイプの値（ローカル値を含む）を上書きするかどうかを示します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+このプロパティの説明については、[getDel()](../../com.aspose.diagram/misc\#getDel--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/moveto/_index.md
+++ b/japanese/java/com.aspose.diagram/moveto/_index.md
@@ -1,0 +1,249 @@
+---
+title: MoveTo
+second_title: Aspose.Diagram for Java API リファレンス
+description: 形状の最初の頂点の x 座標と y 座標、またはパスの途中で切れ目が入った後の最初の頂点の x 座標と y 座標を含みます。
+type: docs
+weight: 248
+url: /ja/java/com.aspose.diagram/moveto/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class MoveTo extends Coordinate
+```
+
+シェイプの最初の頂点の x および y 座標、またはパスの途中で切れた後の最初の頂点の x および y 座標を含みます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [MoveTo()](#MoveTo--) | [MoveTo](../../com.aspose.diagram/moveto) クラスのインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getIX()](#getIX--) | 親要素内の要素のゼロベースインデックスです。 |
+| [getX()](#getX--) | X 要素はパスの最初の頂点の x 座標を表します。 |
+| [getY()](#getY--) | Y 要素はパスの最初の頂点の y 座標を表します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | このプロパティの説明については、[getDel()](../../com.aspose.diagram/moveto\#getDel--) を参照してください。 |
+| [setIX(int value)](#setIX-int-) | このプロパティの説明については、[getIX()](../../com.aspose.diagram/moveto\#getIX--) を参照してください。 |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getX()](../../com.aspose.diagram/moveto\#getX--) を参照してください。 |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getY()](../../com.aspose.diagram/moveto\#getY--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### MoveTo() {#MoveTo--}
+```
+public MoveTo()
+```
+
+
+[MoveTo](../../com.aspose.diagram/moveto) クラスのインスタンスを作成します。
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+親要素内の要素のゼロベースインデックスです。
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+X 要素はパスの最初の頂点の x 座標を表します。MoveTo 要素が 2 つの要素の間に現れる場合、X 要素はパスの切れ目の後の最初の頂点の x 座標を表します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+Y 要素はパスの最初の頂点の y 座標を表します。MoveTo 要素が 2 つの要素の間に現れる場合、Y 要素はパスの切れ目の後の最初の頂点の y 座標を表します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+このプロパティの説明については、[getDel()](../../com.aspose.diagram/moveto\#getDel--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+このプロパティの説明については、[getIX()](../../com.aspose.diagram/moveto\#getIX--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getX()](../../com.aspose.diagram/moveto\#getX--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getY()](../../com.aspose.diagram/moveto\#getY--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/movetocollection/_index.md
+++ b/japanese/java/com.aspose.diagram/movetocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: MoveToCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: MoveTo コレクション。
+type: docs
+weight: 249
+url: /ja/java/com.aspose.diagram/movetocollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class MoveToCollection extends Collection
+```
+
+MoveTo コレクション。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public MoveTo get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[MoveTo](../../com.aspose.diagram/moveto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/nurbsto/_index.md
+++ b/japanese/java/com.aspose.diagram/nurbsto/_index.md
@@ -1,0 +1,374 @@
+---
+title: NURBSTo
+second_title: Aspose.Diagram for Java API リファレンス
+description: 非均一有理 B スプライン (NURBS) の x および y 座標、最後から2番目のノット位置、最後の重み位置、最初のノット位置、最初の重み位置、およびその数式を含みます。
+type: docs
+weight: 250
+url: /ja/java/com.aspose.diagram/nurbsto/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class NURBSTo extends Coordinate
+```
+
+x および y 座標、最後から2番目のノット位置、最後の重み位置、最初のノット位置、最初の重み位置、そして非均一有理 B スプライン (NURBS) の数式を含みます。この情報はそれぞれ X、Y、A、B、C、D、E 要素で指定されます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [NURBSTo()](#NURBSTo--) | [NURBSTo](../../com.aspose.diagram/nurbsto) クラスのインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | 非均一有理 B スプライン (NURBS) の最後から2番目のノット。 |
+| [getB()](#getB--) | 非均一有理 B スプライン (NURBS) の最後の重み。 |
+| [getC()](#getC--) | 非均一有理 B スプライン (NURBS) の最初のノット。 |
+| [getClass()](#getClass--) |  |
+| [getD()](#getD--) | 非均一有理 B スプライン (NURBS) の最初の重み |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getE()](#getE--) | 非均一有理 B スプライン (NURBS) の数式を含みます。 |
+| [getIX()](#getIX--) | 親要素内の要素のゼロベースインデックスです。 |
+| [getX()](#getX--) | 非均一有理 B スプライン (NURBS) の最後の制御点の x 座標。 |
+| [getY()](#getY--) | 非均一有理 B スプライン (NURBS) の最後の制御点の y 座標。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getA()](../../com.aspose.diagram/nurbsto\#getA--) を参照してください。 |
+| [setB(DoubleValue value)](#setB-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getB()](../../com.aspose.diagram/nurbsto\#getB--) を参照してください。 |
+| [setC(DoubleValue value)](#setC-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getC()](../../com.aspose.diagram/nurbsto\#getC--) を参照してください。 |
+| [setD(DoubleValue value)](#setD-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getD()](../../com.aspose.diagram/nurbsto\#getD--) を参照してください。 |
+| [setDel(int value)](#setDel-int-) | このプロパティの説明については、[getDel()](../../com.aspose.diagram/nurbsto\#getDel--) を参照してください。 |
+| [setE(StrValue value)](#setE-com.aspose.diagram.StrValue-) | このプロパティの説明については、[getE()](../../com.aspose.diagram/nurbsto\#getE--) を参照してください |
+| [setIX(int value)](#setIX-int-) | このプロパティの説明については、[getIX()](../../com.aspose.diagram/nurbsto\#getIX--) を参照してください |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getX()](../../com.aspose.diagram/nurbsto\#getX--) を参照してください |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getY()](../../com.aspose.diagram/nurbsto\#getY--) を参照してください |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### NURBSTo() {#NURBSTo--}
+```
+public NURBSTo()
+```
+
+
+[NURBSTo](../../com.aspose.diagram/nurbsto) クラスのインスタンスを作成します。
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+非均一有理 B スプライン (NURBS) の最後から2番目のノット。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getB() {#getB--}
+```
+public DoubleValue getB()
+```
+
+
+非均一有理 B スプライン (NURBS) の最後の重み。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getC() {#getC--}
+```
+public DoubleValue getC()
+```
+
+
+非均一有理 B スプライン (NURBS) の最初のノット。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getD() {#getD--}
+```
+public DoubleValue getD()
+```
+
+
+非均一有理 B スプライン (NURBS) の最初の重み
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getE() {#getE--}
+```
+public StrValue getE()
+```
+
+
+非均一有理 B スプライン (NURBS) の数式を含みます。
+
+**Returns:**
+[StrValue](../../com.aspose.diagram/strvalue)
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+親要素内の要素のゼロベースインデックスです。
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+非均一有理 B スプライン (NURBS) の最後の制御点の x 座標。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+非均一有理 B スプライン (NURBS) の最後の制御点の y 座標。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getA()](../../com.aspose.diagram/nurbsto\#getA--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setB(DoubleValue value) {#setB-com.aspose.diagram.DoubleValue-}
+```
+public void setB(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getB()](../../com.aspose.diagram/nurbsto\#getB--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setC(DoubleValue value) {#setC-com.aspose.diagram.DoubleValue-}
+```
+public void setC(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getC()](../../com.aspose.diagram/nurbsto\#getC--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setD(DoubleValue value) {#setD-com.aspose.diagram.DoubleValue-}
+```
+public void setD(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getD()](../../com.aspose.diagram/nurbsto\#getD--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+このプロパティの説明については、[getDel()](../../com.aspose.diagram/nurbsto\#getDel--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setE(StrValue value) {#setE-com.aspose.diagram.StrValue-}
+```
+public void setE(StrValue value)
+```
+
+
+このプロパティの説明については、[getE()](../../com.aspose.diagram/nurbsto\#getE--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [StrValue](../../com.aspose.diagram/strvalue) |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+このプロパティの説明については、[getIX()](../../com.aspose.diagram/nurbsto\#getIX--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getX()](../../com.aspose.diagram/nurbsto\#getX--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getY()](../../com.aspose.diagram/nurbsto\#getY--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/nurbstocollection/_index.md
+++ b/japanese/java/com.aspose.diagram/nurbstocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: NURBSToCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: NURBSTo コレクション。
+type: docs
+weight: 251
+url: /ja/java/com.aspose.diagram/nurbstocollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class NURBSToCollection extends Collection
+```
+
+NURBSTo コレクション。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public NURBSTo get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[NURBSTo](../../com.aspose.diagram/nurbsto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/objectkind/_index.md
+++ b/japanese/java/com.aspose.diagram/objectkind/_index.md
@@ -1,0 +1,190 @@
+---
+title: ObjectKind
+second_title: Aspose.Diagram for Java API リファレンス
+description: テキスト フィールドのタイプを示します。
+type: docs
+weight: 254
+url: /ja/java/com.aspose.diagram/objectkind/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ObjectKind
+```
+
+テキスト フィールドのタイプを示します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [ObjectKind(int value)](#ObjectKind-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | テキスト フィールドのタイプを示します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/objectkind\#getValue--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ObjectKind(int value) {#ObjectKind-int-}
+```
+public ObjectKind(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+テキスト フィールドのタイプを示します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/objectkind\#getValue--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/objectkindvalue/_index.md
+++ b/japanese/java/com.aspose.diagram/objectkindvalue/_index.md
@@ -1,0 +1,156 @@
+---
+title: ObjectKindValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: テキスト フィールドのタイプを示します。
+type: docs
+weight: 255
+url: /ja/java/com.aspose.diagram/objectkindvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ObjectKindValue
+```
+
+テキスト フィールドのタイプを示します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [HORIZONTAL_IN_VERTICAL](#HORIZONTAL-IN-VERTICAL) | 垂直方向の水平。 |
+| [STANDARD](#STANDARD) | 標準。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### HORIZONTAL_IN_VERTICAL {#HORIZONTAL-IN-VERTICAL}
+```
+public static final int HORIZONTAL_IN_VERTICAL
+```
+
+
+垂直方向の水平。
+
+### STANDARD {#STANDARD}
+```
+public static final int STANDARD
+```
+
+
+標準。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/objecttype/_index.md
+++ b/japanese/java/com.aspose.diagram/objecttype/_index.md
@@ -1,0 +1,183 @@
+---
+title: ObjectType
+second_title: Aspose.Diagram for Java API リファレンス
+description: ForeignType 属性が Object の場合、ForeignData 要素にも ObjectType 属性が必要です。
+type: docs
+weight: 256
+url: /ja/java/com.aspose.diagram/objecttype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ObjectType
+```
+
+If the ForeignType attribute is "Object", the ForeignData element must also have an ObjectType attribute.
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [CONTROL](#CONTROL) | コントロール。 |
+| [EMBEDDED_OBJECT](#EMBEDDED-OBJECT) | 埋め込みオブジェクト。 |
+| [LINKED_OBJECT](#LINKED-OBJECT) | リンクされたオブジェクト。 |
+| [OLE_2_NAMED](#OLE-2-NAMED) | OLE2 名付き。 |
+| [OLE_2_OBJECT](#OLE-2-OBJECT) | OLE2 オブジェクト。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CONTROL {#CONTROL}
+```
+public static final int CONTROL
+```
+
+
+コントロール。
+
+### EMBEDDED_OBJECT {#EMBEDDED-OBJECT}
+```
+public static final int EMBEDDED_OBJECT
+```
+
+
+埋め込みオブジェクト。
+
+### LINKED_OBJECT {#LINKED-OBJECT}
+```
+public static final int LINKED_OBJECT
+```
+
+
+リンクされたオブジェクト。
+
+### OLE_2_NAMED {#OLE-2-NAMED}
+```
+public static final int OLE_2_NAMED
+```
+
+
+OLE2 名付き。
+
+### OLE_2_OBJECT {#OLE-2-OBJECT}
+```
+public static final int OLE_2_OBJECT
+```
+
+
+OLE2 オブジェクト。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/objtype/_index.md
+++ b/japanese/java/com.aspose.diagram/objtype/_index.md
@@ -1,0 +1,179 @@
+---
+title: ObjType
+second_title: Aspose.Diagram for Java API リファレンス
+description: Microsoft Visio を使用して描画ページ上にシェイプを配置する際、オブジェクトが配置可能かルーティング可能かを指定します。
+type: docs
+weight: 252
+url: /ja/java/com.aspose.diagram/objtype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ObjType
+```
+
+Microsoft Visio を使用して描画ページ上にシェイプを配置する際、オブジェクトが配置可能かルーティング可能かを指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [ObjType(int value)](#ObjType-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | Microsoft Visio を使用して描画ページ上にシェイプを配置する際、オブジェクトが配置可能かルーティング可能かを指定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | For the description of this property, please see [getValue()](../../com.aspose.diagram/objtype\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ObjType(int value) {#ObjType-int-}
+```
+public ObjType(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Microsoft Visio を使用して描画ページ上にシェイプを配置する際、オブジェクトが配置可能かルーティング可能かを指定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+For the description of this property, please see [getValue()](../../com.aspose.diagram/objtype\#getValue--)
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/objtypevalue/_index.md
+++ b/japanese/java/com.aspose.diagram/objtypevalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: ObjTypeValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: Microsoft Visio を使用して描画ページ上にシェイプを配置する際、オブジェクトが配置可能かルーティング可能かを指定します。
+type: docs
+weight: 253
+url: /ja/java/com.aspose.diagram/objtypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ObjTypeValue
+```
+
+Microsoft Visio を使用して描画ページ上にシェイプを配置する際、オブジェクトが配置可能かルーティング可能かを指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [DRAWING_CONTEXT](#DRAWING-CONTEXT) | Visio は図面のコンテキストに基づいて決定します。 |
+| [SHAPE_NOT_PLACEABLE_NOT_ROUTABLE](#SHAPE-NOT-PLACEABLE-NOT-ROUTABLE) | シェイプは配置できず、ルーティングもできません。 |
+| [SHAPE_PLACEABLE](#SHAPE-PLACEABLE) | シェイプは配置可能です。 |
+| [SHAPE_PLACEABLE_ROUTABLE](#SHAPE-PLACEABLE-ROUTABLE) | グループには配置可能/ルーティング可能なシェイプが含まれています。 |
+| [SHAPE_ROUTABLE](#SHAPE-ROUTABLE) | Shape はルーティング可能です。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DRAWING_CONTEXT {#DRAWING-CONTEXT}
+```
+public static final int DRAWING_CONTEXT
+```
+
+
+Visio は図面のコンテキストに基づいて決定します。
+
+### SHAPE_NOT_PLACEABLE_NOT_ROUTABLE {#SHAPE-NOT-PLACEABLE-NOT-ROUTABLE}
+```
+public static final int SHAPE_NOT_PLACEABLE_NOT_ROUTABLE
+```
+
+
+シェイプは配置できず、ルーティングもできません。
+
+### SHAPE_PLACEABLE {#SHAPE-PLACEABLE}
+```
+public static final int SHAPE_PLACEABLE
+```
+
+
+シェイプは配置可能です。
+
+### SHAPE_PLACEABLE_ROUTABLE {#SHAPE-PLACEABLE-ROUTABLE}
+```
+public static final int SHAPE_PLACEABLE_ROUTABLE
+```
+
+
+グループには配置可能/ルーティング可能なシェイプが含まれています。
+
+### SHAPE_ROUTABLE {#SHAPE-ROUTABLE}
+```
+public static final int SHAPE_ROUTABLE
+```
+
+
+Shape はルーティング可能です。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/optionsvalue/_index.md
+++ b/japanese/java/com.aspose.diagram/optionsvalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: OptionsValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: オプションの符号なし整数。
+type: docs
+weight: 257
+url: /ja/java/com.aspose.diagram/optionsvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class OptionsValue
+```
+
+オプションの符号なし整数です。データレコードセットに適用するオプションです。可能な値は、以下の表に示すものの1つ以上の組み合わせにすることができます。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [DELAY_QUERY](#DELAY-QUERY) | データレコードセットが次に更新されるまで、コマンド文字列クエリを実行しません。 |
+| [NO_ADV_CONFIG](#NO-ADV-CONFIG) | データレコードセットの「更新の構成」ダイアログ ボックスで、データレコードセットの更新方法に対するユーザーの制御を制限します。 |
+| [NO_EXTERNAL_DATA_UI](#NO-EXTERNAL-DATA-UI) | データレコードセットのデータが外部データ ウィンドウに表示されないようにします。 |
+| [NO_LINK_ON_PASTE](#NO-LINK-ON-PASTE) | シェイプがコピーまたは切り取りされるとき、シェイプ データ リンクをクリップボードにコピーしません。 |
+| [NO_REFRESH_UI](#NO-REFRESH-UI) | データレコードセットが「データの更新」ダイアログ ボックスに表示されないようにします。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DELAY_QUERY {#DELAY-QUERY}
+```
+public static final int DELAY_QUERY
+```
+
+
+データレコードセットが次に更新されるまで、コマンド文字列クエリを実行しません。
+
+### NO_ADV_CONFIG {#NO-ADV-CONFIG}
+```
+public static final int NO_ADV_CONFIG
+```
+
+
+データレコードセットの「更新の構成」ダイアログ ボックスで、データレコードセットの更新方法に対するユーザーの制御を制限します。特に、ユーザーは主キーを変更したり、シェイプ データの上書きタイミングを指定したりできませんが、更新間隔を設定したり、データ ソースを変更したりすることは可能です。
+
+### NO_EXTERNAL_DATA_UI {#NO-EXTERNAL-DATA-UI}
+```
+public static final int NO_EXTERNAL_DATA_UI
+```
+
+
+データレコードセットのデータが外部データ ウィンドウに表示されないようにします。
+
+### NO_LINK_ON_PASTE {#NO-LINK-ON-PASTE}
+```
+public static final int NO_LINK_ON_PASTE
+```
+
+
+シェイプがコピーまたは切り取りされるとき、シェイプ データ リンクをクリップボードにコピーしません。
+
+### NO_REFRESH_UI {#NO-REFRESH-UI}
+```
+public static final int NO_REFRESH_UI
+```
+
+
+データレコードセットが「データの更新」ダイアログ ボックスに表示されないようにします。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/outputformat/_index.md
+++ b/japanese/java/com.aspose.diagram/outputformat/_index.md
@@ -1,0 +1,179 @@
+---
+title: OutputFormat
+second_title: Aspose.Diagram for Java API リファレンス
+description: 図面の出力形式を指定します。
+type: docs
+weight: 258
+url: /ja/java/com.aspose.diagram/outputformat/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class OutputFormat
+```
+
+図面の出力形式を指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [OutputFormat(int value)](#OutputFormat-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | 図面の出力形式を指定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/outputformat\#getValue--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### OutputFormat(int value) {#OutputFormat-int-}
+```
+public OutputFormat(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+図面の出力形式を指定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/outputformat\#getValue--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/outputformatvalue/_index.md
+++ b/japanese/java/com.aspose.diagram/outputformatvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: OutputFormatValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: 図面の出力形式を指定します。
+type: docs
+weight: 259
+url: /ja/java/com.aspose.diagram/outputformatvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class OutputFormatValue
+```
+
+図面の出力形式を指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [DEFAULT_PRINT](#DEFAULT-PRINT) | デフォルト。 |
+| [HTML_OR_GIF_OUTPUT](#HTML-OR-GIF-OUTPUT) | HTML または GIF の出力。 |
+| [POWER_POINT_SLIDE_SHOW](#POWER-POINT-SLIDE-SHOW) | PowerPoint スライドショー。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DEFAULT_PRINT {#DEFAULT-PRINT}
+```
+public static final int DEFAULT_PRINT
+```
+
+
+デフォルト。印刷。
+
+### HTML_OR_GIF_OUTPUT {#HTML-OR-GIF-OUTPUT}
+```
+public static final int HTML_OR_GIF_OUTPUT
+```
+
+
+HTML または GIF の出力。
+
+### POWER_POINT_SLIDE_SHOW {#POWER-POINT-SLIDE-SHOW}
+```
+public static final int POWER_POINT_SLIDE_SHOW
+```
+
+
+PowerPoint スライドショー。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/page/_index.md
+++ b/japanese/java/com.aspose.diagram/page/_index.md
@@ -1,0 +1,1156 @@
+---
+title: ページ
+second_title: Aspose.Diagram for Java API リファレンス
+description: ドキュメント内のページを定義する要素を含みます。
+type: docs
+weight: 260
+url: /ja/java/com.aspose.diagram/page/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Page
+```
+
+ドキュメント内のページを定義する要素を含みます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Page()](#Page--) | コンストラクタ。 |
+| [Page(int ID)](#Page-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [addActiveXControl(int type, double pinX, double pinY, double width, double height)](#addActiveXControl-int-double-double-double-double-) | Activex Control を作成します。 |
+| [addComment(Shape shape, String comment)](#addComment-com.aspose.diagram.Shape-java.lang.String-) | シェイプにコメントを追加します。 |
+| [addComment(double pinX, double pinY, String comment)](#addComment-double-double-java.lang.String-) | 定義された PinX と PinY を使用してコメントを追加します。 |
+| [addComment(long shapeID, String comment)](#addComment-long-java.lang.String-) | シェイプの ID を使用してシェイプにコメントを追加します。 |
+| [addShape(Shape newShape, String masterName)](#addShape-com.aspose.diagram.Shape-java.lang.String-) | マスターで作成されたシェイプを特定のページに追加します。 |
+| [addShape(double pinX, double pinY, double width, double height, InputStream stream)](#addShape-double-double-double-double-java.io.InputStream-) |  |
+| [addShape(double pinX, double pinY, double width, double height, InputStream imageStream, InputStream objectDataStream)](#addShape-double-double-double-double-java.io.InputStream-java.io.InputStream-) |  |
+| [addShape(double pinX, double pinY, double width, double height, String masterName)](#addShape-double-double-double-double-java.lang.String-) | 定義された PinX、PinY、幅、そして高さを使用して、ページ上にマスターで作成されたシェイプを追加します。 |
+| [addShape(double pinX, double pinY, String masterName)](#addShape-double-double-java.lang.String-) | 定義された PinX と PinY を使用して、ページ上にマスターで作成されたシェイプを追加します。 |
+| [addText(double pinX, double pinY, double width, double height, String text)](#addText-double-double-double-double-java.lang.String-) | 定義された PinX と PinY を使用してテキストを追加します。 |
+| [addText(double pinX, double pinY, double width, double height, String text, String fontName, String fontColor, double size)](#addText-double-double-double-double-java.lang.String-java.lang.String-java.lang.String-double-) | 定義された PinX と PinY を使用してテキストを追加します。 |
+| [applyStyle(int textStyle, int lineStyle, int fillStyle)](#applyStyle-int-int-int-) | 全ページにスタイルを適用します。 |
+| [autoSpaceShapes(ShapeCollection shapes, AutoSpaceOptions options)](#autoSpaceShapes-com.aspose.diagram.ShapeCollection-com.aspose.diagram.AutoSpaceOptions-) | シェイプの自動間隔調整 |
+| [bringForward(long shapeId)](#bringForward-long-) | ID で定義されたシェイプを Z オーダーで 1 つ前に移動します。 |
+| [bringToFront(long shapeId)](#bringToFront-long-) | ID で定義されたシェイプを Z オーダーの最前面に移動します。 |
+| [centerDrawing()](#centerDrawing--) | ページの範囲に対してページ上のシェイプを中央揃えにします。 |
+| [connectShapesViaConnector(Shape shapeFrom, int placeFrom, Shape shapeTo, int placeTo, Shape connector)](#connectShapesViaConnector-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-) | コネクタを使用してシェイプを接続します。 |
+| [connectShapesViaConnector(long shapeFromId, int placeFrom, long shapeToId, int placeTo, long connectorId)](#connectShapesViaConnector-long-int-long-int-long-) | コネクタを使用してシェイプを接続します。 |
+| [connectShapesViaConnector(long shapeFromId, String fromConnectionName, long shapeToId, String toConnectionName, long connectorId)](#connectShapesViaConnector-long-java.lang.String-long-java.lang.String-long-) | コネクタを使用してシェイプを接続します。 |
+| [connectShapesViaConnectorIndex(Shape shapeFrom, int fromIndex, Shape shapeTo, int toIndex, Shape connector)](#connectShapesViaConnectorIndex-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-) | コネクタインデックスを使用してシェイプを接続します。 |
+| [connectShapesViaConnectorIndex(long shapeFromId, int fromIndex, long shapeToId, int toIndex, long connectorId)](#connectShapesViaConnectorIndex-long-int-long-int-long-) | コネクタインデックスを使用してシェイプを接続します。 |
+| [copy(Page source)](#copy-com.aspose.diagram.Page-) |  |
+| [dispose()](#dispose--) | アンマネージド リソースの解放、リリース、またはリセットに関連するアプリケーション定義のタスクを実行します。 |
+| [drawEllipse(double pinX, double pinY, double width, double height)](#drawEllipse-double-double-double-double-) | 楕円を描画するプロセス。 |
+| [drawLine(double beginX, double beginY, double endX, double endY)](#drawLine-double-double-double-double-) | 単一の線を描画するプロセス。 |
+| [drawLine(double pinX, double pinY, double width, double height, double[] xyArray)](#drawLine-double-double-double-double-double---) | 線を描画するプロセス。 |
+| [drawPolyline(double pinX, double pinY, double width, double height, double[] xyArray)](#drawPolyline-double-double-double-double-double---) | ポリラインを描画するプロセス。 |
+| [drawRectangle(double pinX, double pinY, double width, double height)](#drawRectangle-double-double-double-double-) | 矩形を描画するプロセス。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAssociatedPage()](#getAssociatedPage--) | 図面のレビュアーが別々のマークアップオーバーレイでマークアップした元の図面ページの ID。 |
+| [getBackPage()](#getBackPage--) | ページの背景ページ。 |
+| [getBackground()](#getBackground--) | ページが背景ページかどうかを示すフラグ。 |
+| [getClass()](#getClass--) |  |
+| [getConnects()](#getConnects--) | 図面内の 2 つの形状間の各接続について Connect 要素を含みます。 |
+| [getID()](#getID--) | 要素の親要素内における一意の ID。 |
+| [getName()](#getName--) | 要素の名前。 |
+| [getNameU()](#getNameU--) | 要素のユニバーサル名。 |
+| [getPageSheet()](#getPageSheet--) | ページまたはマスター要素のページシートを定義する要素を含みます。 |
+| [getPages()](#getPages--) | ページコレクション。 |
+| [getReviewerID()](#getReviewerID--) | マークアップオーバーレイに関連付けられたレビュアーの ID。 |
+| [getShapes()](#getShapes--) | シェイプ コレクション。 |
+| [getViewCenterX()](#getViewCenterX--) | ViewCenterX と ViewCenterY は、新しいビュー（ウィンドウ）が最初に開かれたときにページ上で想定する中心点を指定します。 |
+| [getViewCenterY()](#getViewCenterY--) | ViewCenterX と ViewCenterY は、新しいビュー（ウィンドウ）が最初に開かれたときにページ上で想定する中心点を指定します。 |
+| [getViewScale()](#getViewScale--) | ページの新しいビュー（ウィンドウ）が開かれる際に使用するデフォルトの拡大率。 |
+| [glueShapeToConnectorBeginX(long shapeFromId, String connectionName, long connectorId)](#glueShapeToConnectorBeginX-long-java.lang.String-long-) | シェイプをコネクタの BeginX に接続 |
+| [glueShapeToConnectorEndX(long shapeToId, String connectionName, long connectorId)](#glueShapeToConnectorEndX-long-java.lang.String-long-) | シェイプをコネクタの EndX に接続 |
+| [glueShapes(Shape shapeFrom, int placeTo, Shape shapeTo)](#glueShapes-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-) | シェイプを接続。 |
+| [glueShapes(long shapeFromId, int placeTo, long shapeToId)](#glueShapes-long-int-long-) | シェイプを接続 |
+| [glueShapesInContainer(long shapeFromId, int shapeToBeginConnectionIndex, int shapeToEndConnectionIndex, long shapeToId)](#glueShapesInContainer-long-int-int-long-) | コンテナ内のシェイプを接続 |
+| [glueShapesInContainer(long shapeFromId, String shapeToBeginConnectionName, String shapeToEndConnectionName, long shapeToId)](#glueShapesInContainer-long-java.lang.String-java.lang.String-long-) | 接続名を使用してコンテナ内のシェイプを接続 |
+| [glueShapesInContainerByID(long shapeFromId, int shapeToBeginConnectionID, int shapeToEndConnectionID, long shapeToId)](#glueShapesInContainerByID-long-int-int-long-) | コンテナ内で接続 ID によってシェイプを接続 |
+| [hashCode()](#hashCode--) |  |
+| [layout(LayoutOptions options)](#layout-com.aspose.diagram.LayoutOptions-) | ページのシェイプを配置し、またはコネクタの経路を再設定します。 |
+| [moveTo(int index)](#moveTo-int-) | ページをページ集合内の別の場所に移動します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [sendBackward(long shapeId)](#sendBackward-long-) | ID で定義されたシェイプを Z オーダーで 1 つ後ろに移動します。 |
+| [sendToBack(long shapeId)](#sendToBack-long-) | ID で定義されたシェイプを Z オーダーの最背面に移動します。 |
+| [setAssociatedPage(Page value)](#setAssociatedPage-com.aspose.diagram.Page-) | このプロパティの説明については、[getAssociatedPage()](../../com.aspose.diagram/page\#getAssociatedPage--) を参照してください。 |
+| [setBackPage(Page value)](#setBackPage-com.aspose.diagram.Page-) | このプロパティの説明については、[getBackPage()](../../com.aspose.diagram/page\#getBackPage--) を参照してください。 |
+| [setBackground(int value)](#setBackground-int-) | このプロパティの説明については、[getBackground()](../../com.aspose.diagram/page\#getBackground--) を参照してください。 |
+| [setID(int value)](#setID-int-) | このプロパティの説明については、[getID()](../../com.aspose.diagram/page\#getID--) を参照してください。 |
+| [setName(String value)](#setName-java.lang.String-) | このプロパティの説明については、[getName()](../../com.aspose.diagram/page\#getName--) を参照してください。 |
+| [setNameU(String value)](#setNameU-java.lang.String-) | このプロパティの説明については、[getNameU()](../../com.aspose.diagram/page\#getNameU--) を参照してください。 |
+| [setPages(PageCollection value)](#setPages-com.aspose.diagram.PageCollection-) | このプロパティの説明については、[getPages()](../../com.aspose.diagram/page\#getPages--) を参照してください。 |
+| [setPresetTheme(int value)](#setPresetTheme-int-) | このページにプリセットテーマを適用する |
+| [setPresetThemeQuickStyle(int value)](#setPresetThemeQuickStyle-int-) | このページにプリセットテーマバリアントのクイックスタイルを適用する |
+| [setPresetThemeVariant(int value)](#setPresetThemeVariant-int-) | このページにプリセットテーマバリアントを適用する |
+| [setReviewerID(int value)](#setReviewerID-int-) | このプロパティの説明については、[getReviewerID()](../../com.aspose.diagram/page\#getReviewerID--) を参照してください |
+| [setViewCenterX(double value)](#setViewCenterX-double-) | このプロパティの説明については、[getViewCenterX()](../../com.aspose.diagram/page\#getViewCenterX--) を参照してください |
+| [setViewCenterY(double value)](#setViewCenterY-double-) | このプロパティの説明については、[getViewCenterY()](../../com.aspose.diagram/page\#getViewCenterY--) を参照してください |
+| [setViewScale(double value)](#setViewScale-double-) | このプロパティの説明については、[getViewScale()](../../com.aspose.diagram/page\#getViewScale--) を参照してください |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Page() {#Page--}
+```
+public Page()
+```
+
+
+コンストラクタ。
+
+### Page(int ID) {#Page-int-}
+```
+public Page(int ID)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ID | int |  |
+
+### addActiveXControl(int type, double pinX, double pinY, double width, double height) {#addActiveXControl-int-double-double-double-double-}
+```
+public long addActiveXControl(int type, double pinX, double pinY, double width, double height)
+```
+
+
+Activex Control を作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| タイプ | int | コントロールのタイプです。 |
+| pinX | double | ページに対するシェイプのピン（回転中心）のX座標を指定します。 |
+| pinY | double | ページに対するシェイプのピン（回転中心）のY座標を指定します。 |
+| width | double | シェイプの幅をインチ単位で指定します。 |
+| height | double | シェイプの高さをインチ単位で指定します。 |
+
+**Returns:**
+long -
+### addComment(Shape shape, String comment) {#addComment-com.aspose.diagram.Shape-java.lang.String-}
+```
+public void addComment(Shape shape, String comment)
+```
+
+
+シェイプにコメントを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| shape | [Shape](../../com.aspose.diagram/shape) | コメントを追加しているシェイプを指定します。 |
+| comment | java.lang.String | コメント文字列です。 |
+
+### addComment(double pinX, double pinY, String comment) {#addComment-double-double-java.lang.String-}
+```
+public void addComment(double pinX, double pinY, String comment)
+```
+
+
+定義された PinX と PinY を使用してコメントを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| pinX | double | ページに対するコメントのピン（回転中心）のX座標を指定します。 |
+| pinY | double | ページに対するコメントのピン（回転中心）のY座標を指定します。 |
+| comment | java.lang.String | コメント文字列です。 |
+
+### addComment(long shapeID, String comment) {#addComment-long-java.lang.String-}
+```
+public void addComment(long shapeID, String comment)
+```
+
+
+シェイプの ID を使用してシェイプにコメントを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| shapeID | long |  |
+| comment | java.lang.String | コメント文字列です。 |
+
+### addShape(Shape newShape, String masterName) {#addShape-com.aspose.diagram.Shape-java.lang.String-}
+```
+public long addShape(Shape newShape, String masterName)
+```
+
+
+マスターで作成されたシェイプを特定のページに追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| newShape | [Shape](../../com.aspose.diagram/shape) | 新しいシェイプオブジェクト[Shape](../../com.aspose.diagram/shape)。 |
+| masterName | java.lang.String | マスターの名前です。 |
+
+**Returns:**
+long - 指定されたページ上のシェイプコレクション内でのシェイプの一意のIDです。
+### addShape(double pinX, double pinY, double width, double height, InputStream stream) {#addShape-double-double-double-double-java.io.InputStream-}
+```
+public long addShape(double pinX, double pinY, double width, double height, InputStream stream)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| pinX | double |  |
+| pinY | double |  |
+| width | double |  |
+| height | double |  |
+| ストリーム | java.io.InputStream |  |
+
+**Returns:**
+long
+### addShape(double pinX, double pinY, double width, double height, InputStream imageStream, InputStream objectDataStream) {#addShape-double-double-double-double-java.io.InputStream-java.io.InputStream-}
+```
+public long addShape(double pinX, double pinY, double width, double height, InputStream imageStream, InputStream objectDataStream)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| pinX | double |  |
+| pinY | double |  |
+| width | double |  |
+| height | double |  |
+| imageStream | java.io.InputStream |  |
+| objectDataStream | java.io.InputStream |  |
+
+**Returns:**
+long
+### addShape(double pinX, double pinY, double width, double height, String masterName) {#addShape-double-double-double-double-java.lang.String-}
+```
+public long addShape(double pinX, double pinY, double width, double height, String masterName)
+```
+
+
+定義された PinX、PinY、幅、そして高さを使用して、ページ上にマスターで作成されたシェイプを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| pinX | double | ページに対するシェイプのピン（回転中心）のX座標を指定します。 |
+| pinY | double | ページに対するシェイプのピン（回転中心）のY座標を指定します。 |
+| width | double | シェイプの幅をインチ単位で指定します。 |
+| height | double | シェイプの高さをインチ単位で指定します。 |
+| masterName | java.lang.String | マスターの名前です。 |
+
+**Returns:**
+long - 指定されたページ上のシェイプコレクション内でのシェイプの一意のIDです。
+### addShape(double pinX, double pinY, String masterName) {#addShape-double-double-java.lang.String-}
+```
+public long addShape(double pinX, double pinY, String masterName)
+```
+
+
+定義された PinX と PinY を使用して、ページ上にマスターで作成されたシェイプを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| pinX | double | ページに対するシェイプのピン（回転中心）のX座標を指定します。 |
+| pinY | double | ページに対するシェイプのピン（回転中心）のY座標を指定します。 |
+| masterName | java.lang.String | マスターの名前です。 |
+
+**Returns:**
+long - 指定されたページ上のシェイプコレクション内でのシェイプの一意のIDです。
+### addText(double pinX, double pinY, double width, double height, String text) {#addText-double-double-double-double-java.lang.String-}
+```
+public Shape addText(double pinX, double pinY, double width, double height, String text)
+```
+
+
+定義された PinX と PinY を使用してテキストを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| pinX | double | ページに対するテキストのピン（回転の中心）のx座標を指定します。 |
+| pinY | double | ページに対するテキストのピン（回転の中心）のy座標を指定します。 |
+| width | double |  |
+| height | double |  |
+| テキスト | java.lang.String | テキスト文字列。 |
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape) - Returns a shape object that represents the new text object.
+### addText(double pinX, double pinY, double width, double height, String text, String fontName, String fontColor, double size) {#addText-double-double-double-double-java.lang.String-java.lang.String-java.lang.String-double-}
+```
+public Shape addText(double pinX, double pinY, double width, double height, String text, String fontName, String fontColor, double size)
+```
+
+
+定義された PinX と PinY を使用してテキストを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| pinX | double | ページに対するテキストのピン（回転の中心）のx座標を指定します。 |
+| pinY | double | ページに対するテキストのピン（回転の中心）のy座標を指定します。 |
+| width | double | テキストの幅を指定します。 |
+| height | double | テキストの高さを指定します。 |
+| テキスト | java.lang.String | テキスト文字列。 |
+| fontName | java.lang.String | テキストのフォント名。 |
+| fontColor | java.lang.String | テキストのフォント色。 |
+| size | double | テキストのフォントサイズ。 |
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape) - Returns a shape object that represents the new text object.
+### applyStyle(int textStyle, int lineStyle, int fillStyle) {#applyStyle-int-int-int-}
+```
+public void applyStyle(int textStyle, int lineStyle, int fillStyle)
+```
+
+
+全ページにスタイルを適用します。デフォルト値は -1 です。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| textStyle | int | テキストスタイルID。 |
+| lineStyle | int | ラインスタイルID。 |
+| fillStyle | int | 塗りつぶしスタイルID。 |
+
+### autoSpaceShapes(ShapeCollection shapes, AutoSpaceOptions options) {#autoSpaceShapes-com.aspose.diagram.ShapeCollection-com.aspose.diagram.AutoSpaceOptions-}
+```
+public void autoSpaceShapes(ShapeCollection shapes, AutoSpaceOptions options)
+```
+
+
+シェイプの自動間隔調整
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| shapes | [ShapeCollection](../../com.aspose.diagram/shapecollection) | シェイプが自動的に間隔を持つように指定します。 |
+| options | [AutoSpaceOptions](../../com.aspose.diagram/autospaceoptions) |  |
+
+### bringForward(long shapeId) {#bringForward-long-}
+```
+public void bringForward(long shapeId)
+```
+
+
+ID で定義されたシェイプを Z オーダーで 1 つ前に移動します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| shapeId | long | shape.long の ID。 |
+
+### bringToFront(long shapeId) {#bringToFront-long-}
+```
+public void bringToFront(long shapeId)
+```
+
+
+ID で定義されたシェイプを Z オーダーの最前面に移動します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| shapeId | long | shape.long の ID。 |
+
+### centerDrawing() {#centerDrawing--}
+```
+public void centerDrawing()
+```
+
+
+ページの範囲に対してページのシェイプを中央揃えします。シェイプを中央揃えしても、シェイプ同士の相対位置は変わりません。
+
+### connectShapesViaConnector(Shape shapeFrom, int placeFrom, Shape shapeTo, int placeTo, Shape connector) {#connectShapesViaConnector-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-}
+```
+public void connectShapesViaConnector(Shape shapeFrom, int placeFrom, Shape shapeTo, int placeTo, Shape connector)
+```
+
+
+コネクタを使用してシェイプを接続します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| shapeFrom | [Shape](../../com.aspose.diagram/shape) | コネクタが開始するシェイプは [Shape](../../com.aspose.diagram/shape) です。 |
+| placeFrom | int | コネクタが接続される最初のシェイプ上の位置 Aspose.Diagram.Manipulation.ConnectionPointPlace。 |
+| shapeTo | [Shape](../../com.aspose.diagram/shape) | コネクタが終了するシェイプ [Shape](../../com.aspose.diagram/shape)。 |
+| placeTo | int | コネクタが接続される2番目のシェイプ上の位置 Aspose.Diagram.Manipulation.ConnectionPointPlace。 |
+| connector | [Shape](../../com.aspose.diagram/shape) | タイプが Dynamic connector のシェイプ [Shape](../../com.aspose.diagram/shape)。 |
+
+### connectShapesViaConnector(long shapeFromId, int placeFrom, long shapeToId, int placeTo, long connectorId) {#connectShapesViaConnector-long-int-long-int-long-}
+```
+public void connectShapesViaConnector(long shapeFromId, int placeFrom, long shapeToId, int placeTo, long connectorId)
+```
+
+
+コネクタを使用してシェイプを接続します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| shapeFromId | long | コネクタが開始するシェイプの ID [Shape](../../com.aspose.diagram/shape)。 |
+| placeFrom | int | コネクタが接続される最初のシェイプ上の位置 Aspose.Diagram.Manipulation.ConnectionPointPlace。 |
+| shapeToId | long | コネクタが終了するシェイプの ID [Shape](../../com.aspose.diagram/shape)。 |
+| placeTo | int | コネクタが接続される2番目のシェイプ上の位置 Aspose.Diagram.Manipulation.ConnectionPointPlace。 |
+| connectorId | long | タイプが Dynamic connector のシェイプの ID [Shape](../../com.aspose.diagram/shape)。 |
+
+### connectShapesViaConnector(long shapeFromId, String fromConnectionName, long shapeToId, String toConnectionName, long connectorId) {#connectShapesViaConnector-long-java.lang.String-long-java.lang.String-long-}
+```
+public void connectShapesViaConnector(long shapeFromId, String fromConnectionName, long shapeToId, String toConnectionName, long connectorId)
+```
+
+
+コネクタを使用してシェイプを接続します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| shapeFromId | long | コネクタが開始するシェイプの ID [Shape](../../com.aspose.diagram/shape)。 |
+| fromConnectionName | java.lang.String | コネクタが接続される最初のシェイプ上の接続名。 |
+| shapeToId | long | コネクタが終了するシェイプの ID [Shape](../../com.aspose.diagram/shape)。 |
+| toConnectionName | java.lang.String | コネクタが接続される2番目のシェイプ上の接続名。 |
+| connectorId | long | タイプが Dynamic connector のシェイプの ID [Shape](../../com.aspose.diagram/shape)。 |
+
+### connectShapesViaConnectorIndex(Shape shapeFrom, int fromIndex, Shape shapeTo, int toIndex, Shape connector) {#connectShapesViaConnectorIndex-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-}
+```
+public void connectShapesViaConnectorIndex(Shape shapeFrom, int fromIndex, Shape shapeTo, int toIndex, Shape connector)
+```
+
+
+コネクタインデックスを使用してシェイプを接続します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| shapeFrom | [Shape](../../com.aspose.diagram/shape) | コネクタが開始するシェイプは [Shape](../../com.aspose.diagram/shape) です。 |
+| fromIndex | int | 最初のシェイプ上の接続のインデックス |
+| shapeTo | [Shape](../../com.aspose.diagram/shape) | コネクタが終了するシェイプ [Shape](../../com.aspose.diagram/shape)。 |
+| toIndex | int | 2番目のシェイプ上の接続のインデックス |
+| connector | [Shape](../../com.aspose.diagram/shape) | タイプが Dynamic connector のシェイプ [Shape](../../com.aspose.diagram/shape)。 |
+
+### connectShapesViaConnectorIndex(long shapeFromId, int fromIndex, long shapeToId, int toIndex, long connectorId) {#connectShapesViaConnectorIndex-long-int-long-int-long-}
+```
+public void connectShapesViaConnectorIndex(long shapeFromId, int fromIndex, long shapeToId, int toIndex, long connectorId)
+```
+
+
+コネクタインデックスを使用してシェイプを接続します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| shapeFromId | long | コネクタが開始するシェイプの ID [Shape](../../com.aspose.diagram/shape)。 |
+| fromIndex | int | 最初のシェイプ上の接続のインデックス |
+| shapeToId | long | コネクタが終了するシェイプの ID [Shape](../../com.aspose.diagram/shape)。 |
+| toIndex | int | 2番目のシェイプ上の接続のインデックス |
+| connectorId | long | タイプが Dynamic connector のシェイプの ID [Shape](../../com.aspose.diagram/shape)。 |
+
+### copy(Page source) {#copy-com.aspose.diagram.Page-}
+```
+public void copy(Page source)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| source | [Page](../../com.aspose.diagram/page) |  |
+
+### dispose() {#dispose--}
+```
+public void dispose()
+```
+
+
+アンマネージド リソースの解放、リリース、またはリセットに関連するアプリケーション定義のタスクを実行します。
+
+### drawEllipse(double pinX, double pinY, double width, double height) {#drawEllipse-double-double-double-double-}
+```
+public long drawEllipse(double pinX, double pinY, double width, double height)
+```
+
+
+楕円を描画するプロセス。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| pinX | double | ページに対するシェイプのピン（回転中心）のX座標を指定します。 |
+| pinY | double | ページに対するシェイプのピン（回転中心）のY座標を指定します。 |
+| width | double | シェイプの幅を指定します |
+| height | double | シェイプの高さを指定します |
+
+**Returns:**
+long -
+### drawLine(double beginX, double beginY, double endX, double endY) {#drawLine-double-double-double-double-}
+```
+public long drawLine(double beginX, double beginY, double endX, double endY)
+```
+
+
+単一の線を描画するプロセス。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| beginX | double | ページに対するシェイプの位置の開始 x 座標を指定します。 |
+| beginY | double | ページに対するシェイプの位置の開始 y 座標を指定します。 |
+| endX | double | ページに対するシェイプの位置の終了 x 座標を指定します。 |
+| endY | double | ページに対する形状の位置の終端 y 座標を指定します。 |
+
+**Returns:**
+long - 指定されたページ上のシェイプコレクション内でのシェイプの一意のIDです。
+### drawLine(double pinX, double pinY, double width, double height, double[] xyArray) {#drawLine-double-double-double-double-double---}
+```
+public long drawLine(double pinX, double pinY, double width, double height, double[] xyArray)
+```
+
+
+線を描画するプロセス。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| pinX | double | ページに対するシェイプのピン（回転中心）のX座標を指定します。 |
+| pinY | double | ページに対するシェイプのピン（回転中心）のY座標を指定します。 |
+| width | double | シェイプの幅を指定します |
+| height | double | シェイプの高さを指定します |
+| xyArray | double[] | 新しい形状の点を定義する、交互に並んだ x と y の値の配列 |
+
+**Returns:**
+long - 指定されたページ上のシェイプコレクション内でのシェイプの一意のIDです。
+### drawPolyline(double pinX, double pinY, double width, double height, double[] xyArray) {#drawPolyline-double-double-double-double-double---}
+```
+public long drawPolyline(double pinX, double pinY, double width, double height, double[] xyArray)
+```
+
+
+ポリラインを描画するプロセス。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| pinX | double | ページに対するシェイプのピン（回転中心）のX座標を指定します。 |
+| pinY | double | ページに対するシェイプのピン（回転中心）のY座標を指定します。 |
+| width | double | シェイプの幅を指定します |
+| height | double | シェイプの高さを指定します |
+| xyArray | double[] | 新しい形状の点を定義する、交互に並んだ x と y の値の配列 |
+
+**Returns:**
+long - 指定されたページ上のシェイプコレクション内でのシェイプの一意のIDです。
+### drawRectangle(double pinX, double pinY, double width, double height) {#drawRectangle-double-double-double-double-}
+```
+public long drawRectangle(double pinX, double pinY, double width, double height)
+```
+
+
+矩形を描画するプロセス。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| pinX | double | ページに対するシェイプのピン（回転中心）のX座標を指定します。 |
+| pinY | double | ページに対するシェイプのピン（回転中心）のY座標を指定します。 |
+| width | double | シェイプの幅を指定します |
+| height | double | シェイプの高さを指定します |
+
+**Returns:**
+long - 指定されたページ上のシェイプコレクション内でのシェイプの一意のIDです。
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAssociatedPage() {#getAssociatedPage--}
+```
+public Page getAssociatedPage()
+```
+
+
+図面のレビュアーが別々のマークアップオーバーレイでマークアップした元の図面ページの ID。
+
+**Returns:**
+[Page](../../com.aspose.diagram/page)
+### getBackPage() {#getBackPage--}
+```
+public Page getBackPage()
+```
+
+
+ページの背景ページ。
+
+**Returns:**
+[Page](../../com.aspose.diagram/page)
+### getBackground() {#getBackground--}
+```
+public int getBackground()
+```
+
+
+ページが背景ページかどうかを示すフラグ。
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConnects() {#getConnects--}
+```
+public ConnectCollection getConnects()
+```
+
+
+図面内の 2 つの形状間の各接続について Connect 要素を含みます。
+
+**Returns:**
+[ConnectCollection](../../com.aspose.diagram/connectcollection)
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+要素の親要素内における一意の ID。
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素の名前。
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+要素のユニバーサル名。
+
+**Returns:**
+java.lang.String
+### getPageSheet() {#getPageSheet--}
+```
+public PageSheet getPageSheet()
+```
+
+
+ページまたはマスター要素のページシートを定義する要素を含みます。
+
+**Returns:**
+[PageSheet](../../com.aspose.diagram/pagesheet)
+### getPages() {#getPages--}
+```
+public PageCollection getPages()
+```
+
+
+ページコレクション。
+
+**Returns:**
+[PageCollection](../../com.aspose.diagram/pagecollection)
+### getReviewerID() {#getReviewerID--}
+```
+public int getReviewerID()
+```
+
+
+マークアップオーバーレイに関連付けられたレビュアーの ID。
+
+**Returns:**
+int
+### getShapes() {#getShapes--}
+```
+public ShapeCollection getShapes()
+```
+
+
+シェイプ コレクション。
+
+**Returns:**
+[ShapeCollection](../../com.aspose.diagram/shapecollection)
+### getViewCenterX() {#getViewCenterX--}
+```
+public double getViewCenterX()
+```
+
+
+ViewCenterX と ViewCenterY は、新しいビュー（ウィンドウ）が最初に開かれたときにページ上で想定する中心点を指定します。
+
+**Returns:**
+double
+### getViewCenterY() {#getViewCenterY--}
+```
+public double getViewCenterY()
+```
+
+
+ViewCenterX と ViewCenterY は、新しいビュー（ウィンドウ）が最初に開かれたときにページ上で想定する中心点を指定します。
+
+**Returns:**
+double
+### getViewScale() {#getViewScale--}
+```
+public double getViewScale()
+```
+
+
+ページの新しいビュー（ウィンドウ）を開く際に使用するデフォルトの拡大率です。例: 1 = 100%、1.5 = 150% など。
+
+**Returns:**
+double
+### glueShapeToConnectorBeginX(long shapeFromId, String connectionName, long connectorId) {#glueShapeToConnectorBeginX-long-java.lang.String-long-}
+```
+public void glueShapeToConnectorBeginX(long shapeFromId, String connectionName, long connectorId)
+```
+
+
+シェイプをコネクタの BeginX に接続
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| shapeFromId | long | コネクタが開始するシェイプの ID [Shape](../../com.aspose.diagram/shape)。 |
+| connectionName | java.lang.String | コネクタが接続される形状上の接続名です。 |
+| connectorId | long | タイプが Dynamic connector のシェイプの ID [Shape](../../com.aspose.diagram/shape)。 |
+
+### glueShapeToConnectorEndX(long shapeToId, String connectionName, long connectorId) {#glueShapeToConnectorEndX-long-java.lang.String-long-}
+```
+public void glueShapeToConnectorEndX(long shapeToId, String connectionName, long connectorId)
+```
+
+
+シェイプをコネクタの EndX に接続
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| shapeToId | long | コネクタが終了するシェイプの ID [Shape](../../com.aspose.diagram/shape)。 |
+| connectionName | java.lang.String | コネクタが接続される2番目のシェイプ上の接続名。 |
+| connectorId | long | タイプが Dynamic connector のシェイプの ID [Shape](../../com.aspose.diagram/shape)。 |
+
+### glueShapes(Shape shapeFrom, int placeTo, Shape shapeTo) {#glueShapes-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-}
+```
+public void glueShapes(Shape shapeFrom, int placeTo, Shape shapeTo)
+```
+
+
+シェイプを接続。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| shapeFrom | [Shape](../../com.aspose.diagram/shape) | [Shape](../../com.aspose.diagram/shape) から接着される形状です。 |
+| placeTo | int | 最初の形状上で Aspose.Diagram.Manipulation.ConnectionPointPlace を接着する位置です。 |
+| shapeTo | [Shape](../../com.aspose.diagram/shape) | [Shape](../../com.aspose.diagram/shape) に接着する形状です。 |
+
+### glueShapes(long shapeFromId, int placeTo, long shapeToId) {#glueShapes-long-int-long-}
+```
+public void glueShapes(long shapeFromId, int placeTo, long shapeToId)
+```
+
+
+シェイプを接続
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| shapeFromId | long | [Shape](../../com.aspose.diagram/shape) から接着される形状の ID です。 |
+| placeTo | int | 最初の形状上で Aspose.Diagram.Manipulation.ConnectionPointPlace を接着する位置です。 |
+| shapeToId | long | [Shape](../../com.aspose.diagram/shape) に接着する形状の ID です。 |
+
+### glueShapesInContainer(long shapeFromId, int shapeToBeginConnectionIndex, int shapeToEndConnectionIndex, long shapeToId) {#glueShapesInContainer-long-int-int-long-}
+```
+public void glueShapesInContainer(long shapeFromId, int shapeToBeginConnectionIndex, int shapeToEndConnectionIndex, long shapeToId)
+```
+
+
+コンテナ内のシェイプを接続
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| shapeFromId | long | [Shape](../../com.aspose.diagram/shape) から接着される形状の ID です。 |
+| shapeToBeginConnectionIndex | int | 最初の接続インデックス上で接着する位置です。 |
+| shapeToEndConnectionIndex | int | 終了接続インデックス上で接着する位置です。 |
+| shapeToId | long | [Shape](../../com.aspose.diagram/shape) に接着する形状の ID です。 |
+
+### glueShapesInContainer(long shapeFromId, String shapeToBeginConnectionName, String shapeToEndConnectionName, long shapeToId) {#glueShapesInContainer-long-java.lang.String-java.lang.String-long-}
+```
+public void glueShapesInContainer(long shapeFromId, String shapeToBeginConnectionName, String shapeToEndConnectionName, long shapeToId)
+```
+
+
+接続名を使用してコンテナ内のシェイプを接続
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| shapeFromId | long | [Shape](../../com.aspose.diagram/shape) から接着される形状の ID です。 |
+| shapeToBeginConnectionName | java.lang.String | 最初の接続名上で接着する位置です。 |
+| shapeToEndConnectionName | java.lang.String | 終了接続名上で接着する位置です。 |
+| shapeToId | long | [Shape](../../com.aspose.diagram/shape) に接着する形状の ID です。 |
+
+### glueShapesInContainerByID(long shapeFromId, int shapeToBeginConnectionID, int shapeToEndConnectionID, long shapeToId) {#glueShapesInContainerByID-long-int-int-long-}
+```
+public void glueShapesInContainerByID(long shapeFromId, int shapeToBeginConnectionID, int shapeToEndConnectionID, long shapeToId)
+```
+
+
+コンテナ内で接続 ID によってシェイプを接続
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| shapeFromId | long | [Shape](../../com.aspose.diagram/shape) から接着される形状の ID です。 |
+| shapeToBeginConnectionID | int | 最初の接続 ID 上で接着する位置です。 |
+| shapeToEndConnectionID | int | 終了接続 ID 上で接着する位置です。 |
+| shapeToId | long | [Shape](../../com.aspose.diagram/shape) に接着する形状の ID です。 |
+
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### layout(LayoutOptions options) {#layout-com.aspose.diagram.LayoutOptions-}
+```
+public void layout(LayoutOptions options)
+```
+
+
+ページのシェイプを配置し、またはコネクタの経路を再設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| options | [LayoutOptions](../../com.aspose.diagram/layoutoptions) | [LayoutOptions](../../com.aspose.diagram/layoutoptions) を使用してレイアウトのオプションを構成します。 |
+
+### moveTo(int index) {#moveTo-int-}
+```
+public void moveTo(int index)
+```
+
+
+ページをページ集合内の別の場所に移動します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 宛先ページインデックス。 |
+
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### sendBackward(long shapeId) {#sendBackward-long-}
+```
+public void sendBackward(long shapeId)
+```
+
+
+ID で定義されたシェイプを Z オーダーで 1 つ後ろに移動します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| shapeId | long | shape.long の ID。 |
+
+### sendToBack(long shapeId) {#sendToBack-long-}
+```
+public void sendToBack(long shapeId)
+```
+
+
+ID で定義されたシェイプを Z オーダーの最背面に移動します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| shapeId | long | shape.long の ID。 |
+
+### setAssociatedPage(Page value) {#setAssociatedPage-com.aspose.diagram.Page-}
+```
+public void setAssociatedPage(Page value)
+```
+
+
+このプロパティの説明については、[getAssociatedPage()](../../com.aspose.diagram/page\#getAssociatedPage--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [Page](../../com.aspose.diagram/page) |  |
+
+### setBackPage(Page value) {#setBackPage-com.aspose.diagram.Page-}
+```
+public void setBackPage(Page value)
+```
+
+
+このプロパティの説明については、[getBackPage()](../../com.aspose.diagram/page\#getBackPage--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [Page](../../com.aspose.diagram/page) |  |
+
+### setBackground(int value) {#setBackground-int-}
+```
+public void setBackground(int value)
+```
+
+
+このプロパティの説明については、[getBackground()](../../com.aspose.diagram/page\#getBackground--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+このプロパティの説明については、[getID()](../../com.aspose.diagram/page\#getID--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+このプロパティの説明については、[getName()](../../com.aspose.diagram/page\#getName--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+このプロパティの説明については、[getNameU()](../../com.aspose.diagram/page\#getNameU--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setPages(PageCollection value) {#setPages-com.aspose.diagram.PageCollection-}
+```
+public void setPages(PageCollection value)
+```
+
+
+このプロパティの説明については、[getPages()](../../com.aspose.diagram/page\#getPages--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [PageCollection](../../com.aspose.diagram/pagecollection) |  |
+
+### setPresetTheme(int value) {#setPresetTheme-int-}
+```
+public void setPresetTheme(int value)
+```
+
+
+このページにプリセットテーマを適用する
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setPresetThemeQuickStyle(int value) {#setPresetThemeQuickStyle-int-}
+```
+public void setPresetThemeQuickStyle(int value)
+```
+
+
+このページにプリセットテーマバリアントのクイックスタイルを適用する
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setPresetThemeVariant(int value) {#setPresetThemeVariant-int-}
+```
+public void setPresetThemeVariant(int value)
+```
+
+
+このページにプリセットテーマバリアントを適用する
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setReviewerID(int value) {#setReviewerID-int-}
+```
+public void setReviewerID(int value)
+```
+
+
+このプロパティの説明については、[getReviewerID()](../../com.aspose.diagram/page\#getReviewerID--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setViewCenterX(double value) {#setViewCenterX-double-}
+```
+public void setViewCenterX(double value)
+```
+
+
+このプロパティの説明については、[getViewCenterX()](../../com.aspose.diagram/page\#getViewCenterX--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double |  |
+
+### setViewCenterY(double value) {#setViewCenterY-double-}
+```
+public void setViewCenterY(double value)
+```
+
+
+このプロパティの説明については、[getViewCenterY()](../../com.aspose.diagram/page\#getViewCenterY--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double |  |
+
+### setViewScale(double value) {#setViewScale-double-}
+```
+public void setViewScale(double value)
+```
+
+
+このプロパティの説明については、[getViewScale()](../../com.aspose.diagram/page\#getViewScale--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/pagecollection/_index.md
+++ b/japanese/java/com.aspose.diagram/pagecollection/_index.md
@@ -1,0 +1,259 @@
+---
+title: PageCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: ページコレクション。
+type: docs
+weight: 261
+url: /ja/java/com.aspose.diagram/pagecollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class PageCollection extends Collection
+```
+
+ページコレクション。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(Page page)](#add-com.aspose.diagram.Page-) | コレクションにページを追加します。 |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [dispose()](#dispose--) | アンマネージド リソースの解放、リリース、またはリセットに関連するアプリケーション定義のタスクを実行します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [getPage(int ID)](#getPage-int-) | 指定された ID の要素を取得します。 |
+| [getPage(String name)](#getPage-java.lang.String-) | 指定された名前の要素を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Page page)](#remove-com.aspose.diagram.Page-) | コレクションからページを削除します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Page page) {#add-com.aspose.diagram.Page-}
+```
+public int add(Page page)
+```
+
+
+コレクションにページを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| page | [Page](../../com.aspose.diagram/page) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### dispose() {#dispose--}
+```
+public void dispose()
+```
+
+
+アンマネージド リソースの解放、リリース、またはリセットに関連するアプリケーション定義のタスクを実行します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Page get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[Page](../../com.aspose.diagram/page) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### getPage(int ID) {#getPage-int-}
+```
+public Page getPage(int ID)
+```
+
+
+指定された ID の要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ID | int |  |
+
+**Returns:**
+[Page](../../com.aspose.diagram/page) - 
+### getPage(String name) {#getPage-java.lang.String-}
+```
+public Page getPage(String name)
+```
+
+
+指定された名前の要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String |  |
+
+**Returns:**
+[Page](../../com.aspose.diagram/page) - 
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Page page) {#remove-com.aspose.diagram.Page-}
+```
+public void remove(Page page)
+```
+
+
+コレクションからページを削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| page | [Page](../../com.aspose.diagram/page) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/pageendsavingargs/_index.md
+++ b/japanese/java/com.aspose.diagram/pageendsavingargs/_index.md
@@ -1,0 +1,172 @@
+---
+title: PageEndSavingArgs
+second_title: Aspose.Diagram for Java API リファレンス
+description: ページの情報が保存プロセスを終了します。
+type: docs
+weight: 262
+url: /ja/java/com.aspose.diagram/pageendsavingargs/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.PageSavingArgs](../../com.aspose.diagram/pagesavingargs)
+```
+public class PageEndSavingArgs extends PageSavingArgs
+```
+
+ページの情報が保存プロセスを終了します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getPageCount()](#getPageCount--) | 総ページ数。 |
+| [getPageIndex()](#getPageIndex--) | 現在のページインデックス（0ベース）。 |
+| [hasMorePages()](#hasMorePages--) | 出力すべきページがまだあるかどうかを示す値です。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setHasMorePages(boolean value)](#setHasMorePages-boolean-) | このプロパティの説明については、[hasMorePages()](../../com.aspose.diagram/pageendsavingargs\#hasMorePages--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+総ページ数。
+
+**Returns:**
+int
+### getPageIndex() {#getPageIndex--}
+```
+public int getPageIndex()
+```
+
+
+現在のページインデックス（0ベース）。
+
+**Returns:**
+int
+### hasMorePages() {#hasMorePages--}
+```
+public boolean hasMorePages()
+```
+
+
+出力すべきページがまだあるかどうかを示す値です。デフォルト値は true です。
+
+**Returns:**
+boolean
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setHasMorePages(boolean value) {#setHasMorePages-boolean-}
+```
+public void setHasMorePages(boolean value)
+```
+
+
+このプロパティの説明については、[hasMorePages()](../../com.aspose.diagram/pageendsavingargs\#hasMorePages--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/pagelayout/_index.md
+++ b/japanese/java/com.aspose.diagram/pagelayout/_index.md
@@ -1,0 +1,458 @@
+---
+title: PageLayout
+second_title: Aspose.Diagram for Java API リファレンス
+description: ページ上の図形やコネクタのレイアウト設定を制御するセルを含みます。例えば、ページ上のすべての図形間の間隔、すべてのコネクタ間の間隔、すべてのコネクタのルーティングスタイルなどです。
+type: docs
+weight: 263
+url: /ja/java/com.aspose.diagram/pagelayout/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PageLayout
+```
+
+ページ上の図形やコネクタのレイアウト設定を制御するセルを含みます。例えば、ページ上のすべての図形間の間隔、すべてのコネクタ間の間隔、そしてすべてのコネクタのルーティングスタイルなどです。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAvenueSizeX()](#getAvenueSizeX--) | Microsoft Visioで図面ページ上の図形を配置する際の、図形間の垂直方向のスペース量を決定します。 |
+| [getAvenueSizeY()](#getAvenueSizeY--) | Microsoft Visioで図面ページ上の図形を配置する際の、図形間の垂直方向のスペース量を決定します。 |
+| [getAvoidPageBreaks()](#getAvoidPageBreaks--) | ユーザーが「図形の配置」（図形メニュー）を選択して図形を配置する際、図形がページ上に配置される方法を指定します。 |
+| [getBlockSizeX()](#getBlockSizeX--) | Microsoft Visioで図面ページ上の図形を配置する際に、各図形が収まる必要がある垂直方向のブロックサイズ（領域）を決定します。 |
+| [getBlockSizeY()](#getBlockSizeY--) | Microsoft Visioで図面ページ上の図形を配置する際の、図形間の水平方向のスペース量を決定します。 |
+| [getClass()](#getClass--) |  |
+| [getCtrlAsInput()](#getCtrlAsInput--) | コントロールハンドルで図形を使用する場合、どの図形が親になるかを決定します。 |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getDynamicsOff()](#getDynamicsOff--) | 配置可能な図形が移動し、コネクタが図面ページ上の他の図形やコネクタの周りを再ルーティングするかどうかを指定します。 |
+| [getEnableGrid()](#getEnableGrid--) | ユーザーが「図形の配置」（Shape メニュー）を選択したとき、Microsoft Visio が内部ページグリッドに基づいて図形を配置するかどうかを指定します。 |
+| [getLineAdjustFrom()](#getLineAdjustFrom--) | 動的コネクタが互いに重なる場合に、どのコネクタを間隔を空けるかを指定します。 |
+| [getLineAdjustTo()](#getLineAdjustTo--) | 動的コネクタが互いに重なる場合に、どのコネクタを重ねて配置するかを指定します。 |
+| [getLineJumpCode()](#getLineJumpCode--) | ローカルのラインジャンプスタイルが設定されていない描画ページ上のすべてのコネクタのラインジャンプスタイルを指定します。 |
+| [getLineJumpFactorX()](#getLineJumpFactorX--) | ページ上の動的コネクタの水平セグメントにおけるラインジャンプのサイズを、LineToLineX 要素の値（ページ上のすべてのコネクタ間の水平間隔を指定）に対するパーセンテージで指定します。 |
+| [getLineJumpFactorY()](#getLineJumpFactorY--) | ページ上の動的コネクタの垂直セグメントにおけるラインジャンプのサイズを、LineToLineY 要素の値（ページ上のすべてのコネクタ間の垂直間隔を指定）に対するパーセンテージで指定します。 |
+| [getLineJumpStyle()](#getLineJumpStyle--) | 描画ページ上の動的コネクタの水平セグメントにおいて、ローカルなジャンプ方向が設定されていない場合のラインジャンプの方向を指定します。 |
+| [getLineRouteExt()](#getLineRouteExt--) | ページ上のすべてのコネクタのデフォルト外観を指定します。 |
+| [getLineToLineX()](#getLineToLineX--) | 図面ページ上の動的コネクタ間の最小水平間隔を指定します。 |
+| [getLineToLineY()](#getLineToLineY--) | 図面ページ上の動的コネクタ間の最小垂直間隔を指定します。 |
+| [getLineToNodeX()](#getLineToNodeX--) | 図面ページ上の動的コネクタと図形間の最小垂直間隔を指定します。 |
+| [getLineToNodeY()](#getLineToNodeY--) | Microsoft Visioで図面ページ上の図形を配置する際に、各図形が収まる必要がある水平方向のブロックサイズ（領域）を決定します。 |
+| [getPageLineJumpDirX()](#getPageLineJumpDirX--) | 描画ページ上の垂直動的コネクタにおいて、ローカルなジャンプ方向が設定されていない場合のラインジャンプの方向を指定します。 |
+| [getPageLineJumpDirY()](#getPageLineJumpDirY--) | 図面ページ上の動的コネクタと図形間の最小水平間隔を指定します。 |
+| [getPageShapeSplit()](#getPageShapeSplit--) | ページ上の図形が自動的に分割できるかどうかを示します。 |
+| [getPlaceDepth()](#getPlaceDepth--) | ユーザーが配置可能な図形を別の配置可能な図形の近くへドラッグしたとき、配置可能な図形が離れるかどうかを指定します。 |
+| [getPlaceFlip()](#getPlaceFlip--) | Microsoft Visio の「図形の配置」コマンドを使用して図形を配置する際、ページ上の配置可能な図形が反転または回転する方法を指定します。 |
+| [getPlaceStyle()](#getPlaceStyle--) | ローカルのルーティングスタイルが設定されていない描画ページ上のすべての動的コネクタのルーティングスタイルと方向を指定します。 |
+| [getPlowCode()](#getPlowCode--) | ジャンプを追加したい動的コネクタを決定します。 |
+| [getResizePage()](#getResizePage--) | ユーザーが「図形の配置」（Shapes メニュー）を選択した後、図面を囲むようにページを拡大するかどうかを指定します。 |
+| [getRouteStyle()](#getRouteStyle--) | 自動的にレイアウトされる図面について、レイアウト作成前に図面を解析する方法とレイアウトのタイプを決定する方法を指定します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | このプロパティの説明については、[getDel()](../../com.aspose.diagram/pagelayout\#getDel--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAvenueSizeX() {#getAvenueSizeX--}
+```
+public DoubleValue getAvenueSizeX()
+```
+
+
+Microsoft Visioで図面ページ上の図形を配置する際の、図形間の垂直方向のスペース量を決定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getAvenueSizeY() {#getAvenueSizeY--}
+```
+public DoubleValue getAvenueSizeY()
+```
+
+
+Microsoft Visioで図面ページ上の図形を配置する際の、図形間の垂直方向のスペース量を決定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getAvoidPageBreaks() {#getAvoidPageBreaks--}
+```
+public BoolValue getAvoidPageBreaks()
+```
+
+
+ユーザーが「図形の配置」（図形メニュー）を選択して図形を配置する際、図形がページ上に配置される方法を指定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getBlockSizeX() {#getBlockSizeX--}
+```
+public DoubleValue getBlockSizeX()
+```
+
+
+Microsoft Visioで図面ページ上の図形を配置する際に、各図形が収まる必要がある垂直方向のブロックサイズ（領域）を決定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBlockSizeY() {#getBlockSizeY--}
+```
+public DoubleValue getBlockSizeY()
+```
+
+
+Microsoft Visioで図面ページ上の図形を配置する際の、図形間の水平方向のスペース量を決定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCtrlAsInput() {#getCtrlAsInput--}
+```
+public BoolValue getCtrlAsInput()
+```
+
+
+コントロールハンドルで図形を使用する場合、どの図形が親になるかを決定します。この要素は図面ページ上のすべての図形の動作を設定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getDynamicsOff() {#getDynamicsOff--}
+```
+public BoolValue getDynamicsOff()
+```
+
+
+配置可能な図形が移動し、コネクタが図面ページ上の他の図形やコネクタの周りを再ルーティングするかどうかを指定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getEnableGrid() {#getEnableGrid--}
+```
+public BoolValue getEnableGrid()
+```
+
+
+ユーザーが「図形の配置」（Shape メニュー）を選択したとき、Microsoft Visio が内部ページグリッドに基づいて図形を配置するかどうかを指定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLineAdjustFrom() {#getLineAdjustFrom--}
+```
+public LineAdjustFrom getLineAdjustFrom()
+```
+
+
+動的コネクタが互いに重なる場合に、どのコネクタを間隔を空けるかを指定します。
+
+**Returns:**
+[LineAdjustFrom](../../com.aspose.diagram/lineadjustfrom)
+### getLineAdjustTo() {#getLineAdjustTo--}
+```
+public LineAdjustTo getLineAdjustTo()
+```
+
+
+動的コネクタが互いに重なる場合に、どのコネクタを重ねて配置するかを指定します。
+
+**Returns:**
+[LineAdjustTo](../../com.aspose.diagram/lineadjustto)
+### getLineJumpCode() {#getLineJumpCode--}
+```
+public LineJumpCode getLineJumpCode()
+```
+
+
+ローカルのラインジャンプスタイルが設定されていない描画ページ上のすべてのコネクタのラインジャンプスタイルを指定します。
+
+**Returns:**
+[LineJumpCode](../../com.aspose.diagram/linejumpcode)
+### getLineJumpFactorX() {#getLineJumpFactorX--}
+```
+public DoubleValue getLineJumpFactorX()
+```
+
+
+ページ上の動的コネクタの水平セグメントにおけるラインジャンプのサイズを、LineToLineX 要素の値（ページ上のすべてのコネクタ間の水平間隔を指定）に対するパーセンテージで指定します。この要素の値は 0 から 10 の範囲です。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLineJumpFactorY() {#getLineJumpFactorY--}
+```
+public DoubleValue getLineJumpFactorY()
+```
+
+
+ページ上の動的コネクタの垂直セグメントにおけるラインジャンプのサイズを、LineToLineY 要素の値（ページ上のすべてのコネクタ間の垂直間隔を指定）に対するパーセンテージで指定します。この要素は 0 から 10 の値を含めることができます。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLineJumpStyle() {#getLineJumpStyle--}
+```
+public LineJumpStyle getLineJumpStyle()
+```
+
+
+描画ページ上の動的コネクタの水平セグメントにおいて、ローカルなジャンプ方向が設定されていない場合のラインジャンプの方向を指定します。
+
+**Returns:**
+[LineJumpStyle](../../com.aspose.diagram/linejumpstyle)
+### getLineRouteExt() {#getLineRouteExt--}
+```
+public LineRouteExt getLineRouteExt()
+```
+
+
+ページ上のすべてのコネクタのデフォルト外観を指定します。
+
+**Returns:**
+[LineRouteExt](../../com.aspose.diagram/linerouteext)
+### getLineToLineX() {#getLineToLineX--}
+```
+public DoubleValue getLineToLineX()
+```
+
+
+図面ページ上の動的コネクタ間の最小水平間隔を指定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLineToLineY() {#getLineToLineY--}
+```
+public DoubleValue getLineToLineY()
+```
+
+
+図面ページ上の動的コネクタ間の最小垂直間隔を指定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLineToNodeX() {#getLineToNodeX--}
+```
+public DoubleValue getLineToNodeX()
+```
+
+
+図面ページ上の動的コネクタと図形間の最小垂直間隔を指定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLineToNodeY() {#getLineToNodeY--}
+```
+public DoubleValue getLineToNodeY()
+```
+
+
+Microsoft Visioで図面ページ上の図形を配置する際に、各図形が収まる必要がある水平方向のブロックサイズ（領域）を決定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getPageLineJumpDirX() {#getPageLineJumpDirX--}
+```
+public PageLineJumpDirX getPageLineJumpDirX()
+```
+
+
+描画ページ上の垂直動的コネクタにおいて、ローカルなジャンプ方向が設定されていない場合のラインジャンプの方向を指定します。
+
+**Returns:**
+[PageLineJumpDirX](../../com.aspose.diagram/pagelinejumpdirx)
+### getPageLineJumpDirY() {#getPageLineJumpDirY--}
+```
+public PageLineJumpDirY getPageLineJumpDirY()
+```
+
+
+図面ページ上の動的コネクタと図形間の最小水平間隔を指定します。
+
+**Returns:**
+[PageLineJumpDirY](../../com.aspose.diagram/pagelinejumpdiry)
+### getPageShapeSplit() {#getPageShapeSplit--}
+```
+public BoolValue getPageShapeSplit()
+```
+
+
+ページ上の図形が自動的に分割できるかどうかを示します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getPlaceDepth() {#getPlaceDepth--}
+```
+public PlaceDepth getPlaceDepth()
+```
+
+
+ユーザーが配置可能な図形を別の配置可能な図形の近くへドラッグしたとき、配置可能な図形が離れるかどうかを指定します。
+
+**Returns:**
+[PlaceDepth](../../com.aspose.diagram/placedepth)
+### getPlaceFlip() {#getPlaceFlip--}
+```
+public PlaceFlip getPlaceFlip()
+```
+
+
+Microsoft Visio の「Lay Out Shapes」コマンドを使用してシェイプを配置する際に、ページ上で配置可能なシェイプがどのように反転または回転するかを指定します。以下の十六進値が使用可能です。
+
+**Returns:**
+[PlaceFlip](../../com.aspose.diagram/placeflip)
+### getPlaceStyle() {#getPlaceStyle--}
+```
+public PlaceStyle getPlaceStyle()
+```
+
+
+ローカルのルーティングスタイルが設定されていない描画ページ上のすべての動的コネクタのルーティングスタイルと方向を指定します。
+
+**Returns:**
+[PlaceStyle](../../com.aspose.diagram/placestyle)
+### getPlowCode() {#getPlowCode--}
+```
+public BoolValue getPlowCode()
+```
+
+
+ジャンプを追加したい動的コネクタを決定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getResizePage() {#getResizePage--}
+```
+public BoolValue getResizePage()
+```
+
+
+ユーザーが「図形の配置」（Shapes メニュー）を選択した後、図面を囲むようにページを拡大するかどうかを指定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getRouteStyle() {#getRouteStyle--}
+```
+public RouteStyle getRouteStyle()
+```
+
+
+自動的にレイアウトされる図面について、レイアウト作成前に図面を解析する方法とレイアウトのタイプを決定する方法を指定します。
+
+**Returns:**
+[RouteStyle](../../com.aspose.diagram/routestyle)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+このプロパティの説明については、[getDel()](../../com.aspose.diagram/pagelayout\#getDel--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/pagelinejumpdirx/_index.md
+++ b/japanese/java/com.aspose.diagram/pagelinejumpdirx/_index.md
@@ -1,0 +1,179 @@
+---
+title: PageLineJumpDirX
+second_title: Aspose.Diagram for Java API リファレンス
+description: 描画ページ上の動的コネクタの水平セグメントにおいて、ローカルなジャンプ方向が設定されていない場合のラインジャンプ方向を指定します。
+type: docs
+weight: 264
+url: /ja/java/com.aspose.diagram/pagelinejumpdirx/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PageLineJumpDirX
+```
+
+描画ページ上の動的コネクタの水平セグメントにおいて、ローカルなジャンプ方向が設定されていない場合のラインジャンプの方向を指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageLineJumpDirX(int value)](#PageLineJumpDirX-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | 描画ページ上の動的コネクタの水平セグメントにおいて、ローカルなジャンプ方向が設定されていない場合のラインジャンプの方向を指定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/pagelinejumpdirx\#getValue--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageLineJumpDirX(int value) {#PageLineJumpDirX-int-}
+```
+public PageLineJumpDirX(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+描画ページ上の動的コネクタの水平セグメントにおいて、ローカルなジャンプ方向が設定されていない場合のラインジャンプの方向を指定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/pagelinejumpdirx\#getValue--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/pagelinejumpdirxvalue/_index.md
+++ b/japanese/java/com.aspose.diagram/pagelinejumpdirxvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: PageLineJumpDirXValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: 描画ページ上の動的コネクタの水平セグメントにおいて、ローカルなジャンプ方向が設定されていない場合のラインジャンプ方向を指定します。
+type: docs
+weight: 265
+url: /ja/java/com.aspose.diagram/pagelinejumpdirxvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PageLineJumpDirXValue
+```
+
+描画ページ上の動的コネクタの水平セグメントにおいて、ローカルなジャンプ方向が設定されていない場合のラインジャンプの方向を指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [DEFAULT_UP](#DEFAULT-UP) | デフォルトは上です。 |
+| [DOWN](#DOWN) | 下 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+| [UP](#UP) | 上。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DEFAULT_UP {#DEFAULT-UP}
+```
+public static final int DEFAULT_UP
+```
+
+
+デフォルトは上です。
+
+### DOWN {#DOWN}
+```
+public static final int DOWN
+```
+
+
+下
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### UP {#UP}
+```
+public static final int UP
+```
+
+
+上。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/pagelinejumpdiry/_index.md
+++ b/japanese/java/com.aspose.diagram/pagelinejumpdiry/_index.md
@@ -1,0 +1,179 @@
+---
+title: PageLineJumpDirY
+second_title: Aspose.Diagram for Java API リファレンス
+description: ローカル ジャンプ方向が設定されていない描画ページ上の垂直動的コネクタのライン ジャンプ方向を指定します。
+type: docs
+weight: 266
+url: /ja/java/com.aspose.diagram/pagelinejumpdiry/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PageLineJumpDirY
+```
+
+描画ページ上の垂直動的コネクタにおいて、ローカルなジャンプ方向が設定されていない場合のラインジャンプの方向を指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageLineJumpDirY(int value)](#PageLineJumpDirY-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | 描画ページ上の垂直動的コネクタにおいて、ローカルなジャンプ方向が設定されていない場合のラインジャンプの方向を指定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/pagelinejumpdiry\#getValue--)をご覧ください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageLineJumpDirY(int value) {#PageLineJumpDirY-int-}
+```
+public PageLineJumpDirY(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+描画ページ上の垂直動的コネクタにおいて、ローカルなジャンプ方向が設定されていない場合のラインジャンプの方向を指定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/pagelinejumpdiry\#getValue--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/pagelinejumpdiryvalue/_index.md
+++ b/japanese/java/com.aspose.diagram/pagelinejumpdiryvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: PageLineJumpDirYValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: ローカル ジャンプ方向が設定されていない描画ページ上の垂直動的コネクタのライン ジャンプ方向を指定します。
+type: docs
+weight: 267
+url: /ja/java/com.aspose.diagram/pagelinejumpdiryvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PageLineJumpDirYValue
+```
+
+描画ページ上の垂直動的コネクタにおいて、ローカルなジャンプ方向が設定されていない場合のラインジャンプの方向を指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [DEFAULTLEFT](#DEFAULTLEFT) | デフォルトは左です。 |
+| [LEFT](#LEFT) | 左。 |
+| [RIGHT](#RIGHT) | 右。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DEFAULTLEFT {#DEFAULTLEFT}
+```
+public static final int DEFAULTLEFT
+```
+
+
+デフォルトは左です。
+
+### LEFT {#LEFT}
+```
+public static final int LEFT
+```
+
+
+左。
+
+### RIGHT {#RIGHT}
+```
+public static final int RIGHT
+```
+
+
+右。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/pageprops/_index.md
+++ b/japanese/java/com.aspose.diagram/pageprops/_index.md
@@ -1,0 +1,315 @@
+---
+title: PageProps
+second_title: Aspose.Diagram for Java API リファレンス
+description: ページ幅、ページ高さ、スケールなどのページ属性を制御するセルを含みます。
+type: docs
+weight: 268
+url: /ja/java/com.aspose.diagram/pageprops/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PageProps
+```
+
+ページ幅、ページ高さ、スケールなど、ページ属性を制御するセルを含みます。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getDrawingResizeType()](#getDrawingResizeType--) | 図に合わせて描画ページが自動的にサイズ変更されるかどうかを決定します。 |
+| [getDrawingScale()](#getDrawingScale--) | 現在の描画スケールにおける描画単位の値を表します。 |
+| [getDrawingScaleType()](#getDrawingScaleType--) | ページに使用する描画スケールのタイプを指定します。 |
+| [getDrawingSizeType()](#getDrawingSizeType--) | ページの描画サイズを指定します。 |
+| [getInhibitSnap()](#getInhibitSnap--) | 前景ページ上のシェイプがページ上の他のオブジェクトや背景ページ上のシェイプにスナップするかどうかを指定します。 |
+| [getPageHeight()](#getPageHeight--) | ページの高さを描画単位で指定します。 |
+| [getPageScale()](#getPageScale--) | 現在の描画スケールにおけるデフォルトページ単位の値を指定します。 |
+| [getPageWidth()](#getPageWidth--) | ページの幅を描画単位で指定します。 |
+| [getShdwObliqueAngle()](#getShdwObliqueAngle--) | デフォルトのページ影タイプが適用される際の斜め方向の角度を指定する数値を含みます。 |
+| [getShdwOffsetX()](#getShdwOffsetX--) | シェイプのドロップシャドウがシェイプから水平方向にオフセットされる距離（ページ単位）を指定します。 |
+| [getShdwOffsetY()](#getShdwOffsetY--) | シェイプのドロップシャドウがシェイプから垂直方向にオフセットされる距離（ページ単位）を指定します。 |
+| [getShdwScaleFactor()](#getShdwScaleFactor--) | シェイプのシャドウを拡大または縮小する割合を指定します。 |
+| [getShdwType()](#getShdwType--) | ページのデフォルトの影タイプを示します。 |
+| [getUIVisibility()](#getUIVisibility--) | ページ名がユーザーインターフェイス (UI) に表示されるかどうかを決定します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | このプロパティの説明については、[getDel()](../../com.aspose.diagram/pageprops\#getDel--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getDrawingResizeType() {#getDrawingResizeType--}
+```
+public DrawingResizeType getDrawingResizeType()
+```
+
+
+図に合わせて描画ページが自動的にサイズ変更されるかどうかを決定します。
+
+**Returns:**
+[DrawingResizeType](../../com.aspose.diagram/drawingresizetype)
+### getDrawingScale() {#getDrawingScale--}
+```
+public DoubleValue getDrawingScale()
+```
+
+
+現在の描画スケールにおける描画単位の値を表します。ページの描画スケールは、PageScale 要素に含まれるページ単位と描画単位との比率です。この要素の単位は、ページのデフォルト長さ (DL) 単位を決定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDrawingScaleType() {#getDrawingScaleType--}
+```
+public DrawingScaleType getDrawingScaleType()
+```
+
+
+ページに使用する描画スケールのタイプを指定します。
+
+**Returns:**
+[DrawingScaleType](../../com.aspose.diagram/drawingscaletype)
+### getDrawingSizeType() {#getDrawingSizeType--}
+```
+public DrawingSizeType getDrawingSizeType()
+```
+
+
+ページの描画サイズを指定します。
+
+**Returns:**
+[DrawingSizeType](../../com.aspose.diagram/drawingsizetype)
+### getInhibitSnap() {#getInhibitSnap--}
+```
+public BoolValue getInhibitSnap()
+```
+
+
+前景ページ上のシェイプがページ上の他のオブジェクトや背景ページ上のシェイプにスナップするかどうかを指定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getPageHeight() {#getPageHeight--}
+```
+public DoubleValue getPageHeight()
+```
+
+
+ページの高さを描画単位で指定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getPageScale() {#getPageScale--}
+```
+public DoubleValue getPageScale()
+```
+
+
+現在の描画スケールにおけるデフォルトページ単位の値を指定します。ページの描画スケールは、PageScale 要素のページ単位と DrawingScale 要素に示された描画単位との比率です。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getPageWidth() {#getPageWidth--}
+```
+public DoubleValue getPageWidth()
+```
+
+
+ページの幅を描画単位で指定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShdwObliqueAngle() {#getShdwObliqueAngle--}
+```
+public DoubleValue getShdwObliqueAngle()
+```
+
+
+デフォルトのページ影タイプが適用される際の斜め方向の角度を指定する数値を含みます。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShdwOffsetX() {#getShdwOffsetX--}
+```
+public DoubleValue getShdwOffsetX()
+```
+
+
+シェイプのドロップシャドウがシェイプから水平方向にオフセットされる距離（ページ単位）を指定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShdwOffsetY() {#getShdwOffsetY--}
+```
+public DoubleValue getShdwOffsetY()
+```
+
+
+シェイプのドロップシャドウがシェイプから垂直方向にオフセットされる距離（ページ単位）を指定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShdwScaleFactor() {#getShdwScaleFactor--}
+```
+public DoubleValue getShdwScaleFactor()
+```
+
+
+シェイプのシャドウを拡大または縮小する割合を指定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShdwType() {#getShdwType--}
+```
+public ShdwType getShdwType()
+```
+
+
+ページのデフォルトの影タイプを示します。
+
+**Returns:**
+[ShdwType](../../com.aspose.diagram/shdwtype)
+### getUIVisibility() {#getUIVisibility--}
+```
+public UIVisibility getUIVisibility()
+```
+
+
+ページ名がユーザーインターフェイス (UI) に表示されるかどうかを決定します。値が 1 の場合はページが非表示であることを示し、値が 0 の場合はページが表示されることを示します。
+
+**Returns:**
+[UIVisibility](../../com.aspose.diagram/uivisibility)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+このプロパティの説明については、[getDel()](../../com.aspose.diagram/pageprops\#getDel--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/pagesavingargs/_index.md
+++ b/japanese/java/com.aspose.diagram/pagesavingargs/_index.md
@@ -1,0 +1,147 @@
+---
+title: PageSavingArgs
+second_title: Aspose.Diagram for Java API リファレンス
+description: ページの保存プロセスに関する情報です。
+type: docs
+weight: 269
+url: /ja/java/com.aspose.diagram/pagesavingargs/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PageSavingArgs
+```
+
+ページの保存プロセスに関する情報です。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getPageCount()](#getPageCount--) | 総ページ数。 |
+| [getPageIndex()](#getPageIndex--) | 現在のページインデックス（0ベース）。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+総ページ数。
+
+**Returns:**
+int
+### getPageIndex() {#getPageIndex--}
+```
+public int getPageIndex()
+```
+
+
+現在のページインデックス（0ベース）。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/pagesheet/_index.md
+++ b/japanese/java/com.aspose.diagram/pagesheet/_index.md
@@ -1,0 +1,426 @@
+---
+title: PageSheet
+second_title: Aspose.Diagram for Java API リファレンス
+description: ページまたはマスター要素のページシートを定義する要素を含みます。
+type: docs
+weight: 270
+url: /ja/java/com.aspose.diagram/pagesheet/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PageSheet
+```
+
+ページまたはマスター要素のページシートを定義する要素を含みます。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [copy(PageSheet source)](#copy-com.aspose.diagram.PageSheet-) | ソースオブジェクトから pagesheet をコピーします。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getActs()](#getActs--) | Act 要素のコレクションを含みます。 |
+| [getAnnotations()](#getAnnotations--) | ドキュメントページに挿入されたコメントに関する情報を含む要素が含まれています。 |
+| [getClass()](#getClass--) |  |
+| [getConnectionABCDs()](#getConnectionABCDs--) | ConnectionABCD 要素のコレクションを含みます。 |
+| [getConnections()](#getConnections--) | Connection 要素のコレクションを含みます。 |
+| [getFillStyle()](#getFillStyle--) | PageSheet が塗りつぶし書式を継承する StyleSheet 要素。 |
+| [getForeign()](#getForeign--) | Microsoft Visio ドキュメントで使用される別のプログラムからのオブジェクトの幅と高さを指定する要素を含みます。 |
+| [getForeignData()](#getForeignData--) | Windows メタファイル、ビットマップ、または OLE データなどの画像データの MIME (Multipurpose Internet Mail Extensions) エンコード BLOB を含みます。 |
+| [getHyperlinks()](#getHyperlinks--) | Hyperlink 要素のコレクションを含みます。 |
+| [getLayers()](#getLayers--) | Layer 要素のコレクションを含みます。 |
+| [getLineStyle()](#getLineStyle--) | PageSheet が線書式を継承する StyleSheet 要素。 |
+| [getPageLayout()](#getPageLayout--) | ページ上のすべての図形やコネクタの間隔、ページ上のすべてのコネクタの間隔、コネクタのルーティングスタイルなど、図形とコネクタのページレイアウト設定を制御する Diagram を含みます。 |
+| [getPageProps()](#getPageProps--) | ページ幅、ページ高さ、スケールなどのページ属性を制御する Diagram を含みます。 |
+| [getPrintProps()](#getPrintProps--) | 描画ページがプリンタページ上でどのようにフォーマット（表示）されるかを制御する要素を含みます。 |
+| [getProps()](#getProps--) | Prop 要素のコレクションを含みます。 |
+| [getRulerGrid()](#getRulerGrid--) | ページの定規とグリッドの設定を指定する要素を含みます。 |
+| [getScratchs()](#getScratchs--) | Scratch 要素のコレクションを含みます。 |
+| [getSmartTagDefs()](#getSmartTagDefs--) | SmartTagDef 要素のコレクションを含みます。 |
+| [getTextStyle()](#getTextStyle--) | PageSheet がテキスト書式を継承する StyleSheet 要素。 |
+| [getUniqueID()](#getUniqueID--) | 要素の GUID（グローバル一意識別子）。 |
+| [getUsers()](#getUsers--) | User 要素のコレクションを含みます。 |
+| [getXForm()](#getXForm--) | シェイプに関する一般的な位置情報を指定する要素を含みます。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setFillStyle(StyleSheet value)](#setFillStyle-com.aspose.diagram.StyleSheet-) | このプロパティの説明については、[getFillStyle()](../../com.aspose.diagram/pagesheet\#getFillStyle--) を参照してください。 |
+| [setLineStyle(StyleSheet value)](#setLineStyle-com.aspose.diagram.StyleSheet-) | このプロパティの説明については、[getLineStyle()](../../com.aspose.diagram/pagesheet\#getLineStyle--) を参照してください。 |
+| [setTextStyle(StyleSheet value)](#setTextStyle-com.aspose.diagram.StyleSheet-) | For the description of this property, please see [getTextStyle()](../../com.aspose.diagram/pagesheet\#getTextStyle--) |
+| [setUniqueID(UUID value)](#setUniqueID-java.util.UUID-) | For the description of this property, please see [getUniqueID()](../../com.aspose.diagram/pagesheet\#getUniqueID--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### copy(PageSheet source) {#copy-com.aspose.diagram.PageSheet-}
+```
+public void copy(PageSheet source)
+```
+
+
+ソースオブジェクトから pagesheet をコピーします。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| source | [PageSheet](../../com.aspose.diagram/pagesheet) | source pagesheet. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getActs() {#getActs--}
+```
+public ActCollection getActs()
+```
+
+
+Act 要素のコレクションを含みます。
+
+**Returns:**
+[ActCollection](../../com.aspose.diagram/actcollection)
+### getAnnotations() {#getAnnotations--}
+```
+public AnnotationCollection getAnnotations()
+```
+
+
+ドキュメントページに挿入されたコメントに関する情報を含む要素が含まれています。
+
+**Returns:**
+[AnnotationCollection](../../com.aspose.diagram/annotationcollection)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConnectionABCDs() {#getConnectionABCDs--}
+```
+public ConnectionABCDCollection getConnectionABCDs()
+```
+
+
+ConnectionABCD 要素のコレクションを含みます。
+
+**Returns:**
+[ConnectionABCDCollection](../../com.aspose.diagram/connectionabcdcollection)
+### getConnections() {#getConnections--}
+```
+public ConnectionCollection getConnections()
+```
+
+
+Connection 要素のコレクションを含みます。
+
+**Returns:**
+[ConnectionCollection](../../com.aspose.diagram/connectioncollection)
+### getFillStyle() {#getFillStyle--}
+```
+public StyleSheet getFillStyle()
+```
+
+
+PageSheet が塗りつぶし書式を継承する StyleSheet 要素。
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getForeign() {#getForeign--}
+```
+public Foreign getForeign()
+```
+
+
+Microsoft Visio ドキュメントで使用される他のプログラムからのオブジェクトの幅と高さを指定する要素を含みます。また、オブジェクトの画像が境界内でオフセットされる距離を指定する要素も含みます。
+
+**Returns:**
+[Foreign](../../com.aspose.diagram/foreign)
+### getForeignData() {#getForeignData--}
+```
+public ForeignData getForeignData()
+```
+
+
+Windows メタファイル、ビットマップ、または OLE データなどの画像データの MIME (Multipurpose Internet Mail Extensions) エンコード BLOB を含みます。
+
+**Returns:**
+[ForeignData](../../com.aspose.diagram/foreigndata)
+### getHyperlinks() {#getHyperlinks--}
+```
+public HyperlinkCollection getHyperlinks()
+```
+
+
+Hyperlink 要素のコレクションを含みます。
+
+**Returns:**
+[HyperlinkCollection](../../com.aspose.diagram/hyperlinkcollection)
+### getLayers() {#getLayers--}
+```
+public LayerCollection getLayers()
+```
+
+
+Layer 要素のコレクションを含みます。
+
+**Returns:**
+[LayerCollection](../../com.aspose.diagram/layercollection)
+### getLineStyle() {#getLineStyle--}
+```
+public StyleSheet getLineStyle()
+```
+
+
+PageSheet が線書式を継承する StyleSheet 要素。
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getPageLayout() {#getPageLayout--}
+```
+public PageLayout getPageLayout()
+```
+
+
+ページ上のすべての図形やコネクタの間隔、ページ上のすべてのコネクタの間隔、コネクタのルーティングスタイルなど、図形とコネクタのページレイアウト設定を制御する Diagram を含みます。
+
+**Returns:**
+[PageLayout](../../com.aspose.diagram/pagelayout)
+### getPageProps() {#getPageProps--}
+```
+public PageProps getPageProps()
+```
+
+
+ページ幅、ページ高さ、スケールなどのページ属性を制御する Diagram を含みます。
+
+**Returns:**
+[PageProps](../../com.aspose.diagram/pageprops)
+### getPrintProps() {#getPrintProps--}
+```
+public PrintProps getPrintProps()
+```
+
+
+描画ページがプリンタページ上でどのようにフォーマット（表示）されるかを制御する要素を含みます。
+
+**Returns:**
+[PrintProps](../../com.aspose.diagram/printprops)
+### getProps() {#getProps--}
+```
+public PropCollection getProps()
+```
+
+
+Prop 要素のコレクションを含みます。
+
+**Returns:**
+[PropCollection](../../com.aspose.diagram/propcollection)
+### getRulerGrid() {#getRulerGrid--}
+```
+public RulerGrid getRulerGrid()
+```
+
+
+ページの定規とグリッドの設定を指定する要素を含みます。
+
+**Returns:**
+[RulerGrid](../../com.aspose.diagram/rulergrid)
+### getScratchs() {#getScratchs--}
+```
+public ScratchCollection getScratchs()
+```
+
+
+Scratch 要素のコレクションを含みます。
+
+**Returns:**
+[ScratchCollection](../../com.aspose.diagram/scratchcollection)
+### getSmartTagDefs() {#getSmartTagDefs--}
+```
+public SmartTagDefCollection getSmartTagDefs()
+```
+
+
+SmartTagDef 要素のコレクションを含みます。
+
+**Returns:**
+[SmartTagDefCollection](../../com.aspose.diagram/smarttagdefcollection)
+### getTextStyle() {#getTextStyle--}
+```
+public StyleSheet getTextStyle()
+```
+
+
+PageSheet がテキスト書式を継承する StyleSheet 要素。
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getUniqueID() {#getUniqueID--}
+```
+public UUID getUniqueID()
+```
+
+
+要素の GUID（グローバル一意識別子）。
+
+**Returns:**
+java.util.UUID
+### getUsers() {#getUsers--}
+```
+public UserCollection getUsers()
+```
+
+
+User 要素のコレクションを含みます。
+
+**Returns:**
+[UserCollection](../../com.aspose.diagram/usercollection)
+### getXForm() {#getXForm--}
+```
+public XForm getXForm()
+```
+
+
+シェイプに関する一般的な位置情報を指定する要素を含みます。
+
+**Returns:**
+[XForm](../../com.aspose.diagram/xform)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setFillStyle(StyleSheet value) {#setFillStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setFillStyle(StyleSheet value)
+```
+
+
+このプロパティの説明については、[getFillStyle()](../../com.aspose.diagram/pagesheet\#getFillStyle--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setLineStyle(StyleSheet value) {#setLineStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setLineStyle(StyleSheet value)
+```
+
+
+このプロパティの説明については、[getLineStyle()](../../com.aspose.diagram/pagesheet\#getLineStyle--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setTextStyle(StyleSheet value) {#setTextStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setTextStyle(StyleSheet value)
+```
+
+
+For the description of this property, please see [getTextStyle()](../../com.aspose.diagram/pagesheet\#getTextStyle--)
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setUniqueID(UUID value) {#setUniqueID-java.util.UUID-}
+```
+public void setUniqueID(UUID value)
+```
+
+
+For the description of this property, please see [getUniqueID()](../../com.aspose.diagram/pagesheet\#getUniqueID--)
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.util.UUID |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/pagesize/_index.md
+++ b/japanese/java/com.aspose.diagram/pagesize/_index.md
@@ -1,0 +1,233 @@
+---
+title: PageSize
+second_title: Aspose.Diagram for Java API リファレンス
+description: 生成された画像のページサイズに関する情報を含みます。
+type: docs
+weight: 271
+url: /ja/java/com.aspose.diagram/pagesize/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PageSize
+```
+
+生成された画像のページサイズに関する情報を含みます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageSize(int paperSizeFormat)](#PageSize-int-) | 生成された画像のページサイズを設定するために使用できる、このクラスの新しいインスタンスを初期化します。 |
+| [PageSize(float width, float height)](#PageSize-float-float-) | 生成された画像のページサイズを設定するために使用できる、このクラスの新しいインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getHeight()](#getHeight--) | 生成された画像のページ高さ（ポイント単位）。 |
+| [getPaperSizeFormat()](#getPaperSizeFormat--) | 生成された画像の用紙サイズ形式です。 |
+| [getWidth()](#getWidth--) | 生成された画像のページ幅（ポイント単位）。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setHeight(float value)](#setHeight-float-) | このプロパティの説明については、[getHeight()](../../com.aspose.diagram/pagesize\#getHeight--)をご覧ください。 |
+| [setPaperSizeFormat(int value)](#setPaperSizeFormat-int-) | このプロパティの説明については、[getPaperSizeFormat()](../../com.aspose.diagram/pagesize\#getPaperSizeFormat--)をご覧ください。 |
+| [setWidth(float value)](#setWidth-float-) | このプロパティの説明については、[getWidth()](../../com.aspose.diagram/pagesize\#getWidth--)をご覧ください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageSize(int paperSizeFormat) {#PageSize-int-}
+```
+public PageSize(int paperSizeFormat)
+```
+
+
+生成された画像のページサイズを設定するために使用できる、このクラスの新しいインスタンスを初期化します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| paperSizeFormat | int | Aspose.Diagram.Saving.PaperSizeFormat にすることができます。 |
+
+### PageSize(float width, float height) {#PageSize-float-float-}
+```
+public PageSize(float width, float height)
+```
+
+
+生成された画像のページサイズを設定するために使用できる、このクラスの新しいインスタンスを初期化します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| width | float | 生成された画像のページ幅（ポイント単位）。 |
+| height | float | 生成された画像のページ高さ（ポイント単位）。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getHeight() {#getHeight--}
+```
+public float getHeight()
+```
+
+
+生成された画像のページ高さ（ポイント単位）。値は 0 より大きくなければなりません。Height が設定されている場合、Width も設定する必要があります。
+
+**Returns:**
+float
+### getPaperSizeFormat() {#getPaperSizeFormat--}
+```
+public int getPaperSizeFormat()
+```
+
+
+生成された画像の用紙サイズ形式。Aspose.Diagram.Saving.PaperSizeFormat になる可能性があります。
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public float getWidth()
+```
+
+
+生成された画像のページ幅（ポイント単位）。値は 0 より大きくなければなりません。Width が設定されている場合、Height も設定する必要があります。
+
+**Returns:**
+float
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setHeight(float value) {#setHeight-float-}
+```
+public void setHeight(float value)
+```
+
+
+このプロパティの説明については、[getHeight()](../../com.aspose.diagram/pagesize\#getHeight--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | float |  |
+
+### setPaperSizeFormat(int value) {#setPaperSizeFormat-int-}
+```
+public void setPaperSizeFormat(int value)
+```
+
+
+このプロパティの説明については、[getPaperSizeFormat()](../../com.aspose.diagram/pagesize\#getPaperSizeFormat--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setWidth(float value) {#setWidth-float-}
+```
+public void setWidth(float value)
+```
+
+
+このプロパティの説明については、[getWidth()](../../com.aspose.diagram/pagesize\#getWidth--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | float |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/pagestartsavingargs/_index.md
+++ b/japanese/java/com.aspose.diagram/pagestartsavingargs/_index.md
@@ -1,0 +1,172 @@
+---
+title: PageStartSavingArgs
+second_title: Aspose.Diagram for Java API リファレンス
+description: ページの保存プロセス開始に関する情報です。
+type: docs
+weight: 272
+url: /ja/java/com.aspose.diagram/pagestartsavingargs/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.PageSavingArgs](../../com.aspose.diagram/pagesavingargs)
+```
+public class PageStartSavingArgs extends PageSavingArgs
+```
+
+ページの保存プロセス開始に関する情報です。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getPageCount()](#getPageCount--) | 総ページ数。 |
+| [getPageIndex()](#getPageIndex--) | 現在のページインデックス（0ベース）。 |
+| [hashCode()](#hashCode--) |  |
+| [isToOutput()](#isToOutput--) | ページを出力すべきかどうかを示す値。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setToOutput(boolean value)](#setToOutput-boolean-) | このプロパティの説明については、[isToOutput()](../../com.aspose.diagram/pagestartsavingargs\\#isToOutput--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+総ページ数。
+
+**Returns:**
+int
+### getPageIndex() {#getPageIndex--}
+```
+public int getPageIndex()
+```
+
+
+現在のページインデックス（0ベース）。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isToOutput() {#isToOutput--}
+```
+public boolean isToOutput()
+```
+
+
+ページを出力すべきかどうかを示す値。デフォルト値は true です。
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setToOutput(boolean value) {#setToOutput-boolean-}
+```
+public void setToOutput(boolean value)
+```
+
+
+このプロパティの説明については、[isToOutput()](../../com.aspose.diagram/pagestartsavingargs\\#isToOutput--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/papersizeformat/_index.md
+++ b/japanese/java/com.aspose.diagram/papersizeformat/_index.md
@@ -1,0 +1,435 @@
+---
+title: PaperSizeFormat
+second_title: Aspose.Diagram for Java API リファレンス
+description: 用紙サイズ形式の選択を保存する列挙型です。
+type: docs
+weight: 273
+url: /ja/java/com.aspose.diagram/papersizeformat/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PaperSizeFormat
+```
+
+用紙サイズ形式の選択を保存する列挙型です。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [A_0](#A-0) | A0 paper size format(841mm x 1189mm). |
+| [A_1](#A-1) | A1 paper size format(594mm x 841mm). |
+| [A_2](#A-2) | A2 paper size format(420mm x 594mm). |
+| [A_3](#A-3) | A3 paper size format(297mm x 420mm). |
+| [A_4](#A-4) | A4 paper size format(210mm x 297mm). |
+| [A_5](#A-5) | A5 paper size format(148mm x 210mm). |
+| [A_6](#A-6) | A6 paper size format(105mm x 148mm). |
+| [A_7](#A-7) | A7 paper size format(74mm x 105mm). |
+| [B_0](#B-0) | B0 paper size format(1000mm x 1414mm). |
+| [B_1](#B-1) | B1 paper size format(707mm x 1000mm). |
+| [B_2](#B-2) | B2 paper size format(500mm x 707mm). |
+| [B_3](#B-3) | B3 用紙サイズ形式(353mm x 500mm). |
+| [B_4](#B-4) | B4 用紙サイズ形式(250mm x 353mm). |
+| [B_5](#B-5) | B5 用紙サイズ形式(176mm x 250mm). |
+| [B_6](#B-6) | B6 用紙サイズ形式(125mm x 176mm). |
+| [B_7](#B-7) | B7 用紙サイズ形式(88mm x 125mm). |
+| [COM_10](#COM-10) | COM10 用紙サイズ形式(104.78mm x 241.3mm). |
+| [COM_9](#COM-9) | COM9 用紙サイズ形式(98.4mm x 225.4mInterpolationMode:Invalidm). |
+| [CUSTOM](#CUSTOM) | カスタム用紙サイズ形式. |
+| [C_0](#C-0) | C0 用紙サイズ形式(917mm x 1297mm). |
+| [C_1](#C-1) | C1 用紙サイズ形式(648mm x 917mm). |
+| [C_2](#C-2) | C2 用紙サイズ形式(458mm x 648mm). |
+| [C_3](#C-3) | C3 用紙サイズ形式(324mm x 458mm). |
+| [C_4](#C-4) | C4 用紙サイズ形式(229mm x 324mm). |
+| [C_5](#C-5) | C5 用紙サイズ形式(162mm x 229mm). |
+| [C_6](#C-6) | C6 用紙サイズ形式(114mm x 162mm). |
+| [C_7](#C-7) | C7 用紙サイズ形式(81mm x 114mm). |
+| [DL](#DL) | DL 用紙サイズ形式(110mm x 220mm). |
+| [EXECUTIVE](#EXECUTIVE) | Executive 用紙サイズ形式(184.15mm x 266.7mm). |
+| [LEGAL](#LEGAL) | Legal 用紙サイズ形式(215.9mm x 355.6mm). |
+| [LEGAL_13](#LEGAL-13) | Legal13 用紙サイズ形式(215.9mm x 330.2mm). |
+| [LETTER](#LETTER) | Letter 用紙サイズ形式(215.9mm x 279.7mm). |
+| [MONARCH](#MONARCH) | Monarch 用紙サイズ形式(98.4mm x 190.5mm). |
+| [TABLOID](#TABLOID) | Tabloid 用紙サイズ形式(279.4mm x 431.8mm). |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### A_0 {#A-0}
+```
+public static final int A_0
+```
+
+
+A0 paper size format(841mm x 1189mm).
+
+### A_1 {#A-1}
+```
+public static final int A_1
+```
+
+
+A1 paper size format(594mm x 841mm).
+
+### A_2 {#A-2}
+```
+public static final int A_2
+```
+
+
+A2 paper size format(420mm x 594mm).
+
+### A_3 {#A-3}
+```
+public static final int A_3
+```
+
+
+A3 paper size format(297mm x 420mm).
+
+### A_4 {#A-4}
+```
+public static final int A_4
+```
+
+
+A4 paper size format(210mm x 297mm).
+
+### A_5 {#A-5}
+```
+public static final int A_5
+```
+
+
+A5 paper size format(148mm x 210mm).
+
+### A_6 {#A-6}
+```
+public static final int A_6
+```
+
+
+A6 paper size format(105mm x 148mm).
+
+### A_7 {#A-7}
+```
+public static final int A_7
+```
+
+
+A7 paper size format(74mm x 105mm).
+
+### B_0 {#B-0}
+```
+public static final int B_0
+```
+
+
+B0 paper size format(1000mm x 1414mm).
+
+### B_1 {#B-1}
+```
+public static final int B_1
+```
+
+
+B1 paper size format(707mm x 1000mm).
+
+### B_2 {#B-2}
+```
+public static final int B_2
+```
+
+
+B2 paper size format(500mm x 707mm).
+
+### B_3 {#B-3}
+```
+public static final int B_3
+```
+
+
+B3 用紙サイズ形式(353mm x 500mm).
+
+### B_4 {#B-4}
+```
+public static final int B_4
+```
+
+
+B4 用紙サイズ形式(250mm x 353mm).
+
+### B_5 {#B-5}
+```
+public static final int B_5
+```
+
+
+B5 用紙サイズ形式(176mm x 250mm).
+
+### B_6 {#B-6}
+```
+public static final int B_6
+```
+
+
+B6 用紙サイズ形式(125mm x 176mm).
+
+### B_7 {#B-7}
+```
+public static final int B_7
+```
+
+
+B7 用紙サイズ形式(88mm x 125mm).
+
+### COM_10 {#COM-10}
+```
+public static final int COM_10
+```
+
+
+COM10 用紙サイズ形式(104.78mm x 241.3mm).
+
+### COM_9 {#COM-9}
+```
+public static final int COM_9
+```
+
+
+COM9 用紙サイズ形式(98.4mm x 225.4mInterpolationMode:Invalidm).
+
+### CUSTOM {#CUSTOM}
+```
+public static final int CUSTOM
+```
+
+
+カスタム用紙サイズ形式.
+
+### C_0 {#C-0}
+```
+public static final int C_0
+```
+
+
+C0 用紙サイズ形式(917mm x 1297mm).
+
+### C_1 {#C-1}
+```
+public static final int C_1
+```
+
+
+C1 用紙サイズ形式(648mm x 917mm).
+
+### C_2 {#C-2}
+```
+public static final int C_2
+```
+
+
+C2 用紙サイズ形式(458mm x 648mm).
+
+### C_3 {#C-3}
+```
+public static final int C_3
+```
+
+
+C3 用紙サイズ形式(324mm x 458mm).
+
+### C_4 {#C-4}
+```
+public static final int C_4
+```
+
+
+C4 用紙サイズ形式(229mm x 324mm).
+
+### C_5 {#C-5}
+```
+public static final int C_5
+```
+
+
+C5 用紙サイズ形式(162mm x 229mm).
+
+### C_6 {#C-6}
+```
+public static final int C_6
+```
+
+
+C6 用紙サイズ形式(114mm x 162mm).
+
+### C_7 {#C-7}
+```
+public static final int C_7
+```
+
+
+C7 用紙サイズ形式(81mm x 114mm).
+
+### DL {#DL}
+```
+public static final int DL
+```
+
+
+DL 用紙サイズ形式(110mm x 220mm).
+
+### EXECUTIVE {#EXECUTIVE}
+```
+public static final int EXECUTIVE
+```
+
+
+Executive 用紙サイズ形式(184.15mm x 266.7mm).
+
+### LEGAL {#LEGAL}
+```
+public static final int LEGAL
+```
+
+
+Legal 用紙サイズ形式(215.9mm x 355.6mm).
+
+### LEGAL_13 {#LEGAL-13}
+```
+public static final int LEGAL_13
+```
+
+
+Legal13 用紙サイズ形式(215.9mm x 330.2mm).
+
+### LETTER {#LETTER}
+```
+public static final int LETTER
+```
+
+
+Letter 用紙サイズ形式(215.9mm x 279.7mm).
+
+### MONARCH {#MONARCH}
+```
+public static final int MONARCH
+```
+
+
+Monarch 用紙サイズ形式(98.4mm x 190.5mm).
+
+### TABLOID {#TABLOID}
+```
+public static final int TABLOID
+```
+
+
+Tabloid 用紙サイズ形式(279.4mm x 431.8mm).
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/para/_index.md
+++ b/japanese/java/com.aspose.diagram/para/_index.md
@@ -1,0 +1,549 @@
+---
+title: Para
+second_title: Aspose.Diagram for Java API リファレンス
+description: インデント、行間、箇条書き、段落の横方向揃えなど、シェイプのテキストに対する段落書式要素を含みます。
+type: docs
+weight: 274
+url: /ja/java/com.aspose.diagram/para/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Para
+```
+
+図形のテキストに対する段落書式設定要素を含みます。インデント、行間、箇条書き、段落の水平揃えなどです。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Para()](#Para--) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBullet()](#getBullet--) | 箇条書きのスタイルを決定します。 |
+| [getBulletFont()](#getBulletFont--) | カスタム箇条書き文字列が指定され、Bullet 要素の値が非ゼロの場合に、テキストの書式設定に使用されるフォント番号を表します。 |
+| [getBulletFontSize()](#getBulletFontSize--) | 箇条書きのサイズを指定します。 |
+| [getBulletStr()](#getBulletStr--) | \"カスタム箇条書きスタイルを作成するために使用されます。 |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getFlags()](#getFlags--) | テキストの方向が左から右か右から左かを示します。 |
+| [getHorzAlign()](#getHorzAlign--) | シェイプのテキストブロック内のテキストの水平揃えを指定します。 |
+| [getIX()](#getIX--) | 親要素内の要素のゼロベースインデックスです。 |
+| [getIndFirst()](#getIndFirst--) | シェイプのテキストブロック内の各段落の最初の行が、段落の左インデントからどれだけインデントされるかを指定します。 |
+| [getIndLeft()](#getIndLeft--) | 段落内のすべてのテキスト行が、テキストブロックの左余白からどれだけインデントされるかを指定します。 |
+| [getIndRight()](#getIndRight--) | 段落内のすべてのテキスト行がテキストブロックの右余白からインデントされる距離を指定します。 |
+| [getLocalizeBulletFont()](#getLocalizeBulletFont--) | 箇条書きフォントをローカライズ（別の言語に翻訳）するかどうかを指定します。 |
+| [getSpAfter()](#getSpAfter--) | シェイプのテキストブロック内で各段落の後に挿入されるスペース量を指定します。 |
+| [getSpBefore()](#getSpBefore--) | シェイプのテキストブロック内で各段落の前に挿入されるスペース量を指定します。 |
+| [getSpLine()](#getSpLine--) | テキスト行と次の行との間の距離を指定します。100% はテキスト行の高さです。 |
+| [getTextPosAfterBullet()](#getTextPosAfterBullet--) | 段落の最初の行と箇条書きとの間の距離を表します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setBullet(Bullet value)](#setBullet-com.aspose.diagram.Bullet-) | このプロパティの説明については、[getBullet()](../../com.aspose.diagram/para\#getBullet--) を参照してください。 |
+| [setBulletFont(IntValue value)](#setBulletFont-com.aspose.diagram.IntValue-) | このプロパティの説明については、[getBulletFont()](../../com.aspose.diagram/para\#getBulletFont--) を参照してください。 |
+| [setBulletFontSize(DoubleValue value)](#setBulletFontSize-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getBulletFontSize()](../../com.aspose.diagram/para\#getBulletFontSize--) を参照してください。 |
+| [setBulletStr(Str2Value value)](#setBulletStr-com.aspose.diagram.Str2Value-) | このプロパティの説明については、[getBulletStr()](../../com.aspose.diagram/para\#getBulletStr--) を参照してください。 |
+| [setDel(int value)](#setDel-int-) | このプロパティの説明については、[getDel()](../../com.aspose.diagram/para\#getDel--) を参照してください。 |
+| [setFlags(BoolValue value)](#setFlags-com.aspose.diagram.BoolValue-) | このプロパティの説明については、[getFlags()](../../com.aspose.diagram/para\#getFlags--) を参照してください。 |
+| [setHorzAlign(HorzAlign value)](#setHorzAlign-com.aspose.diagram.HorzAlign-) | このプロパティの説明については、[getHorzAlign()](../../com.aspose.diagram/para\#getHorzAlign--) を参照してください。 |
+| [setIX(int value)](#setIX-int-) | このプロパティの説明については、[getIX()](../../com.aspose.diagram/para\#getIX--) を参照してください。 |
+| [setIndFirst(DoubleValue value)](#setIndFirst-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getIndFirst()](../../com.aspose.diagram/para\#getIndFirst--) を参照してください。 |
+| [setIndLeft(DoubleValue value)](#setIndLeft-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getIndLeft()](../../com.aspose.diagram/para\#getIndLeft--) を参照してください。 |
+| [setIndRight(DoubleValue value)](#setIndRight-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getIndRight()](../../com.aspose.diagram/para\#getIndRight--) を参照してください。 |
+| [setLocalizeBulletFont(LocalizeFont value)](#setLocalizeBulletFont-com.aspose.diagram.LocalizeFont-) | このプロパティの説明については、[getLocalizeBulletFont()](../../com.aspose.diagram/para\#getLocalizeBulletFont--) を参照してください。 |
+| [setSpAfter(DoubleValue value)](#setSpAfter-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getSpAfter()](../../com.aspose.diagram/para\#getSpAfter--) を参照してください。 |
+| [setSpBefore(DoubleValue value)](#setSpBefore-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getSpBefore()](../../com.aspose.diagram/para\#getSpBefore--) を参照してください。 |
+| [setSpLine(DoubleValue value)](#setSpLine-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getSpLine()](../../com.aspose.diagram/para\#getSpLine--) を参照してください。 |
+| [setTextPosAfterBullet(DoubleValue value)](#setTextPosAfterBullet-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getTextPosAfterBullet()](../../com.aspose.diagram/para\#getTextPosAfterBullet--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Para() {#Para--}
+```
+public Para()
+```
+
+
+コンストラクタ。
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBullet() {#getBullet--}
+```
+public Bullet getBullet()
+```
+
+
+箇条書きのスタイルを決定します。
+
+**Returns:**
+[Bullet](../../com.aspose.diagram/bullet)
+### getBulletFont() {#getBulletFont--}
+```
+public IntValue getBulletFont()
+```
+
+
+カスタム箇条書き文字列が指定され、Bullet 要素の値が非ゼロの場合に、テキストの書式設定に使用されるフォント番号を表します。
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getBulletFontSize() {#getBulletFontSize--}
+```
+public DoubleValue getBulletFontSize()
+```
+
+
+箇条書きのサイズを指定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBulletStr() {#getBulletStr--}
+```
+public Str2Value getBulletStr()
+```
+
+
+カスタム箇条書きスタイルを作成するために使用します。スタイルは文字列として入力します（引用符で囲んで）。例として、文字列、 ""ooo."" を入力できます。
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getFlags() {#getFlags--}
+```
+public BoolValue getFlags()
+```
+
+
+テキストの方向が左から右か右から左かを示します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getHorzAlign() {#getHorzAlign--}
+```
+public HorzAlign getHorzAlign()
+```
+
+
+シェイプのテキストブロック内のテキストの水平揃えを指定します。
+
+**Returns:**
+[HorzAlign](../../com.aspose.diagram/horzalign)
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+親要素内の要素のゼロベースインデックスです。
+
+**Returns:**
+int
+### getIndFirst() {#getIndFirst--}
+```
+public DoubleValue getIndFirst()
+```
+
+
+シェイプのテキストブロック内の各段落の最初の行が段落の左インデントからインデントされる距離を指定します。この値は図のスケールに依存しません。図が拡大縮小されても、最初の行のインデントは変わりません。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getIndLeft() {#getIndLeft--}
+```
+public DoubleValue getIndLeft()
+```
+
+
+段落内のすべてのテキスト行がテキストブロックの左余白からインデントされる距離を指定します。この値は図のスケールに依存しません。図が拡大縮小されても、左インデントは変わりません。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getIndRight() {#getIndRight--}
+```
+public DoubleValue getIndRight()
+```
+
+
+段落内のすべてのテキスト行がテキストブロックの右余白からインデントされる距離を指定します。この値は図のスケールに依存しません。図がスケールされても、右インデントは同じままです。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLocalizeBulletFont() {#getLocalizeBulletFont--}
+```
+public LocalizeFont getLocalizeBulletFont()
+```
+
+
+箇条書きフォントをローカライズ（別の言語に翻訳）するかどうかを指定します。
+
+**Returns:**
+[LocalizeFont](../../com.aspose.diagram/localizefont)
+### getSpAfter() {#getSpAfter--}
+```
+public DoubleValue getSpAfter()
+```
+
+
+シェイプのテキストブロック内で各段落の後に挿入されるスペース量を指定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getSpBefore() {#getSpBefore--}
+```
+public DoubleValue getSpBefore()
+```
+
+
+シェイプのテキストブロック内で各段落の前に挿入されるスペース量を指定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getSpLine() {#getSpLine--}
+```
+public DoubleValue getSpLine()
+```
+
+
+テキスト行と次の行との間の距離を指定します。100% はテキスト行の高さです。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTextPosAfterBullet() {#getTextPosAfterBullet--}
+```
+public DoubleValue getTextPosAfterBullet()
+```
+
+
+段落の最初の行と箇条書きとの間の距離を表します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setBullet(Bullet value) {#setBullet-com.aspose.diagram.Bullet-}
+```
+public void setBullet(Bullet value)
+```
+
+
+このプロパティの説明については、[getBullet()](../../com.aspose.diagram/para\#getBullet--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [Bullet](../../com.aspose.diagram/bullet) |  |
+
+### setBulletFont(IntValue value) {#setBulletFont-com.aspose.diagram.IntValue-}
+```
+public void setBulletFont(IntValue value)
+```
+
+
+このプロパティの説明については、[getBulletFont()](../../com.aspose.diagram/para\#getBulletFont--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setBulletFontSize(DoubleValue value) {#setBulletFontSize-com.aspose.diagram.DoubleValue-}
+```
+public void setBulletFontSize(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getBulletFontSize()](../../com.aspose.diagram/para\#getBulletFontSize--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setBulletStr(Str2Value value) {#setBulletStr-com.aspose.diagram.Str2Value-}
+```
+public void setBulletStr(Str2Value value)
+```
+
+
+このプロパティの説明については、[getBulletStr()](../../com.aspose.diagram/para\#getBulletStr--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [Str2Value](../../com.aspose.diagram/str2value) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+このプロパティの説明については、[getDel()](../../com.aspose.diagram/para\#getDel--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setFlags(BoolValue value) {#setFlags-com.aspose.diagram.BoolValue-}
+```
+public void setFlags(BoolValue value)
+```
+
+
+このプロパティの説明については、[getFlags()](../../com.aspose.diagram/para\#getFlags--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setHorzAlign(HorzAlign value) {#setHorzAlign-com.aspose.diagram.HorzAlign-}
+```
+public void setHorzAlign(HorzAlign value)
+```
+
+
+このプロパティの説明については、[getHorzAlign()](../../com.aspose.diagram/para\#getHorzAlign--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [HorzAlign](../../com.aspose.diagram/horzalign) |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+このプロパティの説明については、[getIX()](../../com.aspose.diagram/para\#getIX--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setIndFirst(DoubleValue value) {#setIndFirst-com.aspose.diagram.DoubleValue-}
+```
+public void setIndFirst(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getIndFirst()](../../com.aspose.diagram/para\#getIndFirst--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setIndLeft(DoubleValue value) {#setIndLeft-com.aspose.diagram.DoubleValue-}
+```
+public void setIndLeft(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getIndLeft()](../../com.aspose.diagram/para\#getIndLeft--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setIndRight(DoubleValue value) {#setIndRight-com.aspose.diagram.DoubleValue-}
+```
+public void setIndRight(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getIndRight()](../../com.aspose.diagram/para\#getIndRight--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setLocalizeBulletFont(LocalizeFont value) {#setLocalizeBulletFont-com.aspose.diagram.LocalizeFont-}
+```
+public void setLocalizeBulletFont(LocalizeFont value)
+```
+
+
+このプロパティの説明については、[getLocalizeBulletFont()](../../com.aspose.diagram/para\#getLocalizeBulletFont--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [LocalizeFont](../../com.aspose.diagram/localizefont) |  |
+
+### setSpAfter(DoubleValue value) {#setSpAfter-com.aspose.diagram.DoubleValue-}
+```
+public void setSpAfter(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getSpAfter()](../../com.aspose.diagram/para\#getSpAfter--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setSpBefore(DoubleValue value) {#setSpBefore-com.aspose.diagram.DoubleValue-}
+```
+public void setSpBefore(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getSpBefore()](../../com.aspose.diagram/para\#getSpBefore--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setSpLine(DoubleValue value) {#setSpLine-com.aspose.diagram.DoubleValue-}
+```
+public void setSpLine(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getSpLine()](../../com.aspose.diagram/para\#getSpLine--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTextPosAfterBullet(DoubleValue value) {#setTextPosAfterBullet-com.aspose.diagram.DoubleValue-}
+```
+public void setTextPosAfterBullet(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getTextPosAfterBullet()](../../com.aspose.diagram/para\#getTextPosAfterBullet--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/paracollection/_index.md
+++ b/japanese/java/com.aspose.diagram/paracollection/_index.md
@@ -1,0 +1,234 @@
+---
+title: ParaCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: 段落コレクション。
+type: docs
+weight: 275
+url: /ja/java/com.aspose.diagram/paracollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ParaCollection extends Collection
+```
+
+段落コレクション。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(Para item)](#add-com.aspose.diagram.Para-) | コレクションに Para オブジェクトを追加します。 |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [getPara(int IX)](#getPara-int-) | 指定されたインデックス IX の要素を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Para item)](#remove-com.aspose.diagram.Para-) | コレクションから Para オブジェクトを削除します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Para item) {#add-com.aspose.diagram.Para-}
+```
+public int add(Para item)
+```
+
+
+コレクションに Para オブジェクトを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [Para](../../com.aspose.diagram/para) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Para get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[Para](../../com.aspose.diagram/para) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### getPara(int IX) {#getPara-int-}
+```
+public Para getPara(int IX)
+```
+
+
+指定されたインデックス IX の要素を取得します。要素が存在しない場合は Null を返します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| IX | int |  |
+
+**Returns:**
+[Para](../../com.aspose.diagram/para) - 
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Para item) {#remove-com.aspose.diagram.Para-}
+```
+public void remove(Para item)
+```
+
+
+コレクションから Para オブジェクトを削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [Para](../../com.aspose.diagram/para) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/pdfcompliance/_index.md
+++ b/japanese/java/com.aspose.diagram/pdfcompliance/_index.md
@@ -1,0 +1,156 @@
+---
+title: PdfCompliance
+second_title: Aspose.Diagram for Java API リファレンス
+description: 出力ファイルの PDF 準拠レベルを指定します。
+type: docs
+weight: 276
+url: /ja/java/com.aspose.diagram/pdfcompliance/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PdfCompliance
+```
+
+出力ファイルの PDF 準拠レベルを指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [PDF_15](#PDF-15) | 出力ファイルは PDF 1.5 に準拠します。 |
+| [PDF_A_1_A](#PDF-A-1-A) | 出力ファイルは PDF/A-1a に準拠します。 |
+| [PDF_A_1_B](#PDF-A-1-B) | 出力ファイルは PDF/A-1b に準拠します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PDF_15 {#PDF-15}
+```
+public static final int PDF_15
+```
+
+
+出力ファイルは PDF 1.5 に準拠します。
+
+### PDF_A_1_A {#PDF-A-1-A}
+```
+public static final int PDF_A_1_A
+```
+
+
+出力ファイルは PDF/A-1a に準拠します。
+
+### PDF_A_1_B {#PDF-A-1-B}
+```
+public static final int PDF_A_1_B
+```
+
+
+出力ファイルは PDF/A-1b に準拠します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/pdfdigitalsignaturehashalgorithm/_index.md
+++ b/japanese/java/com.aspose.diagram/pdfdigitalsignaturehashalgorithm/_index.md
@@ -1,0 +1,174 @@
+---
+title: PdfDigitalSignatureHashAlgorithm
+second_title: Aspose.Diagram for Java API リファレンス
+description: デジタル署名で使用されるデジタルハッシュアルゴリズムを指定します。
+type: docs
+weight: 277
+url: /ja/java/com.aspose.diagram/pdfdigitalsignaturehashalgorithm/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PdfDigitalSignatureHashAlgorithm
+```
+
+デジタル署名で使用されるデジタルハッシュアルゴリズムを指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [MD_5](#MD-5) | SHA-1 ハッシュアルゴリズム。 |
+| [SHA_1](#SHA-1) | SHA-1 ハッシュアルゴリズム。 |
+| [SHA_256](#SHA-256) | SHA-256 ハッシュアルゴリズム。 |
+| [SHA_384](#SHA-384) | SHA-384 ハッシュアルゴリズム。 |
+| [SHA_512](#SHA-512) | SHA-512 ハッシュアルゴリズム。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### MD_5 {#MD-5}
+```
+public static final int MD_5
+```
+
+
+SHA-1 ハッシュアルゴリズム。
+
+### SHA_1 {#SHA-1}
+```
+public static final int SHA_1
+```
+
+
+SHA-1 ハッシュアルゴリズム。
+
+### SHA_256 {#SHA-256}
+```
+public static final int SHA_256
+```
+
+
+SHA-256 ハッシュアルゴリズム。
+
+### SHA_384 {#SHA-384}
+```
+public static final int SHA_384
+```
+
+
+SHA-384 ハッシュアルゴリズム。
+
+### SHA_512 {#SHA-512}
+```
+public static final int SHA_512
+```
+
+
+SHA-512 ハッシュアルゴリズム。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/pdfencryptionalgorithm/_index.md
+++ b/japanese/java/com.aspose.diagram/pdfencryptionalgorithm/_index.md
@@ -1,0 +1,147 @@
+---
+title: PdfEncryptionAlgorithm
+second_title: Aspose.Diagram for Java API リファレンス
+description: PDF ドキュメントを暗号化する際に使用する暗号化アルゴリズムを指定します。
+type: docs
+weight: 278
+url: /ja/java/com.aspose.diagram/pdfencryptionalgorithm/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PdfEncryptionAlgorithm
+```
+
+PDF ドキュメントを暗号化する際に使用する暗号化アルゴリズムを指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [RC_4_128](#RC-4-128) | RC4 暗号化、キー長は 128 ビットです。 |
+| [RC_4_40](#RC-4-40) | RC4 暗号化、キー長は 40 ビットです。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RC_4_128 {#RC-4-128}
+```
+public static final int RC_4_128
+```
+
+
+RC4 暗号化、キー長は 128 ビットです。
+
+### RC_4_40 {#RC-4-40}
+```
+public static final int RC_4_40
+```
+
+
+RC4 暗号化、キー長は 40 ビットです。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/pdfencryptiondetails/_index.md
+++ b/japanese/java/com.aspose.diagram/pdfencryptiondetails/_index.md
@@ -1,0 +1,245 @@
+---
+title: PdfEncryptionDetails
+second_title: Aspose.Diagram for Java API リファレンス
+description: PDF 暗号化に関する詳細を含みます。
+type: docs
+weight: 279
+url: /ja/java/com.aspose.diagram/pdfencryptiondetails/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PdfEncryptionDetails
+```
+
+PDF 暗号化に関する詳細を含みます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PdfEncryptionDetails(String userPassword, String ownerPassword, int encryptionAlgorithm)](#PdfEncryptionDetails-java.lang.String-java.lang.String-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getEncryptionAlgorithm()](#getEncryptionAlgorithm--) | 暗号化モードです。 |
+| [getOwnerPassword()](#getOwnerPassword--) | 所有者パスワードです。 |
+| [getPermissions()](#getPermissions--) | 権限です。 |
+| [getUserPassword()](#getUserPassword--) | ユーザーパスワードです。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setEncryptionAlgorithm(int value)](#setEncryptionAlgorithm-int-) | このプロパティの説明については、[getEncryptionAlgorithm()](../../com.aspose.diagram/pdfencryptiondetails\#getEncryptionAlgorithm--) を参照してください。 |
+| [setOwnerPassword(String value)](#setOwnerPassword-java.lang.String-) | このプロパティの説明については、[getOwnerPassword()](../../com.aspose.diagram/pdfencryptiondetails\#getOwnerPassword--) を参照してください。 |
+| [setPermissions(int value)](#setPermissions-int-) | このプロパティの説明については、[getPermissions()](../../com.aspose.diagram/pdfencryptiondetails\#getPermissions--) を参照してください。 |
+| [setUserPassword(String value)](#setUserPassword-java.lang.String-) | このプロパティの説明については、[getUserPassword()](../../com.aspose.diagram/pdfencryptiondetails\#getUserPassword--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PdfEncryptionDetails(String userPassword, String ownerPassword, int encryptionAlgorithm) {#PdfEncryptionDetails-java.lang.String-java.lang.String-int-}
+```
+public PdfEncryptionDetails(String userPassword, String ownerPassword, int encryptionAlgorithm)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| userPassword | java.lang.String |  |
+| ownerPassword | java.lang.String |  |
+| encryptionAlgorithm | int |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getEncryptionAlgorithm() {#getEncryptionAlgorithm--}
+```
+public int getEncryptionAlgorithm()
+```
+
+
+暗号化モードです。
+
+**Returns:**
+int
+### getOwnerPassword() {#getOwnerPassword--}
+```
+public String getOwnerPassword()
+```
+
+
+所有者パスワードです。正しい所有者パスワードでドキュメントを開くと（ユーザーパスワードと同じでないと仮定して）、ドキュメントへの完全な（所有者）アクセスが可能になります。この無制限のアクセスには、ドキュメント\u9225\u6a9a パスワードとアクセス権限を変更できる機能が含まれます。
+
+**Returns:**
+java.lang.String
+### getPermissions() {#getPermissions--}
+```
+public int getPermissions()
+```
+
+
+権限です。
+
+**Returns:**
+int
+### getUserPassword() {#getUserPassword--}
+```
+public String getUserPassword()
+```
+
+
+ユーザーパスワードです。正しいユーザーパスワードでドキュメントを開く（またはユーザーパスワードが設定されていないドキュメントを開く）と、ドキュメント\u9225\u6a9a 暗号化辞書に指定されたユーザーアクセス権限に従って追加の操作を実行できます。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setEncryptionAlgorithm(int value) {#setEncryptionAlgorithm-int-}
+```
+public void setEncryptionAlgorithm(int value)
+```
+
+
+このプロパティの説明については、[getEncryptionAlgorithm()](../../com.aspose.diagram/pdfencryptiondetails\#getEncryptionAlgorithm--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setOwnerPassword(String value) {#setOwnerPassword-java.lang.String-}
+```
+public void setOwnerPassword(String value)
+```
+
+
+このプロパティの説明については、[getOwnerPassword()](../../com.aspose.diagram/pdfencryptiondetails\#getOwnerPassword--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setPermissions(int value) {#setPermissions-int-}
+```
+public void setPermissions(int value)
+```
+
+
+このプロパティの説明については、[getPermissions()](../../com.aspose.diagram/pdfencryptiondetails\#getPermissions--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setUserPassword(String value) {#setUserPassword-java.lang.String-}
+```
+public void setUserPassword(String value)
+```
+
+
+このプロパティの説明については、[getUserPassword()](../../com.aspose.diagram/pdfencryptiondetails\#getUserPassword--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/pdfpermissions/_index.md
+++ b/japanese/java/com.aspose.diagram/pdfpermissions/_index.md
@@ -1,0 +1,219 @@
+---
+title: PdfPermissions
+second_title: Aspose.Diagram for Java API リファレンス
+description: PDF ドキュメントのユーザー権限を指定します。
+type: docs
+weight: 280
+url: /ja/java/com.aspose.diagram/pdfpermissions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PdfPermissions
+```
+
+PDF ドキュメントのユーザー権限を指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [ALLOW_ALL](#ALLOW-ALL) | PDF ドキュメントに対するすべての操作を許可します。 |
+| [CONTENT_COPY](#CONTENT-COPY) | ドキュメントからテキストやグラフィックをコピーまたは抽出することを許可します。アクセシビリティ目的の抽出も含まれます。 |
+| [CONTENT_COPY_FOR_ACCESSIBILITY](#CONTENT-COPY-FOR-ACCESSIBILITY) | 障害者向けのアクセシビリティ支援やその他の目的でテキストとグラフィックの抽出を許可します。 |
+| [DISALLOW_ALL](#DISALLOW-ALL) | PDF ドキュメントに対するすべての操作を禁止します。 |
+| [DOCUMENT_ASSEMBLY](#DOCUMENT-ASSEMBLY) | ドキュメントの組み立てを許可します：ページの挿入、回転、削除や、ブックマークやサムネイル画像などのナビゲーション要素の作成。 |
+| [FILL_IN](#FILL-IN) | フォームへの入力とドキュメントへの署名を許可します。 |
+| [HIGH_RESOLUTION_PRINTING](#HIGH-RESOLUTION-PRINTING) | 可能な限り最高解像度でドキュメントの印刷を許可します。RC4 40 ビット暗号化を使用している場合、このオプションは無視され、Printing が設定されているときは高解像度印刷が許可されます。 |
+| [MODIFY_ANNOTATIONS](#MODIFY-ANNOTATIONS) | テキスト注釈の追加または変更を許可します。 |
+| [MODIFY_CONTENTS](#MODIFY-CONTENTS) | 文書\u9225\u6a9a の内容を変更することを許可します。 |
+| [PRINTING](#PRINTING) | 文書の印刷を許可します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALLOW_ALL {#ALLOW-ALL}
+```
+public static final int ALLOW_ALL
+```
+
+
+PDF ドキュメントに対するすべての操作を許可します。
+
+### CONTENT_COPY {#CONTENT-COPY}
+```
+public static final int CONTENT_COPY
+```
+
+
+ドキュメントからテキストやグラフィックをコピーまたは抽出することを許可します。アクセシビリティ目的の抽出も含まれます。
+
+### CONTENT_COPY_FOR_ACCESSIBILITY {#CONTENT-COPY-FOR-ACCESSIBILITY}
+```
+public static final int CONTENT_COPY_FOR_ACCESSIBILITY
+```
+
+
+障害者向けのアクセシビリティ支援やその他の目的で、テキストとグラフィックの抽出を許可します。RC4 40ビット暗号化を使用する場合、このオプションは無視され、ContentCopy が設定されている場合は常にアクセシビリティが許可されます。
+
+### DISALLOW_ALL {#DISALLOW-ALL}
+```
+public static final int DISALLOW_ALL
+```
+
+
+PDF 文書に対するすべての操作を禁止します。これはデフォルト値です。
+
+### DOCUMENT_ASSEMBLY {#DOCUMENT-ASSEMBLY}
+```
+public static final int DOCUMENT_ASSEMBLY
+```
+
+
+文書の組み立てを許可します：ページの挿入、回転、削除や、ブックマークやサムネイル画像などのナビゲーション要素の作成。RC4 40ビット暗号化を使用する場合、このオプションは無視され、ModifyContents が設定されているときに文書の組み立てが許可されます。
+
+### FILL_IN {#FILL-IN}
+```
+public static final int FILL_IN
+```
+
+
+フォームへの入力と文書への署名を許可します。RC4 40ビット暗号化を使用する場合、このオプションは無視され、ModifyAnnotations が設定されている場合は常にフォームへの入力が許可されます。
+
+### HIGH_RESOLUTION_PRINTING {#HIGH-RESOLUTION-PRINTING}
+```
+public static final int HIGH_RESOLUTION_PRINTING
+```
+
+
+可能な限り最高解像度でドキュメントの印刷を許可します。RC4 40 ビット暗号化を使用している場合、このオプションは無視され、Printing が設定されているときは高解像度印刷が許可されます。
+
+### MODIFY_ANNOTATIONS {#MODIFY-ANNOTATIONS}
+```
+public static final int MODIFY_ANNOTATIONS
+```
+
+
+テキスト注釈の追加または変更を許可します。RC4 40ビット暗号化を使用する場合、このオプションはフォームフィールドへの入力も許可します。
+
+### MODIFY_CONTENTS {#MODIFY-CONTENTS}
+```
+public static final int MODIFY_CONTENTS
+```
+
+
+文書\u9225\u6a9a の内容を変更することを許可します。
+
+### PRINTING {#PRINTING}
+```
+public static final int PRINTING
+```
+
+
+文書の印刷を許可します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/pdfsaveoptions/_index.md
+++ b/japanese/java/com.aspose.diagram/pdfsaveoptions/_index.md
@@ -1,0 +1,679 @@
+---
+title: PdfSaveOptions
+second_title: Aspose.Diagram for Java API リファレンス
+description: ダイアグラムページを PDF にレンダリングする際に追加オプションを指定できます。
+type: docs
+weight: 281
+url: /ja/java/com.aspose.diagram/pdfsaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.SaveOptions](../../com.aspose.diagram/saveoptions), [com.aspose.diagram.RenderingSaveOptions](../../com.aspose.diagram/renderingsaveoptions)
+```
+public class PdfSaveOptions extends RenderingSaveOptions
+```
+
+ダイアグラムページを PDF にレンダリングする際に追加オプションを指定できます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PdfSaveOptions()](#PdfSaveOptions--) | このクラスの新しいインスタンスを初期化します。このインスタンスは Aspose.Diagram.SaveFileFormat 形式でドキュメントを保存するために使用できます。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | 指定された保存形式に適したクラスの保存オプションオブジェクトを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCompliance()](#getCompliance--) | 生成された PDF ドキュメントの希望する準拠レベル。 |
+| [getDefaultFont()](#getDefaultFont--) | 図内の文字が Unicode で、正しいフォント値が設定されていない、またはフォントがローカルにインストールされていない場合、pdf、画像、または XPS でブロックとして表示されることがあります。 |
+| [getEmfRenderSetting()](#getEmfRenderSetting--) | Emf メタファイルのレンダリング設定です。 |
+| [getEncryptionDetails()](#getEncryptionDetails--) | 暗号化の詳細。 |
+| [getEnlargePage()](#getEnlargePage--) | ページを拡大するかどうかを指定します。 |
+| [getExportGuideShapes()](#getExportGuideShapes--) | ガイドシェイプをエクスポートするかどうかを定義します。 |
+| [getExportHiddenPage()](#getExportHiddenPage--) | 非表示ページをエクスポートするかどうかを定義します。 |
+| [getHorizontalResolution()](#getHorizontalResolution--) | 生成された画像の水平解像度（ドット毎インチ）です。 |
+| [getJpegQuality()](#getJpegQuality--) | 画像の JPEG 圧縮品質を指定します（JPEG 圧縮が使用されている場合）。 |
+| [getPageCount()](#getPageCount--) | PDF にレンダリングするページ数です。 |
+| [getPageIndex()](#getPageIndex--) | レンダリングする最初のページの 0 ベースインデックス。 |
+| [getPageSavingCallback()](#getPageSavingCallback--) | ページ保存プロセスの進行状況を制御/表示します。 |
+| [getPageSize()](#getPageSize--) | 生成された画像のページサイズ。 |
+| [getSaveForegroundPagesOnly()](#getSaveForegroundPagesOnly--) | すべてのページを画像として保存するか、前景のみを保存するかを指定します。 |
+| [getSaveFormat()](#getSaveFormat--) | この保存オプションオブジェクトが使用された場合、レンダリングされた図ページが保存される形式を指定します。 |
+| [getShapes()](#getShapes--) | レンダリングするシェイプ。 |
+| [getSplitMultiPages()](#getSplitMultiPages--) | ページ設定に従って図を複数ページに分割するかどうかを定義します。 |
+| [getTextCompression()](#getTextCompression--) | 画像を除くすべてのコンテンツストリームに使用する圧縮タイプを指定します。 |
+| [getVerticalResolution()](#getVerticalResolution--) | 生成された画像の垂直解像度（ドット毎インチ）です。 |
+| [getWarningCallback()](#getWarningCallback--) | 警告コールバック。 |
+| [hashCode()](#hashCode--) |  |
+| [isExportComments()](#isExportComments--) | コメントをエクスポートするかどうかを定義します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCompliance(int value)](#setCompliance-int-) | このプロパティの説明については、[getCompliance()](../../com.aspose.diagram/pdfsaveoptions\#getCompliance--) を参照してください。 |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | このプロパティの説明については、[getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--) を参照してください。 |
+| [setEmfRenderSetting(int value)](#setEmfRenderSetting-int-) | このプロパティの説明については、[getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--) を参照してください。 |
+| [setEncryptionDetails(PdfEncryptionDetails value)](#setEncryptionDetails-com.aspose.diagram.PdfEncryptionDetails-) | このプロパティの説明については、[getEncryptionDetails()](../../com.aspose.diagram/pdfsaveoptions\#getEncryptionDetails--) を参照してください。 |
+| [setEnlargePage(boolean value)](#setEnlargePage-boolean-) | このプロパティの説明については、[getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--) を参照してください。 |
+| [setExportComments(boolean value)](#setExportComments-boolean-) | このプロパティの説明については、[isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--) を参照してください。 |
+| [setExportGuideShapes(boolean value)](#setExportGuideShapes-boolean-) | このプロパティの説明については、[getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--) を参照してください。 |
+| [setExportHiddenPage(boolean value)](#setExportHiddenPage-boolean-) | このプロパティの説明については、[getExportHiddenPage()](../../com.aspose.diagram/pdfsaveoptions\#getExportHiddenPage--) を参照してください。 |
+| [setHorizontalResolution(int value)](#setHorizontalResolution-int-) | このプロパティの説明については、[getHorizontalResolution()](../../com.aspose.diagram/pdfsaveoptions\#getHorizontalResolution--) を参照してください。 |
+| [setJpegQuality(int value)](#setJpegQuality-int-) | このプロパティの説明については、[getJpegQuality()](../../com.aspose.diagram/pdfsaveoptions\#getJpegQuality--) を参照してください。 |
+| [setPageCount(int value)](#setPageCount-int-) | このプロパティの説明については、[getPageCount()](../../com.aspose.diagram/pdfsaveoptions\#getPageCount--) を参照してください。 |
+| [setPageIndex(int value)](#setPageIndex-int-) | このプロパティの説明については、[getPageIndex()](../../com.aspose.diagram/pdfsaveoptions\#getPageIndex--) を参照してください。 |
+| [setPageSavingCallback(IPageSavingCallback value)](#setPageSavingCallback-com.aspose.diagram.IPageSavingCallback-) | このプロパティの説明については、[getPageSavingCallback()](../../com.aspose.diagram/pdfsaveoptions\#getPageSavingCallback--) を参照してください。 |
+| [setPageSize(PageSize value)](#setPageSize-com.aspose.diagram.PageSize-) | このプロパティの説明については、[getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--) を参照してください。 |
+| [setSaveForegroundPagesOnly(boolean value)](#setSaveForegroundPagesOnly-boolean-) | このプロパティの説明については、[getSaveForegroundPagesOnly()](../../com.aspose.diagram/pdfsaveoptions\#getSaveForegroundPagesOnly--) を参照してください。 |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | このプロパティの説明については、[getSaveFormat()](../../com.aspose.diagram/pdfsaveoptions\#getSaveFormat--) を参照してください。 |
+| [setShapes(ShapeCollection value)](#setShapes-com.aspose.diagram.ShapeCollection-) | このプロパティの説明については、[getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--) を参照してください。 |
+| [setSplitMultiPages(boolean value)](#setSplitMultiPages-boolean-) | このプロパティの説明については、[getSplitMultiPages()](../../com.aspose.diagram/pdfsaveoptions\#getSplitMultiPages--) を参照してください。 |
+| [setTextCompression(int value)](#setTextCompression-int-) | このプロパティの説明については、[getTextCompression()](../../com.aspose.diagram/pdfsaveoptions\#getTextCompression--) を参照してください。 |
+| [setVerticalResolution(int value)](#setVerticalResolution-int-) | このプロパティの説明については、[getVerticalResolution()](../../com.aspose.diagram/pdfsaveoptions\#getVerticalResolution--) を参照してください。 |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PdfSaveOptions() {#PdfSaveOptions--}
+```
+public PdfSaveOptions()
+```
+
+
+このクラスの新しいインスタンスを初期化します。このインスタンスは Aspose.Diagram.SaveFileFormat 形式でドキュメントを保存するために使用できます。
+
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+指定された保存形式に適したクラスの保存オプションオブジェクトを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| saveFormat | int | 保存オプションオブジェクトを作成するための Aspose.Diagram.SaveFileFormat です。 |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCompliance() {#getCompliance--}
+```
+public int getCompliance()
+```
+
+
+生成された PDF ドキュメントの目的とする準拠レベルです。デフォルトは PdfCompliance.PDF\_15 です。
+
+**Returns:**
+int
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+ダイアグラム内の文字が Unicode で、正しいフォントが設定されていない、またはフォントがローカルにインストールされていない場合、PDF、画像、または XPS で文字がブロックとして表示されることがあります。MingLiu や MS Gothic などの DefaultFont を設定して、これらの文字を表示してください。
+
+**Returns:**
+java.lang.String
+### getEmfRenderSetting() {#getEmfRenderSetting--}
+```
+public int getEmfRenderSetting()
+```
+
+
+Emf メタファイルのレンダリング設定です。\"EMF+ Dual\" と識別される EMF メタファイルは、EMF+ レコードと EMF レコードの両方を含むことができます。画像のレンダリングには、どちらのレコードタイプも使用でき、EMF+ レコードのみ、または EMF レコードのみを使用することもできます。EmfPlusPrefer が設定されている場合は EMF+ レコードが解析され、設定されていない場合は EMF レコードのみが解析されます。デフォルト値は EmfOnly です。
+
+**Returns:**
+int
+### getEncryptionDetails() {#getEncryptionDetails--}
+```
+public PdfEncryptionDetails getEncryptionDetails()
+```
+
+
+暗号化の詳細です。設定されていない場合、暗号化は行われません。
+
+**Returns:**
+[PdfEncryptionDetails](../../com.aspose.diagram/pdfencryptiondetails)
+### getEnlargePage() {#getEnlargePage--}
+```
+public boolean getEnlargePage()
+```
+
+
+ページを拡大するかどうかを指定します。true の場合はページを拡大し、false の場合は拡大しません。デフォルト値は true です。
+
+**Returns:**
+boolean
+### getExportGuideShapes() {#getExportGuideShapes--}
+```
+public boolean getExportGuideShapes()
+```
+
+
+ガイドシェイプをエクスポートするかどうかを定義します。デフォルト値は true です。
+
+**Returns:**
+boolean
+### getExportHiddenPage() {#getExportHiddenPage--}
+```
+public boolean getExportHiddenPage()
+```
+
+
+非表示ページをエクスポートするかどうかを定義します。デフォルト値は true です。
+
+**Returns:**
+boolean
+### getHorizontalResolution() {#getHorizontalResolution--}
+```
+public int getHorizontalResolution()
+```
+
+
+生成された画像の水平解像度（ドット毎インチ）です。Emf 形式の画像を除く画像生成メソッドに適用されます。デフォルト値は 96 です。
+
+**Returns:**
+int
+### getJpegQuality() {#getJpegQuality--}
+```
+public int getJpegQuality()
+```
+
+
+画像の JPEG 圧縮品質を指定します（JPEG 圧縮が使用されている場合）。デフォルトは 95 です。
+
+**Returns:**
+int
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+PDF にレンダリングするページ数です。デフォルトは MaxValue で、これは図のすべてのページがレンダリングされることを意味します。
+
+**Returns:**
+int
+### getPageIndex() {#getPageIndex--}
+```
+public int getPageIndex()
+```
+
+
+レンダリングする最初のページの 0 ベースインデックスです。デフォルトは 0 です。
+
+**Returns:**
+int
+### getPageSavingCallback() {#getPageSavingCallback--}
+```
+public IPageSavingCallback getPageSavingCallback()
+```
+
+
+ページ保存プロセスの進行状況を制御/表示します。
+
+**Returns:**
+[IPageSavingCallback](../../com.aspose.diagram/ipagesavingcallback)
+### getPageSize() {#getPageSize--}
+```
+public PageSize getPageSize()
+```
+
+
+生成された画像のページサイズです。 [PageSize](../../com.aspose.diagram/pagesize) または null にできます。デフォルト値は null です。PageSize が null の場合、生成された画像のページサイズはソース図から取得されます。
+
+**Returns:**
+[PageSize](../../com.aspose.diagram/pagesize)
+### getSaveForegroundPagesOnly() {#getSaveForegroundPagesOnly--}
+```
+public boolean getSaveForegroundPagesOnly()
+```
+
+
+すべてのページを画像として保存するか、前景のみを保存するかを指定します。true の場合、前景ページのみがレンダリングされます（背景が存在すれば含む）。false の場合、前景ページがレンダリングされた後、空の背景ページが続きます。PageCount が 1 より大きい場合にのみ true を返すことができます。デフォルト値は false です。
+
+**Returns:**
+boolean
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+この保存オプションオブジェクトが使用される場合、レンダリングされた図ページが保存される形式を指定します。Aspose.Diagram.SaveFileFormat のみ使用できます。
+
+**Returns:**
+int
+### getShapes() {#getShapes--}
+```
+public ShapeCollection getShapes()
+```
+
+
+レンダリングするシェイプです。デフォルトのカウントは 0 です。
+
+**Returns:**
+[ShapeCollection](../../com.aspose.diagram/shapecollection)
+### getSplitMultiPages() {#getSplitMultiPages--}
+```
+public boolean getSplitMultiPages()
+```
+
+
+ページ設定に従って図を複数ページに分割するかどうかを定義します。デフォルト値は false です。
+
+**Returns:**
+boolean
+### getTextCompression() {#getTextCompression--}
+```
+public int getTextCompression()
+```
+
+
+画像を除くすべてのコンテンツストリームで使用される圧縮タイプを指定します。デフォルトは PdfTextCompression.FLATE です。
+
+**Returns:**
+int
+### getVerticalResolution() {#getVerticalResolution--}
+```
+public int getVerticalResolution()
+```
+
+
+生成された画像の垂直解像度（dpi）です。Emf 形式の画像を除く画像生成メソッドに適用されます。デフォルト値は 96 です。
+
+**Returns:**
+int
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+警告コールバック。
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExportComments() {#isExportComments--}
+```
+public boolean isExportComments()
+```
+
+
+コメントをエクスポートするかどうかを定義します。デフォルト値は false です。
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCompliance(int value) {#setCompliance-int-}
+```
+public void setCompliance(int value)
+```
+
+
+このプロパティの説明については、[getCompliance()](../../com.aspose.diagram/pdfsaveoptions\#getCompliance--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+このプロパティの説明については、[getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setEmfRenderSetting(int value) {#setEmfRenderSetting-int-}
+```
+public void setEmfRenderSetting(int value)
+```
+
+
+このプロパティの説明については、[getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setEncryptionDetails(PdfEncryptionDetails value) {#setEncryptionDetails-com.aspose.diagram.PdfEncryptionDetails-}
+```
+public void setEncryptionDetails(PdfEncryptionDetails value)
+```
+
+
+このプロパティの説明については、[getEncryptionDetails()](../../com.aspose.diagram/pdfsaveoptions\#getEncryptionDetails--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [PdfEncryptionDetails](../../com.aspose.diagram/pdfencryptiondetails) |  |
+
+### setEnlargePage(boolean value) {#setEnlargePage-boolean-}
+```
+public void setEnlargePage(boolean value)
+```
+
+
+このプロパティの説明については、[getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setExportComments(boolean value) {#setExportComments-boolean-}
+```
+public void setExportComments(boolean value)
+```
+
+
+このプロパティの説明については、[isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setExportGuideShapes(boolean value) {#setExportGuideShapes-boolean-}
+```
+public void setExportGuideShapes(boolean value)
+```
+
+
+このプロパティの説明については、[getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setExportHiddenPage(boolean value) {#setExportHiddenPage-boolean-}
+```
+public void setExportHiddenPage(boolean value)
+```
+
+
+このプロパティの説明については、[getExportHiddenPage()](../../com.aspose.diagram/pdfsaveoptions\#getExportHiddenPage--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setHorizontalResolution(int value) {#setHorizontalResolution-int-}
+```
+public void setHorizontalResolution(int value)
+```
+
+
+このプロパティの説明については、[getHorizontalResolution()](../../com.aspose.diagram/pdfsaveoptions\#getHorizontalResolution--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setJpegQuality(int value) {#setJpegQuality-int-}
+```
+public void setJpegQuality(int value)
+```
+
+
+このプロパティの説明については、[getJpegQuality()](../../com.aspose.diagram/pdfsaveoptions\#getJpegQuality--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setPageCount(int value) {#setPageCount-int-}
+```
+public void setPageCount(int value)
+```
+
+
+このプロパティの説明については、[getPageCount()](../../com.aspose.diagram/pdfsaveoptions\#getPageCount--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setPageIndex(int value) {#setPageIndex-int-}
+```
+public void setPageIndex(int value)
+```
+
+
+このプロパティの説明については、[getPageIndex()](../../com.aspose.diagram/pdfsaveoptions\#getPageIndex--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setPageSavingCallback(IPageSavingCallback value) {#setPageSavingCallback-com.aspose.diagram.IPageSavingCallback-}
+```
+public void setPageSavingCallback(IPageSavingCallback value)
+```
+
+
+このプロパティの説明については、[getPageSavingCallback()](../../com.aspose.diagram/pdfsaveoptions\#getPageSavingCallback--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [IPageSavingCallback](../../com.aspose.diagram/ipagesavingcallback) |  |
+
+### setPageSize(PageSize value) {#setPageSize-com.aspose.diagram.PageSize-}
+```
+public void setPageSize(PageSize value)
+```
+
+
+このプロパティの説明については、[getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [PageSize](../../com.aspose.diagram/pagesize) |  |
+
+### setSaveForegroundPagesOnly(boolean value) {#setSaveForegroundPagesOnly-boolean-}
+```
+public void setSaveForegroundPagesOnly(boolean value)
+```
+
+
+このプロパティの説明については、[getSaveForegroundPagesOnly()](../../com.aspose.diagram/pdfsaveoptions\#getSaveForegroundPagesOnly--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+このプロパティの説明については、[getSaveFormat()](../../com.aspose.diagram/pdfsaveoptions\#getSaveFormat--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setShapes(ShapeCollection value) {#setShapes-com.aspose.diagram.ShapeCollection-}
+```
+public void setShapes(ShapeCollection value)
+```
+
+
+このプロパティの説明については、[getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [ShapeCollection](../../com.aspose.diagram/shapecollection) |  |
+
+### setSplitMultiPages(boolean value) {#setSplitMultiPages-boolean-}
+```
+public void setSplitMultiPages(boolean value)
+```
+
+
+このプロパティの説明については、[getSplitMultiPages()](../../com.aspose.diagram/pdfsaveoptions\#getSplitMultiPages--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setTextCompression(int value) {#setTextCompression-int-}
+```
+public void setTextCompression(int value)
+```
+
+
+このプロパティの説明については、[getTextCompression()](../../com.aspose.diagram/pdfsaveoptions\#getTextCompression--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setVerticalResolution(int value) {#setVerticalResolution-int-}
+```
+public void setVerticalResolution(int value)
+```
+
+
+このプロパティの説明については、[getVerticalResolution()](../../com.aspose.diagram/pdfsaveoptions\#getVerticalResolution--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/pdftextcompression/_index.md
+++ b/japanese/java/com.aspose.diagram/pdftextcompression/_index.md
@@ -1,0 +1,147 @@
+---
+title: PdfTextCompression
+second_title: Aspose.Diagram for Java API リファレンス
+description: 画像を除く PDF ファイル内のすべてのコンテンツに適用される圧縮タイプを指定します。
+type: docs
+weight: 282
+url: /ja/java/com.aspose.diagram/pdftextcompression/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PdfTextCompression
+```
+
+画像を除く PDF ファイル内のすべてのコンテンツに適用される圧縮タイプを指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [FLATE](#FLATE) | Flate（ZIP）圧縮。 |
+| [NONE](#NONE) | 圧縮なし。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FLATE {#FLATE}
+```
+public static final int FLATE
+```
+
+
+Flate（ZIP）圧縮。
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+圧縮なし。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/pinposvalue/_index.md
+++ b/japanese/java/com.aspose.diagram/pinposvalue/_index.md
@@ -1,0 +1,219 @@
+---
+title: PinPosValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: 図形のピン位置を指定します。
+type: docs
+weight: 283
+url: /ja/java/com.aspose.diagram/pinposvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PinPosValue
+```
+
+図形のピン位置を指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [BOTTOM_CENTER](#BOTTOM-CENTER) | 下部-中央 |
+| [BOTTOM_LEFT](#BOTTOM-LEFT) | 左下。 |
+| [BOTTOM_RIGHT](#BOTTOM-RIGHT) | 右下 |
+| [CENTER_CENTER](#CENTER-CENTER) | 中央-中央 |
+| [CENTER_LEFT](#CENTER-LEFT) | 左中央。 |
+| [CENTER_RIGHT](#CENTER-RIGHT) | 右中央 |
+| [TOP_CENTER](#TOP-CENTER) | 上部中央 |
+| [TOP_LEFT](#TOP-LEFT) | 左上 |
+| [TOP_RIGHT](#TOP-RIGHT) | 右上 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOTTOM_CENTER {#BOTTOM-CENTER}
+```
+public static final int BOTTOM_CENTER
+```
+
+
+下部-中央
+
+### BOTTOM_LEFT {#BOTTOM-LEFT}
+```
+public static final int BOTTOM_LEFT
+```
+
+
+左下。
+
+### BOTTOM_RIGHT {#BOTTOM-RIGHT}
+```
+public static final int BOTTOM_RIGHT
+```
+
+
+右下
+
+### CENTER_CENTER {#CENTER-CENTER}
+```
+public static final int CENTER_CENTER
+```
+
+
+中央-中央
+
+### CENTER_LEFT {#CENTER-LEFT}
+```
+public static final int CENTER_LEFT
+```
+
+
+左中央。
+
+### CENTER_RIGHT {#CENTER-RIGHT}
+```
+public static final int CENTER_RIGHT
+```
+
+
+右中央
+
+### TOP_CENTER {#TOP-CENTER}
+```
+public static final int TOP_CENTER
+```
+
+
+上部中央
+
+### TOP_LEFT {#TOP-LEFT}
+```
+public static final int TOP_LEFT
+```
+
+
+左上
+
+### TOP_RIGHT {#TOP-RIGHT}
+```
+public static final int TOP_RIGHT
+```
+
+
+右上
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/pixeloffsetmode/_index.md
+++ b/japanese/java/com.aspose.diagram/pixeloffsetmode/_index.md
@@ -1,0 +1,183 @@
+---
+title: PixelOffsetMode
+second_title: Aspose.Diagram for Java API リファレンス
+description: レンダリング時のピクセルのオフセット方法を指定します。
+type: docs
+weight: 284
+url: /ja/java/com.aspose.diagram/pixeloffsetmode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PixelOffsetMode
+```
+
+レンダリング時のピクセルのオフセット方法を指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [DEFAULT](#DEFAULT) | デフォルトモードを指定します。 |
+| [HALF](#HALF) | 高速アンチエイリアシングのために、ピクセルが水平方向および垂直方向に -0.5 ユニットだけオフセットされることを指定します。 |
+| [HIGH_QUALITY](#HIGH-QUALITY) | 高品質・低速のレンダリングを指定します。 |
+| [HIGH_SPEED](#HIGH-SPEED) | 高速・低品質のレンダリングを指定します。 |
+| [INVALID](#INVALID) | 無効なモードを指定します。 |
+| [NONE](#NONE) | ピクセルオフセットなしを指定します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DEFAULT {#DEFAULT}
+```
+public static final int DEFAULT
+```
+
+
+デフォルトモードを指定します。
+
+### HALF {#HALF}
+```
+public static final int HALF
+```
+
+
+高速アンチエイリアシングのために、ピクセルが水平方向および垂直方向に -0.5 ユニットだけオフセットされることを指定します。
+
+### HIGH_QUALITY {#HIGH-QUALITY}
+```
+public static final int HIGH_QUALITY
+```
+
+
+高品質・低速のレンダリングを指定します。
+
+### HIGH_SPEED {#HIGH-SPEED}
+```
+public static final int HIGH_SPEED
+```
+
+
+高速・低品質のレンダリングを指定します。
+
+### INVALID {#INVALID}
+```
+public static final int INVALID
+```
+
+
+無効なモードを指定します。
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+ピクセルオフセットなしを指定します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/placedepth/_index.md
+++ b/japanese/java/com.aspose.diagram/placedepth/_index.md
@@ -1,0 +1,179 @@
+---
+title: PlaceDepth
+second_title: Aspose.Diagram for Java API リファレンス
+description: 自動的にレイアウトされる図形について、レイアウト作成前に図形がどのように解析されるかの方法を指定し、レイアウトの種類を決定します。
+type: docs
+weight: 285
+url: /ja/java/com.aspose.diagram/placedepth/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PlaceDepth
+```
+
+自動的にレイアウトされる図面について、レイアウト作成前に図面を解析する方法とレイアウトのタイプを決定する方法を指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PlaceDepth(int value)](#PlaceDepth-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | 自動的にレイアウトされる図面について、レイアウト作成前に図面を解析する方法とレイアウトのタイプを決定する方法を指定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | For the description of this property, please see [getValue()](../../com.aspose.diagram/placedepth\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PlaceDepth(int value) {#PlaceDepth-int-}
+```
+public PlaceDepth(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+自動的にレイアウトされる図面について、レイアウト作成前に図面を解析する方法とレイアウトのタイプを決定する方法を指定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+For the description of this property, please see [getValue()](../../com.aspose.diagram/placedepth\#getValue--)
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/placedepthvalue/_index.md
+++ b/japanese/java/com.aspose.diagram/placedepthvalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: PlaceDepthValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: 自動的にレイアウトされる図形について、レイアウト作成前に図形がどのように解析されるかの方法を指定し、レイアウトの種類を決定します。
+type: docs
+weight: 286
+url: /ja/java/com.aspose.diagram/placedepthvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PlaceDepthValue
+```
+
+自動的にレイアウトされる図面について、レイアウト作成前に図面を解析する方法とレイアウトのタイプを決定する方法を指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [DEEP](#DEEP) | 深い。 |
+| [MEDIUM](#MEDIUM) | 中程度。 |
+| [PAGE_DEFAULT](#PAGE-DEFAULT) | Page default. |
+| [SHALLOW](#SHALLOW) | 浅い。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DEEP {#DEEP}
+```
+public static final int DEEP
+```
+
+
+深い。
+
+### MEDIUM {#MEDIUM}
+```
+public static final int MEDIUM
+```
+
+
+中程度。
+
+### PAGE_DEFAULT {#PAGE-DEFAULT}
+```
+public static final int PAGE_DEFAULT
+```
+
+
+Page default.
+
+### SHALLOW {#SHALLOW}
+```
+public static final int SHALLOW
+```
+
+
+浅い。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/placeflip/_index.md
+++ b/japanese/java/com.aspose.diagram/placeflip/_index.md
@@ -1,0 +1,179 @@
+---
+title: PlaceFlip
+second_title: Aspose.Diagram for Java API リファレンス
+description: Microsoft Visio の「図形の配置」コマンドを使用して図形を配置する際、ページ上の配置可能な図形が反転または回転する方法を指定します。
+type: docs
+weight: 287
+url: /ja/java/com.aspose.diagram/placeflip/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PlaceFlip
+```
+
+Microsoft Visio の「Lay Out Shapes」コマンドを使用してシェイプを配置する際に、ページ上で配置可能なシェイプがどのように反転または回転するかを指定します。以下の十六進値が使用可能です。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PlaceFlip(int value)](#PlaceFlip-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | Microsoft Visio の「図形の配置」コマンドを使用して図形を配置する際、ページ上の配置可能な図形が反転または回転する方法を指定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | For the description of this property, please see [getValue()](../../com.aspose.diagram/placeflip\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PlaceFlip(int value) {#PlaceFlip-int-}
+```
+public PlaceFlip(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Microsoft Visio の「Lay Out Shapes」コマンドを使用してシェイプを配置する際に、ページ上で配置可能なシェイプがどのように反転または回転するかを指定します。以下の十六進値が使用可能です。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+For the description of this property, please see [getValue()](../../com.aspose.diagram/placeflip\#getValue--)
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/placeflipvalue/_index.md
+++ b/japanese/java/com.aspose.diagram/placeflipvalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: PlaceFlipValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: Microsoft Visio の「図形の配置」コマンドを使用して図形を配置する際、ページ上の配置可能な図形が反転または回転する方法を指定します。
+type: docs
+weight: 288
+url: /ja/java/com.aspose.diagram/placeflipvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PlaceFlipValue
+```
+
+Microsoft Visio の「Lay Out Shapes」コマンドを使用してシェイプを配置する際に、ページ上で配置可能なシェイプがどのように反転または回転するかを指定します。以下の十六進値が使用可能です。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [DEFAULT_NO_FLIP](#DEFAULT-NO-FLIP) | デフォルト。 |
+| [FLIP_90_INCREMENTS](#FLIP-90-INCREMENTS) | 90度単位で反転します。 |
+| [FLIP_HORIZONTAL](#FLIP-HORIZONTAL) | 水平に反転します。 |
+| [FLIP_VERTICAL](#FLIP-VERTICAL) | 垂直に反転します。 |
+| [NO_FLIP](#NO-FLIP) | 反転しません。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DEFAULT_NO_FLIP {#DEFAULT-NO-FLIP}
+```
+public static final int DEFAULT_NO_FLIP
+```
+
+
+デフォルト。反転しません。
+
+### FLIP_90_INCREMENTS {#FLIP-90-INCREMENTS}
+```
+public static final int FLIP_90_INCREMENTS
+```
+
+
+90度単位で反転します。
+
+### FLIP_HORIZONTAL {#FLIP-HORIZONTAL}
+```
+public static final int FLIP_HORIZONTAL
+```
+
+
+水平に反転します。
+
+### FLIP_VERTICAL {#FLIP-VERTICAL}
+```
+public static final int FLIP_VERTICAL
+```
+
+
+垂直に反転します。
+
+### NO_FLIP {#NO-FLIP}
+```
+public static final int NO_FLIP
+```
+
+
+反転しません。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/placestyle/_index.md
+++ b/japanese/java/com.aspose.diagram/placestyle/_index.md
@@ -1,0 +1,179 @@
+---
+title: PlaceStyle
+second_title: Aspose.Diagram for Java API リファレンス
+description: Specifies how shapes are placed on the page when shapes are laid out when a user selects Lay Out Shapes Shape menu.
+type: docs
+weight: 289
+url: /ja/java/com.aspose.diagram/placestyle/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PlaceStyle
+```
+
+ユーザーが「図形の配置」（図形メニュー）を選択して図形を配置する際、図形がページ上に配置される方法を指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PlaceStyle(int value)](#PlaceStyle-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | ユーザーが「図形の配置」（図形メニュー）を選択して図形を配置する際、図形がページ上に配置される方法を指定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/placestyle\\#getValue--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PlaceStyle(int value) {#PlaceStyle-int-}
+```
+public PlaceStyle(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+ユーザーが「図形の配置」（図形メニュー）を選択して図形を配置する際、図形がページ上に配置される方法を指定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/placestyle\\#getValue--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/placestylevalue/_index.md
+++ b/japanese/java/com.aspose.diagram/placestylevalue/_index.md
@@ -1,0 +1,201 @@
+---
+title: PlaceStyleValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: Specifies how shapes are placed on the page when shapes are laid out when a user selects Lay Out Shapes Shape menu.
+type: docs
+weight: 290
+url: /ja/java/com.aspose.diagram/placestylevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PlaceStyleValue
+```
+
+ユーザーが「図形の配置」（図形メニュー）を選択して図形を配置する際、図形がページ上に配置される方法を指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [BOTTOM_TO_TOP](#BOTTOM-TO-TOP) | Bottom to top. |
+| [CIRCULAR](#CIRCULAR) | Circular. |
+| [DEFAULT_RADIAL](#DEFAULT-RADIAL) | デフォルト。 |
+| [LEFT_TO_RIGHT](#LEFT-TO-RIGHT) | Left to right. |
+| [RADIAL](#RADIAL) | Radial. |
+| [RIGHT_TO_LEFT](#RIGHT-TO-LEFT) | Right to left. |
+| [TOP_TO_BOTTOM](#TOP-TO-BOTTOM) | Top to bottom. |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOTTOM_TO_TOP {#BOTTOM-TO-TOP}
+```
+public static final int BOTTOM_TO_TOP
+```
+
+
+Bottom to top.
+
+### CIRCULAR {#CIRCULAR}
+```
+public static final int CIRCULAR
+```
+
+
+Circular.
+
+### DEFAULT_RADIAL {#DEFAULT-RADIAL}
+```
+public static final int DEFAULT_RADIAL
+```
+
+
+Default. Radial.
+
+### LEFT_TO_RIGHT {#LEFT-TO-RIGHT}
+```
+public static final int LEFT_TO_RIGHT
+```
+
+
+Left to right.
+
+### RADIAL {#RADIAL}
+```
+public static final int RADIAL
+```
+
+
+Radial.
+
+### RIGHT_TO_LEFT {#RIGHT-TO-LEFT}
+```
+public static final int RIGHT_TO_LEFT
+```
+
+
+Right to left.
+
+### TOP_TO_BOTTOM {#TOP-TO-BOTTOM}
+```
+public static final int TOP_TO_BOTTOM
+```
+
+
+Top to bottom.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/polylineto/_index.md
+++ b/japanese/java/com.aspose.diagram/polylineto/_index.md
@@ -1,0 +1,274 @@
+---
+title: PolylineTo
+second_title: Aspose.Diagram for Java API リファレンス
+description: ポリラインの最後の点の x および y 座標とポリラインの式を含みます。
+type: docs
+weight: 291
+url: /ja/java/com.aspose.diagram/polylineto/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class PolylineTo extends Coordinate
+```
+
+ポリラインの最後の点の x および y 座標とポリライン式を含みます。座標は X 要素と Y 要素で指定され、式は A 要素で指定されます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PolylineTo()](#PolylineTo--) | [PolylineTo](../../com.aspose.diagram/polylineto) クラスのインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | ポリライン式です。 |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getIX()](#getIX--) | 親要素内の要素のゼロベースインデックスです。 |
+| [getX()](#getX--) | ポリラインの終端頂点の x 座標です。 |
+| [getY()](#getY--) | ポリラインの終端頂点の y 座標です。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(StrValue value)](#setA-com.aspose.diagram.StrValue-) | このプロパティの説明については、[getA()](../../com.aspose.diagram/polylineto\#getA--) を参照してください |
+| [setDel(int value)](#setDel-int-) | このプロパティの説明については、[getDel()](../../com.aspose.diagram/polylineto\#getDel--) を参照してください |
+| [setIX(int value)](#setIX-int-) | このプロパティの説明については、[getIX()](../../com.aspose.diagram/polylineto\#getIX--) を参照してください |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getX()](../../com.aspose.diagram/polylineto\#getX--) を参照してください |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getY()](../../com.aspose.diagram/polylineto\#getY--) を参照してください |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PolylineTo() {#PolylineTo--}
+```
+public PolylineTo()
+```
+
+
+[PolylineTo](../../com.aspose.diagram/polylineto) クラスのインスタンスを作成します。
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public StrValue getA()
+```
+
+
+ポリライン式です。
+
+**Returns:**
+[StrValue](../../com.aspose.diagram/strvalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+親要素内の要素のゼロベースインデックスです。
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+ポリラインの終端頂点の x 座標です。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+ポリラインの終端頂点の y 座標です。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(StrValue value) {#setA-com.aspose.diagram.StrValue-}
+```
+public void setA(StrValue value)
+```
+
+
+このプロパティの説明については、[getA()](../../com.aspose.diagram/polylineto\#getA--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [StrValue](../../com.aspose.diagram/strvalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+このプロパティの説明については、[getDel()](../../com.aspose.diagram/polylineto\#getDel--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+このプロパティの説明については、[getIX()](../../com.aspose.diagram/polylineto\#getIX--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getX()](../../com.aspose.diagram/polylineto\#getX--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getY()](../../com.aspose.diagram/polylineto\#getY--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/polylinetocollection/_index.md
+++ b/japanese/java/com.aspose.diagram/polylinetocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: PolylineToCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: PolylineTo コレクション。
+type: docs
+weight: 292
+url: /ja/java/com.aspose.diagram/polylinetocollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class PolylineToCollection extends Collection
+```
+
+PolylineTo コレクション。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public PolylineTo get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[PolylineTo](../../com.aspose.diagram/polylineto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/pos/_index.md
+++ b/japanese/java/com.aspose.diagram/pos/_index.md
@@ -1,0 +1,204 @@
+---
+title: Pos
+second_title: Aspose.Diagram for Java API リファレンス
+description: ベースラインに対するシェイプのテキスト位置を指定します。
+type: docs
+weight: 293
+url: /ja/java/com.aspose.diagram/pos/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Pos
+```
+
+シェイプのテキストの位置をベースラインに対して指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Pos(int value)](#Pos-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | シェイプのテキストの位置をベースラインに対して指定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | このプロパティの説明については、[getUfe()](../../com.aspose.diagram/pos\#getUfe--) を参照してください。 |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/pos\#getValue--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Pos(int value) {#Pos-int-}
+```
+public Pos(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+シェイプのテキストの位置をベースラインに対して指定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+このプロパティの説明については、[getUfe()](../../com.aspose.diagram/pos\#getUfe--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/pos\#getValue--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/posvalue/_index.md
+++ b/japanese/java/com.aspose.diagram/posvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: PosValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: ベースラインに対するシェイプのテキスト位置を指定します。
+type: docs
+weight: 294
+url: /ja/java/com.aspose.diagram/posvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PosValue
+```
+
+シェイプのテキストの位置をベースラインに対して指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [NORMAL_POSITION](#NORMAL-POSITION) | 通常の位置。 |
+| [SUBSCRIPT](#SUBSCRIPT) | 下付き。 |
+| [SUPERSCRIPT](#SUPERSCRIPT) | 上付き。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### NORMAL_POSITION {#NORMAL-POSITION}
+```
+public static final int NORMAL_POSITION
+```
+
+
+通常の位置。
+
+### SUBSCRIPT {#SUBSCRIPT}
+```
+public static final int SUBSCRIPT
+```
+
+
+下付き。
+
+### SUPERSCRIPT {#SUPERSCRIPT}
+```
+public static final int SUPERSCRIPT
+```
+
+
+上付き。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/pp/_index.md
+++ b/japanese/java/com.aspose.diagram/pp/_index.md
@@ -1,0 +1,154 @@
+---
+title: Pp
+second_title: Aspose.Diagram for Java API リファレンス
+description: 段落プロパティ ランの開始を指定します。
+type: docs
+weight: 295
+url: /ja/java/com.aspose.diagram/pp/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.FormatTxt](../../com.aspose.diagram/formattxt)
+```
+public class Pp extends FormatTxt
+```
+
+段落プロパティのランの開始位置を指定します。ランはテキストの末尾まで、または次のものまで定義されます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Pp(int IX)](#Pp-int-) | コンストラクタ |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getValue()](#getValue--) | 値 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Pp(int IX) {#Pp-int-}
+```
+public Pp(int IX)
+```
+
+
+コンストラクタ
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| IX | int | このランに適用される書式を指定する Para 要素のインデックスです。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+値
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/presetcameratype/_index.md
+++ b/japanese/java/com.aspose.diagram/presetcameratype/_index.md
@@ -1,0 +1,687 @@
+---
+title: PresetCameraType
+second_title: Aspose.Diagram for Java API リファレンス
+description: 位置を含むすべてのカメラプロパティを設定するさまざまなアルゴリズム手法を表します。
+type: docs
+weight: 296
+url: /ja/java/com.aspose.diagram/presetcameratype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PresetCameraType
+```
+
+位置を含むすべてのカメラ プロパティを設定するさまざまなアルゴリズム手法を表します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [ISOMETRIC_BOTTOM_DOWN](#ISOMETRIC-BOTTOM-DOWN) |  |
+| [ISOMETRIC_BOTTOM_UP](#ISOMETRIC-BOTTOM-UP) |  |
+| [ISOMETRIC_LEFT_DOWN](#ISOMETRIC-LEFT-DOWN) |  |
+| [ISOMETRIC_LEFT_UP](#ISOMETRIC-LEFT-UP) |  |
+| [ISOMETRIC_OFF_AXIS_1_LEFT](#ISOMETRIC-OFF-AXIS-1-LEFT) |  |
+| [ISOMETRIC_OFF_AXIS_1_RIGHT](#ISOMETRIC-OFF-AXIS-1-RIGHT) |  |
+| [ISOMETRIC_OFF_AXIS_1_TOP](#ISOMETRIC-OFF-AXIS-1-TOP) |  |
+| [ISOMETRIC_OFF_AXIS_2_LEFT](#ISOMETRIC-OFF-AXIS-2-LEFT) |  |
+| [ISOMETRIC_OFF_AXIS_2_RIGHT](#ISOMETRIC-OFF-AXIS-2-RIGHT) |  |
+| [ISOMETRIC_OFF_AXIS_2_TOP](#ISOMETRIC-OFF-AXIS-2-TOP) |  |
+| [ISOMETRIC_OFF_AXIS_3_BOTTOM](#ISOMETRIC-OFF-AXIS-3-BOTTOM) |  |
+| [ISOMETRIC_OFF_AXIS_3_LEFT](#ISOMETRIC-OFF-AXIS-3-LEFT) |  |
+| [ISOMETRIC_OFF_AXIS_3_RIGHT](#ISOMETRIC-OFF-AXIS-3-RIGHT) |  |
+| [ISOMETRIC_OFF_AXIS_4_BOTTOM](#ISOMETRIC-OFF-AXIS-4-BOTTOM) |  |
+| [ISOMETRIC_OFF_AXIS_4_LEFT](#ISOMETRIC-OFF-AXIS-4-LEFT) |  |
+| [ISOMETRIC_OFF_AXIS_4_RIGHT](#ISOMETRIC-OFF-AXIS-4-RIGHT) |  |
+| [ISOMETRIC_RIGHT_DOWN](#ISOMETRIC-RIGHT-DOWN) |  |
+| [ISOMETRIC_RIGHT_UP](#ISOMETRIC-RIGHT-UP) |  |
+| [ISOMETRIC_TOP_DOWN](#ISOMETRIC-TOP-DOWN) |  |
+| [ISOMETRIC_TOP_UP](#ISOMETRIC-TOP-UP) |  |
+| [LEGACY_OBLIQUE_BOTTOM](#LEGACY-OBLIQUE-BOTTOM) |  |
+| [LEGACY_OBLIQUE_BOTTOM_LEFT](#LEGACY-OBLIQUE-BOTTOM-LEFT) |  |
+| [LEGACY_OBLIQUE_BOTTOM_RIGHT](#LEGACY-OBLIQUE-BOTTOM-RIGHT) |  |
+| [LEGACY_OBLIQUE_FRONT](#LEGACY-OBLIQUE-FRONT) |  |
+| [LEGACY_OBLIQUE_LEFT](#LEGACY-OBLIQUE-LEFT) |  |
+| [LEGACY_OBLIQUE_RIGHT](#LEGACY-OBLIQUE-RIGHT) |  |
+| [LEGACY_OBLIQUE_TOP](#LEGACY-OBLIQUE-TOP) |  |
+| [LEGACY_OBLIQUE_TOP_LEFT](#LEGACY-OBLIQUE-TOP-LEFT) |  |
+| [LEGACY_OBLIQUE_TOP_RIGHT](#LEGACY-OBLIQUE-TOP-RIGHT) |  |
+| [LEGACY_PERSPECTIVE_BOTTOM](#LEGACY-PERSPECTIVE-BOTTOM) |  |
+| [LEGACY_PERSPECTIVE_BOTTOM_LEFT](#LEGACY-PERSPECTIVE-BOTTOM-LEFT) |  |
+| [LEGACY_PERSPECTIVE_BOTTOM_RIGHT](#LEGACY-PERSPECTIVE-BOTTOM-RIGHT) |  |
+| [LEGACY_PERSPECTIVE_FRONT](#LEGACY-PERSPECTIVE-FRONT) |  |
+| [LEGACY_PERSPECTIVE_LEFT](#LEGACY-PERSPECTIVE-LEFT) |  |
+| [LEGACY_PERSPECTIVE_RIGHT](#LEGACY-PERSPECTIVE-RIGHT) |  |
+| [LEGACY_PERSPECTIVE_TOP](#LEGACY-PERSPECTIVE-TOP) |  |
+| [LEGACY_PERSPECTIVE_TOP_LEFT](#LEGACY-PERSPECTIVE-TOP-LEFT) |  |
+| [LEGACY_PERSPECTIVE_TOP_RIGHT](#LEGACY-PERSPECTIVE-TOP-RIGHT) |  |
+| [OBLIQUE_BOTTOM](#OBLIQUE-BOTTOM) |  |
+| [OBLIQUE_BOTTOM_LEFT](#OBLIQUE-BOTTOM-LEFT) |  |
+| [OBLIQUE_BOTTOM_RIGHT](#OBLIQUE-BOTTOM-RIGHT) |  |
+| [OBLIQUE_LEFT](#OBLIQUE-LEFT) |  |
+| [OBLIQUE_RIGHT](#OBLIQUE-RIGHT) |  |
+| [OBLIQUE_TOP](#OBLIQUE-TOP) |  |
+| [OBLIQUE_TOP_LEFT](#OBLIQUE-TOP-LEFT) |  |
+| [OBLIQUE_TOP_RIGHT](#OBLIQUE-TOP-RIGHT) |  |
+| [ORTHOGRAPHIC_FRONT](#ORTHOGRAPHIC-FRONT) |  |
+| [PERSPECTIVE_ABOVE](#PERSPECTIVE-ABOVE) |  |
+| [PERSPECTIVE_ABOVE_LEFT_FACING](#PERSPECTIVE-ABOVE-LEFT-FACING) |  |
+| [PERSPECTIVE_ABOVE_RIGHT_FACING](#PERSPECTIVE-ABOVE-RIGHT-FACING) |  |
+| [PERSPECTIVE_BELOW](#PERSPECTIVE-BELOW) |  |
+| [PERSPECTIVE_CONTRASTING_LEFT_FACING](#PERSPECTIVE-CONTRASTING-LEFT-FACING) |  |
+| [PERSPECTIVE_CONTRASTING_RIGHT_FACING](#PERSPECTIVE-CONTRASTING-RIGHT-FACING) |  |
+| [PERSPECTIVE_FRONT](#PERSPECTIVE-FRONT) |  |
+| [PERSPECTIVE_HEROIC_EXTREME_LEFT_FACING](#PERSPECTIVE-HEROIC-EXTREME-LEFT-FACING) |  |
+| [PERSPECTIVE_HEROIC_EXTREME_RIGHT_FACING](#PERSPECTIVE-HEROIC-EXTREME-RIGHT-FACING) |  |
+| [PERSPECTIVE_HEROIC_LEFT_FACING](#PERSPECTIVE-HEROIC-LEFT-FACING) |  |
+| [PERSPECTIVE_HEROIC_RIGHT_FACING](#PERSPECTIVE-HEROIC-RIGHT-FACING) |  |
+| [PERSPECTIVE_LEFT](#PERSPECTIVE-LEFT) |  |
+| [PERSPECTIVE_RELAXED](#PERSPECTIVE-RELAXED) |  |
+| [PERSPECTIVE_RELAXED_MODERATELY](#PERSPECTIVE-RELAXED-MODERATELY) |  |
+| [PERSPECTIVE_RIGHT](#PERSPECTIVE-RIGHT) |  |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ISOMETRIC_BOTTOM_DOWN {#ISOMETRIC-BOTTOM-DOWN}
+```
+public static final int ISOMETRIC_BOTTOM_DOWN
+```
+
+
+
+
+### ISOMETRIC_BOTTOM_UP {#ISOMETRIC-BOTTOM-UP}
+```
+public static final int ISOMETRIC_BOTTOM_UP
+```
+
+
+
+
+### ISOMETRIC_LEFT_DOWN {#ISOMETRIC-LEFT-DOWN}
+```
+public static final int ISOMETRIC_LEFT_DOWN
+```
+
+
+
+
+### ISOMETRIC_LEFT_UP {#ISOMETRIC-LEFT-UP}
+```
+public static final int ISOMETRIC_LEFT_UP
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_1_LEFT {#ISOMETRIC-OFF-AXIS-1-LEFT}
+```
+public static final int ISOMETRIC_OFF_AXIS_1_LEFT
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_1_RIGHT {#ISOMETRIC-OFF-AXIS-1-RIGHT}
+```
+public static final int ISOMETRIC_OFF_AXIS_1_RIGHT
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_1_TOP {#ISOMETRIC-OFF-AXIS-1-TOP}
+```
+public static final int ISOMETRIC_OFF_AXIS_1_TOP
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_2_LEFT {#ISOMETRIC-OFF-AXIS-2-LEFT}
+```
+public static final int ISOMETRIC_OFF_AXIS_2_LEFT
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_2_RIGHT {#ISOMETRIC-OFF-AXIS-2-RIGHT}
+```
+public static final int ISOMETRIC_OFF_AXIS_2_RIGHT
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_2_TOP {#ISOMETRIC-OFF-AXIS-2-TOP}
+```
+public static final int ISOMETRIC_OFF_AXIS_2_TOP
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_3_BOTTOM {#ISOMETRIC-OFF-AXIS-3-BOTTOM}
+```
+public static final int ISOMETRIC_OFF_AXIS_3_BOTTOM
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_3_LEFT {#ISOMETRIC-OFF-AXIS-3-LEFT}
+```
+public static final int ISOMETRIC_OFF_AXIS_3_LEFT
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_3_RIGHT {#ISOMETRIC-OFF-AXIS-3-RIGHT}
+```
+public static final int ISOMETRIC_OFF_AXIS_3_RIGHT
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_4_BOTTOM {#ISOMETRIC-OFF-AXIS-4-BOTTOM}
+```
+public static final int ISOMETRIC_OFF_AXIS_4_BOTTOM
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_4_LEFT {#ISOMETRIC-OFF-AXIS-4-LEFT}
+```
+public static final int ISOMETRIC_OFF_AXIS_4_LEFT
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_4_RIGHT {#ISOMETRIC-OFF-AXIS-4-RIGHT}
+```
+public static final int ISOMETRIC_OFF_AXIS_4_RIGHT
+```
+
+
+
+
+### ISOMETRIC_RIGHT_DOWN {#ISOMETRIC-RIGHT-DOWN}
+```
+public static final int ISOMETRIC_RIGHT_DOWN
+```
+
+
+
+
+### ISOMETRIC_RIGHT_UP {#ISOMETRIC-RIGHT-UP}
+```
+public static final int ISOMETRIC_RIGHT_UP
+```
+
+
+
+
+### ISOMETRIC_TOP_DOWN {#ISOMETRIC-TOP-DOWN}
+```
+public static final int ISOMETRIC_TOP_DOWN
+```
+
+
+
+
+### ISOMETRIC_TOP_UP {#ISOMETRIC-TOP-UP}
+```
+public static final int ISOMETRIC_TOP_UP
+```
+
+
+
+
+### LEGACY_OBLIQUE_BOTTOM {#LEGACY-OBLIQUE-BOTTOM}
+```
+public static final int LEGACY_OBLIQUE_BOTTOM
+```
+
+
+
+
+### LEGACY_OBLIQUE_BOTTOM_LEFT {#LEGACY-OBLIQUE-BOTTOM-LEFT}
+```
+public static final int LEGACY_OBLIQUE_BOTTOM_LEFT
+```
+
+
+
+
+### LEGACY_OBLIQUE_BOTTOM_RIGHT {#LEGACY-OBLIQUE-BOTTOM-RIGHT}
+```
+public static final int LEGACY_OBLIQUE_BOTTOM_RIGHT
+```
+
+
+
+
+### LEGACY_OBLIQUE_FRONT {#LEGACY-OBLIQUE-FRONT}
+```
+public static final int LEGACY_OBLIQUE_FRONT
+```
+
+
+
+
+### LEGACY_OBLIQUE_LEFT {#LEGACY-OBLIQUE-LEFT}
+```
+public static final int LEGACY_OBLIQUE_LEFT
+```
+
+
+
+
+### LEGACY_OBLIQUE_RIGHT {#LEGACY-OBLIQUE-RIGHT}
+```
+public static final int LEGACY_OBLIQUE_RIGHT
+```
+
+
+
+
+### LEGACY_OBLIQUE_TOP {#LEGACY-OBLIQUE-TOP}
+```
+public static final int LEGACY_OBLIQUE_TOP
+```
+
+
+
+
+### LEGACY_OBLIQUE_TOP_LEFT {#LEGACY-OBLIQUE-TOP-LEFT}
+```
+public static final int LEGACY_OBLIQUE_TOP_LEFT
+```
+
+
+
+
+### LEGACY_OBLIQUE_TOP_RIGHT {#LEGACY-OBLIQUE-TOP-RIGHT}
+```
+public static final int LEGACY_OBLIQUE_TOP_RIGHT
+```
+
+
+
+
+### LEGACY_PERSPECTIVE_BOTTOM {#LEGACY-PERSPECTIVE-BOTTOM}
+```
+public static final int LEGACY_PERSPECTIVE_BOTTOM
+```
+
+
+
+
+### LEGACY_PERSPECTIVE_BOTTOM_LEFT {#LEGACY-PERSPECTIVE-BOTTOM-LEFT}
+```
+public static final int LEGACY_PERSPECTIVE_BOTTOM_LEFT
+```
+
+
+
+
+### LEGACY_PERSPECTIVE_BOTTOM_RIGHT {#LEGACY-PERSPECTIVE-BOTTOM-RIGHT}
+```
+public static final int LEGACY_PERSPECTIVE_BOTTOM_RIGHT
+```
+
+
+
+
+### LEGACY_PERSPECTIVE_FRONT {#LEGACY-PERSPECTIVE-FRONT}
+```
+public static final int LEGACY_PERSPECTIVE_FRONT
+```
+
+
+
+
+### LEGACY_PERSPECTIVE_LEFT {#LEGACY-PERSPECTIVE-LEFT}
+```
+public static final int LEGACY_PERSPECTIVE_LEFT
+```
+
+
+
+
+### LEGACY_PERSPECTIVE_RIGHT {#LEGACY-PERSPECTIVE-RIGHT}
+```
+public static final int LEGACY_PERSPECTIVE_RIGHT
+```
+
+
+
+
+### LEGACY_PERSPECTIVE_TOP {#LEGACY-PERSPECTIVE-TOP}
+```
+public static final int LEGACY_PERSPECTIVE_TOP
+```
+
+
+
+
+### LEGACY_PERSPECTIVE_TOP_LEFT {#LEGACY-PERSPECTIVE-TOP-LEFT}
+```
+public static final int LEGACY_PERSPECTIVE_TOP_LEFT
+```
+
+
+
+
+### LEGACY_PERSPECTIVE_TOP_RIGHT {#LEGACY-PERSPECTIVE-TOP-RIGHT}
+```
+public static final int LEGACY_PERSPECTIVE_TOP_RIGHT
+```
+
+
+
+
+### OBLIQUE_BOTTOM {#OBLIQUE-BOTTOM}
+```
+public static final int OBLIQUE_BOTTOM
+```
+
+
+
+
+### OBLIQUE_BOTTOM_LEFT {#OBLIQUE-BOTTOM-LEFT}
+```
+public static final int OBLIQUE_BOTTOM_LEFT
+```
+
+
+
+
+### OBLIQUE_BOTTOM_RIGHT {#OBLIQUE-BOTTOM-RIGHT}
+```
+public static final int OBLIQUE_BOTTOM_RIGHT
+```
+
+
+
+
+### OBLIQUE_LEFT {#OBLIQUE-LEFT}
+```
+public static final int OBLIQUE_LEFT
+```
+
+
+
+
+### OBLIQUE_RIGHT {#OBLIQUE-RIGHT}
+```
+public static final int OBLIQUE_RIGHT
+```
+
+
+
+
+### OBLIQUE_TOP {#OBLIQUE-TOP}
+```
+public static final int OBLIQUE_TOP
+```
+
+
+
+
+### OBLIQUE_TOP_LEFT {#OBLIQUE-TOP-LEFT}
+```
+public static final int OBLIQUE_TOP_LEFT
+```
+
+
+
+
+### OBLIQUE_TOP_RIGHT {#OBLIQUE-TOP-RIGHT}
+```
+public static final int OBLIQUE_TOP_RIGHT
+```
+
+
+
+
+### ORTHOGRAPHIC_FRONT {#ORTHOGRAPHIC-FRONT}
+```
+public static final int ORTHOGRAPHIC_FRONT
+```
+
+
+
+
+### PERSPECTIVE_ABOVE {#PERSPECTIVE-ABOVE}
+```
+public static final int PERSPECTIVE_ABOVE
+```
+
+
+
+
+### PERSPECTIVE_ABOVE_LEFT_FACING {#PERSPECTIVE-ABOVE-LEFT-FACING}
+```
+public static final int PERSPECTIVE_ABOVE_LEFT_FACING
+```
+
+
+
+
+### PERSPECTIVE_ABOVE_RIGHT_FACING {#PERSPECTIVE-ABOVE-RIGHT-FACING}
+```
+public static final int PERSPECTIVE_ABOVE_RIGHT_FACING
+```
+
+
+
+
+### PERSPECTIVE_BELOW {#PERSPECTIVE-BELOW}
+```
+public static final int PERSPECTIVE_BELOW
+```
+
+
+
+
+### PERSPECTIVE_CONTRASTING_LEFT_FACING {#PERSPECTIVE-CONTRASTING-LEFT-FACING}
+```
+public static final int PERSPECTIVE_CONTRASTING_LEFT_FACING
+```
+
+
+
+
+### PERSPECTIVE_CONTRASTING_RIGHT_FACING {#PERSPECTIVE-CONTRASTING-RIGHT-FACING}
+```
+public static final int PERSPECTIVE_CONTRASTING_RIGHT_FACING
+```
+
+
+
+
+### PERSPECTIVE_FRONT {#PERSPECTIVE-FRONT}
+```
+public static final int PERSPECTIVE_FRONT
+```
+
+
+
+
+### PERSPECTIVE_HEROIC_EXTREME_LEFT_FACING {#PERSPECTIVE-HEROIC-EXTREME-LEFT-FACING}
+```
+public static final int PERSPECTIVE_HEROIC_EXTREME_LEFT_FACING
+```
+
+
+
+
+### PERSPECTIVE_HEROIC_EXTREME_RIGHT_FACING {#PERSPECTIVE-HEROIC-EXTREME-RIGHT-FACING}
+```
+public static final int PERSPECTIVE_HEROIC_EXTREME_RIGHT_FACING
+```
+
+
+
+
+### PERSPECTIVE_HEROIC_LEFT_FACING {#PERSPECTIVE-HEROIC-LEFT-FACING}
+```
+public static final int PERSPECTIVE_HEROIC_LEFT_FACING
+```
+
+
+
+
+### PERSPECTIVE_HEROIC_RIGHT_FACING {#PERSPECTIVE-HEROIC-RIGHT-FACING}
+```
+public static final int PERSPECTIVE_HEROIC_RIGHT_FACING
+```
+
+
+
+
+### PERSPECTIVE_LEFT {#PERSPECTIVE-LEFT}
+```
+public static final int PERSPECTIVE_LEFT
+```
+
+
+
+
+### PERSPECTIVE_RELAXED {#PERSPECTIVE-RELAXED}
+```
+public static final int PERSPECTIVE_RELAXED
+```
+
+
+
+
+### PERSPECTIVE_RELAXED_MODERATELY {#PERSPECTIVE-RELAXED-MODERATELY}
+```
+public static final int PERSPECTIVE_RELAXED_MODERATELY
+```
+
+
+
+
+### PERSPECTIVE_RIGHT {#PERSPECTIVE-RIGHT}
+```
+public static final int PERSPECTIVE_RIGHT
+```
+
+
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/presetcolormatricsvalue/_index.md
+++ b/japanese/java/com.aspose.diagram/presetcolormatricsvalue/_index.md
@@ -1,0 +1,192 @@
+---
+title: PresetColorMatricsValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: Used to set Shape theme styles color property
+type: docs
+weight: 297
+url: /ja/java/com.aspose.diagram/presetcolormatricsvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PresetColorMatricsValue
+```
+
+Shape のテーマ スタイルの色プロパティを設定するために使用されます。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [COLOR_1](#COLOR-1) | Color1. |
+| [COLOR_2](#COLOR-2) | Color2. |
+| [COLOR_3](#COLOR-3) | Color3. |
+| [COLOR_4](#COLOR-4) | Color4. |
+| [COLOR_5](#COLOR-5) | Color5. |
+| [COLOR_6](#COLOR-6) | Color6. |
+| [COLOR_7](#COLOR-7) | Color7. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### COLOR_1 {#COLOR-1}
+```
+public static final int COLOR_1
+```
+
+
+Color1.
+
+### COLOR_2 {#COLOR-2}
+```
+public static final int COLOR_2
+```
+
+
+Color2.
+
+### COLOR_3 {#COLOR-3}
+```
+public static final int COLOR_3
+```
+
+
+Color3.
+
+### COLOR_4 {#COLOR-4}
+```
+public static final int COLOR_4
+```
+
+
+Color4.
+
+### COLOR_5 {#COLOR-5}
+```
+public static final int COLOR_5
+```
+
+
+Color5.
+
+### COLOR_6 {#COLOR-6}
+```
+public static final int COLOR_6
+```
+
+
+Color6.
+
+### COLOR_7 {#COLOR-7}
+```
+public static final int COLOR_7
+```
+
+
+Color7.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/presetquickstylevalue/_index.md
+++ b/japanese/java/com.aspose.diagram/presetquickstylevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: PresetQuickStyleValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: テーマのクイック スタイル値を指定します。
+type: docs
+weight: 298
+url: /ja/java/com.aspose.diagram/presetquickstylevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PresetQuickStyleValue
+```
+
+テーマのクイック スタイル値を指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [VARIANT_STYLE_1](#VARIANT-STYLE-1) | VariantStyle1. |
+| [VARIANT_STYLE_2](#VARIANT-STYLE-2) | VariantStyle2. |
+| [VARIANT_STYLE_3](#VARIANT-STYLE-3) | VariantStyle3. |
+| [VARIANT_STYLE_4](#VARIANT-STYLE-4) | VariantStyle4. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### VARIANT_STYLE_1 {#VARIANT-STYLE-1}
+```
+public static final int VARIANT_STYLE_1
+```
+
+
+VariantStyle1.
+
+### VARIANT_STYLE_2 {#VARIANT-STYLE-2}
+```
+public static final int VARIANT_STYLE_2
+```
+
+
+VariantStyle2.
+
+### VARIANT_STYLE_3 {#VARIANT-STYLE-3}
+```
+public static final int VARIANT_STYLE_3
+```
+
+
+VariantStyle3.
+
+### VARIANT_STYLE_4 {#VARIANT-STYLE-4}
+```
+public static final int VARIANT_STYLE_4
+```
+
+
+VariantStyle4.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/presetshadowtype/_index.md
+++ b/japanese/java/com.aspose.diagram/presetshadowtype/_index.md
@@ -1,0 +1,354 @@
+---
+title: PresetShadowType
+second_title: Aspose.Diagram for Java API リファレンス
+description: プリセットの影タイプを表します。
+type: docs
+weight: 299
+url: /ja/java/com.aspose.diagram/presetshadowtype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PresetShadowType
+```
+
+プリセットの影タイプを表します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [BELOW](#BELOW) | 下側の外部シャドウ。 |
+| [CUSTOM](#CUSTOM) | カスタムシャドウ。 |
+| [INSIDE_BOTTOM](#INSIDE-BOTTOM) | 下部の内部シャドウ。 |
+| [INSIDE_CENTER](#INSIDE-CENTER) | 中央の内部シャドウ。 |
+| [INSIDE_DIAGONAL_BOTTOM_LEFT](#INSIDE-DIAGONAL-BOTTOM-LEFT) | 左下斜めの内部シャドウ。 |
+| [INSIDE_DIAGONAL_BOTTOM_RIGHT](#INSIDE-DIAGONAL-BOTTOM-RIGHT) | 右下斜めの内部シャドウ。 |
+| [INSIDE_DIAGONAL_TOP_LEFT](#INSIDE-DIAGONAL-TOP-LEFT) | 左上斜めの内部シャドウ。 |
+| [INSIDE_DIAGONAL_TOP_RIGHT](#INSIDE-DIAGONAL-TOP-RIGHT) | 右上斜めの内部シャドウ。 |
+| [INSIDE_LEFT](#INSIDE-LEFT) | 左側の内部シャドウ。 |
+| [INSIDE_RIGHT](#INSIDE-RIGHT) | 右側の内部シャドウ。 |
+| [INSIDE_TOP](#INSIDE-TOP) | 上部の内部シャドウ。 |
+| [NO_SHADOW](#NO-SHADOW) | 影なし。 |
+| [OFFSET_BOTTOM](#OFFSET-BOTTOM) | 下側の外部シャドウオフセット。 |
+| [OFFSET_CENTER](#OFFSET-CENTER) | 中央の外部シャドウオフセット。 |
+| [OFFSET_DIAGONAL_BOTTOM_LEFT](#OFFSET-DIAGONAL-BOTTOM-LEFT) | 左下斜めの外部シャドウオフセット。 |
+| [OFFSET_DIAGONAL_BOTTOM_RIGHT](#OFFSET-DIAGONAL-BOTTOM-RIGHT) | 右下斜めの外部シャドウオフセット。 |
+| [OFFSET_DIAGONAL_TOP_LEFT](#OFFSET-DIAGONAL-TOP-LEFT) | 左上斜めの外部シャドウオフセット。 |
+| [OFFSET_DIAGONAL_TOP_RIGHT](#OFFSET-DIAGONAL-TOP-RIGHT) | 右上斜めの外部シャドウオフセット。 |
+| [OFFSET_LEFT](#OFFSET-LEFT) | 左側の外部シャドウオフセット。 |
+| [OFFSET_RIGHT](#OFFSET-RIGHT) | 右側の外部シャドウオフセット。 |
+| [OFFSET_TOP](#OFFSET-TOP) | 上側の外部シャドウオフセット。 |
+| [PERSPECTIVE_DIAGONAL_LOWER_LEFT](#PERSPECTIVE-DIAGONAL-LOWER-LEFT) | 左下斜めの外部シャドウパースペクティブ。 |
+| [PERSPECTIVE_DIAGONAL_LOWER_RIGHT](#PERSPECTIVE-DIAGONAL-LOWER-RIGHT) | 右下斜めの外部シャドウパースペクティブ。 |
+| [PERSPECTIVE_DIAGONAL_UPPER_LEFT](#PERSPECTIVE-DIAGONAL-UPPER-LEFT) | 左上斜めの外部シャドウパースペクティブ。 |
+| [PERSPECTIVE_DIAGONAL_UPPER_RIGHT](#PERSPECTIVE-DIAGONAL-UPPER-RIGHT) | 右上斜めの外部シャドウパースペクティブ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BELOW {#BELOW}
+```
+public static final int BELOW
+```
+
+
+下側の外部シャドウ。
+
+### CUSTOM {#CUSTOM}
+```
+public static final int CUSTOM
+```
+
+
+カスタムシャドウ。
+
+### INSIDE_BOTTOM {#INSIDE-BOTTOM}
+```
+public static final int INSIDE_BOTTOM
+```
+
+
+下部の内部シャドウ。
+
+### INSIDE_CENTER {#INSIDE-CENTER}
+```
+public static final int INSIDE_CENTER
+```
+
+
+中央の内部シャドウ。
+
+### INSIDE_DIAGONAL_BOTTOM_LEFT {#INSIDE-DIAGONAL-BOTTOM-LEFT}
+```
+public static final int INSIDE_DIAGONAL_BOTTOM_LEFT
+```
+
+
+左下斜めの内部シャドウ。
+
+### INSIDE_DIAGONAL_BOTTOM_RIGHT {#INSIDE-DIAGONAL-BOTTOM-RIGHT}
+```
+public static final int INSIDE_DIAGONAL_BOTTOM_RIGHT
+```
+
+
+右下斜めの内部シャドウ。
+
+### INSIDE_DIAGONAL_TOP_LEFT {#INSIDE-DIAGONAL-TOP-LEFT}
+```
+public static final int INSIDE_DIAGONAL_TOP_LEFT
+```
+
+
+左上斜めの内部シャドウ。
+
+### INSIDE_DIAGONAL_TOP_RIGHT {#INSIDE-DIAGONAL-TOP-RIGHT}
+```
+public static final int INSIDE_DIAGONAL_TOP_RIGHT
+```
+
+
+右上斜めの内部シャドウ。
+
+### INSIDE_LEFT {#INSIDE-LEFT}
+```
+public static final int INSIDE_LEFT
+```
+
+
+左側の内部シャドウ。
+
+### INSIDE_RIGHT {#INSIDE-RIGHT}
+```
+public static final int INSIDE_RIGHT
+```
+
+
+右側の内部シャドウ。
+
+### INSIDE_TOP {#INSIDE-TOP}
+```
+public static final int INSIDE_TOP
+```
+
+
+上部の内部シャドウ。
+
+### NO_SHADOW {#NO-SHADOW}
+```
+public static final int NO_SHADOW
+```
+
+
+影なし。
+
+### OFFSET_BOTTOM {#OFFSET-BOTTOM}
+```
+public static final int OFFSET_BOTTOM
+```
+
+
+下側の外部シャドウオフセット。
+
+### OFFSET_CENTER {#OFFSET-CENTER}
+```
+public static final int OFFSET_CENTER
+```
+
+
+中央の外部シャドウオフセット。
+
+### OFFSET_DIAGONAL_BOTTOM_LEFT {#OFFSET-DIAGONAL-BOTTOM-LEFT}
+```
+public static final int OFFSET_DIAGONAL_BOTTOM_LEFT
+```
+
+
+左下斜めの外部シャドウオフセット。
+
+### OFFSET_DIAGONAL_BOTTOM_RIGHT {#OFFSET-DIAGONAL-BOTTOM-RIGHT}
+```
+public static final int OFFSET_DIAGONAL_BOTTOM_RIGHT
+```
+
+
+右下斜めの外部シャドウオフセット。
+
+### OFFSET_DIAGONAL_TOP_LEFT {#OFFSET-DIAGONAL-TOP-LEFT}
+```
+public static final int OFFSET_DIAGONAL_TOP_LEFT
+```
+
+
+左上斜めの外部シャドウオフセット。
+
+### OFFSET_DIAGONAL_TOP_RIGHT {#OFFSET-DIAGONAL-TOP-RIGHT}
+```
+public static final int OFFSET_DIAGONAL_TOP_RIGHT
+```
+
+
+右上斜めの外部シャドウオフセット。
+
+### OFFSET_LEFT {#OFFSET-LEFT}
+```
+public static final int OFFSET_LEFT
+```
+
+
+左側の外部シャドウオフセット。
+
+### OFFSET_RIGHT {#OFFSET-RIGHT}
+```
+public static final int OFFSET_RIGHT
+```
+
+
+右側の外部シャドウオフセット。
+
+### OFFSET_TOP {#OFFSET-TOP}
+```
+public static final int OFFSET_TOP
+```
+
+
+上側の外部シャドウオフセット。
+
+### PERSPECTIVE_DIAGONAL_LOWER_LEFT {#PERSPECTIVE-DIAGONAL-LOWER-LEFT}
+```
+public static final int PERSPECTIVE_DIAGONAL_LOWER_LEFT
+```
+
+
+左下斜めの外部シャドウパースペクティブ。
+
+### PERSPECTIVE_DIAGONAL_LOWER_RIGHT {#PERSPECTIVE-DIAGONAL-LOWER-RIGHT}
+```
+public static final int PERSPECTIVE_DIAGONAL_LOWER_RIGHT
+```
+
+
+右下斜めの外部シャドウパースペクティブ。
+
+### PERSPECTIVE_DIAGONAL_UPPER_LEFT {#PERSPECTIVE-DIAGONAL-UPPER-LEFT}
+```
+public static final int PERSPECTIVE_DIAGONAL_UPPER_LEFT
+```
+
+
+左上斜めの外部シャドウパースペクティブ。
+
+### PERSPECTIVE_DIAGONAL_UPPER_RIGHT {#PERSPECTIVE-DIAGONAL-UPPER-RIGHT}
+```
+public static final int PERSPECTIVE_DIAGONAL_UPPER_RIGHT
+```
+
+
+右上斜めの外部シャドウパースペクティブ。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/presetstylematricsvalue/_index.md
+++ b/japanese/java/com.aspose.diagram/presetstylematricsvalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: PresetStyleMatricsValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: Shape のテーマ スタイル プロパティを設定するために使用されます。
+type: docs
+weight: 300
+url: /ja/java/com.aspose.diagram/presetstylematricsvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PresetStyleMatricsValue
+```
+
+Shape のテーマ スタイル プロパティを設定するために使用されます。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [STYLE_1](#STYLE-1) | Style1 |
+| [STYLE_2](#STYLE-2) | Style2 |
+| [STYLE_3](#STYLE-3) | Style3 |
+| [STYLE_4](#STYLE-4) | Style4 |
+| [STYLE_5](#STYLE-5) | Style5 |
+| [STYLE_6](#STYLE-6) | Style6 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### STYLE_1 {#STYLE-1}
+```
+public static final int STYLE_1
+```
+
+
+Style1
+
+### STYLE_2 {#STYLE-2}
+```
+public static final int STYLE_2
+```
+
+
+Style2
+
+### STYLE_3 {#STYLE-3}
+```
+public static final int STYLE_3
+```
+
+
+Style3
+
+### STYLE_4 {#STYLE-4}
+```
+public static final int STYLE_4
+```
+
+
+Style4
+
+### STYLE_5 {#STYLE-5}
+```
+public static final int STYLE_5
+```
+
+
+Style5
+
+### STYLE_6 {#STYLE-6}
+```
+public static final int STYLE_6
+```
+
+
+Style6
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/presetthemevalue/_index.md
+++ b/japanese/java/com.aspose.diagram/presetthemevalue/_index.md
@@ -1,0 +1,372 @@
+---
+title: PresetThemeValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: テーマの値を指定します。
+type: docs
+weight: 301
+url: /ja/java/com.aspose.diagram/presetthemevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PresetThemeValue
+```
+
+テーマの値を指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [BUBBLE](#BUBBLE) | バブル |
+| [CLOUDS](#CLOUDS) | 雲 |
+| [DAYBREAK](#DAYBREAK) | 夜明け |
+| [FACET](#FACET) | ファセット |
+| [GEMSTONE](#GEMSTONE) | 宝石 |
+| [INTEGRAL](#INTEGRAL) | Integral |
+| [ION](#ION) | Ion |
+| [LINEAR](#LINEAR) | Linear |
+| [LINES](#LINES) | Lines |
+| [MARKER](#MARKER) | Marker |
+| [NO_THEME](#NO-THEME) | NoTheme |
+| [OFFICE](#OFFICE) | Office |
+| [ORGANIC](#ORGANIC) | Organic |
+| [PARALLEL](#PARALLEL) | Parallel |
+| [PEN](#PEN) | Pen |
+| [PENCIL](#PENCIL) | Pencil |
+| [PROMINENCE](#PROMINENCE) | Prominence |
+| [RADIANCE](#RADIANCE) | Radiance |
+| [RETROSPECT](#RETROSPECT) | Retrospect |
+| [SEQUENCE](#SEQUENCE) | Sequence |
+| [SHADE](#SHADE) | Shade |
+| [SIMPLE](#SIMPLE) | Simple |
+| [SLICE](#SLICE) | Slice |
+| [SMOKE](#SMOKE) | Smoke |
+| [WHISP](#WHISP) | Whisp |
+| [WHITE_BOARD](#WHITE-BOARD) | WhiteBoard |
+| [ZEPHYR](#ZEPHYR) | Zephyr |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BUBBLE {#BUBBLE}
+```
+public static final int BUBBLE
+```
+
+
+バブル
+
+### CLOUDS {#CLOUDS}
+```
+public static final int CLOUDS
+```
+
+
+雲
+
+### DAYBREAK {#DAYBREAK}
+```
+public static final int DAYBREAK
+```
+
+
+夜明け
+
+### FACET {#FACET}
+```
+public static final int FACET
+```
+
+
+ファセット
+
+### GEMSTONE {#GEMSTONE}
+```
+public static final int GEMSTONE
+```
+
+
+宝石
+
+### INTEGRAL {#INTEGRAL}
+```
+public static final int INTEGRAL
+```
+
+
+Integral
+
+### ION {#ION}
+```
+public static final int ION
+```
+
+
+Ion
+
+### LINEAR {#LINEAR}
+```
+public static final int LINEAR
+```
+
+
+Linear
+
+### LINES {#LINES}
+```
+public static final int LINES
+```
+
+
+Lines
+
+### MARKER {#MARKER}
+```
+public static final int MARKER
+```
+
+
+Marker
+
+### NO_THEME {#NO-THEME}
+```
+public static final int NO_THEME
+```
+
+
+NoTheme
+
+### OFFICE {#OFFICE}
+```
+public static final int OFFICE
+```
+
+
+Office
+
+### ORGANIC {#ORGANIC}
+```
+public static final int ORGANIC
+```
+
+
+Organic
+
+### PARALLEL {#PARALLEL}
+```
+public static final int PARALLEL
+```
+
+
+Parallel
+
+### PEN {#PEN}
+```
+public static final int PEN
+```
+
+
+Pen
+
+### PENCIL {#PENCIL}
+```
+public static final int PENCIL
+```
+
+
+Pencil
+
+### PROMINENCE {#PROMINENCE}
+```
+public static final int PROMINENCE
+```
+
+
+Prominence
+
+### RADIANCE {#RADIANCE}
+```
+public static final int RADIANCE
+```
+
+
+Radiance
+
+### RETROSPECT {#RETROSPECT}
+```
+public static final int RETROSPECT
+```
+
+
+Retrospect
+
+### SEQUENCE {#SEQUENCE}
+```
+public static final int SEQUENCE
+```
+
+
+Sequence
+
+### SHADE {#SHADE}
+```
+public static final int SHADE
+```
+
+
+Shade
+
+### SIMPLE {#SIMPLE}
+```
+public static final int SIMPLE
+```
+
+
+Simple
+
+### SLICE {#SLICE}
+```
+public static final int SLICE
+```
+
+
+Slice
+
+### SMOKE {#SMOKE}
+```
+public static final int SMOKE
+```
+
+
+Smoke
+
+### WHISP {#WHISP}
+```
+public static final int WHISP
+```
+
+
+Whisp
+
+### WHITE_BOARD {#WHITE-BOARD}
+```
+public static final int WHITE_BOARD
+```
+
+
+WhiteBoard
+
+### ZEPHYR {#ZEPHYR}
+```
+public static final int ZEPHYR
+```
+
+
+Zephyr
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/presetthemevariantvalue/_index.md
+++ b/japanese/java/com.aspose.diagram/presetthemevariantvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: PresetThemeVariantValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: テーマのバリアント値を指定します。
+type: docs
+weight: 302
+url: /ja/java/com.aspose.diagram/presetthemevariantvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PresetThemeVariantValue
+```
+
+テーマのバリアント値を指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [VARIANT_1](#VARIANT-1) | Variant1. |
+| [VARIANT_2](#VARIANT-2) | Variant2. |
+| [VARIANT_3](#VARIANT-3) | Variant3. |
+| [VARIANT_4](#VARIANT-4) | Variant4. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### VARIANT_1 {#VARIANT-1}
+```
+public static final int VARIANT_1
+```
+
+
+Variant1.
+
+### VARIANT_2 {#VARIANT-2}
+```
+public static final int VARIANT_2
+```
+
+
+Variant2.
+
+### VARIANT_3 {#VARIANT-3}
+```
+public static final int VARIANT_3
+```
+
+
+Variant3.
+
+### VARIANT_4 {#VARIANT-4}
+```
+public static final int VARIANT_4
+```
+
+
+Variant4.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/previewscope/_index.md
+++ b/japanese/java/com.aspose.diagram/previewscope/_index.md
@@ -1,0 +1,179 @@
+---
+title: PreviewScope
+second_title: Aspose.Diagram for Java API リファレンス
+description: ドキュメントにプレビューが含まれるかどうか、含まれる場合はプレビューが最初のページのみを表示するか、ドキュメント内のすべてのページを表示するかを指定します。
+type: docs
+weight: 303
+url: /ja/java/com.aspose.diagram/previewscope/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PreviewScope
+```
+
+ドキュメントにプレビューが含まれるかどうか、含まれる場合はプレビューが最初のページのみを表示するか、ドキュメント全体のページを表示するかを指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PreviewScope(int value)](#PreviewScope-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | ドキュメントにプレビューが含まれるかどうか、含まれる場合はプレビューが最初のページのみを表示するか、ドキュメント全体のページを表示するかを指定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/previewscope\#getValue--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PreviewScope(int value) {#PreviewScope-int-}
+```
+public PreviewScope(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+ドキュメントにプレビューが含まれるかどうか、含まれる場合はプレビューが最初のページのみを表示するか、ドキュメント全体のページを表示するかを指定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/previewscope\#getValue--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/previewscopevalue/_index.md
+++ b/japanese/java/com.aspose.diagram/previewscopevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: PreviewScopeValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: ドキュメントにプレビューが含まれるかどうか、含まれる場合はプレビューが最初のページのみを表示するか、ドキュメント内のすべてのページを表示するかを指定します。
+type: docs
+weight: 304
+url: /ja/java/com.aspose.diagram/previewscopevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PreviewScopeValue
+```
+
+ドキュメントにプレビューが含まれるかどうか、含まれる場合はプレビューが最初のページのみを表示するか、ドキュメント全体のページを表示するかを指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [ALL_PAGES](#ALL-PAGES) | All pages. |
+| [FIRST_PAGE](#FIRST-PAGE) | First page. |
+| [NO_PREVIEW](#NO-PREVIEW) | No preview. |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALL_PAGES {#ALL-PAGES}
+```
+public static final int ALL_PAGES
+```
+
+
+All pages.
+
+### FIRST_PAGE {#FIRST-PAGE}
+```
+public static final int FIRST_PAGE
+```
+
+
+First page.
+
+### NO_PREVIEW {#NO-PREVIEW}
+```
+public static final int NO_PREVIEW
+```
+
+
+No preview.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/printpageorientation/_index.md
+++ b/japanese/java/com.aspose.diagram/printpageorientation/_index.md
@@ -1,0 +1,180 @@
+---
+title: PrintPageOrientation
+second_title: Aspose.Diagram for Java API リファレンス
+description: ページが縦向きで印刷されるか横向きで印刷されるかを決定します。
+type: docs
+weight: 305
+url: /ja/java/com.aspose.diagram/printpageorientation/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PrintPageOrientation
+```
+
+ページが縦向きで印刷されるか横向きで印刷されるかを決定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PrintPageOrientation(PrintProps pp, int value)](#PrintPageOrientation-com.aspose.diagram.PrintProps-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | ページが縦向きで印刷されるか横向きで印刷されるかを決定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | For the description of this property, please see [getValue()](../../com.aspose.diagram/printpageorientation\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PrintPageOrientation(PrintProps pp, int value) {#PrintPageOrientation-com.aspose.diagram.PrintProps-int-}
+```
+public PrintPageOrientation(PrintProps pp, int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| pp | [PrintProps](../../com.aspose.diagram/printprops) |  |
+| 値 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+ページが縦向きで印刷されるか横向きで印刷されるかを決定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+For the description of this property, please see [getValue()](../../com.aspose.diagram/printpageorientation\#getValue--)
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/printpageorientationvalue/_index.md
+++ b/japanese/java/com.aspose.diagram/printpageorientationvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: PrintPageOrientationValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: ページが縦向きで印刷されるか横向きで印刷されるかを決定します。
+type: docs
+weight: 306
+url: /ja/java/com.aspose.diagram/printpageorientationvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PrintPageOrientationValue
+```
+
+ページが縦向きで印刷されるか横向きで印刷されるかを決定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [LANDSCAPE](#LANDSCAPE) | Landscape. |
+| [PORTRAIT](#PORTRAIT) | Portrait. |
+| [SAME_AS_PRINTER](#SAME-AS-PRINTER) | Same as printer. |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LANDSCAPE {#LANDSCAPE}
+```
+public static final int LANDSCAPE
+```
+
+
+Landscape.
+
+### PORTRAIT {#PORTRAIT}
+```
+public static final int PORTRAIT
+```
+
+
+Portrait.
+
+### SAME_AS_PRINTER {#SAME-AS-PRINTER}
+```
+public static final int SAME_AS_PRINTER
+```
+
+
+Same as printer.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/printprops/_index.md
+++ b/japanese/java/com.aspose.diagram/printprops/_index.md
@@ -1,0 +1,315 @@
+---
+title: PrintProps
+second_title: Aspose.Diagram for Java API リファレンス
+description: 描画ページがプリンター ページにどのように表示されるかを制御する要素を含みます。
+type: docs
+weight: 307
+url: /ja/java/com.aspose.diagram/printprops/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PrintProps
+```
+
+描画ページがプリンタページ上でどのようにフォーマット（表示）されるかを制御する要素を含みます。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCenterX()](#getCenterX--) | 描画ページが印刷ページ上で水平方向に中央揃えになるかどうかを決定します。 |
+| [getCenterY()](#getCenterY--) | 描画ページが印刷ページ上で垂直方向に中央揃えになるかどうかを決定します。 |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getOnPage()](#getOnPage--) | 描画が特定の枚数のプリンタページに印刷されるかどうかを示します。 |
+| [getPageBottomMargin()](#getPageBottomMargin--) | 印刷ページの下部余白を指定します。 |
+| [getPageLeftMargin()](#getPageLeftMargin--) | 印刷ページの左側余白を指定します。 |
+| [getPageRightMargin()](#getPageRightMargin--) | 印刷ページの右側余白を指定します。 |
+| [getPageTopMargin()](#getPageTopMargin--) | プリンタページの上部余白を指定します。 |
+| [getPagesX()](#getPagesX--) | 描画ページを水平方向に収めるプリンタページ数を決定します。 |
+| [getPagesY()](#getPagesY--) | 描画ページを垂直方向に収めるプリンタページ数を決定します。 |
+| [getPaperKind()](#getPaperKind--) | ページを印刷する用紙の種類を指定します。 |
+| [getPaperSource()](#getPaperSource--) | ページの用紙供給元を決定します。 |
+| [getPrintGrid()](#getPrintGrid--) | ドキュメントページを印刷する際にグリッドを印刷するかどうかを指定します。 |
+| [getPrintPageOrientation()](#getPrintPageOrientation--) | ページが縦向きで印刷されるか横向きで印刷されるかを決定します。 |
+| [getScaleX()](#getScaleX--) | プリンタページ上の描画ページの拡大率（x（水平方向））のパーセンテージを指定します。 |
+| [getScaleY()](#getScaleY--) | 描画ページをプリンターページ上で拡大する割合（y（垂直）方向）を指定します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | このプロパティの説明については、[getDel()](../../com.aspose.diagram/printprops\#getDel--)をご覧ください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCenterX() {#getCenterX--}
+```
+public BoolValue getCenterX()
+```
+
+
+描画ページが印刷ページ上で水平方向に中央揃えになるかどうかを決定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getCenterY() {#getCenterY--}
+```
+public BoolValue getCenterY()
+```
+
+
+描画ページが印刷ページ上で垂直方向に中央揃えになるかどうかを決定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getOnPage() {#getOnPage--}
+```
+public BoolValue getOnPage()
+```
+
+
+描画が特定の枚数のプリンタページに印刷されるかどうかを示します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getPageBottomMargin() {#getPageBottomMargin--}
+```
+public DoubleValue getPageBottomMargin()
+```
+
+
+印刷ページの下部余白を指定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getPageLeftMargin() {#getPageLeftMargin--}
+```
+public DoubleValue getPageLeftMargin()
+```
+
+
+印刷ページの左側余白を指定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getPageRightMargin() {#getPageRightMargin--}
+```
+public DoubleValue getPageRightMargin()
+```
+
+
+印刷ページの右側余白を指定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getPageTopMargin() {#getPageTopMargin--}
+```
+public DoubleValue getPageTopMargin()
+```
+
+
+プリンタページの上部余白を指定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getPagesX() {#getPagesX--}
+```
+public IntValue getPagesX()
+```
+
+
+描画ページを水平方向に収めるプリンタページ数を決定します。
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getPagesY() {#getPagesY--}
+```
+public IntValue getPagesY()
+```
+
+
+描画ページを垂直方向に収めるプリンタページ数を決定します。
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getPaperKind() {#getPaperKind--}
+```
+public IntValue getPaperKind()
+```
+
+
+ページを印刷する用紙の種類を指定します。
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getPaperSource() {#getPaperSource--}
+```
+public IntValue getPaperSource()
+```
+
+
+ページの用紙供給元を決定します。
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getPrintGrid() {#getPrintGrid--}
+```
+public BoolValue getPrintGrid()
+```
+
+
+ドキュメントページを印刷する際にグリッドを印刷するかどうかを指定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getPrintPageOrientation() {#getPrintPageOrientation--}
+```
+public PrintPageOrientation getPrintPageOrientation()
+```
+
+
+ページが縦向きで印刷されるか横向きで印刷されるかを決定します。
+
+**Returns:**
+[PrintPageOrientation](../../com.aspose.diagram/printpageorientation)
+### getScaleX() {#getScaleX--}
+```
+public DoubleValue getScaleX()
+```
+
+
+プリンタページ上の描画ページの拡大率（x（水平方向））のパーセンテージを指定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getScaleY() {#getScaleY--}
+```
+public DoubleValue getScaleY()
+```
+
+
+描画ページをプリンターページ上で拡大する割合（y（垂直）方向）を指定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+このプロパティの説明については、[getDel()](../../com.aspose.diagram/printprops\#getDel--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/printsaveoptions/_index.md
+++ b/japanese/java/com.aspose.diagram/printsaveoptions/_index.md
@@ -1,0 +1,429 @@
+---
+title: PrintSaveOptions
+second_title: Aspose.Diagram for Java API リファレンス
+description: 図を印刷する際に追加オプションを指定できるようにします。
+type: docs
+weight: 308
+url: /ja/java/com.aspose.diagram/printsaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.SaveOptions](../../com.aspose.diagram/saveoptions), [com.aspose.diagram.RenderingSaveOptions](../../com.aspose.diagram/renderingsaveoptions)
+```
+public class PrintSaveOptions extends RenderingSaveOptions
+```
+
+図を印刷する際に追加オプションを指定できるようにします。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PrintSaveOptions()](#PrintSaveOptions--) | このクラスの新しいインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | 指定された保存形式に適したクラスの保存オプションオブジェクトを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDefaultFont()](#getDefaultFont--) | 図内の文字が Unicode で、正しいフォント値が設定されていない、またはフォントがローカルにインストールされていない場合、pdf、画像、または XPS でブロックとして表示されることがあります。 |
+| [getEmfRenderSetting()](#getEmfRenderSetting--) | Emf メタファイルのレンダリング設定です。 |
+| [getEnlargePage()](#getEnlargePage--) | ページを拡大するかどうかを指定します。 |
+| [getExportGuideShapes()](#getExportGuideShapes--) | ガイドシェイプをエクスポートするかどうかを定義します。 |
+| [getPageCount()](#getPageCount--) | マルチページ ファイルに保存する際にレンダリングするページ数です。 |
+| [getPageSize()](#getPageSize--) | 生成された画像のページサイズ。 |
+| [getSaveForegroundPagesOnly()](#getSaveForegroundPagesOnly--) | すべてのページを印刷するか、前景のみを印刷するかを指定します。 |
+| [getSaveFormat()](#getSaveFormat--) | この保存オプションオブジェクトが使用される場合、ドキュメントが保存される形式を指定します。 |
+| [getShapes()](#getShapes--) | レンダリングするシェイプ。 |
+| [getWarningCallback()](#getWarningCallback--) | 警告コールバック。 |
+| [hashCode()](#hashCode--) |  |
+| [isExportComments()](#isExportComments--) | コメントをエクスポートするかどうかを定義します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | このプロパティの説明については、[getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--) を参照してください。 |
+| [setEmfRenderSetting(int value)](#setEmfRenderSetting-int-) | このプロパティの説明については、[getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--) を参照してください。 |
+| [setEnlargePage(boolean value)](#setEnlargePage-boolean-) | このプロパティの説明については、[getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--) を参照してください。 |
+| [setExportComments(boolean value)](#setExportComments-boolean-) | このプロパティの説明については、[isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--) を参照してください。 |
+| [setExportGuideShapes(boolean value)](#setExportGuideShapes-boolean-) | このプロパティの説明については、[getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--) を参照してください。 |
+| [setPageCount(int value)](#setPageCount-int-) | このプロパティの説明については、[getPageCount()](../../com.aspose.diagram/printsaveoptions\#getPageCount--) を参照してください。 |
+| [setPageSize(PageSize value)](#setPageSize-com.aspose.diagram.PageSize-) | このプロパティの説明については、[getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--) を参照してください。 |
+| [setSaveForegroundPagesOnly(boolean value)](#setSaveForegroundPagesOnly-boolean-) | このプロパティの説明については、[getSaveForegroundPagesOnly()](../../com.aspose.diagram/printsaveoptions\#getSaveForegroundPagesOnly--) を参照してください。 |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | このプロパティの説明については、[getSaveFormat()](../../com.aspose.diagram/saveoptions\#getSaveFormat--) を参照してください。 |
+| [setShapes(ShapeCollection value)](#setShapes-com.aspose.diagram.ShapeCollection-) | このプロパティの説明については、[getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--) を参照してください。 |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PrintSaveOptions() {#PrintSaveOptions--}
+```
+public PrintSaveOptions()
+```
+
+
+このクラスの新しいインスタンスを初期化します。
+
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+指定された保存形式に適したクラスの保存オプションオブジェクトを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| saveFormat | int | 保存オプションオブジェクトを作成するための Aspose.Diagram.SaveFileFormat です。 |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+ダイアグラム内の文字が Unicode で、正しいフォントが設定されていない、またはフォントがローカルにインストールされていない場合、PDF、画像、または XPS で文字がブロックとして表示されることがあります。MingLiu や MS Gothic などの DefaultFont を設定して、これらの文字を表示してください。
+
+**Returns:**
+java.lang.String
+### getEmfRenderSetting() {#getEmfRenderSetting--}
+```
+public int getEmfRenderSetting()
+```
+
+
+Emf メタファイルのレンダリング設定です。\"EMF+ Dual\" と識別される EMF メタファイルは、EMF+ レコードと EMF レコードの両方を含むことができます。画像のレンダリングには、どちらのレコードタイプも使用でき、EMF+ レコードのみ、または EMF レコードのみを使用することもできます。EmfPlusPrefer が設定されている場合は EMF+ レコードが解析され、設定されていない場合は EMF レコードのみが解析されます。デフォルト値は EmfOnly です。
+
+**Returns:**
+int
+### getEnlargePage() {#getEnlargePage--}
+```
+public boolean getEnlargePage()
+```
+
+
+ページを拡大するかどうかを指定します。true の場合はページを拡大し、false の場合は拡大しません。デフォルト値は true です。
+
+**Returns:**
+boolean
+### getExportGuideShapes() {#getExportGuideShapes--}
+```
+public boolean getExportGuideShapes()
+```
+
+
+ガイドシェイプをエクスポートするかどうかを定義します。デフォルト値は true です。
+
+**Returns:**
+boolean
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+マルチページ ファイルに保存する際にレンダリングするページ数です。デフォルトは MaxValue で、これは図のすべてのページが印刷されることを意味します。
+
+**Returns:**
+int
+### getPageSize() {#getPageSize--}
+```
+public PageSize getPageSize()
+```
+
+
+生成された画像のページサイズです。 [PageSize](../../com.aspose.diagram/pagesize) または null にできます。デフォルト値は null です。PageSize が null の場合、生成された画像のページサイズはソース図から取得されます。
+
+**Returns:**
+[PageSize](../../com.aspose.diagram/pagesize)
+### getSaveForegroundPagesOnly() {#getSaveForegroundPagesOnly--}
+```
+public boolean getSaveForegroundPagesOnly()
+```
+
+
+すべてのページを印刷するか、前景のみを印刷するかを指定します。true の場合、前景ページのみが印刷されます（背景が存在すればそれも含む）。false の場合、前景ページが印刷された後に空の背景ページが続きます（背景が存在すればそれも印刷されます）。PageCount が 1 より大きい場合にのみ true を返すことができます。デフォルト値は false です。
+
+**Returns:**
+boolean
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+この保存オプションオブジェクトが使用される場合、ドキュメントが保存される形式を指定します。
+
+**Returns:**
+int
+### getShapes() {#getShapes--}
+```
+public ShapeCollection getShapes()
+```
+
+
+レンダリングするシェイプです。デフォルトのカウントは 0 です。
+
+**Returns:**
+[ShapeCollection](../../com.aspose.diagram/shapecollection)
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+警告コールバック。
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExportComments() {#isExportComments--}
+```
+public boolean isExportComments()
+```
+
+
+コメントをエクスポートするかどうかを定義します。デフォルト値は false です。
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+このプロパティの説明については、[getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setEmfRenderSetting(int value) {#setEmfRenderSetting-int-}
+```
+public void setEmfRenderSetting(int value)
+```
+
+
+このプロパティの説明については、[getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setEnlargePage(boolean value) {#setEnlargePage-boolean-}
+```
+public void setEnlargePage(boolean value)
+```
+
+
+このプロパティの説明については、[getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setExportComments(boolean value) {#setExportComments-boolean-}
+```
+public void setExportComments(boolean value)
+```
+
+
+このプロパティの説明については、[isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setExportGuideShapes(boolean value) {#setExportGuideShapes-boolean-}
+```
+public void setExportGuideShapes(boolean value)
+```
+
+
+このプロパティの説明については、[getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setPageCount(int value) {#setPageCount-int-}
+```
+public void setPageCount(int value)
+```
+
+
+このプロパティの説明については、[getPageCount()](../../com.aspose.diagram/printsaveoptions\#getPageCount--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setPageSize(PageSize value) {#setPageSize-com.aspose.diagram.PageSize-}
+```
+public void setPageSize(PageSize value)
+```
+
+
+このプロパティの説明については、[getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [PageSize](../../com.aspose.diagram/pagesize) |  |
+
+### setSaveForegroundPagesOnly(boolean value) {#setSaveForegroundPagesOnly-boolean-}
+```
+public void setSaveForegroundPagesOnly(boolean value)
+```
+
+
+このプロパティの説明については、[getSaveForegroundPagesOnly()](../../com.aspose.diagram/printsaveoptions\#getSaveForegroundPagesOnly--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+このプロパティの説明については、[getSaveFormat()](../../com.aspose.diagram/saveoptions\#getSaveFormat--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setShapes(ShapeCollection value) {#setShapes-com.aspose.diagram.ShapeCollection-}
+```
+public void setShapes(ShapeCollection value)
+```
+
+
+このプロパティの説明については、[getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [ShapeCollection](../../com.aspose.diagram/shapecollection) |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/prop/_index.md
+++ b/japanese/java/com.aspose.diagram/prop/_index.md
@@ -1,0 +1,384 @@
+---
+title: プロパティ
+second_title: Aspose.Diagram for Java API リファレンス
+description: カスタム プロパティを定義する要素と、データをシェイプに関連付ける要素を含みます。
+type: docs
+weight: 309
+url: /ja/java/com.aspose.diagram/prop/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Prop
+```
+
+カスタム プロパティを定義する要素と、データをシェイプに関連付ける要素を含みます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Prop()](#Prop--) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCalendar()](#getCalendar--) | カスタム プロパティ、テキスト フィールド、要素の数式に使用されるカレンダーを決定します。 |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getFormat()](#getFormat--) | Format 要素は、文字列、固定リスト、数値、可変リスト、日付または時刻、期間、または通貨であるカスタム プロパティの書式設定を指定します。 |
+| [getID()](#getID--) | 要素の親要素内における一意の ID。 |
+| [getIX()](#getIX--) | 親要素内の要素のゼロベースインデックスです。 |
+| [getInvisible()](#getInvisible--) | Invisible 要素は、Microsoft Visio のカスタム プロパティ ダイアログ ボックスでカスタム プロパティが表示されるかどうかを指定します。 |
+| [getLabel()](#getLabel--) | カスタム プロパティ ダイアログ ボックスにユーザーに表示されるラベルを指定します。 |
+| [getLangID()](#getLangID--) | セルの数式、テキスト、カスタムプロパティ、またはコメントが入力された言語のロケール ID (LCID) を示します。 |
+| [getName()](#getName--) | 要素の名前。 |
+| [getNameU()](#getNameU--) | 要素のユニバーサル名。 |
+| [getPrompt()](#getPrompt--) | Prompt 要素は、プロパティが選択されたときにカスタム プロパティ ダイアログ ボックスにユーザーに表示される説明的または指示的なテキストを指定します。 |
+| [getSortKey()](#getSortKey--) | カスタム プロパティがアプリケーションのユーザー インターフェイスに一覧表示される順序を決定するキーを指定します。 |
+| [getType()](#getType--) | Type はカスタム プロパティの値のデータ型を指定します。 |
+| [getValue()](#getValue--) | 明示的な名前空間でプレフィックスが付けられ、ドキュメントに保存される、ソリューション固有の整形式 XML データを含みます。 |
+| [getVerify()](#getVerify--) | インスタンスが作成されたとき、またはシェイプが複製またはコピーされたときに、ユーザーにシェイプのカスタム プロパティ情報の入力を求めるかどうかを指定します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | このプロパティの説明については、[getDel()](../../com.aspose.diagram/prop\#getDel--) を参照してください。 |
+| [setID(int value)](#setID-int-) | このプロパティの説明については、[getID()](../../com.aspose.diagram/prop\#getID--) を参照してください。 |
+| [setIX(int value)](#setIX-int-) | このプロパティの説明については、[getIX()](../../com.aspose.diagram/prop\#getIX--) を参照してください。 |
+| [setName(String value)](#setName-java.lang.String-) | このプロパティの説明については、[getName()](../../com.aspose.diagram/prop\#getName--) を参照してください。 |
+| [setNameU(String value)](#setNameU-java.lang.String-) | このプロパティの説明については、[getNameU()](../../com.aspose.diagram/prop\#getNameU--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Prop() {#Prop--}
+```
+public Prop()
+```
+
+
+コンストラクタ。
+
+### deepClone() {#deepClone--}
+```
+public Prop deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+[Prop](../../com.aspose.diagram/prop) - 
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCalendar() {#getCalendar--}
+```
+public Calendar getCalendar()
+```
+
+
+カスタム プロパティ、テキスト フィールド、要素の数式に使用されるカレンダーを決定します。
+
+**Returns:**
+[Calendar](../../com.aspose.diagram/calendar)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getFormat() {#getFormat--}
+```
+public StrValue getFormat()
+```
+
+
+Format 要素は、文字列、固定リスト、数値、可変リスト、日付または時刻、期間、または通貨であるカスタム プロパティの書式設定を指定します。カスタム プロパティのタイプは、対応する Type 要素で指定されます。
+
+**Returns:**
+[StrValue](../../com.aspose.diagram/strvalue)
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+要素の親要素内における一意の ID。
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+親要素内の要素のゼロベースインデックスです。
+
+**Returns:**
+int
+### getInvisible() {#getInvisible--}
+```
+public BoolValue getInvisible()
+```
+
+
+Invisible 要素は、Microsoft Visio のカスタム プロパティ ダイアログ ボックスでカスタム プロパティが表示されるかどうかを指定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLabel() {#getLabel--}
+```
+public Str2Value getLabel()
+```
+
+
+カスタム プロパティ ダイアログ ボックスにユーザーに表示されるラベルを指定します。
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getLangID() {#getLangID--}
+```
+public IntValue getLangID()
+```
+
+
+セルの数式、テキスト、カスタムプロパティ、またはコメントが入力された言語のロケール ID (LCID) を示します。
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素の名前。
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+要素のユニバーサル名。
+
+**Returns:**
+java.lang.String
+### getPrompt() {#getPrompt--}
+```
+public Str2Value getPrompt()
+```
+
+
+Prompt 要素は、プロパティが選択されたときにカスタム プロパティ ダイアログ ボックスにユーザーに表示される説明または指示テキストを指定します。このテキストは、カスタム プロパティ ウィンドウでプロパティ上にマウス ポインタを停止させたときのツールチップとしても表示されます。
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getSortKey() {#getSortKey--}
+```
+public Str2Value getSortKey()
+```
+
+
+カスタム プロパティがアプリケーションのユーザー インターフェイスに一覧表示される順序を決定するキーを指定します。
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getType() {#getType--}
+```
+public TypeProp getType()
+```
+
+
+Type はカスタム プロパティの値のデータ型を指定します。
+
+**Returns:**
+[TypeProp](../../com.aspose.diagram/typeprop)
+### getValue() {#getValue--}
+```
+public Value getValue()
+```
+
+
+明示的な名前空間でプレフィックスが付けられ、ドキュメントに保存される、ソリューション固有の整形式 XML データを含みます。
+
+**Returns:**
+[Value](../../com.aspose.diagram/value)
+### getVerify() {#getVerify--}
+```
+public BoolValue getVerify()
+```
+
+
+インスタンスが作成されたとき、またはシェイプが複製またはコピーされたときに、ユーザーにシェイプのカスタム プロパティ情報の入力を求めるかどうかを指定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+このプロパティの説明については、[getDel()](../../com.aspose.diagram/prop\#getDel--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+このプロパティの説明については、[getID()](../../com.aspose.diagram/prop\#getID--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+このプロパティの説明については、[getIX()](../../com.aspose.diagram/prop\#getIX--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+このプロパティの説明については、[getName()](../../com.aspose.diagram/prop\#getName--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+このプロパティの説明については、[getNameU()](../../com.aspose.diagram/prop\#getNameU--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/propcollection/_index.md
+++ b/japanese/java/com.aspose.diagram/propcollection/_index.md
@@ -1,0 +1,250 @@
+---
+title: PropCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: Prop コレクション。
+type: docs
+weight: 310
+url: /ja/java/com.aspose.diagram/propcollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class PropCollection extends Collection
+```
+
+Prop コレクション。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(Prop item)](#add-com.aspose.diagram.Prop-) | コレクションに Prop オブジェクトを追加します。 |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [getProp(int ID)](#getProp-int-) | 指定された ID の要素を取得します。 |
+| [getProp(String name)](#getProp-java.lang.String-) | 指定された名前の要素を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Prop item)](#remove-com.aspose.diagram.Prop-) | コレクションから Prop オブジェクトを削除します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Prop item) {#add-com.aspose.diagram.Prop-}
+```
+public int add(Prop item)
+```
+
+
+コレクションに Prop オブジェクトを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [Prop](../../com.aspose.diagram/prop) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Prop get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[Prop](../../com.aspose.diagram/prop) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### getProp(int ID) {#getProp-int-}
+```
+public Prop getProp(int ID)
+```
+
+
+指定された ID の要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ID | int |  |
+
+**Returns:**
+[Prop](../../com.aspose.diagram/prop) - 
+### getProp(String name) {#getProp-java.lang.String-}
+```
+public Prop getProp(String name)
+```
+
+
+指定された名前の要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String |  |
+
+**Returns:**
+[Prop](../../com.aspose.diagram/prop) - 
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Prop item) {#remove-com.aspose.diagram.Prop-}
+```
+public void remove(Prop item)
+```
+
+
+コレクションから Prop オブジェクトを削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [Prop](../../com.aspose.diagram/prop) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/proptype/_index.md
+++ b/japanese/java/com.aspose.diagram/proptype/_index.md
@@ -1,0 +1,165 @@
+---
+title: PropType
+second_title: Aspose.Diagram for Java API リファレンス
+description: プロパティのタイプ。
+type: docs
+weight: 311
+url: /ja/java/com.aspose.diagram/proptype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PropType
+```
+
+プロパティのタイプ。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [BOOL](#BOOL) | ブール値。 |
+| [DATE](#DATE) | 日付。 |
+| [NUMBER](#NUMBER) | Number. |
+| [STRING](#STRING) | 文字列。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOOL {#BOOL}
+```
+public static final int BOOL
+```
+
+
+ブール値。
+
+### DATE {#DATE}
+```
+public static final int DATE
+```
+
+
+日付。
+
+### NUMBER {#NUMBER}
+```
+public static final int NUMBER
+```
+
+
+Number.
+
+### STRING {#STRING}
+```
+public static final int STRING
+```
+
+
+文字列。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/protection/_index.md
+++ b/japanese/java/com.aspose.diagram/protection/_index.md
@@ -1,0 +1,370 @@
+---
+title: 保護
+second_title: Aspose.Diagram for Java API リファレンス
+description: ロックはシェイプへの偶発的な変更を防止するのに役立ちますが、他の状況で Microsoft Visio が値をリセットすることは防げません。
+type: docs
+weight: 312
+url: /ja/java/com.aspose.diagram/protection/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Protection
+```
+
+ロック機能はシェイプへの偶発的な変更を防止するのに役立ちますが、他の状況で Microsoft Visio が値をリセットすることは防げません。また、ShapeSheet ウィンドウで行われた変更からも保護されません。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getLockAspect()](#getLockAspect--) | 図形のアスペクト比がロックされているかどうかを指定します。 |
+| [getLockBegin()](#getLockBegin--) | 1 次元図形の開始点が特定の位置にロックされているかどうかを指定します。 |
+| [getLockCalcWH()](#getLockCalcWH--) | 図形の選択矩形がロックされているかどうかを指定します。これにより、頂点が編集されたり、Geom 要素内の要素タイプが変更されたりしても再計算されません。 |
+| [getLockCrop()](#getLockCrop--) | Microsoft Visio の Crop ツールで切り取られないように、外部オブジェクトがロックされているかどうかを指定します。 |
+| [getLockCustProp()](#getLockCustProp--) | ユーザーが「カスタム プロパティの定義」ダイアログ ボックスを使用して、ユーザー インターフェイス (UI) でカスタム プロパティを追加、削除、または変更できるかどうかを決定します。 |
+| [getLockDelete()](#getLockDelete--) | 図形が削除されないようにロックされているかどうかを指定します。 |
+| [getLockEnd()](#getLockEnd--) | 1 次元図形の終了点が特定の位置にロックされているかどうかを指定します。 |
+| [getLockFormat()](#getLockFormat--) | 図形の書式設定がロックされていて変更できないかどうかを指定します。 |
+| [getLockFromGroupFormat()](#getLockFromGroupFormat--) | サブシェイプが、Visio ユーザー インターフェイスで親グループ シェイプに適用される書式設定の変更をブロックできるようにし、そうでなければ個々のグループ シェイプにカスケードされるのを防ぎます。 |
+| [getLockGroup()](#getLockGroup--) | グループがロックされていて、グループ解除できないかどうかを指定します。 |
+| [getLockHeight()](#getLockHeight--) | 図形の高さがロックされているかどうかを指定します。 |
+| [getLockMoveX()](#getLockMoveX--) | 図形の水平位置がロックされていて、水平に移動できないかどうかを指定します。 |
+| [getLockMoveY()](#getLockMoveY--) | 図形の垂直位置がロックされていて、垂直に移動できないかどうかを指定します。 |
+| [getLockRotate()](#getLockRotate--) | Microsoft Visio の回転ツールや「左に回転」または「右に回転」コマンドで図形が回転されないようにロックされているかどうかを指定します。 |
+| [getLockSelect()](#getLockSelect--) | 図形の選択矩形がロックされているかどうかを指定します。これにより、頂点が編集されたり、Geom 要素内の要素タイプが変更されたりしても再計算されません。 |
+| [getLockTextEdit()](#getLockTextEdit--) | 図形のテキストがロックされていて、編集できないかどうかを指定します。 |
+| [getLockThemeColors()](#getLockThemeColors--) | ユーザーが図形にテーマカラーを適用することを防止します。 |
+| [getLockThemeEffects()](#getLockThemeEffects--) | ユーザーがシェイプにテーマ効果を適用するのを防止します。 |
+| [getLockVtxEdit()](#getLockVtxEdit--) | シェイプの頂点がロックされているかどうかを指定し、ツールバーのいかなるツールでも編集できないようにします。 |
+| [getLockWidth()](#getLockWidth--) | シェイプの幅がロックされているかどうかを指定し、サイズ変更時に幅が変わらないようにします。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | このプロパティの説明については、[getDel()](../../com.aspose.diagram/protection\#getDel--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getLockAspect() {#getLockAspect--}
+```
+public BoolValue getLockAspect()
+```
+
+
+シェイプのアスペクト比がロックされているかどうかを指定します。ロックされている場合、シェイプは比例的にサイズ変更でき、単一の次元でサイズ変更することはできません。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockBegin() {#getLockBegin--}
+```
+public BoolValue getLockBegin()
+```
+
+
+1 次元図形の開始点が特定の位置にロックされているかどうかを指定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockCalcWH() {#getLockCalcWH--}
+```
+public BoolValue getLockCalcWH()
+```
+
+
+図形の選択矩形がロックされているかどうかを指定します。これにより、頂点が編集されたり、Geom 要素内の要素タイプが変更されたりしても再計算されません。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockCrop() {#getLockCrop--}
+```
+public BoolValue getLockCrop()
+```
+
+
+Microsoft Visio の Crop ツールで切り取られないように、外部オブジェクトがロックされているかどうかを指定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockCustProp() {#getLockCustProp--}
+```
+public BoolValue getLockCustProp()
+```
+
+
+ユーザーが「カスタム プロパティの定義」ダイアログ ボックスを使用して、ユーザー インターフェイス (UI) でカスタム プロパティを追加、削除、または変更できるかどうかを決定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockDelete() {#getLockDelete--}
+```
+public BoolValue getLockDelete()
+```
+
+
+図形が削除されないようにロックされているかどうかを指定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockEnd() {#getLockEnd--}
+```
+public BoolValue getLockEnd()
+```
+
+
+1 次元図形の終了点が特定の位置にロックされているかどうかを指定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockFormat() {#getLockFormat--}
+```
+public BoolValue getLockFormat()
+```
+
+
+シェイプの書式設定がロックされているかどうかを指定し、変更できないようにします。具体的には、この要素はテキスト、線、塗りの書式設定の変更や、シェイプが継承する Style 要素の変更から保護します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockFromGroupFormat() {#getLockFromGroupFormat--}
+```
+public BoolValue getLockFromGroupFormat()
+```
+
+
+サブシェイプが、Visio ユーザー インターフェイスで親グループ シェイプに適用される書式設定の変更をブロックできるようにし、そうでなければ個々のグループ シェイプにカスケードされるのを防ぎます。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockGroup() {#getLockGroup--}
+```
+public BoolValue getLockGroup()
+```
+
+
+グループがロックされていて、グループ解除できないかどうかを指定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockHeight() {#getLockHeight--}
+```
+public BoolValue getLockHeight()
+```
+
+
+シェイプの高さがロックされているかどうかを指定します。ロックされている場合、サイズ変更時に高さは変わりません。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockMoveX() {#getLockMoveX--}
+```
+public BoolValue getLockMoveX()
+```
+
+
+図形の水平位置がロックされていて、水平に移動できないかどうかを指定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockMoveY() {#getLockMoveY--}
+```
+public BoolValue getLockMoveY()
+```
+
+
+図形の垂直位置がロックされていて、垂直に移動できないかどうかを指定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockRotate() {#getLockRotate--}
+```
+public BoolValue getLockRotate()
+```
+
+
+Microsoft Visio の回転ツールや「左に回転」または「右に回転」コマンドで図形が回転されないようにロックされているかどうかを指定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockSelect() {#getLockSelect--}
+```
+public BoolValue getLockSelect()
+```
+
+
+図形の選択矩形がロックされているかどうかを指定します。これにより、頂点が編集されたり、Geom 要素内の要素タイプが変更されたりしても再計算されません。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockTextEdit() {#getLockTextEdit--}
+```
+public BoolValue getLockTextEdit()
+```
+
+
+シェイプのテキストがロックされているかどうかを指定し、編集できないようにします。ただし、テキストはスタイルを適用したり、テキスト ダイアログ ボックスのフォント タブの Style オプションを使用して書式設定することは可能です。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockThemeColors() {#getLockThemeColors--}
+```
+public BoolValue getLockThemeColors()
+```
+
+
+ユーザーが図形にテーマカラーを適用することを防止します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockThemeEffects() {#getLockThemeEffects--}
+```
+public BoolValue getLockThemeEffects()
+```
+
+
+ユーザーがシェイプにテーマ効果を適用するのを防止します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockVtxEdit() {#getLockVtxEdit--}
+```
+public BoolValue getLockVtxEdit()
+```
+
+
+シェイプの頂点がロックされているかどうかを指定し、ツールバーのいかなるツールでも編集できないようにします。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockWidth() {#getLockWidth--}
+```
+public BoolValue getLockWidth()
+```
+
+
+シェイプの幅がロックされているかどうかを指定し、サイズ変更時に幅が変わらないようにします。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+このプロパティの説明については、[getDel()](../../com.aspose.diagram/protection\#getDel--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/radiobuttonactivexcontrol/_index.md
+++ b/japanese/java/com.aspose.diagram/radiobuttonactivexcontrol/_index.md
@@ -1,0 +1,679 @@
+---
+title: RadioButtonActiveXControl
+second_title: Aspose.Diagram for Java API リファレンス
+description: RadioButton ActiveX コントロールを表します。
+type: docs
+weight: 313
+url: /ja/java/com.aspose.diagram/radiobuttonactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol), [com.aspose.diagram.ToggleButtonActiveXControl](../../com.aspose.diagram/togglebuttonactivexcontrol)
+```
+public class RadioButtonActiveXControl extends ToggleButtonActiveXControl
+```
+
+RadioButton ActiveX コントロールを表します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAccelerator()](#getAccelerator--) | コントロールのアクセラレータキーです。 |
+| [getAlignment()](#getAlignment--) | コントロールに対する Caption の位置です。 |
+| [getBackOleColor()](#getBackOleColor--) | 背景の OLE カラー。 |
+| [getCaption()](#getCaption--) | コントロール上に表示される説明テキストです。 |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | コントロールのバイナリ データ。 |
+| [getForeOleColor()](#getForeOleColor--) | 前景の OLE カラー。 |
+| [getGroupName()](#getGroupName--) | グループの名前です。 |
+| [getHeight()](#getHeight--) | ポイント単位のコントロールの高さ。 |
+| [getIMEMode()](#getIMEMode--) | コントロールがフォーカスを受け取る際の Input Method Editor のデフォルト実行時モード。 |
+| [getMouseIcon()](#getMouseIcon--) | コントロールのマウスポインタとして表示するカスタムアイコンです。 |
+| [getMousePointer()](#getMousePointer--) | コントロールのマウスポインタとして表示されるアイコンの種類です。 |
+| [getPicture()](#getPicture--) | 画像のデータです。 |
+| [getPicturePosition()](#getPicturePosition--) | コントロールのキャプションに対する画像の位置。 |
+| [getSpecialEffect()](#getSpecialEffect--) | コントロールの特殊効果です。 |
+| [getType()](#getType--) | ActiveX コントロールのタイプを取得します。 |
+| [getValue()](#getValue--) | コントロールがチェックされているかどうかを示します。 |
+| [getWidth()](#getWidth--) | ポイント単位のコントロールの幅です。 |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | コントロールが全内容を表示するために自動的にサイズ変更されるかどうかを示します。 |
+| [isEnabled()](#isEnabled--) | コントロールがフォーカスを受け取り、ユーザー生成イベントに応答できるかどうかを示します。 |
+| [isLocked()](#isLocked--) | コントロール内のデータが編集ロックされているかどうかを示します。 |
+| [isTransparent()](#isTransparent--) | コントロールが透明かどうかを示します。 |
+| [isTripleState()](#isTripleState--) | 指定されたコントロールが Null 値をどのように表示するかを示します。 |
+| [isWordWrapped()](#isWordWrapped--) | コントロールの内容が行末で自動的に折り返されるかどうかを示します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAccelerator(char value)](#setAccelerator-char-) | このプロパティの説明については、[getAccelerator()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getAccelerator--) を参照してください。 |
+| [setAlignment(int value)](#setAlignment-int-) | このプロパティの説明については、[getAlignment()](../../com.aspose.diagram/radiobuttonactivexcontrol\#getAlignment--) を参照してください。 |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | このプロパティの説明については、[isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) を参照してください |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | このプロパティの説明については、[getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) を参照してください |
+| [setCaption(String value)](#setCaption-java.lang.String-) | このプロパティの説明については、[getCaption()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getCaption--) を参照してください。 |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | このプロパティの説明については、[isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) を参照してください |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | このプロパティの説明については、[getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) を参照してください |
+| [setGroupName(String value)](#setGroupName-java.lang.String-) | このプロパティの説明については、[getGroupName()](../../com.aspose.diagram/radiobuttonactivexcontrol\#getGroupName--) を参照してください。 |
+| [setHeight(double value)](#setHeight-double-) | このプロパティの説明については、[getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) を参照してください |
+| [setIMEMode(int value)](#setIMEMode-int-) | このプロパティの説明については、[getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) を参照してください |
+| [setLocked(boolean value)](#setLocked-boolean-) | このプロパティの説明については、[isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) を参照してください |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | このプロパティの説明については、[getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) を参照してください |
+| [setMousePointer(int value)](#setMousePointer-int-) | このプロパティの説明については、[getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) を参照してください |
+| [setPicture(byte[] value)](#setPicture-byte---) | このプロパティの説明については、[getPicture()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getPicture--) を参照してください。 |
+| [setPicturePosition(int value)](#setPicturePosition-int-) | このプロパティの説明については、[getPicturePosition()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getPicturePosition--) を参照してください。 |
+| [setSpecialEffect(int value)](#setSpecialEffect-int-) | このプロパティの説明については、[getSpecialEffect()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getSpecialEffect--) を参照してください。 |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | このプロパティの説明については、[isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) を参照してください |
+| [setTripleState(boolean value)](#setTripleState-boolean-) | このプロパティの説明については、[isTripleState()](../../com.aspose.diagram/togglebuttonactivexcontrol\#isTripleState--) を参照してください。 |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getValue--) を参照してください。 |
+| [setWidth(double value)](#setWidth-double-) | このプロパティの説明については、[getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) を参照してください |
+| [setWordWrapped(boolean value)](#setWordWrapped-boolean-) | このプロパティの説明については、[isWordWrapped()](../../com.aspose.diagram/radiobuttonactivexcontrol\#isWordWrapped--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAccelerator() {#getAccelerator--}
+```
+public char getAccelerator()
+```
+
+
+コントロールのアクセラレータキーです。
+
+**Returns:**
+char
+### getAlignment() {#getAlignment--}
+```
+public int getAlignment()
+```
+
+
+コントロールに対する Caption の位置です。
+
+**Returns:**
+int
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+背景の OLE カラー。
+
+**Returns:**
+int
+### getCaption() {#getCaption--}
+```
+public String getCaption()
+```
+
+
+コントロール上に表示される説明テキストです。
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+コントロールのバイナリ データ。
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+前景の OLE カラーです。Image コントロールには適用されません。
+
+**Returns:**
+int
+### getGroupName() {#getGroupName--}
+```
+public String getGroupName()
+```
+
+
+グループの名前です。
+
+**Returns:**
+java.lang.String
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+ポイント単位のコントロールの高さ。
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+コントロールがフォーカスを受け取る際の Input Method Editor のデフォルト実行時モード。
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+コントロールのマウスポインタとして表示するカスタムアイコンです。
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+コントロールのマウスポインタとして表示されるアイコンの種類です。
+
+**Returns:**
+int
+### getPicture() {#getPicture--}
+```
+public byte[] getPicture()
+```
+
+
+画像のデータです。
+
+**Returns:**
+byte[]
+### getPicturePosition() {#getPicturePosition--}
+```
+public int getPicturePosition()
+```
+
+
+コントロールのキャプションに対する画像の位置。
+
+**Returns:**
+int
+### getSpecialEffect() {#getSpecialEffect--}
+```
+public int getSpecialEffect()
+```
+
+
+コントロールの特殊効果です。
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+ActiveX コントロールのタイプを取得します。
+
+**Returns:**
+int
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+コントロールがチェックされているかどうかを示します。
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+ポイント単位のコントロールの幅です。
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+コントロールが全内容を表示するために自動的にサイズ変更されるかどうかを示します。
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+コントロールがフォーカスを受け取り、ユーザー生成イベントに応答できるかどうかを示します。
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+コントロール内のデータが編集ロックされているかどうかを示します。
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+コントロールが透明かどうかを示します。
+
+**Returns:**
+boolean
+### isTripleState() {#isTripleState--}
+```
+public boolean isTripleState()
+```
+
+
+指定されたコントロールが Null 値をどのように表示するかを示します。
+
+| ------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| 設定 | 説明 |
+| True    | コントロールは Yes、No、Null の状態を循環します。Value プロパティが Null に設定されている場合、コントロールは暗く（グレー表示）なります。 |
+| False   | (Default) コントロールは Yes と No の状態を循環します。Null 値は No 値として表示されます。 |
+
+|
+
+**Returns:**
+boolean
+### isWordWrapped() {#isWordWrapped--}
+```
+public boolean isWordWrapped()
+```
+
+
+コントロールの内容が行末で自動的に折り返されるかどうかを示します。
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAccelerator(char value) {#setAccelerator-char-}
+```
+public void setAccelerator(char value)
+```
+
+
+このプロパティの説明については、[getAccelerator()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getAccelerator--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | char |  |
+
+### setAlignment(int value) {#setAlignment-int-}
+```
+public void setAlignment(int value)
+```
+
+
+このプロパティの説明については、[getAlignment()](../../com.aspose.diagram/radiobuttonactivexcontrol\#getAlignment--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+このプロパティの説明については、[isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+このプロパティの説明については、[getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setCaption(String value) {#setCaption-java.lang.String-}
+```
+public void setCaption(String value)
+```
+
+
+このプロパティの説明については、[getCaption()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getCaption--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+このプロパティの説明については、[isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+このプロパティの説明については、[getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setGroupName(String value) {#setGroupName-java.lang.String-}
+```
+public void setGroupName(String value)
+```
+
+
+このプロパティの説明については、[getGroupName()](../../com.aspose.diagram/radiobuttonactivexcontrol\#getGroupName--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+このプロパティの説明については、[getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+このプロパティの説明については、[getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+このプロパティの説明については、[isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+このプロパティの説明については、[getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+このプロパティの説明については、[getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setPicture(byte[] value) {#setPicture-byte---}
+```
+public void setPicture(byte[] value)
+```
+
+
+このプロパティの説明については、[getPicture()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getPicture--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | byte[] |  |
+
+### setPicturePosition(int value) {#setPicturePosition-int-}
+```
+public void setPicturePosition(int value)
+```
+
+
+このプロパティの説明については、[getPicturePosition()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getPicturePosition--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setSpecialEffect(int value) {#setSpecialEffect-int-}
+```
+public void setSpecialEffect(int value)
+```
+
+
+このプロパティの説明については、[getSpecialEffect()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getSpecialEffect--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+このプロパティの説明については、[isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setTripleState(boolean value) {#setTripleState-boolean-}
+```
+public void setTripleState(boolean value)
+```
+
+
+このプロパティの説明については、[isTripleState()](../../com.aspose.diagram/togglebuttonactivexcontrol\#isTripleState--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getValue--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+このプロパティの説明については、[getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double |  |
+
+### setWordWrapped(boolean value) {#setWordWrapped-boolean-}
+```
+public void setWordWrapped(boolean value)
+```
+
+
+このプロパティの説明については、[isWordWrapped()](../../com.aspose.diagram/radiobuttonactivexcontrol\#isWordWrapped--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/rectanglealignmenttype/_index.md
+++ b/japanese/java/com.aspose.diagram/rectanglealignmenttype/_index.md
@@ -1,0 +1,210 @@
+---
+title: RectangleAlignmentType
+second_title: Aspose.Diagram for Java API リファレンス
+description: 2 つの矩形を相互に配置する方法を表します。
+type: docs
+weight: 314
+url: /ja/java/com.aspose.diagram/rectanglealignmenttype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class RectangleAlignmentType
+```
+
+2 つの矩形を相互に配置する方法を表します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [BOTTOM](#BOTTOM) | 下 |
+| [BOTTOM_LEFT](#BOTTOM-LEFT) | BottomLeft |
+| [BOTTOM_RIGHT](#BOTTOM-RIGHT) | BottomRight |
+| [CENTER](#CENTER) | Center |
+| [LEFT](#LEFT) | Left |
+| [RIGHT](#RIGHT) | Right |
+| [TOP](#TOP) | Top |
+| [TOP_LEFT](#TOP-LEFT) | TopLeft |
+| [TOP_RIGHT](#TOP-RIGHT) | TopRight |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOTTOM {#BOTTOM}
+```
+public static final int BOTTOM
+```
+
+
+下
+
+### BOTTOM_LEFT {#BOTTOM-LEFT}
+```
+public static final int BOTTOM_LEFT
+```
+
+
+BottomLeft
+
+### BOTTOM_RIGHT {#BOTTOM-RIGHT}
+```
+public static final int BOTTOM_RIGHT
+```
+
+
+BottomRight
+
+### CENTER {#CENTER}
+```
+public static final int CENTER
+```
+
+
+Center
+
+### LEFT {#LEFT}
+```
+public static final int LEFT
+```
+
+
+Left
+
+### RIGHT {#RIGHT}
+```
+public static final int RIGHT
+```
+
+
+Right
+
+### TOP {#TOP}
+```
+public static final int TOP
+```
+
+
+Top
+
+### TOP_LEFT {#TOP-LEFT}
+```
+public static final int TOP_LEFT
+```
+
+
+TopLeft
+
+### TOP_RIGHT {#TOP-RIGHT}
+```
+public static final int TOP_RIGHT
+```
+
+
+TopRight
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/reflectioneffecttype/_index.md
+++ b/japanese/java/com.aspose.diagram/reflectioneffecttype/_index.md
@@ -1,0 +1,226 @@
+---
+title: ReflectionEffectType
+second_title: Aspose.Diagram for Java API リファレンス
+description: 
+type: docs
+weight: 315
+url: /ja/java/com.aspose.diagram/reflectioneffecttype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ReflectionEffectType
+```
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [CUSTOM](#CUSTOM) | カスタム反射効果です。 |
+| [FULL_REFLECTION_4_PT_OFFSET](#FULL-REFLECTION-4-PT-OFFSET) | 完全な反射、4pt オフセット。 |
+| [FULL_REFLECTION_8_PT_OFFSET](#FULL-REFLECTION-8-PT-OFFSET) | 完全な反射、8pt オフセット。 |
+| [FULL_REFLECTION_TOUCHING](#FULL-REFLECTION-TOUCHING) | 完全な反射、接触。 |
+| [HALF_REFLECTION_4_PT_OFFSET](#HALF-REFLECTION-4-PT-OFFSET) | 半分の反射、4pt オフセット。 |
+| [HALF_REFLECTION_8_PT_OFFSET](#HALF-REFLECTION-8-PT-OFFSET) | 半分の反射、8pt オフセット。 |
+| [HALF_REFLECTION_TOUCHING](#HALF-REFLECTION-TOUCHING) | 半分の反射、接触。 |
+| [NONE](#NONE) | 反射効果なし。 |
+| [TIGHT_REFLECTION_4_PT_OFFSET](#TIGHT-REFLECTION-4-PT-OFFSET) | タイトな反射、4pt オフセット。 |
+| [TIGHT_REFLECTION_8_PT_OFFSET](#TIGHT-REFLECTION-8-PT-OFFSET) | タイトな反射、8pt オフセット。 |
+| [TIGHT_REFLECTION_TOUCHING](#TIGHT-REFLECTION-TOUCHING) | タイトな反射、接触。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CUSTOM {#CUSTOM}
+```
+public static final int CUSTOM
+```
+
+
+カスタム反射効果です。
+
+### FULL_REFLECTION_4_PT_OFFSET {#FULL-REFLECTION-4-PT-OFFSET}
+```
+public static final int FULL_REFLECTION_4_PT_OFFSET
+```
+
+
+完全な反射、4pt オフセット。
+
+### FULL_REFLECTION_8_PT_OFFSET {#FULL-REFLECTION-8-PT-OFFSET}
+```
+public static final int FULL_REFLECTION_8_PT_OFFSET
+```
+
+
+完全な反射、8pt オフセット。
+
+### FULL_REFLECTION_TOUCHING {#FULL-REFLECTION-TOUCHING}
+```
+public static final int FULL_REFLECTION_TOUCHING
+```
+
+
+完全な反射、接触。
+
+### HALF_REFLECTION_4_PT_OFFSET {#HALF-REFLECTION-4-PT-OFFSET}
+```
+public static final int HALF_REFLECTION_4_PT_OFFSET
+```
+
+
+半分の反射、4pt オフセット。
+
+### HALF_REFLECTION_8_PT_OFFSET {#HALF-REFLECTION-8-PT-OFFSET}
+```
+public static final int HALF_REFLECTION_8_PT_OFFSET
+```
+
+
+半分の反射、8pt オフセット。
+
+### HALF_REFLECTION_TOUCHING {#HALF-REFLECTION-TOUCHING}
+```
+public static final int HALF_REFLECTION_TOUCHING
+```
+
+
+半分の反射、接触。
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+反射効果なし。
+
+### TIGHT_REFLECTION_4_PT_OFFSET {#TIGHT-REFLECTION-4-PT-OFFSET}
+```
+public static final int TIGHT_REFLECTION_4_PT_OFFSET
+```
+
+
+タイトな反射、4pt オフセット。
+
+### TIGHT_REFLECTION_8_PT_OFFSET {#TIGHT-REFLECTION-8-PT-OFFSET}
+```
+public static final int TIGHT_REFLECTION_8_PT_OFFSET
+```
+
+
+タイトな反射、8pt オフセット。
+
+### TIGHT_REFLECTION_TOUCHING {#TIGHT-REFLECTION-TOUCHING}
+```
+public static final int TIGHT_REFLECTION_TOUCHING
+```
+
+
+タイトな反射、接触。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/relcubbezto/_index.md
+++ b/japanese/java/com.aspose.diagram/relcubbezto/_index.md
@@ -1,0 +1,349 @@
+---
+title: RelCubBezTo
+second_title: Aspose.Diagram for Java API リファレンス
+description: RelCubBezTo の点の x 座標と y 座標を含みます。
+type: docs
+weight: 316
+url: /ja/java/com.aspose.diagram/relcubbezto/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class RelCubBezTo extends Coordinate
+```
+
+RelCubBezTo の点の x および y 座標を含みます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [RelCubBezTo()](#RelCubBezTo--) | [RelCubBezTo](../../com.aspose.diagram/relcubbezto) クラスのインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | 曲線の開始点にある制御点の相対座標系での x 座標。 |
+| [getB()](#getB--) | 曲線の開始点にある制御点の相対座標系での y 座標。 |
+| [getC()](#getC--) | 曲線の終点にある制御点の相対座標系での x 座標。 |
+| [getClass()](#getClass--) |  |
+| [getD()](#getD--) | 曲線の終点にある制御点の相対座標系での y 座標。 |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getIX()](#getIX--) | 親要素内の要素のゼロベースインデックスです。 |
+| [getX()](#getX--) | 相対座標系における終点の x 座標。 |
+| [getY()](#getY--) | 相対座標における終点の y 座標です。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getA()](../../com.aspose.diagram/relcubbezto\#getA--) を参照してください。 |
+| [setB(DoubleValue value)](#setB-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getB()](../../com.aspose.diagram/relcubbezto\#getB--) を参照してください。 |
+| [setC(DoubleValue value)](#setC-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getC()](../../com.aspose.diagram/relcubbezto\#getC--) を参照してください。 |
+| [setD(DoubleValue value)](#setD-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getD()](../../com.aspose.diagram/relcubbezto\#getD--) を参照してください。 |
+| [setDel(int value)](#setDel-int-) | このプロパティの説明については、[getDel()](../../com.aspose.diagram/relcubbezto\#getDel--) を参照してください。 |
+| [setIX(int value)](#setIX-int-) | このプロパティの説明については、[getIX()](../../com.aspose.diagram/relcubbezto\#getIX--) を参照してください。 |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getX()](../../com.aspose.diagram/relcubbezto\#getX--) を参照してください。 |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getY()](../../com.aspose.diagram/relcubbezto\#getY--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RelCubBezTo() {#RelCubBezTo--}
+```
+public RelCubBezTo()
+```
+
+
+[RelCubBezTo](../../com.aspose.diagram/relcubbezto) クラスのインスタンスを作成します。
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+曲線の開始点にある制御点の相対座標系での x 座標。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getB() {#getB--}
+```
+public DoubleValue getB()
+```
+
+
+曲線の開始点にある制御点の相対座標系での y 座標。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getC() {#getC--}
+```
+public DoubleValue getC()
+```
+
+
+曲線の終点にある制御点の相対座標系での x 座標。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getD() {#getD--}
+```
+public DoubleValue getD()
+```
+
+
+曲線の終点にある制御点の相対座標系での y 座標。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+親要素内の要素のゼロベースインデックスです。
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+相対座標系における終点の x 座標。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+相対座標における終点の y 座標です。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getA()](../../com.aspose.diagram/relcubbezto\#getA--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setB(DoubleValue value) {#setB-com.aspose.diagram.DoubleValue-}
+```
+public void setB(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getB()](../../com.aspose.diagram/relcubbezto\#getB--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setC(DoubleValue value) {#setC-com.aspose.diagram.DoubleValue-}
+```
+public void setC(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getC()](../../com.aspose.diagram/relcubbezto\#getC--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setD(DoubleValue value) {#setD-com.aspose.diagram.DoubleValue-}
+```
+public void setD(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getD()](../../com.aspose.diagram/relcubbezto\#getD--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+このプロパティの説明については、[getDel()](../../com.aspose.diagram/relcubbezto\#getDel--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+このプロパティの説明については、[getIX()](../../com.aspose.diagram/relcubbezto\#getIX--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getX()](../../com.aspose.diagram/relcubbezto\#getX--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getY()](../../com.aspose.diagram/relcubbezto\#getY--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/relcubbeztocollection/_index.md
+++ b/japanese/java/com.aspose.diagram/relcubbeztocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: RelCubBezToCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: RelCubBezTo コレクション。
+type: docs
+weight: 317
+url: /ja/java/com.aspose.diagram/relcubbeztocollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class RelCubBezToCollection extends Collection
+```
+
+RelCubBezTo コレクション。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public RelCubBezTo get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[RelCubBezTo](../../com.aspose.diagram/relcubbezto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/relellipticalarcto/_index.md
+++ b/japanese/java/com.aspose.diagram/relellipticalarcto/_index.md
@@ -1,0 +1,349 @@
+---
+title: RelEllipticalArcTo
+second_title: Aspose.Diagram for Java API リファレンス
+description: 楕円弧に関する情報を指定する要素を含みます。座標は相対座標として指定されます。
+type: docs
+weight: 318
+url: /ja/java/com.aspose.diagram/relellipticalarcto/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class RelEllipticalArcTo extends Coordinate
+```
+
+楕円弧に関する情報を指定する要素を含みます。座標は相対座標として指定されます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [RelEllipticalArcTo()](#RelEllipticalArcTo--) | [EllipticalArcTo](../../com.aspose.diagram/ellipticalarcto) クラスのインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | 円弧の制御点の x 座標。 |
+| [getB()](#getB--) | 円弧の制御点の y 座標。 |
+| [getC()](#getC--) | 円弧の主軸が親の x 軸に対してなす角度。 |
+| [getClass()](#getClass--) |  |
+| [getD()](#getD--) | 円弧の主軸と副軸の比率。 |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getIX()](#getIX--) | 親要素内の要素のゼロベースインデックスです。 |
+| [getX()](#getX--) | 楕円弧の終端頂点の x 座標。 |
+| [getY()](#getY--) | 楕円弧の終端頂点の y 座標。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getA()](../../com.aspose.diagram/relellipticalarcto\#getA--) を参照してください。 |
+| [setB(DoubleValue value)](#setB-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getB()](../../com.aspose.diagram/relellipticalarcto\#getB--) を参照してください。 |
+| [setC(DoubleValue value)](#setC-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getC()](../../com.aspose.diagram/relellipticalarcto\#getC--) を参照してください。 |
+| [setD(DoubleValue value)](#setD-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getD()](../../com.aspose.diagram/relellipticalarcto\#getD--) を参照してください。 |
+| [setDel(int value)](#setDel-int-) | このプロパティの説明については、[getDel()](../../com.aspose.diagram/relellipticalarcto\#getDel--) を参照してください。 |
+| [setIX(int value)](#setIX-int-) | このプロパティの説明については、[getIX()](../../com.aspose.diagram/relellipticalarcto\#getIX--) を参照してください。 |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getX()](../../com.aspose.diagram/relellipticalarcto\#getX--) を参照してください。 |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getY()](../../com.aspose.diagram/relellipticalarcto\#getY--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RelEllipticalArcTo() {#RelEllipticalArcTo--}
+```
+public RelEllipticalArcTo()
+```
+
+
+[EllipticalArcTo](../../com.aspose.diagram/ellipticalarcto) クラスのインスタンスを作成します。
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+円弧の制御点の x 座標です。制御点は円弧の開始点と終了点の中間付近に配置するのが最適です。そうしないと、円弧は制御点を通過させるために極端に大きくなる可能性があり、予測できない結果を招くことがあります。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getB() {#getB--}
+```
+public DoubleValue getB()
+```
+
+
+円弧の制御点の y 座標。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getC() {#getC--}
+```
+public DoubleValue getC()
+```
+
+
+円弧の主軸が親の x 軸に対してなす角度。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getD() {#getD--}
+```
+public DoubleValue getD()
+```
+
+
+円弧の長軸と短軸の比率です。これらの語の通常の意味にもかかわらず、長軸が短軸より大きい必要はなく、したがってこの比率が 1 より大きい必要もありません。この要素を 0 以下または 1000 超の値に設定すると、予測できない結果になる可能性があります。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+親要素内の要素のゼロベースインデックスです。
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+楕円弧の終端頂点の x 座標。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+楕円弧の終端頂点の y 座標。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getA()](../../com.aspose.diagram/relellipticalarcto\#getA--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setB(DoubleValue value) {#setB-com.aspose.diagram.DoubleValue-}
+```
+public void setB(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getB()](../../com.aspose.diagram/relellipticalarcto\#getB--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setC(DoubleValue value) {#setC-com.aspose.diagram.DoubleValue-}
+```
+public void setC(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getC()](../../com.aspose.diagram/relellipticalarcto\#getC--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setD(DoubleValue value) {#setD-com.aspose.diagram.DoubleValue-}
+```
+public void setD(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getD()](../../com.aspose.diagram/relellipticalarcto\#getD--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+このプロパティの説明については、[getDel()](../../com.aspose.diagram/relellipticalarcto\#getDel--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+このプロパティの説明については、[getIX()](../../com.aspose.diagram/relellipticalarcto\#getIX--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getX()](../../com.aspose.diagram/relellipticalarcto\#getX--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getY()](../../com.aspose.diagram/relellipticalarcto\#getY--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/relellipticalarctocollection/_index.md
+++ b/japanese/java/com.aspose.diagram/relellipticalarctocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: RelEllipticalArcToCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: RelEllipticalArcTo コレクション。
+type: docs
+weight: 319
+url: /ja/java/com.aspose.diagram/relellipticalarctocollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class RelEllipticalArcToCollection extends Collection
+```
+
+RelEllipticalArcTo コレクション。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public RelEllipticalArcTo get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[RelEllipticalArcTo](../../com.aspose.diagram/relellipticalarcto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/rellineto/_index.md
+++ b/japanese/java/com.aspose.diagram/rellineto/_index.md
@@ -1,0 +1,249 @@
+---
+title: RelLineTo
+second_title: Aspose.Diagram for Java API リファレンス
+description: 直線セグメントの終点頂点の x および y 座標を含みます。
+type: docs
+weight: 320
+url: /ja/java/com.aspose.diagram/rellineto/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class RelLineTo extends Coordinate
+```
+
+直線セグメントの終点の x および y 座標を含みます。これらの座標はそれぞれ X 要素と Y 要素に格納されています。座標は相対座標として指定されます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [RelLineTo()](#RelLineTo--) | [LineTo](../../com.aspose.diagram/lineto) クラスのインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getIX()](#getIX--) | 親要素内の要素のゼロベースインデックスです。 |
+| [getX()](#getX--) | 直線セグメントの終点頂点の x 座標。 |
+| [getY()](#getY--) | 直線セグメントの終点頂点の y 座標。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | このプロパティの説明については、[getDel()](../../com.aspose.diagram/rellineto\#getDel--) を参照してください。 |
+| [setIX(int value)](#setIX-int-) | このプロパティの説明については、[getIX()](../../com.aspose.diagram/rellineto\#getIX--) を参照してください。 |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getX()](../../com.aspose.diagram/rellineto\#getX--) を参照してください。 |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getY()](../../com.aspose.diagram/rellineto\#getY--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RelLineTo() {#RelLineTo--}
+```
+public RelLineTo()
+```
+
+
+[LineTo](../../com.aspose.diagram/lineto) クラスのインスタンスを作成します。
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+親要素内の要素のゼロベースインデックスです。
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+直線セグメントの終点頂点の x 座標。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+直線セグメントの終点頂点の y 座標。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+このプロパティの説明については、[getDel()](../../com.aspose.diagram/rellineto\#getDel--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+このプロパティの説明については、[getIX()](../../com.aspose.diagram/rellineto\#getIX--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getX()](../../com.aspose.diagram/rellineto\#getX--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getY()](../../com.aspose.diagram/rellineto\#getY--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/rellinetocollection/_index.md
+++ b/japanese/java/com.aspose.diagram/rellinetocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: RelLineToCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: RelLineTo コレクション。
+type: docs
+weight: 321
+url: /ja/java/com.aspose.diagram/rellinetocollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class RelLineToCollection extends Collection
+```
+
+RelLineTo コレクション。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public RelLineTo get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[RelLineTo](../../com.aspose.diagram/rellineto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/relmoveto/_index.md
+++ b/japanese/java/com.aspose.diagram/relmoveto/_index.md
@@ -1,0 +1,249 @@
+---
+title: RelMoveTo
+second_title: Aspose.Diagram for Java API リファレンス
+description: 形状の最初の頂点の x および y 座標、またはパスの途中でのブレーク後の最初の頂点の x および y 座標を含みます。座標は相対座標として指定されます。
+type: docs
+weight: 322
+url: /ja/java/com.aspose.diagram/relmoveto/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class RelMoveTo extends Coordinate
+```
+
+形状の最初の頂点の x および y 座標、またはパスの途中で切れ目が入った後の最初の頂点の x および y 座標を含みます。座標は相対座標として指定されます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [RelMoveTo()](#RelMoveTo--) | [MoveTo](../../com.aspose.diagram/moveto) クラスのインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getIX()](#getIX--) | 親要素内の要素のゼロベースインデックスです。 |
+| [getX()](#getX--) | X 要素はパスの最初の頂点の x 座標を表します。 |
+| [getY()](#getY--) | Y 要素はパスの最初の頂点の y 座標を表します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | このプロパティの説明については、[getDel()](../../com.aspose.diagram/relmoveto\#getDel--) を参照してください。 |
+| [setIX(int value)](#setIX-int-) | このプロパティの説明については、[getIX()](../../com.aspose.diagram/relmoveto\#getIX--) を参照してください。 |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getX()](../../com.aspose.diagram/relmoveto\#getX--) を参照してください。 |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getY()](../../com.aspose.diagram/relmoveto\#getY--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RelMoveTo() {#RelMoveTo--}
+```
+public RelMoveTo()
+```
+
+
+[MoveTo](../../com.aspose.diagram/moveto) クラスのインスタンスを作成します。
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+親要素内の要素のゼロベースインデックスです。
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+X 要素はパスの最初の頂点の x 座標を表します。MoveTo 要素が 2 つの要素の間に現れる場合、X 要素はパスの切れ目の後の最初の頂点の x 座標を表します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+Y 要素はパスの最初の頂点の y 座標を表します。MoveTo 要素が 2 つの要素の間に現れる場合、Y 要素はパスの切れ目の後の最初の頂点の y 座標を表します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+このプロパティの説明については、[getDel()](../../com.aspose.diagram/relmoveto\#getDel--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+このプロパティの説明については、[getIX()](../../com.aspose.diagram/relmoveto\#getIX--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getX()](../../com.aspose.diagram/relmoveto\#getX--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getY()](../../com.aspose.diagram/relmoveto\#getY--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/relmovetocollection/_index.md
+++ b/japanese/java/com.aspose.diagram/relmovetocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: RelMoveToCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: RelMoveTo コレクション。
+type: docs
+weight: 323
+url: /ja/java/com.aspose.diagram/relmovetocollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class RelMoveToCollection extends Collection
+```
+
+RelMoveTo コレクション。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public RelMoveTo get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[RelMoveTo](../../com.aspose.diagram/relmoveto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/relquadbezto/_index.md
+++ b/japanese/java/com.aspose.diagram/relquadbezto/_index.md
@@ -1,0 +1,299 @@
+---
+title: RelQuadBezTo
+second_title: Aspose.Diagram for Java API リファレンス
+description: RelQuadBezTo の点の x 座標と y 座標を含みます。
+type: docs
+weight: 324
+url: /ja/java/com.aspose.diagram/relquadbezto/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class RelQuadBezTo extends Coordinate
+```
+
+RelQuadBezTo のポイントの x および y 座標を含みます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [RelQuadBezTo()](#RelQuadBezTo--) | [RelCubBezTo](../../com.aspose.diagram/relcubbezto) クラスのインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | 相対座標系における制御点の x 座標。 |
+| [getB()](#getB--) | 相対座標系における制御点の y 座標。 |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getIX()](#getIX--) | 親要素内の要素のゼロベースインデックスです。 |
+| [getX()](#getX--) | 相対座標系における終点の x 座標。 |
+| [getY()](#getY--) | 相対座標における終点の y 座標です。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getA()](../../com.aspose.diagram/relquadbezto\#getA--) を参照してください。 |
+| [setB(DoubleValue value)](#setB-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getB()](../../com.aspose.diagram/relquadbezto\#getB--) を参照してください。 |
+| [setDel(int value)](#setDel-int-) | このプロパティの説明については、[getDel()](../../com.aspose.diagram/relquadbezto\#getDel--) を参照してください。 |
+| [setIX(int value)](#setIX-int-) | このプロパティの説明については、[getIX()](../../com.aspose.diagram/relquadbezto\#getIX--) を参照してください。 |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getX()](../../com.aspose.diagram/relquadbezto\#getX--) を参照してください。 |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getY()](../../com.aspose.diagram/relquadbezto\#getY--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RelQuadBezTo() {#RelQuadBezTo--}
+```
+public RelQuadBezTo()
+```
+
+
+[RelCubBezTo](../../com.aspose.diagram/relcubbezto) クラスのインスタンスを作成します。
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+相対座標系における制御点の x 座標。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getB() {#getB--}
+```
+public DoubleValue getB()
+```
+
+
+相対座標系における制御点の y 座標。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+親要素内の要素のゼロベースインデックスです。
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+相対座標系における終点の x 座標。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+相対座標における終点の y 座標です。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getA()](../../com.aspose.diagram/relquadbezto\#getA--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setB(DoubleValue value) {#setB-com.aspose.diagram.DoubleValue-}
+```
+public void setB(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getB()](../../com.aspose.diagram/relquadbezto\#getB--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+このプロパティの説明については、[getDel()](../../com.aspose.diagram/relquadbezto\#getDel--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+このプロパティの説明については、[getIX()](../../com.aspose.diagram/relquadbezto\#getIX--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getX()](../../com.aspose.diagram/relquadbezto\#getX--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getY()](../../com.aspose.diagram/relquadbezto\#getY--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/relquadbeztocollection/_index.md
+++ b/japanese/java/com.aspose.diagram/relquadbeztocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: RelQuadBezToCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: RelQuadBezTo コレクション。
+type: docs
+weight: 325
+url: /ja/java/com.aspose.diagram/relquadbeztocollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class RelQuadBezToCollection extends Collection
+```
+
+RelQuadBezTo コレクション。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public RelQuadBezTo get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[RelQuadBezTo](../../com.aspose.diagram/relquadbezto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/removehiddeninfoitem/_index.md
+++ b/japanese/java/com.aspose.diagram/removehiddeninfoitem/_index.md
@@ -1,0 +1,183 @@
+---
+title: RemoveHiddenInfoItem
+second_title: Aspose.Diagram for Java API リファレンス
+description: 図の非表示情報を削除することを指定します。
+type: docs
+weight: 326
+url: /ja/java/com.aspose.diagram/removehiddeninfoitem/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class RemoveHiddenInfoItem
+```
+
+図の非表示情報を削除することを指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [DATA_RECORD_SETS](#DATA-RECORD-SETS) | DataRecordSets. |
+| [MASTERS](#MASTERS) | Masters. |
+| [PERSONAL_INFO](#PERSONAL-INFO) | PersonalInfo. |
+| [SHAPES](#SHAPES) | Shapes. |
+| [STYLES](#STYLES) | Styles. |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DATA_RECORD_SETS {#DATA-RECORD-SETS}
+```
+public static final int DATA_RECORD_SETS
+```
+
+
+DataRecordSets.
+
+### MASTERS {#MASTERS}
+```
+public static final int MASTERS
+```
+
+
+Masters.
+
+### PERSONAL_INFO {#PERSONAL-INFO}
+```
+public static final int PERSONAL_INFO
+```
+
+
+PersonalInfo.
+
+### SHAPES {#SHAPES}
+```
+public static final int SHAPES
+```
+
+
+Shapes.
+
+### STYLES {#STYLES}
+```
+public static final int STYLES
+```
+
+
+Styles.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/renderingsaveoptions/_index.md
+++ b/japanese/java/com.aspose.diagram/renderingsaveoptions/_index.md
@@ -1,0 +1,366 @@
+---
+title: RenderingSaveOptions
+second_title: Aspose.Diagram for Java API リファレンス
+description: これは、ユーザーが図を特定の形式で保存する際に追加オプションを指定できるクラスのための抽象基底クラスです。
+type: docs
+weight: 327
+url: /ja/java/com.aspose.diagram/renderingsaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.SaveOptions](../../com.aspose.diagram/saveoptions)
+```
+public abstract class RenderingSaveOptions extends SaveOptions
+```
+
+これは、ユーザーが図を特定の形式で保存する際に追加オプションを指定できるクラスのための抽象基底クラスです。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | 指定された保存形式に適したクラスの保存オプションオブジェクトを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDefaultFont()](#getDefaultFont--) | 図内の文字が Unicode で、正しいフォント値が設定されていない、またはフォントがローカルにインストールされていない場合、pdf、画像、または XPS でブロックとして表示されることがあります。 |
+| [getEmfRenderSetting()](#getEmfRenderSetting--) | Emf メタファイルのレンダリング設定です。 |
+| [getEnlargePage()](#getEnlargePage--) | ページを拡大するかどうかを指定します。 |
+| [getExportGuideShapes()](#getExportGuideShapes--) | ガイドシェイプをエクスポートするかどうかを定義します。 |
+| [getPageSize()](#getPageSize--) | 生成された画像のページサイズ。 |
+| [getSaveFormat()](#getSaveFormat--) | この保存オプションオブジェクトが使用される場合、ドキュメントが保存される形式を指定します。 |
+| [getShapes()](#getShapes--) | レンダリングするシェイプ。 |
+| [getWarningCallback()](#getWarningCallback--) | 警告コールバック。 |
+| [hashCode()](#hashCode--) |  |
+| [isExportComments()](#isExportComments--) | コメントをエクスポートするかどうかを定義します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | このプロパティの説明については、[getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--) を参照してください。 |
+| [setEmfRenderSetting(int value)](#setEmfRenderSetting-int-) | このプロパティの説明については、[getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--) を参照してください。 |
+| [setEnlargePage(boolean value)](#setEnlargePage-boolean-) | このプロパティの説明については、[getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--) を参照してください。 |
+| [setExportComments(boolean value)](#setExportComments-boolean-) | このプロパティの説明については、[isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--) を参照してください。 |
+| [setExportGuideShapes(boolean value)](#setExportGuideShapes-boolean-) | このプロパティの説明については、[getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--) を参照してください。 |
+| [setPageSize(PageSize value)](#setPageSize-com.aspose.diagram.PageSize-) | このプロパティの説明については、[getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--) を参照してください。 |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | このプロパティの説明については、[getSaveFormat()](../../com.aspose.diagram/saveoptions\#getSaveFormat--) を参照してください。 |
+| [setShapes(ShapeCollection value)](#setShapes-com.aspose.diagram.ShapeCollection-) | このプロパティの説明については、[getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--) を参照してください。 |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+指定された保存形式に適したクラスの保存オプションオブジェクトを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| saveFormat | int | 保存オプションオブジェクトを作成するための Aspose.Diagram.SaveFileFormat です。 |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+ダイアグラム内の文字が Unicode で、正しいフォントが設定されていない、またはフォントがローカルにインストールされていない場合、PDF、画像、または XPS で文字がブロックとして表示されることがあります。MingLiu や MS Gothic などの DefaultFont を設定して、これらの文字を表示してください。
+
+**Returns:**
+java.lang.String
+### getEmfRenderSetting() {#getEmfRenderSetting--}
+```
+public int getEmfRenderSetting()
+```
+
+
+Emf メタファイルのレンダリング設定です。\"EMF+ Dual\" と識別される EMF メタファイルは、EMF+ レコードと EMF レコードの両方を含むことができます。画像のレンダリングには、どちらのレコードタイプも使用でき、EMF+ レコードのみ、または EMF レコードのみを使用することもできます。EmfPlusPrefer が設定されている場合は EMF+ レコードが解析され、設定されていない場合は EMF レコードのみが解析されます。デフォルト値は EmfOnly です。
+
+**Returns:**
+int
+### getEnlargePage() {#getEnlargePage--}
+```
+public boolean getEnlargePage()
+```
+
+
+ページを拡大するかどうかを指定します。true の場合はページを拡大し、false の場合は拡大しません。デフォルト値は true です。
+
+**Returns:**
+boolean
+### getExportGuideShapes() {#getExportGuideShapes--}
+```
+public boolean getExportGuideShapes()
+```
+
+
+ガイドシェイプをエクスポートするかどうかを定義します。デフォルト値は true です。
+
+**Returns:**
+boolean
+### getPageSize() {#getPageSize--}
+```
+public PageSize getPageSize()
+```
+
+
+生成された画像のページサイズです。 [PageSize](../../com.aspose.diagram/pagesize) または null にできます。デフォルト値は null です。PageSize が null の場合、生成された画像のページサイズはソース図から取得されます。
+
+**Returns:**
+[PageSize](../../com.aspose.diagram/pagesize)
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+この保存オプションオブジェクトが使用される場合、ドキュメントが保存される形式を指定します。
+
+**Returns:**
+int
+### getShapes() {#getShapes--}
+```
+public ShapeCollection getShapes()
+```
+
+
+レンダリングするシェイプです。デフォルトのカウントは 0 です。
+
+**Returns:**
+[ShapeCollection](../../com.aspose.diagram/shapecollection)
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+警告コールバック。
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExportComments() {#isExportComments--}
+```
+public boolean isExportComments()
+```
+
+
+コメントをエクスポートするかどうかを定義します。デフォルト値は false です。
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+このプロパティの説明については、[getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setEmfRenderSetting(int value) {#setEmfRenderSetting-int-}
+```
+public void setEmfRenderSetting(int value)
+```
+
+
+このプロパティの説明については、[getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setEnlargePage(boolean value) {#setEnlargePage-boolean-}
+```
+public void setEnlargePage(boolean value)
+```
+
+
+このプロパティの説明については、[getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setExportComments(boolean value) {#setExportComments-boolean-}
+```
+public void setExportComments(boolean value)
+```
+
+
+このプロパティの説明については、[isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setExportGuideShapes(boolean value) {#setExportGuideShapes-boolean-}
+```
+public void setExportGuideShapes(boolean value)
+```
+
+
+このプロパティの説明については、[getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setPageSize(PageSize value) {#setPageSize-com.aspose.diagram.PageSize-}
+```
+public void setPageSize(PageSize value)
+```
+
+
+このプロパティの説明については、[getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [PageSize](../../com.aspose.diagram/pagesize) |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+このプロパティの説明については、[getSaveFormat()](../../com.aspose.diagram/saveoptions\#getSaveFormat--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setShapes(ShapeCollection value) {#setShapes-com.aspose.diagram.ShapeCollection-}
+```
+public void setShapes(ShapeCollection value)
+```
+
+
+このプロパティの説明については、[getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [ShapeCollection](../../com.aspose.diagram/shapecollection) |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/resizemode/_index.md
+++ b/japanese/java/com.aspose.diagram/resizemode/_index.md
@@ -1,0 +1,204 @@
+---
+title: ResizeMode
+second_title: Aspose.Diagram for Java API リファレンス
+description: グループ内に含まれる形状の現在のリサイズ動作設定を指定します。
+type: docs
+weight: 328
+url: /ja/java/com.aspose.diagram/resizemode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ResizeMode
+```
+
+グループ内に含まれる形状の現在のリサイズ動作設定を指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [ResizeMode(int value)](#ResizeMode-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | グループ内に含まれる形状の現在のリサイズ動作設定を指定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | For the description of this property, please see [getUfe()](../../com.aspose.diagram/resizemode\#getUfe--) |
+| [setValue(int value)](#setValue-int-) | For the description of this property, please see [getValue()](../../com.aspose.diagram/resizemode\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ResizeMode(int value) {#ResizeMode-int-}
+```
+public ResizeMode(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+グループ内に含まれる形状の現在のリサイズ動作設定を指定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+For the description of this property, please see [getUfe()](../../com.aspose.diagram/resizemode\#getUfe--)
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+For the description of this property, please see [getValue()](../../com.aspose.diagram/resizemode\#getValue--)
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/resizemodevalue/_index.md
+++ b/japanese/java/com.aspose.diagram/resizemodevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: ResizeModeValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: グループ内に含まれる形状の現在のリサイズ動作設定を指定します。
+type: docs
+weight: 329
+url: /ja/java/com.aspose.diagram/resizemodevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ResizeModeValue
+```
+
+グループ内に含まれる形状の現在のリサイズ動作設定を指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [REPOSITION_ONLY](#REPOSITION-ONLY) | 再配置のみ。 |
+| [SCALE_WITH_GROUP](#SCALE-WITH-GROUP) | グループに合わせてスケール。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+| [USE_GROUP_SETTING](#USE-GROUP-SETTING) | グループの設定を使用する。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### REPOSITION_ONLY {#REPOSITION-ONLY}
+```
+public static final int REPOSITION_ONLY
+```
+
+
+再配置のみ。
+
+### SCALE_WITH_GROUP {#SCALE-WITH-GROUP}
+```
+public static final int SCALE_WITH_GROUP
+```
+
+
+グループに合わせてスケール。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### USE_GROUP_SETTING {#USE-GROUP-SETTING}
+```
+public static final int USE_GROUP_SETTING
+```
+
+
+グループの設定を使用する。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/reviewer/_index.md
+++ b/japanese/java/com.aspose.diagram/reviewer/_index.md
@@ -1,0 +1,243 @@
+---
+title: レビュアー
+second_title: Aspose.Diagram for Java API リファレンス
+description: 文書レビュアーに関する識別情報を含む要素を含みます。
+type: docs
+weight: 330
+url: /ja/java/com.aspose.diagram/reviewer/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Reviewer
+```
+
+文書レビュアーに関する識別情報を含む要素を含みます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Reviewer()](#Reviewer--) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getColor()](#getColor--) | Color 要素は、文書レビュアーのマークアップに割り当てられた色を表す RGB 値を指定します。 |
+| [getCurrentIndex()](#getCurrentIndex--) | 現在のレビュアーが文書に別のコメントを追加するときに追加される MarkerIndex 要素の値を示します。 |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getIX()](#getIX--) | 親要素内の要素のゼロベースインデックスです。 |
+| [getInitials()](#getInitials--) | 文書レビュアーのイニシャルが含まれます。 |
+| [getName()](#getName--) | Name 要素は、文書レビュアーの名前を指定します。 |
+| [getReviewerID()](#getReviewerID--) | ドキュメントにマークアップを追加したレビュアーの ID 番号を含みます。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | このプロパティの説明については、[getDel()](../../com.aspose.diagram/reviewer\#getDel--) を参照してください。 |
+| [setIX(int value)](#setIX-int-) | このプロパティの説明については、[getIX()](../../com.aspose.diagram/reviewer\#getIX--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Reviewer() {#Reviewer--}
+```
+public Reviewer()
+```
+
+
+コンストラクタ。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColor() {#getColor--}
+```
+public ColorValue getColor()
+```
+
+
+Color 要素は、文書レビュアーのマークアップに割り当てられた色を表す RGB 値を指定します。
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getCurrentIndex() {#getCurrentIndex--}
+```
+public IntValue getCurrentIndex()
+```
+
+
+現在のレビュアーが文書に別のコメントを追加するときに追加される MarkerIndex 要素の値を示します。
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+親要素内の要素のゼロベースインデックスです。
+
+**Returns:**
+int
+### getInitials() {#getInitials--}
+```
+public Str2Value getInitials()
+```
+
+
+文書レビュアーのイニシャルが含まれます。
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getName() {#getName--}
+```
+public Str2Value getName()
+```
+
+
+Name 要素は、文書レビュアーの名前を指定します。
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getReviewerID() {#getReviewerID--}
+```
+public IntValue getReviewerID()
+```
+
+
+ドキュメントにマークアップを追加したレビュアーの ID 番号を含みます。
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+このプロパティの説明については、[getDel()](../../com.aspose.diagram/reviewer\#getDel--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+このプロパティの説明については、[getIX()](../../com.aspose.diagram/reviewer\#getIX--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/reviewercollection/_index.md
+++ b/japanese/java/com.aspose.diagram/reviewercollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: ReviewerCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: Reviewer コレクション。
+type: docs
+weight: 331
+url: /ja/java/com.aspose.diagram/reviewercollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ReviewerCollection extends Collection
+```
+
+Reviewer コレクション。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(Reviewer item)](#add-com.aspose.diagram.Reviewer-) | コレクションに Reviewer オブジェクトを追加します。 |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Reviewer item)](#remove-com.aspose.diagram.Reviewer-) | コレクションから Reviewer オブジェクトを削除します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Reviewer item) {#add-com.aspose.diagram.Reviewer-}
+```
+public int add(Reviewer item)
+```
+
+
+コレクションに Reviewer オブジェクトを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [Reviewer](../../com.aspose.diagram/reviewer) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Reviewer get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[Reviewer](../../com.aspose.diagram/reviewer) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Reviewer item) {#remove-com.aspose.diagram.Reviewer-}
+```
+public void remove(Reviewer item)
+```
+
+
+コレクションから Reviewer オブジェクトを削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [Reviewer](../../com.aspose.diagram/reviewer) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/rotationtype/_index.md
+++ b/japanese/java/com.aspose.diagram/rotationtype/_index.md
@@ -1,0 +1,179 @@
+---
+title: RotationType
+second_title: Aspose.Diagram for Java API リファレンス
+description: シェイプの影のタイプを指定します。
+type: docs
+weight: 332
+url: /ja/java/com.aspose.diagram/rotationtype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class RotationType
+```
+
+シェイプの影のタイプを指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [RotationType(int value)](#RotationType-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | ベベルのタイプを指定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/rotationtype\\#getValue--)をご覧ください |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RotationType(int value) {#RotationType-int-}
+```
+public RotationType(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+ベベルのタイプを指定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/rotationtype\\#getValue--)をご覧ください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/rotationtypevalue/_index.md
+++ b/japanese/java/com.aspose.diagram/rotationtypevalue/_index.md
@@ -1,0 +1,201 @@
+---
+title: RotationTypeValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: 形状の効果プロパティの投影タイプを指定します。
+type: docs
+weight: 333
+url: /ja/java/com.aspose.diagram/rotationtypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class RotationTypeValue
+```
+
+形状の効果プロパティの投影タイプを指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [NONE](#NONE) | 3D効果の回転がないことを指定します。 |
+| [OBLIQUE_FROM_BOTTOM_LEFT](#OBLIQUE-FROM-BOTTOM-LEFT) | シェイプのバウンディングボックスの左下隅から斜め投影で回転することを指定します。 |
+| [OBLIQUE_FROM_BOTTOM_RIGHT](#OBLIQUE-FROM-BOTTOM-RIGHT) | シェイプのバウンディングボックスの右下隅から斜め投影で回転することを指定します。 |
+| [OBLIQUE_FROM_TOP_LEFT](#OBLIQUE-FROM-TOP-LEFT) | シェイプのバウンディングボックスの左上隅から斜め投影で回転することを指定します。 |
+| [OBLIQUE_FROM_TOP_RIGHT](#OBLIQUE-FROM-TOP-RIGHT) | シェイプのバウンディングボックスの右上隅から斜め投影で回転することを指定します。 |
+| [PARALLEL](#PARALLEL) | 3D効果プロパティに平行投影が適用されることを指定します。 |
+| [PERSPECTIVE](#PERSPECTIVE) | シェイプが透視投影で回転することを指定します。 |
+| [UNDEFINED](#UNDEFINED) | ライトリグなし。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+3D効果の回転がないことを指定します。
+
+### OBLIQUE_FROM_BOTTOM_LEFT {#OBLIQUE-FROM-BOTTOM-LEFT}
+```
+public static final int OBLIQUE_FROM_BOTTOM_LEFT
+```
+
+
+シェイプのバウンディングボックスの左下隅から斜め投影で回転することを指定します。
+
+### OBLIQUE_FROM_BOTTOM_RIGHT {#OBLIQUE-FROM-BOTTOM-RIGHT}
+```
+public static final int OBLIQUE_FROM_BOTTOM_RIGHT
+```
+
+
+シェイプのバウンディングボックスの右下隅から斜め投影で回転することを指定します。
+
+### OBLIQUE_FROM_TOP_LEFT {#OBLIQUE-FROM-TOP-LEFT}
+```
+public static final int OBLIQUE_FROM_TOP_LEFT
+```
+
+
+シェイプのバウンディングボックスの左上隅から斜め投影で回転することを指定します。
+
+### OBLIQUE_FROM_TOP_RIGHT {#OBLIQUE-FROM-TOP-RIGHT}
+```
+public static final int OBLIQUE_FROM_TOP_RIGHT
+```
+
+
+シェイプのバウンディングボックスの右上隅から斜め投影で回転することを指定します。
+
+### PARALLEL {#PARALLEL}
+```
+public static final int PARALLEL
+```
+
+
+3D効果プロパティに平行投影が適用されることを指定します。
+
+### PERSPECTIVE {#PERSPECTIVE}
+```
+public static final int PERSPECTIVE
+```
+
+
+シェイプが透視投影で回転することを指定します。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+ライトリグなし。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/routestyle/_index.md
+++ b/japanese/java/com.aspose.diagram/routestyle/_index.md
@@ -1,0 +1,179 @@
+---
+title: RouteStyle
+second_title: Aspose.Diagram for Java API リファレンス
+description: 描画ページ上のローカル ルーティング スタイルを持たないすべての動的コネクタのルーティング スタイルと方向を指定します。
+type: docs
+weight: 334
+url: /ja/java/com.aspose.diagram/routestyle/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class RouteStyle
+```
+
+ローカルのルーティングスタイルが設定されていない描画ページ上のすべての動的コネクタのルーティングスタイルと方向を指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [RouteStyle(int value)](#RouteStyle-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | ローカルのルーティングスタイルが設定されていない描画ページ上のすべての動的コネクタのルーティングスタイルと方向を指定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/routestyle\#getValue--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RouteStyle(int value) {#RouteStyle-int-}
+```
+public RouteStyle(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+ローカルのルーティングスタイルが設定されていない描画ページ上のすべての動的コネクタのルーティングスタイルと方向を指定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/routestyle\#getValue--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/routestylevalue/_index.md
+++ b/japanese/java/com.aspose.diagram/routestylevalue/_index.md
@@ -1,0 +1,345 @@
+---
+title: RouteStyleValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: 描画ページ上のローカル ルーティング スタイルを持たないすべての動的コネクタのルーティング スタイルと方向を指定します。
+type: docs
+weight: 335
+url: /ja/java/com.aspose.diagram/routestylevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class RouteStyleValue
+```
+
+ローカルのルーティングスタイルが設定されていない描画ページ上のすべての動的コネクタのルーティングスタイルと方向を指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [CENTER_TO_CENTER](#CENTER-TO-CENTER) | Center to center. |
+| [DEFAULT_RIGHT_ANGLE](#DEFAULT-RIGHT-ANGLE) | デフォルト。 |
+| [FLOWCHART_BOTTOM_TO_TOP](#FLOWCHART-BOTTOM-TO-TOP) | フローチャート（下から上へ）。 |
+| [FLOWCHART_LEFT_TO_RIGHT](#FLOWCHART-LEFT-TO-RIGHT) | フローチャート（左から右へ）。 |
+| [FLOWCHART_RIGHT_TO_LEFT](#FLOWCHART-RIGHT-TO-LEFT) | フローチャート（右から左へ）。 |
+| [FLOWCHART_TOP_TO_BOTTOM](#FLOWCHART-TOP-TO-BOTTOM) | フローチャート（上から下へ）。 |
+| [NETWORK](#NETWORK) | ネットワーク。 |
+| [ORGANIZATION_CHART_BOTTOM_TO_TOP](#ORGANIZATION-CHART-BOTTOM-TO-TOP) | 組織図（下から上へ）。 |
+| [ORGANIZATION_CHART_LEFT_TO_RIGHT](#ORGANIZATION-CHART-LEFT-TO-RIGHT) | 組織図は左から右へ。 |
+| [ORGANIZATION_CHART_RIGHT_TO_LEFT](#ORGANIZATION-CHART-RIGHT-TO-LEFT) | 組織図は右から左へ。 |
+| [ORGANIZATION_CHART_TOP_TO_BOTTOM](#ORGANIZATION-CHART-TOP-TO-BOTTOM) | 組織図は上から下へ。 |
+| [RIGHT_ANGLE](#RIGHT-ANGLE) | Right angle. |
+| [SIMPLE_BOTTOM_TO_TOP](#SIMPLE-BOTTOM-TO-TOP) | シンプルな下から上へ。 |
+| [SIMPLE_HORIZONTAL_VERTICAL](#SIMPLE-HORIZONTAL-VERTICAL) | シンプルな水平・垂直。 |
+| [SIMPLE_LEFT_TO_RIGHT](#SIMPLE-LEFT-TO-RIGHT) | シンプルな左から右へ。 |
+| [SIMPLE_RIGHT_TO_LEFT](#SIMPLE-RIGHT-TO-LEFT) | シンプルな右から左へ。 |
+| [SIMPLE_TOP_TO_BOTTOM](#SIMPLE-TOP-TO-BOTTOM) | シンプルな上から下へ。 |
+| [SIMPLE_VERTICAL_HORIZONTAL](#SIMPLE-VERTICAL-HORIZONTAL) | シンプルな垂直・水平。 |
+| [STRAIGHT](#STRAIGHT) | Straight. |
+| [TREE_BOTTOM_TO_TOP](#TREE-BOTTOM-TO-TOP) | ツリーは下から上へ。 |
+| [TREE_LEFT_TO_RIGHT](#TREE-LEFT-TO-RIGHT) | ツリーは左から右へ。 |
+| [TREE_RIGHT_TO_LEFT](#TREE-RIGHT-TO-LEFT) | ツリーは右から左へ。 |
+| [TREE_TOP_TO_BOTTOM](#TREE-TOP-TO-BOTTOM) | ツリーは上から下へ。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CENTER_TO_CENTER {#CENTER-TO-CENTER}
+```
+public static final int CENTER_TO_CENTER
+```
+
+
+Center to center.
+
+### DEFAULT_RIGHT_ANGLE {#DEFAULT-RIGHT-ANGLE}
+```
+public static final int DEFAULT_RIGHT_ANGLE
+```
+
+
+デフォルト。直角。
+
+### FLOWCHART_BOTTOM_TO_TOP {#FLOWCHART-BOTTOM-TO-TOP}
+```
+public static final int FLOWCHART_BOTTOM_TO_TOP
+```
+
+
+フローチャート（下から上へ）。
+
+### FLOWCHART_LEFT_TO_RIGHT {#FLOWCHART-LEFT-TO-RIGHT}
+```
+public static final int FLOWCHART_LEFT_TO_RIGHT
+```
+
+
+フローチャート（左から右へ）。
+
+### FLOWCHART_RIGHT_TO_LEFT {#FLOWCHART-RIGHT-TO-LEFT}
+```
+public static final int FLOWCHART_RIGHT_TO_LEFT
+```
+
+
+フローチャート（右から左へ）。
+
+### FLOWCHART_TOP_TO_BOTTOM {#FLOWCHART-TOP-TO-BOTTOM}
+```
+public static final int FLOWCHART_TOP_TO_BOTTOM
+```
+
+
+フローチャート（上から下へ）。
+
+### NETWORK {#NETWORK}
+```
+public static final int NETWORK
+```
+
+
+ネットワーク。
+
+### ORGANIZATION_CHART_BOTTOM_TO_TOP {#ORGANIZATION-CHART-BOTTOM-TO-TOP}
+```
+public static final int ORGANIZATION_CHART_BOTTOM_TO_TOP
+```
+
+
+組織図（下から上へ）。
+
+### ORGANIZATION_CHART_LEFT_TO_RIGHT {#ORGANIZATION-CHART-LEFT-TO-RIGHT}
+```
+public static final int ORGANIZATION_CHART_LEFT_TO_RIGHT
+```
+
+
+組織図は左から右へ。
+
+### ORGANIZATION_CHART_RIGHT_TO_LEFT {#ORGANIZATION-CHART-RIGHT-TO-LEFT}
+```
+public static final int ORGANIZATION_CHART_RIGHT_TO_LEFT
+```
+
+
+組織図は右から左へ。
+
+### ORGANIZATION_CHART_TOP_TO_BOTTOM {#ORGANIZATION-CHART-TOP-TO-BOTTOM}
+```
+public static final int ORGANIZATION_CHART_TOP_TO_BOTTOM
+```
+
+
+組織図は上から下へ。
+
+### RIGHT_ANGLE {#RIGHT-ANGLE}
+```
+public static final int RIGHT_ANGLE
+```
+
+
+Right angle.
+
+### SIMPLE_BOTTOM_TO_TOP {#SIMPLE-BOTTOM-TO-TOP}
+```
+public static final int SIMPLE_BOTTOM_TO_TOP
+```
+
+
+シンプルな下から上へ。
+
+### SIMPLE_HORIZONTAL_VERTICAL {#SIMPLE-HORIZONTAL-VERTICAL}
+```
+public static final int SIMPLE_HORIZONTAL_VERTICAL
+```
+
+
+シンプルな水平・垂直。
+
+### SIMPLE_LEFT_TO_RIGHT {#SIMPLE-LEFT-TO-RIGHT}
+```
+public static final int SIMPLE_LEFT_TO_RIGHT
+```
+
+
+シンプルな左から右へ。
+
+### SIMPLE_RIGHT_TO_LEFT {#SIMPLE-RIGHT-TO-LEFT}
+```
+public static final int SIMPLE_RIGHT_TO_LEFT
+```
+
+
+シンプルな右から左へ。
+
+### SIMPLE_TOP_TO_BOTTOM {#SIMPLE-TOP-TO-BOTTOM}
+```
+public static final int SIMPLE_TOP_TO_BOTTOM
+```
+
+
+シンプルな上から下へ。
+
+### SIMPLE_VERTICAL_HORIZONTAL {#SIMPLE-VERTICAL-HORIZONTAL}
+```
+public static final int SIMPLE_VERTICAL_HORIZONTAL
+```
+
+
+シンプルな垂直・水平。
+
+### STRAIGHT {#STRAIGHT}
+```
+public static final int STRAIGHT
+```
+
+
+Straight.
+
+### TREE_BOTTOM_TO_TOP {#TREE-BOTTOM-TO-TOP}
+```
+public static final int TREE_BOTTOM_TO_TOP
+```
+
+
+ツリーは下から上へ。
+
+### TREE_LEFT_TO_RIGHT {#TREE-LEFT-TO-RIGHT}
+```
+public static final int TREE_LEFT_TO_RIGHT
+```
+
+
+ツリーは左から右へ。
+
+### TREE_RIGHT_TO_LEFT {#TREE-RIGHT-TO-LEFT}
+```
+public static final int TREE_RIGHT_TO_LEFT
+```
+
+
+ツリーは右から左へ。
+
+### TREE_TOP_TO_BOTTOM {#TREE-TOP-TO-BOTTOM}
+```
+public static final int TREE_TOP_TO_BOTTOM
+```
+
+
+ツリーは上から下へ。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/row/_index.md
+++ b/japanese/java/com.aspose.diagram/row/_index.md
@@ -1,0 +1,213 @@
+---
+title: Row
+second_title: Aspose.Diagram for Java API リファレンス
+description: データレコードセットの行を示します。
+type: docs
+weight: 336
+url: /ja/java/com.aspose.diagram/row/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Row
+```
+
+データレコードセットの行を示します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Row()](#Row--) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getPageID()](#getPageID--) | シェイプのページ ID。 |
+| [getRowID()](#getRowID--) | 元の行 ID。 |
+| [getShapeID()](#getShapeID--) | シェイプの Shape ID。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setPageID(long value)](#setPageID-long-) | このプロパティの説明については、[getPageID()](../../com.aspose.diagram/row\#getPageID--) を参照してください。 |
+| [setRowID(long value)](#setRowID-long-) | このプロパティの説明については、[getRowID()](../../com.aspose.diagram/row\#getRowID--) を参照してください。 |
+| [setShapeID(long value)](#setShapeID-long-) | このプロパティの説明については、[getShapeID()](../../com.aspose.diagram/row\#getShapeID--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Row() {#Row--}
+```
+public Row()
+```
+
+
+コンストラクタ。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getPageID() {#getPageID--}
+```
+public long getPageID()
+```
+
+
+シェイプのページ ID。
+
+**Returns:**
+long
+### getRowID() {#getRowID--}
+```
+public long getRowID()
+```
+
+
+元の行 ID。
+
+**Returns:**
+long
+### getShapeID() {#getShapeID--}
+```
+public long getShapeID()
+```
+
+
+シェイプの Shape ID。
+
+**Returns:**
+long
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setPageID(long value) {#setPageID-long-}
+```
+public void setPageID(long value)
+```
+
+
+このプロパティの説明については、[getPageID()](../../com.aspose.diagram/row\#getPageID--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | long |  |
+
+### setRowID(long value) {#setRowID-long-}
+```
+public void setRowID(long value)
+```
+
+
+このプロパティの説明については、[getRowID()](../../com.aspose.diagram/row\#getRowID--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | long |  |
+
+### setShapeID(long value) {#setShapeID-long-}
+```
+public void setShapeID(long value)
+```
+
+
+このプロパティの説明については、[getShapeID()](../../com.aspose.diagram/row\#getShapeID--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | long |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/rowcollection/_index.md
+++ b/japanese/java/com.aspose.diagram/rowcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: RowCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: Row コレクション。
+type: docs
+weight: 337
+url: /ja/java/com.aspose.diagram/rowcollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class RowCollection extends Collection
+```
+
+Row コレクション。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(Row row)](#add-com.aspose.diagram.Row-) | コレクションに行を追加します。 |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Row row)](#remove-com.aspose.diagram.Row-) | コレクションから行を削除します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Row row) {#add-com.aspose.diagram.Row-}
+```
+public int add(Row row)
+```
+
+
+コレクションに行を追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| row | [Row](../../com.aspose.diagram/row) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Row get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[Row](../../com.aspose.diagram/row) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Row row) {#remove-com.aspose.diagram.Row-}
+```
+public void remove(Row row)
+```
+
+
+コレクションから行を削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| row | [Row](../../com.aspose.diagram/row) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/rule/_index.md
+++ b/japanese/java/com.aspose.diagram/rule/_index.md
@@ -1,0 +1,338 @@
+---
+title: Rule
+second_title: Aspose.Diagram for Java API リファレンス
+description: 図の検証ルールセット内の単一の検証ルールを表します。
+type: docs
+weight: 338
+url: /ja/java/com.aspose.diagram/rule/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Rule
+```
+
+図の検証ルールセット内の単一の検証ルールを表します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Rule()](#Rule--) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCategory()](#getCategory--) | Issues ウィンドウの Category 列に表示されるテキストを指定します。 |
+| [getClass()](#getClass--) |  |
+| [getDescription()](#getDescription--) | ユーザーインターフェイスに表示される検証ルールの説明です。 |
+| [getID()](#getID--) | 検証ルールの一意の識別子を指定します。 |
+| [getIgnored()](#getIgnored--) | 検証ルールが現在無視されているかどうかを指定します。 |
+| [getNameU()](#getNameU--) | 検証ルールのユニバーサル名を指定します。 |
+| [getRuleFilter()](#getRuleFilter--) | 検証ルールを対象オブジェクトに適用すべきかどうかを決定する論理式を指定します。 |
+| [getRuleTarget()](#getRuleTarget--) | 検証ルールが適用されるオブジェクトのタイプを指定します。 |
+| [getRuleTest()](#getRuleTest--) | 対象オブジェクトが検証ルールを満たすかどうかを決定する論理式を指定します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCategory(String value)](#setCategory-java.lang.String-) | このプロパティの説明については、[getCategory()](../../com.aspose.diagram/rule\#getCategory--) を参照してください。 |
+| [setDescription(String value)](#setDescription-java.lang.String-) | このプロパティの説明については、[getDescription()](../../com.aspose.diagram/rule\#getDescription--) を参照してください。 |
+| [setID(long value)](#setID-long-) | このプロパティの説明については、[getID()](../../com.aspose.diagram/rule\#getID--) を参照してください。 |
+| [setIgnored(int value)](#setIgnored-int-) | このプロパティの説明については、[getIgnored()](../../com.aspose.diagram/rule\#getIgnored--) を参照してください。 |
+| [setNameU(String value)](#setNameU-java.lang.String-) | このプロパティの説明については、[getNameU()](../../com.aspose.diagram/rule\#getNameU--) を参照してください。 |
+| [setRuleFilter(RuleValue value)](#setRuleFilter-com.aspose.diagram.RuleValue-) | このプロパティの説明については、[getRuleFilter()](../../com.aspose.diagram/rule\#getRuleFilter--) を参照してください。 |
+| [setRuleTarget(int value)](#setRuleTarget-int-) | このプロパティの説明については、[getRuleTarget()](../../com.aspose.diagram/rule\#getRuleTarget--) を参照してください。 |
+| [setRuleTest(RuleValue value)](#setRuleTest-com.aspose.diagram.RuleValue-) | このプロパティの説明については、[getRuleTest()](../../com.aspose.diagram/rule\#getRuleTest--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Rule() {#Rule--}
+```
+public Rule()
+```
+
+
+コンストラクタ。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCategory() {#getCategory--}
+```
+public String getCategory()
+```
+
+
+Issues ウィンドウの Category 列に表示されるテキストを指定します。デフォルトは空文字列です。
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDescription() {#getDescription--}
+```
+public String getDescription()
+```
+
+
+ユーザーインターフェイスに表示される検証ルールの説明です。デフォルトは "Unknown" です。
+
+**Returns:**
+java.lang.String
+### getID() {#getID--}
+```
+public long getID()
+```
+
+
+検証ルールの一意の識別子を指定します。
+
+**Returns:**
+long
+### getIgnored() {#getIgnored--}
+```
+public int getIgnored()
+```
+
+
+検証ルールが現在無視されているかどうかを指定します。デフォルトは False です。
+
+**Returns:**
+int
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+検証ルールのユニバーサル名を指定します。
+
+**Returns:**
+java.lang.String
+### getRuleFilter() {#getRuleFilter--}
+```
+public RuleValue getRuleFilter()
+```
+
+
+検証ルールを対象オブジェクトに適用すべきかどうかを決定する論理式を指定します。
+
+**Returns:**
+[RuleValue](../../com.aspose.diagram/rulevalue)
+### getRuleTarget() {#getRuleTarget--}
+```
+public int getRuleTarget()
+```
+
+
+検証ルールが適用されるオブジェクトのタイプを指定します。
+
+**Returns:**
+int
+### getRuleTest() {#getRuleTest--}
+```
+public RuleValue getRuleTest()
+```
+
+
+対象オブジェクトが検証ルールを満たすかどうかを決定する論理式を指定します。
+
+**Returns:**
+[RuleValue](../../com.aspose.diagram/rulevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCategory(String value) {#setCategory-java.lang.String-}
+```
+public void setCategory(String value)
+```
+
+
+このプロパティの説明については、[getCategory()](../../com.aspose.diagram/rule\#getCategory--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setDescription(String value) {#setDescription-java.lang.String-}
+```
+public void setDescription(String value)
+```
+
+
+このプロパティの説明については、[getDescription()](../../com.aspose.diagram/rule\#getDescription--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setID(long value) {#setID-long-}
+```
+public void setID(long value)
+```
+
+
+このプロパティの説明については、[getID()](../../com.aspose.diagram/rule\#getID--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | long |  |
+
+### setIgnored(int value) {#setIgnored-int-}
+```
+public void setIgnored(int value)
+```
+
+
+このプロパティの説明については、[getIgnored()](../../com.aspose.diagram/rule\#getIgnored--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+このプロパティの説明については、[getNameU()](../../com.aspose.diagram/rule\#getNameU--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setRuleFilter(RuleValue value) {#setRuleFilter-com.aspose.diagram.RuleValue-}
+```
+public void setRuleFilter(RuleValue value)
+```
+
+
+このプロパティの説明については、[getRuleFilter()](../../com.aspose.diagram/rule\#getRuleFilter--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [RuleValue](../../com.aspose.diagram/rulevalue) |  |
+
+### setRuleTarget(int value) {#setRuleTarget-int-}
+```
+public void setRuleTarget(int value)
+```
+
+
+このプロパティの説明については、[getRuleTarget()](../../com.aspose.diagram/rule\#getRuleTarget--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setRuleTest(RuleValue value) {#setRuleTest-com.aspose.diagram.RuleValue-}
+```
+public void setRuleTest(RuleValue value)
+```
+
+
+このプロパティの説明については、[getRuleTest()](../../com.aspose.diagram/rule\#getRuleTest--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [RuleValue](../../com.aspose.diagram/rulevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/rulecollection/_index.md
+++ b/japanese/java/com.aspose.diagram/rulecollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: RuleCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: ルール コレクション。
+type: docs
+weight: 339
+url: /ja/java/com.aspose.diagram/rulecollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class RuleCollection extends Collection
+```
+
+ルール コレクション。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(Rule rule)](#add-com.aspose.diagram.Rule-) | コレクションにルールを追加します。 |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Rule rule)](#remove-com.aspose.diagram.Rule-) | コレクションからルールを削除します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Rule rule) {#add-com.aspose.diagram.Rule-}
+```
+public int add(Rule rule)
+```
+
+
+コレクションにルールを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| rule | [Rule](../../com.aspose.diagram/rule) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Rule get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[Rule](../../com.aspose.diagram/rule) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Rule rule) {#remove-com.aspose.diagram.Rule-}
+```
+public void remove(Rule rule)
+```
+
+
+コレクションからルールを削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| rule | [Rule](../../com.aspose.diagram/rule) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/ruleinfo/_index.md
+++ b/japanese/java/com.aspose.diagram/ruleinfo/_index.md
@@ -1,0 +1,194 @@
+---
+title: RuleInfo
+second_title: Aspose.Diagram for Java API リファレンス
+description: 親の検証問題が関連する検証ルールに関する情報を指定します。
+type: docs
+weight: 340
+url: /ja/java/com.aspose.diagram/ruleinfo/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class RuleInfo
+```
+
+親の検証問題が関連する検証ルールに関する情報を指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [RuleInfo(long ruleSetID, long ruleID)](#RuleInfo-long-long-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getRuleId()](#getRuleId--) | 親の課題に関連する検証ルールの一意の識別子を指定します。 |
+| [getRuleSetId()](#getRuleSetId--) | 親課題が関連する検証ルールセットの一意の識別子を指定します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setRuleId(long value)](#setRuleId-long-) | このプロパティの説明については、[getRuleId()](../../com.aspose.diagram/ruleinfo\#getRuleId--) を参照してください。 |
+| [setRuleSetId(long value)](#setRuleSetId-long-) | このプロパティの説明については、[getRuleSetId()](../../com.aspose.diagram/ruleinfo\#getRuleSetId--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RuleInfo(long ruleSetID, long ruleID) {#RuleInfo-long-long-}
+```
+public RuleInfo(long ruleSetID, long ruleID)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ruleSetID | long |  |
+| ruleID | long |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getRuleId() {#getRuleId--}
+```
+public long getRuleId()
+```
+
+
+親の課題に関連する検証ルールの一意の識別子を指定します。
+
+**Returns:**
+long
+### getRuleSetId() {#getRuleSetId--}
+```
+public long getRuleSetId()
+```
+
+
+親課題が関連する検証ルールセットの一意の識別子を指定します。
+
+**Returns:**
+long
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setRuleId(long value) {#setRuleId-long-}
+```
+public void setRuleId(long value)
+```
+
+
+このプロパティの説明については、[getRuleId()](../../com.aspose.diagram/ruleinfo\#getRuleId--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | long |  |
+
+### setRuleSetId(long value) {#setRuleSetId-long-}
+```
+public void setRuleSetId(long value)
+```
+
+
+このプロパティの説明については、[getRuleSetId()](../../com.aspose.diagram/ruleinfo\#getRuleSetId--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | long |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/rulerdensity/_index.md
+++ b/japanese/java/com.aspose.diagram/rulerdensity/_index.md
@@ -1,0 +1,179 @@
+---
+title: RulerDensity
+second_title: Aspose.Diagram for Java API リファレンス
+description: ページの定規上の水平分割を指定します。
+type: docs
+weight: 344
+url: /ja/java/com.aspose.diagram/rulerdensity/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class RulerDensity
+```
+
+ページの定規上の水平分割を指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [RulerDensity(int value)](#RulerDensity-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | ページの定規上の水平分割を指定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/rulerdensity\#getValue--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RulerDensity(int value) {#RulerDensity-int-}
+```
+public RulerDensity(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+ページの定規上の水平分割を指定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/rulerdensity\#getValue--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/rulerdensityvalue/_index.md
+++ b/japanese/java/com.aspose.diagram/rulerdensityvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: RulerDensityValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: ページの定規上の水平分割を指定します。
+type: docs
+weight: 345
+url: /ja/java/com.aspose.diagram/rulerdensityvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class RulerDensityValue
+```
+
+ページの定規上の水平分割を指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [COARSE](#COARSE) | 粗い。 |
+| [FINE](#FINE) | 細かいです。 |
+| [NORMAL](#NORMAL) | 標準。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### COARSE {#COARSE}
+```
+public static final int COARSE
+```
+
+
+粗い。
+
+### FINE {#FINE}
+```
+public static final int FINE
+```
+
+
+細かいです。
+
+### NORMAL {#NORMAL}
+```
+public static final int NORMAL
+```
+
+
+標準。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/rulergrid/_index.md
+++ b/japanese/java/com.aspose.diagram/rulergrid/_index.md
@@ -1,0 +1,260 @@
+---
+title: RulerGrid
+second_title: Aspose.Diagram for Java API リファレンス
+description: ページの定規とグリッドの設定を指定する要素を含みます。
+type: docs
+weight: 346
+url: /ja/java/com.aspose.diagram/rulergrid/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class RulerGrid
+```
+
+ページの定規とグリッドの設定を指定する要素を含みます。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getXGridDensity()](#getXGridDensity--) | ページの y 軸（垂直）定規の原点を指定します。 |
+| [getXGridOrigin()](#getXGridOrigin--) | ページのグリッド原点の水平座標を指定します。 |
+| [getXGridSpacing()](#getXGridSpacing--) | 固定グリッドにおける水平線間の距離を指定します（つまり、XGridDensity 要素が 0 に設定された RulerGrid 要素）。 |
+| [getXRulerDensity()](#getXRulerDensity--) | ページの定規上の水平分割を指定します。 |
+| [getXRulerOrigin()](#getXRulerOrigin--) | ページの x 軸（水平）定規の原点を指定します。 |
+| [getYGridDensity()](#getYGridDensity--) | ページで使用する垂直グリッドのタイプを指定します。 |
+| [getYGridOrigin()](#getYGridOrigin--) | ページ上のグリッドの垂直原点を指定します。 |
+| [getYGridSpacing()](#getYGridSpacing--) | 固定グリッドにおける垂直線間の距離を指定します（つまり、YGridDensity 要素が 0 に設定された RulerGrid 要素）。 |
+| [getYRulerDensity()](#getYRulerDensity--) | ページの定規上の垂直分割を指定します。 |
+| [getYRulerOrigin()](#getYRulerOrigin--) | ページの y 軸（垂直）定規の原点を指定します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | このプロパティの説明については、[getDel()](../../com.aspose.diagram/rulergrid\#getDel--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getXGridDensity() {#getXGridDensity--}
+```
+public GridDensity getXGridDensity()
+```
+
+
+ページの y 軸（垂直）定規の原点を指定します。
+
+**Returns:**
+[GridDensity](../../com.aspose.diagram/griddensity)
+### getXGridOrigin() {#getXGridOrigin--}
+```
+public DoubleValue getXGridOrigin()
+```
+
+
+ページのグリッド原点の水平座標を指定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getXGridSpacing() {#getXGridSpacing--}
+```
+public DoubleValue getXGridSpacing()
+```
+
+
+固定グリッドにおける水平線間の距離を指定します（つまり、XGridDensity 要素が 0 に設定された RulerGrid 要素）。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getXRulerDensity() {#getXRulerDensity--}
+```
+public RulerDensity getXRulerDensity()
+```
+
+
+ページの定規上の水平分割を指定します。
+
+**Returns:**
+[RulerDensity](../../com.aspose.diagram/rulerdensity)
+### getXRulerOrigin() {#getXRulerOrigin--}
+```
+public DoubleValue getXRulerOrigin()
+```
+
+
+ページの x 軸（水平）定規の原点を指定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getYGridDensity() {#getYGridDensity--}
+```
+public GridDensity getYGridDensity()
+```
+
+
+ページで使用する垂直グリッドのタイプを指定します。
+
+**Returns:**
+[GridDensity](../../com.aspose.diagram/griddensity)
+### getYGridOrigin() {#getYGridOrigin--}
+```
+public DoubleValue getYGridOrigin()
+```
+
+
+ページ上のグリッドの垂直原点を指定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getYGridSpacing() {#getYGridSpacing--}
+```
+public DoubleValue getYGridSpacing()
+```
+
+
+固定グリッドにおける垂直線間の距離を指定します（つまり、YGridDensity 要素が 0 に設定された RulerGrid 要素）。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getYRulerDensity() {#getYRulerDensity--}
+```
+public RulerDensity getYRulerDensity()
+```
+
+
+ページの定規上の垂直分割を指定します。
+
+**Returns:**
+[RulerDensity](../../com.aspose.diagram/rulerdensity)
+### getYRulerOrigin() {#getYRulerOrigin--}
+```
+public DoubleValue getYRulerOrigin()
+```
+
+
+ページの y 軸（垂直）定規の原点を指定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+このプロパティの説明については、[getDel()](../../com.aspose.diagram/rulergrid\#getDel--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/ruleset/_index.md
+++ b/japanese/java/com.aspose.diagram/ruleset/_index.md
@@ -1,0 +1,299 @@
+---
+title: RuleSet
+second_title: Aspose.Diagram for Java API リファレンス
+description: 図の検証ルールのセットを表します。
+type: docs
+weight: 341
+url: /ja/java/com.aspose.diagram/ruleset/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class RuleSet
+```
+
+図の検証ルールのセットを表します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [RuleSet()](#RuleSet--) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDescription()](#getDescription--) | ユーザーインターフェイスに表示される検証ルールセットの説明を指定します。 |
+| [getEnabled()](#getEnabled--) | 現在のドキュメントで検証がトリガーされたときに、指定された検証ルールセット内のルールがチェックされるかどうかを指定します。 |
+| [getID()](#getID--) | 検証ルールセットの一意の識別子を指定します。 |
+| [getName()](#getName--) | 検証ルールセットのローカル名を指定します。 |
+| [getNameU()](#getNameU--) | 検証ルールセットのユニバーサル名を指定します。 |
+| [getRuleSetFlags()](#getRuleSetFlags--) | ルールセットが「チェックするルール」リストに表示されるかどうかを指定します。 |
+| [getRules()](#getRules--) | ルール コレクション。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDescription(String value)](#setDescription-java.lang.String-) | このプロパティの説明については、[getDescription()](../../com.aspose.diagram/ruleset\#getDescription--) を参照してください。 |
+| [setEnabled(int value)](#setEnabled-int-) | このプロパティの説明については、[getEnabled()](../../com.aspose.diagram/ruleset\#getEnabled--) を参照してください。 |
+| [setID(long value)](#setID-long-) | このプロパティの説明については、[getID()](../../com.aspose.diagram/ruleset\#getID--) を参照してください。 |
+| [setName(String value)](#setName-java.lang.String-) | このプロパティの説明については、[getName()](../../com.aspose.diagram/ruleset\#getName--) を参照してください。 |
+| [setNameU(String value)](#setNameU-java.lang.String-) | このプロパティの説明については、[getNameU()](../../com.aspose.diagram/ruleset\#getNameU--) を参照してください。 |
+| [setRuleSetFlags(int value)](#setRuleSetFlags-int-) | このプロパティの説明については、[getRuleSetFlags()](../../com.aspose.diagram/ruleset\#getRuleSetFlags--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RuleSet() {#RuleSet--}
+```
+public RuleSet()
+```
+
+
+コンストラクタ。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDescription() {#getDescription--}
+```
+public String getDescription()
+```
+
+
+ユーザーインターフェイスに表示される検証ルールセットの説明を指定します。既定値は空文字列です。
+
+**Returns:**
+java.lang.String
+### getEnabled() {#getEnabled--}
+```
+public int getEnabled()
+```
+
+
+現在のドキュメントで検証がトリガーされたときに、指定された検証ルールセットのルールがチェックされるかどうかを指定します。既定値は True です。
+
+**Returns:**
+int
+### getID() {#getID--}
+```
+public long getID()
+```
+
+
+検証ルールセットの一意の識別子を指定します。
+
+**Returns:**
+long
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+検証ルールセットのローカル名を指定します。既定は NameU 属性の値です。
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+検証ルールセットのユニバーサル名を指定します。
+
+**Returns:**
+java.lang.String
+### getRuleSetFlags() {#getRuleSetFlags--}
+```
+public int getRuleSetFlags()
+```
+
+
+ルールセットが「チェックするルール」リストに表示されるかどうかを指定します。
+
+**Returns:**
+int
+### getRules() {#getRules--}
+```
+public RuleCollection getRules()
+```
+
+
+ルール コレクション。
+
+**Returns:**
+[RuleCollection](../../com.aspose.diagram/rulecollection)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDescription(String value) {#setDescription-java.lang.String-}
+```
+public void setDescription(String value)
+```
+
+
+このプロパティの説明については、[getDescription()](../../com.aspose.diagram/ruleset\#getDescription--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setEnabled(int value) {#setEnabled-int-}
+```
+public void setEnabled(int value)
+```
+
+
+このプロパティの説明については、[getEnabled()](../../com.aspose.diagram/ruleset\#getEnabled--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setID(long value) {#setID-long-}
+```
+public void setID(long value)
+```
+
+
+このプロパティの説明については、[getID()](../../com.aspose.diagram/ruleset\#getID--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | long |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+このプロパティの説明については、[getName()](../../com.aspose.diagram/ruleset\#getName--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+このプロパティの説明については、[getNameU()](../../com.aspose.diagram/ruleset\#getNameU--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setRuleSetFlags(int value) {#setRuleSetFlags-int-}
+```
+public void setRuleSetFlags(int value)
+```
+
+
+このプロパティの説明については、[getRuleSetFlags()](../../com.aspose.diagram/ruleset\#getRuleSetFlags--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/rulesetcollection/_index.md
+++ b/japanese/java/com.aspose.diagram/rulesetcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: RuleSetCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: RuleSet コレクション。
+type: docs
+weight: 342
+url: /ja/java/com.aspose.diagram/rulesetcollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class RuleSetCollection extends Collection
+```
+
+RuleSet コレクション。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(RuleSet ruleSet)](#add-com.aspose.diagram.RuleSet-) | コレクションに ruleSet を追加します。 |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(RuleSet ruleSet)](#remove-com.aspose.diagram.RuleSet-) | コレクションから ruleSet を削除します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(RuleSet ruleSet) {#add-com.aspose.diagram.RuleSet-}
+```
+public int add(RuleSet ruleSet)
+```
+
+
+コレクションに ruleSet を追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ruleSet | [RuleSet](../../com.aspose.diagram/ruleset) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public RuleSet get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[RuleSet](../../com.aspose.diagram/ruleset) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(RuleSet ruleSet) {#remove-com.aspose.diagram.RuleSet-}
+```
+public void remove(RuleSet ruleSet)
+```
+
+
+コレクションから ruleSet を削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ruleSet | [RuleSet](../../com.aspose.diagram/ruleset) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/rulevalue/_index.md
+++ b/japanese/java/com.aspose.diagram/rulevalue/_index.md
@@ -1,0 +1,194 @@
+---
+title: RuleValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: ルール 値。
+type: docs
+weight: 343
+url: /ja/java/com.aspose.diagram/rulevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class RuleValue
+```
+
+ルール 値。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [RuleValue(String formula, String value)](#RuleValue-java.lang.String-java.lang.String-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFormula()](#getFormula--) | 要素の式を表します。 |
+| [getValue()](#getValue--) | ルール 値。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setFormula(String value)](#setFormula-java.lang.String-) | このプロパティの説明については、[getFormula()](../../com.aspose.diagram/rulevalue\#getFormula--) をご覧ください。 |
+| [setValue(String value)](#setValue-java.lang.String-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/rulevalue\#getValue--) をご覧ください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RuleValue(String formula, String value) {#RuleValue-java.lang.String-java.lang.String-}
+```
+public RuleValue(String formula, String value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| formula | java.lang.String |  |
+| 値 | java.lang.String |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFormula() {#getFormula--}
+```
+public String getFormula()
+```
+
+
+要素の式を表します。この属性には次の文字列のいずれかが含まれます：ローカルに式が存在する場合は "someFormula"、ローカルで式が削除またはブロックされている場合は "No Formula"、式が継承されている場合は "Inh"。属性が存在しない場合、要素の式は単純な定数です。
+
+**Returns:**
+java.lang.String
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+ルール 値。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setFormula(String value) {#setFormula-java.lang.String-}
+```
+public void setFormula(String value)
+```
+
+
+このプロパティの説明については、[getFormula()](../../com.aspose.diagram/rulevalue\#getFormula--) をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setValue(String value) {#setValue-java.lang.String-}
+```
+public void setValue(String value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/rulevalue\#getValue--) をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/savefileformat/_index.md
+++ b/japanese/java/com.aspose.diagram/savefileformat/_index.md
@@ -1,0 +1,309 @@
+---
+title: SaveFileFormat
+second_title: Aspose.Diagram for Java API リファレンス
+description: 図の形式選択を保存するための列挙体です。
+type: docs
+weight: 348
+url: /ja/java/com.aspose.diagram/savefileformat/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class SaveFileFormat
+```
+
+図の形式選択を保存するための列挙体です。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [BMP](#BMP) | Bmp 画像形式です。 |
+| [EMF](#EMF) | EMF 画像形式です。 |
+| [GIF](#GIF) | Gif 形式です。 |
+| [HTML](#HTML) | Html 形式です。 |
+| [JPEG](#JPEG) | Jpeg 画像形式です。 |
+| [PDF](#PDF) | Pdf 形式です。 |
+| [PNG](#PNG) | Png 画像形式です。 |
+| [SVG](#SVG) | Svg 形式。 |
+| [TIFF](#TIFF) | Tiff 画像形式。 |
+| [VDX](#VDX) | MS Visio Vdx xml 形式。 |
+| [VSDM](#VSDM) | MS Visio Vsdm ファイル形式（マクロを有効にします）。 |
+| [VSDX](#VSDX) | MS Visio 2013 Vsdx ファイル形式。 |
+| [VSSM](#VSSM) | MS Visio Vssm ファイル形式（マクロを有効にします）。 |
+| [VSSX](#VSSX) | MS Visio 2013 Vssx ファイル形式 |
+| [VSTM](#VSTM) | MS Visio Vstm ファイル形式（マクロを有効にします）。 |
+| [VSTX](#VSTX) | MS Visio 2013 Vstx ファイル形式、テンプレートファイル。 |
+| [VSX](#VSX) | MS Visio Vsx xml ステンシル形式。 |
+| [VTX](#VTX) | MS Visio Vst xml テンプレート形式。 |
+| [XAML](#XAML) | Xaml 形式。 |
+| [XPS](#XPS) | Xps 形式。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BMP {#BMP}
+```
+public static final int BMP
+```
+
+
+Bmp 画像形式です。
+
+### EMF {#EMF}
+```
+public static final int EMF
+```
+
+
+EMF 画像形式です。
+
+### GIF {#GIF}
+```
+public static final int GIF
+```
+
+
+Gif 形式です。
+
+### HTML {#HTML}
+```
+public static final int HTML
+```
+
+
+Html 形式です。
+
+### JPEG {#JPEG}
+```
+public static final int JPEG
+```
+
+
+Jpeg 画像形式です。
+
+### PDF {#PDF}
+```
+public static final int PDF
+```
+
+
+Pdf 形式です。
+
+### PNG {#PNG}
+```
+public static final int PNG
+```
+
+
+Png 画像形式です。
+
+### SVG {#SVG}
+```
+public static final int SVG
+```
+
+
+Svg 形式。
+
+### TIFF {#TIFF}
+```
+public static final int TIFF
+```
+
+
+Tiff 画像形式。
+
+### VDX {#VDX}
+```
+public static final int VDX
+```
+
+
+MS Visio Vdx xml 形式。
+
+### VSDM {#VSDM}
+```
+public static final int VSDM
+```
+
+
+MS Visio Vsdm ファイル形式（マクロを有効にします）。
+
+### VSDX {#VSDX}
+```
+public static final int VSDX
+```
+
+
+MS Visio 2013 Vsdx ファイル形式。
+
+### VSSM {#VSSM}
+```
+public static final int VSSM
+```
+
+
+MS Visio Vssm ファイル形式（マクロを有効にします）。
+
+### VSSX {#VSSX}
+```
+public static final int VSSX
+```
+
+
+MS Visio 2013 Vssx ファイル形式
+
+### VSTM {#VSTM}
+```
+public static final int VSTM
+```
+
+
+MS Visio Vstm ファイル形式（マクロを有効にします）。
+
+### VSTX {#VSTX}
+```
+public static final int VSTX
+```
+
+
+MS Visio 2013 Vstx ファイル形式、テンプレートファイル。
+
+### VSX {#VSX}
+```
+public static final int VSX
+```
+
+
+MS Visio Vsx xml ステンシル形式。
+
+### VTX {#VTX}
+```
+public static final int VTX
+```
+
+
+MS Visio Vst xml テンプレート形式。
+
+### XAML {#XAML}
+```
+public static final int XAML
+```
+
+
+Xaml 形式。
+
+### XPS {#XPS}
+```
+public static final int XPS
+```
+
+
+Xps 形式。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/saveoptions/_index.md
+++ b/japanese/java/com.aspose.diagram/saveoptions/_index.md
@@ -1,0 +1,216 @@
+---
+title: SaveOptions
+second_title: Aspose.Diagram for Java API リファレンス
+description: これは、ユーザーが図を特定の形式で保存する際に追加オプションを指定できるクラスのための抽象基底クラスです。
+type: docs
+weight: 349
+url: /ja/java/com.aspose.diagram/saveoptions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public abstract class SaveOptions
+```
+
+これは、特定の形式で図を保存する際に、ユーザーが追加オプションを指定できるようにするクラスの抽象基底クラスです。SaveOptions クラスまたはその派生クラスのインスタンスは、ストリーム Save または文字列 Save のオーバーロードに渡され、ドキュメントを保存する際のカスタムオプションを定義できるようにします。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | 指定された保存形式に適したクラスの保存オプションオブジェクトを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDefaultFont()](#getDefaultFont--) | 図内の文字が Unicode で、正しいフォント値が設定されていない、またはフォントがローカルにインストールされていない場合、pdf、画像、または XPS でブロックとして表示されることがあります。 |
+| [getSaveFormat()](#getSaveFormat--) | この保存オプションオブジェクトが使用される場合、ドキュメントが保存される形式を指定します。 |
+| [getWarningCallback()](#getWarningCallback--) | 警告コールバック。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | このプロパティの説明については、[getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--) を参照してください。 |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | このプロパティの説明については、[getSaveFormat()](../../com.aspose.diagram/saveoptions\#getSaveFormat--) を参照してください。 |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+指定された保存形式に適したクラスの保存オプションオブジェクトを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| saveFormat | int | 保存オプションオブジェクトを作成するための Aspose.Diagram.SaveFileFormat です。 |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+ダイアグラム内の文字が Unicode で、正しいフォントが設定されていない、またはフォントがローカルにインストールされていない場合、PDF、画像、または XPS で文字がブロックとして表示されることがあります。MingLiu や MS Gothic などの DefaultFont を設定して、これらの文字を表示してください。
+
+**Returns:**
+java.lang.String
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+この保存オプションオブジェクトが使用される場合、ドキュメントが保存される形式を指定します。
+
+**Returns:**
+int
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+警告コールバック。
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+このプロパティの説明については、[getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+このプロパティの説明については、[getSaveFormat()](../../com.aspose.diagram/saveoptions\#getSaveFormat--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/scratch/_index.md
+++ b/japanese/java/com.aspose.diagram/scratch/_index.md
@@ -1,0 +1,349 @@
+---
+title: Scratch
+second_title: Aspose.Diagram for Java API リファレンス
+description: 他の要素から参照される数式を入力およびテストするための作業領域を含みます。
+type: docs
+weight: 350
+url: /ja/java/com.aspose.diagram/scratch/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Scratch
+```
+
+他の要素から参照される数式の入力およびテスト用の作業領域を含みます。この要素は、繰り返し使用される複雑な計算を分離するために通常使用されます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Scratch()](#Scratch--) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | 汎用要素です。 |
+| [getB()](#getB--) | 汎用スクラッチ要素です。 |
+| [getC()](#getC--) | 汎用要素です。 |
+| [getClass()](#getClass--) |  |
+| [getD()](#getD--) | 汎用要素です。 |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getIX()](#getIX--) | 親要素内の要素のゼロベースインデックスです。 |
+| [getX()](#getX--) | ローカル座標系でシェイプ上の x 座標を指定します。 |
+| [getY()](#getY--) | ローカル座標系でシェイプ上の y 座標を指定します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(Value value)](#setA-com.aspose.diagram.Value-) | このプロパティの説明については、[getA()](../../com.aspose.diagram/scratch\#getA--) を参照してください。 |
+| [setB(Value value)](#setB-com.aspose.diagram.Value-) | このプロパティの説明については、[getB()](../../com.aspose.diagram/scratch\#getB--) を参照してください |
+| [setC(Value value)](#setC-com.aspose.diagram.Value-) | このプロパティの説明については、[getC()](../../com.aspose.diagram/scratch\#getC--) を参照してください |
+| [setD(Value value)](#setD-com.aspose.diagram.Value-) | このプロパティの説明については、[getD()](../../com.aspose.diagram/scratch\#getD--) を参照してください |
+| [setDel(int value)](#setDel-int-) | このプロパティの説明については、[getDel()](../../com.aspose.diagram/scratch\#getDel--) を参照してください |
+| [setIX(int value)](#setIX-int-) | このプロパティの説明については、[getIX()](../../com.aspose.diagram/scratch\#getIX--) を参照してください |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getX()](../../com.aspose.diagram/scratch\#getX--) を参照してください |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getY()](../../com.aspose.diagram/scratch\#getY--) を参照してください |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Scratch() {#Scratch--}
+```
+public Scratch()
+```
+
+
+コンストラクタ。
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public Value getA()
+```
+
+
+汎用要素です。
+
+**Returns:**
+[Value](../../com.aspose.diagram/value)
+### getB() {#getB--}
+```
+public Value getB()
+```
+
+
+汎用スクラッチ要素です。
+
+**Returns:**
+[Value](../../com.aspose.diagram/value)
+### getC() {#getC--}
+```
+public Value getC()
+```
+
+
+汎用要素です。
+
+**Returns:**
+[Value](../../com.aspose.diagram/value)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getD() {#getD--}
+```
+public Value getD()
+```
+
+
+汎用要素です。
+
+**Returns:**
+[Value](../../com.aspose.diagram/value)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+親要素内の要素のゼロベースインデックスです。
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+ローカル座標系でシェイプ上の x 座標を指定します。以下の表は、それを含む要素に基づく X 要素を説明しています。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+ローカル座標系でシェイプ上の y 座標を指定します。ローカル座標系とは、ページではなくシェイプを基準とした座標系です。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(Value value) {#setA-com.aspose.diagram.Value-}
+```
+public void setA(Value value)
+```
+
+
+このプロパティの説明については、[getA()](../../com.aspose.diagram/scratch\#getA--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [Value](../../com.aspose.diagram/value) |  |
+
+### setB(Value value) {#setB-com.aspose.diagram.Value-}
+```
+public void setB(Value value)
+```
+
+
+このプロパティの説明については、[getB()](../../com.aspose.diagram/scratch\#getB--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [Value](../../com.aspose.diagram/value) |  |
+
+### setC(Value value) {#setC-com.aspose.diagram.Value-}
+```
+public void setC(Value value)
+```
+
+
+このプロパティの説明については、[getC()](../../com.aspose.diagram/scratch\#getC--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [Value](../../com.aspose.diagram/value) |  |
+
+### setD(Value value) {#setD-com.aspose.diagram.Value-}
+```
+public void setD(Value value)
+```
+
+
+このプロパティの説明については、[getD()](../../com.aspose.diagram/scratch\#getD--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [Value](../../com.aspose.diagram/value) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+このプロパティの説明については、[getDel()](../../com.aspose.diagram/scratch\#getDel--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+このプロパティの説明については、[getIX()](../../com.aspose.diagram/scratch\#getIX--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getX()](../../com.aspose.diagram/scratch\#getX--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getY()](../../com.aspose.diagram/scratch\#getY--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/scratchcollection/_index.md
+++ b/japanese/java/com.aspose.diagram/scratchcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: ScratchCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: スクラッチ コレクション。
+type: docs
+weight: 351
+url: /ja/java/com.aspose.diagram/scratchcollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ScratchCollection extends Collection
+```
+
+スクラッチ コレクション。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(Scratch item)](#add-com.aspose.diagram.Scratch-) | コレクションに Scratch オブジェクトを追加します。 |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Scratch item)](#remove-com.aspose.diagram.Scratch-) | コレクションから Scratch オブジェクトを削除します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Scratch item) {#add-com.aspose.diagram.Scratch-}
+```
+public int add(Scratch item)
+```
+
+
+コレクションに Scratch オブジェクトを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [Scratch](../../com.aspose.diagram/scratch) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Scratch get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[Scratch](../../com.aspose.diagram/scratch) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Scratch item) {#remove-com.aspose.diagram.Scratch-}
+```
+public void remove(Scratch item)
+```
+
+
+コレクションから Scratch オブジェクトを削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [Scratch](../../com.aspose.diagram/scratch) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/scrollbaractivexcontrol/_index.md
+++ b/japanese/java/com.aspose.diagram/scrollbaractivexcontrol/_index.md
@@ -1,0 +1,572 @@
+---
+title: ScrollBarActiveXControl
+second_title: Aspose.Diagram for Java API リファレンス
+description: ScrollBar コントロールを表します。
+type: docs
+weight: 352
+url: /ja/java/com.aspose.diagram/scrollbaractivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol), [com.aspose.diagram.SpinButtonActiveXControl](../../com.aspose.diagram/spinbuttonactivexcontrol)
+```
+public class ScrollBarActiveXControl extends SpinButtonActiveXControl
+```
+
+ScrollBar コントロールを表します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBackOleColor()](#getBackOleColor--) | 背景の OLE カラー。 |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | コントロールのバイナリ データ。 |
+| [getForeOleColor()](#getForeOleColor--) | 前景の OLE カラー。 |
+| [getHeight()](#getHeight--) | ポイント単位のコントロールの高さ。 |
+| [getIMEMode()](#getIMEMode--) | コントロールがフォーカスを受け取る際の Input Method Editor のデフォルト実行時モード。 |
+| [getLargeChange()](#getLargeChange--) | Position プロパティが変化する量 |
+| [getMax()](#getMax--) | 許容される最大値。 |
+| [getMin()](#getMin--) | 許容される最小値。 |
+| [getMouseIcon()](#getMouseIcon--) | コントロールのマウスポインタとして表示するカスタムアイコンです。 |
+| [getMousePointer()](#getMousePointer--) | コントロールのマウスポインタとして表示されるアイコンの種類です。 |
+| [getOrientation()](#getOrientation--) | SpinButton または ScrollBar が垂直方向か水平方向かを示します。 |
+| [getPosition()](#getPosition--) | 値。 |
+| [getSmallChange()](#getSmallChange--) | Position プロパティが変化する量 |
+| [getType()](#getType--) | ActiveX コントロールのタイプを取得します。 |
+| [getWidth()](#getWidth--) | ポイント単位のコントロールの幅です。 |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | コントロールが全内容を表示するために自動的にサイズ変更されるかどうかを示します。 |
+| [isEnabled()](#isEnabled--) | コントロールがフォーカスを受け取り、ユーザー生成イベントに応答できるかどうかを示します。 |
+| [isLocked()](#isLocked--) | コントロール内のデータが編集ロックされているかどうかを示します。 |
+| [isTransparent()](#isTransparent--) | コントロールが透明かどうかを示します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | このプロパティの説明については、[isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) を参照してください |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | このプロパティの説明については、[getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) を参照してください |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | このプロパティの説明については、[isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) を参照してください |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | このプロパティの説明については、[getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) を参照してください |
+| [setHeight(double value)](#setHeight-double-) | このプロパティの説明については、[getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) を参照してください |
+| [setIMEMode(int value)](#setIMEMode-int-) | このプロパティの説明については、[getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) を参照してください |
+| [setLargeChange(int value)](#setLargeChange-int-) | このプロパティの説明については、[getLargeChange()](../../com.aspose.diagram/scrollbaractivexcontrol\#getLargeChange--) をご覧ください。 |
+| [setLocked(boolean value)](#setLocked-boolean-) | このプロパティの説明については、[isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) を参照してください |
+| [setMax(int value)](#setMax-int-) | このプロパティの説明については、[getMax()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getMax--) をご覧ください。 |
+| [setMin(int value)](#setMin-int-) | このプロパティの説明については、[getMin()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getMin--) をご覧ください。 |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | このプロパティの説明については、[getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) を参照してください |
+| [setMousePointer(int value)](#setMousePointer-int-) | このプロパティの説明については、[getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) を参照してください |
+| [setOrientation(int value)](#setOrientation-int-) | このプロパティの説明については、[getOrientation()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getOrientation--) をご覧ください。 |
+| [setPosition(int value)](#setPosition-int-) | このプロパティの説明については、[getPosition()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getPosition--) をご覧ください。 |
+| [setSmallChange(int value)](#setSmallChange-int-) | このプロパティの説明については、[getSmallChange()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getSmallChange--) をご覧ください。 |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | このプロパティの説明については、[isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) を参照してください |
+| [setWidth(double value)](#setWidth-double-) | このプロパティの説明については、[getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) を参照してください |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+背景の OLE カラー。
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+コントロールのバイナリ データ。
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+前景の OLE カラーです。Image コントロールには適用されません。
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+ポイント単位のコントロールの高さ。
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+コントロールがフォーカスを受け取る際の Input Method Editor のデフォルト実行時モード。
+
+**Returns:**
+int
+### getLargeChange() {#getLargeChange--}
+```
+public int getLargeChange()
+```
+
+
+Position プロパティが変化する量
+
+**Returns:**
+int
+### getMax() {#getMax--}
+```
+public int getMax()
+```
+
+
+許容される最大値。
+
+**Returns:**
+int
+### getMin() {#getMin--}
+```
+public int getMin()
+```
+
+
+許容される最小値。
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+コントロールのマウスポインタとして表示するカスタムアイコンです。
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+コントロールのマウスポインタとして表示されるアイコンの種類です。
+
+**Returns:**
+int
+### getOrientation() {#getOrientation--}
+```
+public int getOrientation()
+```
+
+
+SpinButton または ScrollBar が垂直方向か水平方向かを示します。
+
+**Returns:**
+int
+### getPosition() {#getPosition--}
+```
+public int getPosition()
+```
+
+
+値。
+
+**Returns:**
+int
+### getSmallChange() {#getSmallChange--}
+```
+public int getSmallChange()
+```
+
+
+Position プロパティが変化する量
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+ActiveX コントロールのタイプを取得します。
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+ポイント単位のコントロールの幅です。
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+コントロールが全内容を表示するために自動的にサイズ変更されるかどうかを示します。
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+コントロールがフォーカスを受け取り、ユーザー生成イベントに応答できるかどうかを示します。
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+コントロール内のデータが編集ロックされているかどうかを示します。
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+コントロールが透明かどうかを示します。
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+このプロパティの説明については、[isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+このプロパティの説明については、[getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+このプロパティの説明については、[isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+このプロパティの説明については、[getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+このプロパティの説明については、[getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+このプロパティの説明については、[getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setLargeChange(int value) {#setLargeChange-int-}
+```
+public void setLargeChange(int value)
+```
+
+
+このプロパティの説明については、[getLargeChange()](../../com.aspose.diagram/scrollbaractivexcontrol\#getLargeChange--) をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+このプロパティの説明については、[isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setMax(int value) {#setMax-int-}
+```
+public void setMax(int value)
+```
+
+
+このプロパティの説明については、[getMax()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getMax--) をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setMin(int value) {#setMin-int-}
+```
+public void setMin(int value)
+```
+
+
+このプロパティの説明については、[getMin()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getMin--) をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+このプロパティの説明については、[getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+このプロパティの説明については、[getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setOrientation(int value) {#setOrientation-int-}
+```
+public void setOrientation(int value)
+```
+
+
+このプロパティの説明については、[getOrientation()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getOrientation--) をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setPosition(int value) {#setPosition-int-}
+```
+public void setPosition(int value)
+```
+
+
+このプロパティの説明については、[getPosition()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getPosition--) をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setSmallChange(int value) {#setSmallChange-int-}
+```
+public void setSmallChange(int value)
+```
+
+
+このプロパティの説明については、[getSmallChange()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getSmallChange--) をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+このプロパティの説明については、[isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+このプロパティの説明については、[getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/selectmode/_index.md
+++ b/japanese/java/com.aspose.diagram/selectmode/_index.md
@@ -1,0 +1,179 @@
+---
+title: SelectMode
+second_title: Aspose.Diagram for Java API リファレンス
+description: ユーザーがグループ シェイプとそのメンバーを選択する方法を指定します。
+type: docs
+weight: 353
+url: /ja/java/com.aspose.diagram/selectmode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class SelectMode
+```
+
+ユーザーがグループ シェイプとそのメンバーを選択する方法を指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [SelectMode(int value)](#SelectMode-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | ユーザーがグループ シェイプとそのメンバーを選択する方法を指定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/selectmode\#getValue--)をご覧ください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SelectMode(int value) {#SelectMode-int-}
+```
+public SelectMode(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+ユーザーがグループ シェイプとそのメンバーを選択する方法を指定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/selectmode\#getValue--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/selectmodevalue/_index.md
+++ b/japanese/java/com.aspose.diagram/selectmodevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: SelectModeValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: ユーザーがグループ シェイプとそのメンバーを選択する方法を指定します。
+type: docs
+weight: 354
+url: /ja/java/com.aspose.diagram/selectmodevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class SelectModeValue
+```
+
+ユーザーがグループ シェイプとそのメンバーを選択する方法を指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [GROUP_SHAPE_FIRST](#GROUP-SHAPE-FIRST) | 最初にグループシェイプを選択します。 |
+| [GROUP_SHAPE_ONLY](#GROUP-SHAPE-ONLY) | グループシェイプのみを選択します。 |
+| [MEMBERS_GROUP_FIRST](#MEMBERS-GROUP-FIRST) | 最初にグループのメンバーを選択します。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GROUP_SHAPE_FIRST {#GROUP-SHAPE-FIRST}
+```
+public static final int GROUP_SHAPE_FIRST
+```
+
+
+最初にグループシェイプを選択します。
+
+### GROUP_SHAPE_ONLY {#GROUP-SHAPE-ONLY}
+```
+public static final int GROUP_SHAPE_ONLY
+```
+
+
+グループシェイプのみを選択します。
+
+### MEMBERS_GROUP_FIRST {#MEMBERS-GROUP-FIRST}
+```
+public static final int MEMBERS_GROUP_FIRST
+```
+
+
+最初にグループのメンバーを選択します。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/shape/_index.md
+++ b/japanese/java/com.aspose.diagram/shape/_index.md
@@ -1,0 +1,1760 @@
+---
+title: Shape
+second_title: Aspose.Diagram for Java API リファレンス
+description: マスターページまたはグループシェイプ要素内のシェイプを定義する要素を含みます。
+type: docs
+weight: 355
+url: /ja/java/com.aspose.diagram/shape/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Shape
+```
+
+マスター、ページ、またはグループ シェイプ要素内でシェイプを定義する要素を含みます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Shape()](#Shape--) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [bringForward()](#bringForward--) | シェイプを Z オーダーで 1 つ前に移動します。 |
+| [bringToFront()](#bringToFront--) | シェイプを Z オーダーの最前面に移動します。 |
+| [centerDrawing()](#centerDrawing--) | ページの範囲に対してシェイプを中央揃えにします。 |
+| [connectedShapes(int flag, String categoryFilter)](#connectedShapes-int-java.lang.String-) | シェイプに接続されているシェイプの識別子 (ID) を含む配列を返します。 |
+| [copy(Shape source)](#copy-com.aspose.diagram.Shape-) |  |
+| [dependsOnShapes()](#dependsOnShapes--) | シェイプに依存しているシェイプの識別子を含む配列を返します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getActiveXControl()](#getActiveXControl--) | ActiveX コントロールを取得します。 |
+| [getActs()](#getActs--) | Act 要素のコレクションを含みます。 |
+| [getAlign()](#getAlign--) | シェイプが貼り付けられているガイドまたはガイドポイントに対するシェイプの配置を示します。 |
+| [getChars()](#getChars--) | Char 要素のコレクションを含みます。 |
+| [getClass()](#getClass--) |  |
+| [getClippingPath()](#getClippingPath--) |  |
+| [getConnectionABCDs()](#getConnectionABCDs--) | ConnectionABCD 要素のコレクションを含みます。 |
+| [getConnections()](#getConnections--) | Connection 要素のコレクションを含みます。 |
+| [getConnectorRule()](#getConnectorRule--) | シェイプに接続されているシェイプ ID と connecton を含む connectorRule を返します。 |
+| [getConnectorsType()](#getConnectorsType--) | コネクタのタイプを取得します。 |
+| [getControlData()](#getControlData--) | コントロールのデータを取得します。 |
+| [getControls()](#getControls--) | Control 要素のコレクションを含みます。 |
+| [getData1()](#getData1--) | シェイプに関する追加情報を提供するために使用される任意の文字列値を含みます。 |
+| [getData2()](#getData2--) | シェイプに関する追加情報を提供するために使用される任意の文字列値を含みます。 |
+| [getData3()](#getData3--) | シェイプに関する追加情報を提供するために使用される任意の文字列値を含みます。 |
+| [getDel()](#getDel--) | 要素がローカルで削除されているかどうかを示すフラグです。 |
+| [getDiagram()](#getDiagram--) | Visio オブジェクト階層のルート要素です。 |
+| [getDisplayText()](#getDisplayText--) | インターフェイスに表示されるテキストを取得します。 |
+| [getEvent()](#getEvent--) | シェイプ イベントを制御する数式を指定する要素を含みます。 |
+| [getFields()](#getFields--) | Field 要素のコレクションを含みます。 |
+| [getFill()](#getFill--) | シェイプとシェイプのドロップシャドウの現在の塗りつぶし書式設定値を含み、パターン、前景色、背景色が含まれます。 |
+| [getFillStyle()](#getFillStyle--) | このシェイプが塗りつぶし書式を継承する StyleSheet。 |
+| [getForeign()](#getForeign--) | Microsoft Visio ドキュメントで使用される別のプログラムからのオブジェクトの幅と高さを指定する要素を含みます。 |
+| [getForeignData()](#getForeignData--) | Windows メタファイル、ビットマップ、または OLE データなどの画像データの MIME (Multipurpose Internet Mail Extensions) エンコード BLOB を含みます。 |
+| [getGeoms()](#getGeoms--) | Geom 要素のコレクションを含みます。 |
+| [getGroup()](#getGroup--) | グループにシェイプを追加する方法、グループのメンバーを移動する方法、グループを選択する方法を制御する要素を含みます。 |
+| [getHelp()](#getHelp--) | Shape 要素のヘルプファイルトピックと著作権情報を指定する要素を含みます。 |
+| [getHyperlinks()](#getHyperlinks--) | Hyperlink 要素のコレクションを含みます。 |
+| [getID()](#getID--) | 要素の親要素内における一意の ID。 |
+| [getImage()](#getImage--) | ビットマップのガンマ、明るさ、コントラスト、ぼかし、シャープ、ノイズ除去、透明度の値を含みます。 |
+| [getInheritChars()](#getInheritChars--) | マスターシェイプから継承されたシェイプの文字値を含みます。 |
+| [getInheritFill()](#getInheritFill--) | 親スタイルとマスターシェイプから継承されたシェイプの塗りつぶし書式値を含みます。 |
+| [getInheritGeoms()](#getInheritGeoms--) | マスタ形状から継承された形状の Geoms 値を含みます。 |
+| [getInheritLine()](#getInheritLine--) | 親スタイルとマスタ形状から継承された形状の line formatting 値を含みます。 |
+| [getInheritParas()](#getInheritParas--) | 親スタイルとマスタ形状から継承された形状の paras を含みます。 |
+| [getInheritProps()](#getInheritProps--) | マスタ形状から継承された形状の props を含みます。 |
+| [getInheritTextBlock()](#getInheritTextBlock--) | 親スタイルとマスタ形状から継承された形状の textblock 値を含みます。 |
+| [getInheritUsers()](#getInheritUsers--) | マスタ形状から継承された形状の users を含みます。 |
+| [getLayerMem()](#getLayerMem--) | LayerMember 要素を含み、シェイプが割り当てられる各レイヤーを指定します。 |
+| [getLayout()](#getLayout--) | シェイプの配置とコネクタのルーティング設定を制御する要素を含みます。 |
+| [getLine()](#getLine--) | パターン、太さ、色など、シェイプの線属性を制御する要素を含みます。 |
+| [getLineStyle()](#getLineStyle--) | この形状が line formatting を継承する StyleSheet |
+| [getMaster()](#getMaster--) | 形状がデータを継承する Master |
+| [getMasterShape()](#getMasterShape--) | この属性は、グループ shape のメンバーであり、かつそのグループが master のインスタンスである shape にのみ存在する場合があります。 |
+| [getMisc()](#getMisc--) | Shape 要素のヘルプファイルトピックと著作権情報を指定する要素を含みます。 |
+| [getName()](#getName--) | 要素の名前。 |
+| [getNameU()](#getNameU--) | 要素のユニバーサル名。 |
+| [getOneD()](#getOneD--) | 形状が一次元 (1-D) オブジェクトとして動作するかどうかを決定します。 |
+| [getPage()](#getPage--) | Visio オブジェクト階層のルート要素です。 |
+| [getParas()](#getParas--) | Para 要素のコレクションを含みます。 |
+| [getParentShape()](#getParentShape--) | shape の親。 |
+| [getProps()](#getProps--) | Prop 要素のコレクションを含みます。 |
+| [getProtection()](#getProtection--) | ロックはシェイプへの偶発的な変更を防止するのに役立ちますが、他の状況で Microsoft Visio が値をリセットすることは防げません。 |
+| [getPureText()](#getPureText--) | テキスト文字列を取得 |
+| [getRootShape()](#getRootShape--) | この shape が master インスタンスの一部である場合、インスタンスのトップレベル shape を返します。 |
+| [getScratchs()](#getScratchs--) | Scratch 要素のコレクションを含みます。 |
+| [getShapes()](#getShapes--) | Shape 要素のコレクションを含みます。 |
+| [getSmartTagDefs()](#getSmartTagDefs--) | SmartTagDef 要素のコレクションを含みます。 |
+| [getTabsCollection()](#getTabsCollection--) | Tab 要素のコレクションを含みます。 |
+| [getText()](#getText--) | シェイプのテキストを含みます。 |
+| [getTextBlock()](#getTextBlock--) | シェイプのテキスト ブロック内のテキストの配置、余白、デフォルトのタブ位置を指定する要素を含みます。 |
+| [getTextStyle()](#getTextStyle--) | この shape が text formatting を継承する StyleSheet。 |
+| [getTextXForm()](#getTextXForm--) | シェイプのテキスト ブロックに関する位置情報を指定する要素を含みます。 |
+| [getThreeDFormat()](#getThreeDFormat--) | ThreeDFormat を取得します。 |
+| [getTwoD()](#getTwoD--) | shape が二次元 (2-D) オブジェクトとして動作するかどうかを決定します。 |
+| [getType()](#getType--) | shape のタイプ。 |
+| [getUniqueID()](#getUniqueID--) | shape に割り当てられた GUID (グローバルに一意な識別子)。 |
+| [getUsers()](#getUsers--) | User 要素のコレクションを含みます。 |
+| [getXForm()](#getXForm--) | シェイプに関する一般的な位置情報を指定する要素を含みます。 |
+| [getXForm1D()](#getXForm1D--) | 1 次元シェイプの開始点と終了点の x 座標と y 座標を含みます。 |
+| [getZOrderIndex()](#getZOrderIndex--) | ガイド shape を除く、z 順序における shape のインデックスを返します。 |
+| [gluedShapes(int flag, String categoryFilter, Shape otherShape)](#gluedShapes-int-java.lang.String-com.aspose.diagram.Shape-) | shape に貼り付けられた shape の識別子を含む配列を返します。 |
+| [hashCode()](#hashCode--) |  |
+| [isConnected(Shape shape)](#isConnected-com.aspose.diagram.Shape-) | この 2 つの shape が接続されているかどうかを示します。 |
+| [isContain(Shape shape)](#isContain-com.aspose.diagram.Shape-) | この shape が別の shape を含んでいるかどうかを示します。 |
+| [isGlued(Shape shape)](#isGlued-com.aspose.diagram.Shape-) | この 2 つの shape が接着されているかどうかを示します。 |
+| [isInGroup()](#isInGroup--) | この shape が group shape に含まれているかどうかを示します。 |
+| [isIntersect(Shape shape)](#isIntersect-com.aspose.diagram.Shape-) | このシェイプが別のシェイプと交差しているかどうかを示します。 |
+| [isTextEmpty()](#isTextEmpty--) | シェイプにテキストがあり、テキストが空かどうかを示します。 |
+| [move(double dX, double dY)](#move-double-double-) | シェイプを現在位置から dX および dY インチだけ移動させます。 |
+| [moveTo(double newPinX, double newPinY)](#moveTo-double-double-) | シェイプをページ上の新しい絶対位置に移動させます。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [refreshData()](#refreshData--) | シェイプのテキストやその他を変更した際に、xform、接続、geom を含むシェイプの位置を更新します。 |
+| [replaceText(String text, String replaceText)](#replaceText-java.lang.String-java.lang.String-) | シェイプのテキスト文字列を置き換えます。 |
+| [sendBackward()](#sendBackward--) | シェイプを Z オーダーで 1 つ後ろに移動させます。 |
+| [sendToBack()](#sendToBack--) | シェイプを Z オーダーの最背面に移動させます。 |
+| [setAngle(double angle)](#setAngle-double-) | シェイプの新しい角度を設定します。 |
+| [setClippingPath(String value)](#setClippingPath-java.lang.String-) | このプロパティの説明については、[getClippingPath()](../../com.aspose.diagram/shape\#getClippingPath--) を参照してください。 |
+| [setConnectorsType(int type)](#setConnectorsType-int-) | コネクタのタイプを設定します。 |
+| [setData1(String value)](#setData1-java.lang.String-) | このプロパティの説明については、[getData1()](../../com.aspose.diagram/shape\#getData1--) を参照してください。 |
+| [setData2(String value)](#setData2-java.lang.String-) | このプロパティの説明については、[getData2()](../../com.aspose.diagram/shape\#getData2--) を参照してください。 |
+| [setData3(String value)](#setData3-java.lang.String-) | このプロパティの説明については、[getData3()](../../com.aspose.diagram/shape\#getData3--) を参照してください。 |
+| [setDel(int value)](#setDel-int-) | このプロパティの説明については、[getDel()](../../com.aspose.diagram/shape\#getDel--) を参照してください。 |
+| [setDiagram(Diagram value)](#setDiagram-com.aspose.diagram.Diagram-) | このプロパティの説明については、[getDiagram()](../../com.aspose.diagram/shape\#getDiagram--) を参照してください。 |
+| [setEvent(Event value)](#setEvent-com.aspose.diagram.Event-) | このプロパティの説明については、[getEvent()](../../com.aspose.diagram/shape\#getEvent--) を参照してください。 |
+| [setFillStyle(StyleSheet value)](#setFillStyle-com.aspose.diagram.StyleSheet-) | このプロパティの説明については、[getFillStyle()](../../com.aspose.diagram/shape\#getFillStyle--) を参照してください。 |
+| [setHeight(double height)](#setHeight-double-) | シェイプの新しい高さを設定します。 |
+| [setID(long value)](#setID-long-) | このプロパティの説明については、[getID()](../../com.aspose.diagram/shape\#getID--) を参照してください。 |
+| [setLineStyle(StyleSheet value)](#setLineStyle-com.aspose.diagram.StyleSheet-) | このプロパティの説明については、[getLineStyle()](../../com.aspose.diagram/shape\#getLineStyle--) を参照してください。 |
+| [setMaster(Master value)](#setMaster-com.aspose.diagram.Master-) | このプロパティの説明については、[getMaster()](../../com.aspose.diagram/shape\#getMaster--) を参照してください。 |
+| [setMasterShape(Shape value)](#setMasterShape-com.aspose.diagram.Shape-) | このプロパティの説明については、[getMasterShape()](../../com.aspose.diagram/shape\#getMasterShape--) を参照してください。 |
+| [setName(String value)](#setName-java.lang.String-) | このプロパティの説明については、[getName()](../../com.aspose.diagram/shape\#getName--) を参照してください。 |
+| [setNameU(String value)](#setNameU-java.lang.String-) | このプロパティの説明については、[getNameU()](../../com.aspose.diagram/shape\#getNameU--) を参照してください。 |
+| [setPage(Page value)](#setPage-com.aspose.diagram.Page-) | このプロパティの説明については、[getPage()](../../com.aspose.diagram/shape\\#getPage--) を参照してください。 |
+| [setParentShape(Shape value)](#setParentShape-com.aspose.diagram.Shape-) | このプロパティの説明については、[getParentShape()](../../com.aspose.diagram/shape\\#getParentShape--) を参照してください。 |
+| [setPresetTheme(int value)](#setPresetTheme-int-) | このシェイプにプリセットテーマを適用する |
+| [setPresetThemeQuickStyle(int value)](#setPresetThemeQuickStyle-int-) | このシェイプにプリセットテーマバリアントのクイックスタイルを適用する |
+| [setPresetThemeStyleMatrics(int styleIndex, int colorIndex)](#setPresetThemeStyleMatrics-int-int-) | このシェイプにプリセットテーマバリアントのクイックスタイルを適用する。シェイプスタイルのドロップダウンリストにあるテーマスタイルオプションのように |
+| [setPresetThemeVariant(int value)](#setPresetThemeVariant-int-) | このシェイプにプリセットテーマバリアントを適用する |
+| [setProps(PropCollection value)](#setProps-com.aspose.diagram.PropCollection-) | このプロパティの説明については、[getProps()](../../com.aspose.diagram/shape\\#getProps--) を参照してください。 |
+| [setText(Text value)](#setText-com.aspose.diagram.Text-) | このプロパティの説明については、[getText()](../../com.aspose.diagram/shape\\#getText--) を参照してください。 |
+| [setTextStyle(StyleSheet value)](#setTextStyle-com.aspose.diagram.StyleSheet-) | このプロパティの説明については、[getTextStyle()](../../com.aspose.diagram/shape\\#getTextStyle--) を参照してください。 |
+| [setTwoD(boolean value)](#setTwoD-boolean-) | このプロパティの説明については、[getTwoD()](../../com.aspose.diagram/shape\\#getTwoD--) を参照してください。 |
+| [setType(int value)](#setType-int-) | このプロパティの説明については、[getType()](../../com.aspose.diagram/shape\\#getType--) を参照してください。 |
+| [setUniqueID(UUID value)](#setUniqueID-java.util.UUID-) | このプロパティの説明については、[getUniqueID()](../../com.aspose.diagram/shape\\#getUniqueID--) を参照してください。 |
+| [setWidth(double width)](#setWidth-double-) | シェイプの新しい幅を設定します。 |
+| [setXForm(XForm value)](#setXForm-com.aspose.diagram.XForm-) | このプロパティの説明については、[getXForm()](../../com.aspose.diagram/shape\\#getXForm--) を参照してください。 |
+| [setXForm1D(XForm1D value)](#setXForm1D-com.aspose.diagram.XForm1D-) | このプロパティの説明については、[getXForm1D()](../../com.aspose.diagram/shape\\#getXForm1D--) を参照してください。 |
+| [toHTML(InputStream stream, HTMLSaveOptions options)](#toHTML-java.io.InputStream-com.aspose.diagram.HTMLSaveOptions-) | シェイプのHTMLを作成し、指定された形式でストリームに保存します。 |
+| [toHTML(OutputStream stream, HTMLSaveOptions options)](#toHTML-java.io.OutputStream-com.aspose.diagram.HTMLSaveOptions-) | シェイプのHTMLを作成し、指定された形式でストリームに保存します。 |
+| [toHTML(String fileName, HTMLSaveOptions options)](#toHTML-java.lang.String-com.aspose.diagram.HTMLSaveOptions-) | HTMLを作成し、ファイルに保存します。 |
+| [toImage(InputStream stream, ImageSaveOptions options)](#toImage-java.io.InputStream-com.aspose.diagram.ImageSaveOptions-) | シェイプの画像を作成し、指定された形式でストリームに保存します。 |
+| [toImage(OutputStream stream, ImageSaveOptions options)](#toImage-java.io.OutputStream-com.aspose.diagram.ImageSaveOptions-) | シェイプの画像を作成し、指定された形式でストリームに保存します。 |
+| [toImage(String imageFile, ImageSaveOptions options)](#toImage-java.lang.String-com.aspose.diagram.ImageSaveOptions-) | シェイプの画像を作成し、ファイルに保存します。 |
+| [toPdf(InputStream stream)](#toPdf-java.io.InputStream-) | シェイプのPDFを作成し、ストリームに保存します。 |
+| [toPdf(OutputStream stream)](#toPdf-java.io.OutputStream-) | シェイプのPDFを作成し、ストリームに保存します。 |
+| [toPdf(String fileName)](#toPdf-java.lang.String-) | シェイプをPDFファイルに保存します。 |
+| [toString()](#toString--) |  |
+| [toSvg(String imageFile, SVGSaveOptions options)](#toSvg-java.lang.String-com.aspose.diagram.SVGSaveOptions-) | シェイプをSVGファイルに保存します。 |
+| [ungroup()](#ungroup--) | シェイプのグループ解除 |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Shape() {#Shape--}
+```
+public Shape()
+```
+
+
+コンストラクタ。
+
+### bringForward() {#bringForward--}
+```
+public void bringForward()
+```
+
+
+シェイプを Z オーダーで 1 つ前に移動します。
+
+### bringToFront() {#bringToFront--}
+```
+public void bringToFront()
+```
+
+
+シェイプを Z オーダーの最前面に移動します。
+
+### centerDrawing() {#centerDrawing--}
+```
+public void centerDrawing()
+```
+
+
+ページの範囲に対してシェイプを中央揃えにします。
+
+### connectedShapes(int flag, String categoryFilter) {#connectedShapes-int-java.lang.String-}
+```
+public long[] connectedShapes(int flag, String categoryFilter)
+```
+
+
+シェイプに接続されているシェイプの識別子 (ID) を含む配列を返します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| フラグ | int | コネクタの方向性で返されるシェイプIDの配列をフィルタリングします。可能な値についてはRemarksをご参照くださいAspose.Diagram.ConnectedShapesFlags。 |
+| categoryFilter | java.lang.String | 指定された categoryString に一致するシェイプの ID に限定して、返されるシェイプ ID の配列をフィルタリングします。 |
+
+**Returns:**
+long[] - ID の配列 long。
+### copy(Shape source) {#copy-com.aspose.diagram.Shape-}
+```
+public void copy(Shape source)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| source | [Shape](../../com.aspose.diagram/shape) |  |
+
+### dependsOnShapes() {#dependsOnShapes--}
+```
+public long[] dependsOnShapes()
+```
+
+
+シェイプに依存しているシェイプの識別子を含む配列を返します。
+
+**Returns:**
+long[] - ID の配列 long。
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getActiveXControl() {#getActiveXControl--}
+```
+public ActiveXControl getActiveXControl()
+```
+
+
+ActiveX コントロールを取得します。
+
+**Returns:**
+[ActiveXControl](../../com.aspose.diagram/activexcontrol)
+### getActs() {#getActs--}
+```
+public ActCollection getActs()
+```
+
+
+Act 要素のコレクションを含みます。
+
+**Returns:**
+[ActCollection](../../com.aspose.diagram/actcollection)
+### getAlign() {#getAlign--}
+```
+public Align getAlign()
+```
+
+
+形状が接着されているガイドまたはガイドポイントに対する形状の配置を示します。Align 要素は、ガイドまたはガイドポイントに接着された形状に対してのみ表示されます。
+
+**Returns:**
+[Align](../../com.aspose.diagram/align)
+### getChars() {#getChars--}
+```
+public CharCollection getChars()
+```
+
+
+Char 要素のコレクションを含みます。
+
+**Returns:**
+[CharCollection](../../com.aspose.diagram/charcollection)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getClippingPath() {#getClippingPath--}
+```
+public String getClippingPath()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getConnectionABCDs() {#getConnectionABCDs--}
+```
+public ConnectionABCDCollection getConnectionABCDs()
+```
+
+
+ConnectionABCD 要素のコレクションを含みます。
+
+**Returns:**
+[ConnectionABCDCollection](../../com.aspose.diagram/connectionabcdcollection)
+### getConnections() {#getConnections--}
+```
+public ConnectionCollection getConnections()
+```
+
+
+Connection 要素のコレクションを含みます。
+
+**Returns:**
+[ConnectionCollection](../../com.aspose.diagram/connectioncollection)
+### getConnectorRule() {#getConnectorRule--}
+```
+public ConnectorRule getConnectorRule()
+```
+
+
+シェイプに接続されているシェイプ ID と connecton を含む connectorRule を返します。
+
+**Returns:**
+[ConnectorRule](../../com.aspose.diagram/connectorrule) - ConnectorRule.
+### getConnectorsType() {#getConnectorsType--}
+```
+public int getConnectorsType()
+```
+
+
+コネクタのタイプを取得します。
+
+**Returns:**
+int
+### getControlData() {#getControlData--}
+```
+public byte[] getControlData()
+```
+
+
+コントロールのデータを取得します。
+
+**Returns:**
+byte[]
+### getControls() {#getControls--}
+```
+public ControlCollection getControls()
+```
+
+
+Control 要素のコレクションを含みます。
+
+**Returns:**
+[ControlCollection](../../com.aspose.diagram/controlcollection)
+### getData1() {#getData1--}
+```
+public String getData1()
+```
+
+
+シェイプに関する追加情報を提供するために使用される任意の文字列値を含みます。
+
+**Returns:**
+java.lang.String
+### getData2() {#getData2--}
+```
+public String getData2()
+```
+
+
+シェイプに関する追加情報を提供するために使用される任意の文字列値を含みます。
+
+**Returns:**
+java.lang.String
+### getData3() {#getData3--}
+```
+public String getData3()
+```
+
+
+シェイプに関する追加情報を提供するために使用される任意の文字列値を含みます。
+
+**Returns:**
+java.lang.String
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+要素がローカルで削除されているかを示すフラグです。値が 1 の場合、要素はローカルで削除されたことを示します。
+
+**Returns:**
+int
+### getDiagram() {#getDiagram--}
+```
+public Diagram getDiagram()
+```
+
+
+Visio オブジェクト階層のルート要素です。
+
+**Returns:**
+[Diagram](../../com.aspose.diagram/diagram)
+### getDisplayText() {#getDisplayText--}
+```
+public String getDisplayText()
+```
+
+
+インターフェイスに表示されるテキストを取得します。
+
+**Returns:**
+java.lang.String
+### getEvent() {#getEvent--}
+```
+public Event getEvent()
+```
+
+
+シェイプ イベントを制御する数式を指定する要素を含みます。
+
+**Returns:**
+[Event](../../com.aspose.diagram/event)
+### getFields() {#getFields--}
+```
+public FieldCollection getFields()
+```
+
+
+Field 要素のコレクションを含みます。
+
+**Returns:**
+[FieldCollection](../../com.aspose.diagram/fieldcollection)
+### getFill() {#getFill--}
+```
+public Fill getFill()
+```
+
+
+シェイプとシェイプのドロップシャドウの現在の塗りつぶし書式設定値を含み、パターン、前景色、背景色が含まれます。
+
+**Returns:**
+[Fill](../../com.aspose.diagram/fill)
+### getFillStyle() {#getFillStyle--}
+```
+public StyleSheet getFillStyle()
+```
+
+
+このシェイプが塗りつぶし書式を継承する StyleSheet。
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getForeign() {#getForeign--}
+```
+public Foreign getForeign()
+```
+
+
+Microsoft Visio ドキュメントで使用される他のプログラムからのオブジェクトの幅と高さを指定する要素を含みます。また、オブジェクトの画像が境界内でオフセットされる距離を指定する要素も含みます。
+
+**Returns:**
+[Foreign](../../com.aspose.diagram/foreign)
+### getForeignData() {#getForeignData--}
+```
+public ForeignData getForeignData()
+```
+
+
+Windows メタファイル、ビットマップ、または OLE データなどの画像データの MIME (Multipurpose Internet Mail Extensions) エンコード BLOB を含みます。
+
+**Returns:**
+[ForeignData](../../com.aspose.diagram/foreigndata)
+### getGeoms() {#getGeoms--}
+```
+public GeomCollection getGeoms()
+```
+
+
+Geom 要素のコレクションを含みます。
+
+**Returns:**
+[GeomCollection](../../com.aspose.diagram/geomcollection)
+### getGroup() {#getGroup--}
+```
+public Group getGroup()
+```
+
+
+グループにシェイプを追加する方法、グループのメンバーを移動する方法、グループを選択する方法を制御する要素を含みます。
+
+**Returns:**
+[Group](../../com.aspose.diagram/group)
+### getHelp() {#getHelp--}
+```
+public Help getHelp()
+```
+
+
+Shape 要素のヘルプファイルトピックと著作権情報を指定する要素を含みます。
+
+**Returns:**
+[Help](../../com.aspose.diagram/help)
+### getHyperlinks() {#getHyperlinks--}
+```
+public HyperlinkCollection getHyperlinks()
+```
+
+
+Hyperlink 要素のコレクションを含みます。
+
+**Returns:**
+[HyperlinkCollection](../../com.aspose.diagram/hyperlinkcollection)
+### getID() {#getID--}
+```
+public long getID()
+```
+
+
+要素の親要素内における一意の ID。
+
+**Returns:**
+long
+### getImage() {#getImage--}
+```
+public Image getImage()
+```
+
+
+ビットマップのガンマ、明るさ、コントラスト、ぼかし、シャープ、ノイズ除去、透明度の値を含みます。
+
+**Returns:**
+[Image](../../com.aspose.diagram/image)
+### getInheritChars() {#getInheritChars--}
+```
+public CharCollection getInheritChars()
+```
+
+
+マスターシェイプから継承されたシェイプの文字値を含みます。
+
+**Returns:**
+[CharCollection](../../com.aspose.diagram/charcollection)
+### getInheritFill() {#getInheritFill--}
+```
+public Fill getInheritFill()
+```
+
+
+親スタイルとマスターシェイプから継承されたシェイプの塗りつぶし書式値を含みます。
+
+**Returns:**
+[Fill](../../com.aspose.diagram/fill)
+### getInheritGeoms() {#getInheritGeoms--}
+```
+public GeomCollection getInheritGeoms()
+```
+
+
+マスタ形状から継承された形状の Geoms 値を含みます。
+
+**Returns:**
+[GeomCollection](../../com.aspose.diagram/geomcollection)
+### getInheritLine() {#getInheritLine--}
+```
+public Line getInheritLine()
+```
+
+
+親スタイルとマスタ形状から継承された形状の line formatting 値を含みます。
+
+**Returns:**
+[Line](../../com.aspose.diagram/line)
+### getInheritParas() {#getInheritParas--}
+```
+public ParaCollection getInheritParas()
+```
+
+
+親スタイルとマスタ形状から継承された形状の paras を含みます。
+
+**Returns:**
+[ParaCollection](../../com.aspose.diagram/paracollection)
+### getInheritProps() {#getInheritProps--}
+```
+public PropCollection getInheritProps()
+```
+
+
+マスタ形状から継承された形状の props を含みます。
+
+**Returns:**
+[PropCollection](../../com.aspose.diagram/propcollection)
+### getInheritTextBlock() {#getInheritTextBlock--}
+```
+public TextBlock getInheritTextBlock()
+```
+
+
+親スタイルとマスタ形状から継承された形状の textblock 値を含みます。
+
+**Returns:**
+[TextBlock](../../com.aspose.diagram/textblock)
+### getInheritUsers() {#getInheritUsers--}
+```
+public UserCollection getInheritUsers()
+```
+
+
+マスタ形状から継承された形状の users を含みます。
+
+**Returns:**
+[UserCollection](../../com.aspose.diagram/usercollection)
+### getLayerMem() {#getLayerMem--}
+```
+public LayerMem getLayerMem()
+```
+
+
+LayerMember 要素を含み、シェイプが割り当てられる各レイヤーを指定します。
+
+**Returns:**
+[LayerMem](../../com.aspose.diagram/layermem)
+### getLayout() {#getLayout--}
+```
+public Layout getLayout()
+```
+
+
+シェイプの配置とコネクタのルーティング設定を制御する要素を含みます。
+
+**Returns:**
+[Layout](../../com.aspose.diagram/layout)
+### getLine() {#getLine--}
+```
+public Line getLine()
+```
+
+
+シェイプの線属性（パターン、太さ、色など）を制御する要素が含まれます。これらの要素は、線端が書式設定されているか（例: 矢じり）、線端書式のサイズ、線に適用される丸みの円の半径、そして線のキャップスタイル（丸形または四角形）を決定します。
+
+**Returns:**
+[Line](../../com.aspose.diagram/line)
+### getLineStyle() {#getLineStyle--}
+```
+public StyleSheet getLineStyle()
+```
+
+
+この形状が line formatting を継承する StyleSheet
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getMaster() {#getMaster--}
+```
+public Master getMaster()
+```
+
+
+形状がデータを継承する Master
+
+**Returns:**
+[Master](../../com.aspose.diagram/master)
+### getMasterShape() {#getMasterShape--}
+```
+public Shape getMasterShape()
+```
+
+
+この属性は、グループ シェイプのメンバーであり、かつそのグループがマスターのインスタンスであるシェイプにのみ存在する可能性があります。属性には、マスター内の対応するサブシェイプを参照する ID が含まれます。
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape)
+### getMisc() {#getMisc--}
+```
+public Misc getMisc()
+```
+
+
+Shape 要素のヘルプファイルトピックと著作権情報を指定する要素を含みます。
+
+**Returns:**
+[Misc](../../com.aspose.diagram/misc)
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素の名前。
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+要素のユニバーサル名。
+
+**Returns:**
+java.lang.String
+### getOneD() {#getOneD--}
+```
+public boolean getOneD()
+```
+
+
+シェイプが一次元 (1-D) オブジェクトとして動作するかどうかを決定します。読み取り専用です。
+
+**Returns:**
+boolean
+### getPage() {#getPage--}
+```
+public Page getPage()
+```
+
+
+Visio オブジェクト階層のルート要素です。
+
+**Returns:**
+[Page](../../com.aspose.diagram/page)
+### getParas() {#getParas--}
+```
+public ParaCollection getParas()
+```
+
+
+Para 要素のコレクションを含みます。
+
+**Returns:**
+[ParaCollection](../../com.aspose.diagram/paracollection)
+### getParentShape() {#getParentShape--}
+```
+public Shape getParentShape()
+```
+
+
+shape の親。
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape)
+### getProps() {#getProps--}
+```
+public PropCollection getProps()
+```
+
+
+Prop 要素のコレクションを含みます。
+
+**Returns:**
+[PropCollection](../../com.aspose.diagram/propcollection)
+### getProtection() {#getProtection--}
+```
+public Protection getProtection()
+```
+
+
+ロック機能はシェイプへの偶発的な変更を防止するのに役立ちますが、他の状況で Microsoft Visio が値をリセットすることは防げません。また、ShapeSheet ウィンドウで行われた変更からも保護されません。
+
+**Returns:**
+[Protection](../../com.aspose.diagram/protection)
+### getPureText() {#getPureText--}
+```
+public String getPureText()
+```
+
+
+テキスト文字列を取得
+
+**Returns:**
+java.lang.String
+### getRootShape() {#getRootShape--}
+```
+public Shape getRootShape()
+```
+
+
+このシェイプがマスター インスタンスの一部である場合、インスタンスの最上位シェイプを返します。読み取り専用です。
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape)
+### getScratchs() {#getScratchs--}
+```
+public ScratchCollection getScratchs()
+```
+
+
+Scratch 要素のコレクションを含みます。
+
+**Returns:**
+[ScratchCollection](../../com.aspose.diagram/scratchcollection)
+### getShapes() {#getShapes--}
+```
+public ShapeCollection getShapes()
+```
+
+
+Shape 要素のコレクションを含みます。
+
+**Returns:**
+[ShapeCollection](../../com.aspose.diagram/shapecollection)
+### getSmartTagDefs() {#getSmartTagDefs--}
+```
+public SmartTagDefCollection getSmartTagDefs()
+```
+
+
+SmartTagDef 要素のコレクションを含みます。
+
+**Returns:**
+[SmartTagDefCollection](../../com.aspose.diagram/smarttagdefcollection)
+### getTabsCollection() {#getTabsCollection--}
+```
+public TabsCollection getTabsCollection()
+```
+
+
+Tab 要素のコレクションを含みます。
+
+**Returns:**
+[TabsCollection](../../com.aspose.diagram/tabscollection)
+### getText() {#getText--}
+```
+public Text getText()
+```
+
+
+シェイプのテキストを含みます。
+
+**Returns:**
+[Text](../../com.aspose.diagram/text)
+### getTextBlock() {#getTextBlock--}
+```
+public TextBlock getTextBlock()
+```
+
+
+シェイプのテキスト ブロック内のテキストの配置、余白、デフォルトのタブ位置を指定する要素を含みます。
+
+**Returns:**
+[TextBlock](../../com.aspose.diagram/textblock)
+### getTextStyle() {#getTextStyle--}
+```
+public StyleSheet getTextStyle()
+```
+
+
+この shape が text formatting を継承する StyleSheet。
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getTextXForm() {#getTextXForm--}
+```
+public TextXForm getTextXForm()
+```
+
+
+シェイプのテキスト ブロックに関する位置情報を指定する要素を含みます。
+
+**Returns:**
+[TextXForm](../../com.aspose.diagram/textxform)
+### getThreeDFormat() {#getThreeDFormat--}
+```
+public ThreeDFormat getThreeDFormat()
+```
+
+
+ThreeDFormat を取得します。
+
+**Returns:**
+[ThreeDFormat](../../com.aspose.diagram/threedformat)
+### getTwoD() {#getTwoD--}
+```
+public boolean getTwoD()
+```
+
+
+shape が二次元 (2-D) オブジェクトとして動作するかどうかを決定します。
+
+**Returns:**
+boolean
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+シェイプのタイプです。次のいずれかの値になる可能性があります: Group、Shape、Guide、または Foreign。
+
+**Returns:**
+int
+### getUniqueID() {#getUniqueID--}
+```
+public UUID getUniqueID()
+```
+
+
+shape に割り当てられた GUID (グローバルに一意な識別子)。
+
+**Returns:**
+java.util.UUID
+### getUsers() {#getUsers--}
+```
+public UserCollection getUsers()
+```
+
+
+User 要素のコレクションを含みます。
+
+**Returns:**
+[UserCollection](../../com.aspose.diagram/usercollection)
+### getXForm() {#getXForm--}
+```
+public XForm getXForm()
+```
+
+
+シェイプに関する一般的な位置情報を指定する要素を含みます。
+
+**Returns:**
+[XForm](../../com.aspose.diagram/xform)
+### getXForm1D() {#getXForm1D--}
+```
+public XForm1D getXForm1D()
+```
+
+
+1 次元シェイプの開始点と終了点の x および y 座標が含まれます。この要素は 1 次元シェイプにのみ表示されます。
+
+**Returns:**
+[XForm1D](../../com.aspose.diagram/xform1d)
+### getZOrderIndex() {#getZOrderIndex--}
+```
+public int getZOrderIndex()
+```
+
+
+ガイド shape を除く、z 順序における shape のインデックスを返します。
+
+**Returns:**
+int
+### gluedShapes(int flag, String categoryFilter, Shape otherShape) {#gluedShapes-int-java.lang.String-com.aspose.diagram.Shape-}
+```
+public long[] gluedShapes(int flag, String categoryFilter, Shape otherShape)
+```
+
+
+shape に貼り付けられた shape の識別子を含む配列を返します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| フラグ | int | 返されるシェイプの接続ポイントの次元性と方向性です。可能な値については Remarks を参照してください Aspose.Diagram.GluedShapesFlags。 |
+| categoryFilter | java.lang.String | 指定された categoryString に一致するシェイプの ID に限定して、返されるシェイプ ID の配列をフィルタリングします。 |
+| otherShape | [Shape](../../com.aspose.diagram/shape) | オプション: 返されるシェイプが追加で貼り付けられる必要がある別のシェイプで、[Shape](../../com.aspose.diagram/shape) または null にできます。 |
+
+**Returns:**
+long[] - ID の配列 long。
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isConnected(Shape shape) {#isConnected-com.aspose.diagram.Shape-}
+```
+public boolean isConnected(Shape shape)
+```
+
+
+この 2 つの shape が接続されているかどうかを示します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| shape | [Shape](../../com.aspose.diagram/shape) | シェイプ |
+
+**Returns:**
+boolean
+### isContain(Shape shape) {#isContain-com.aspose.diagram.Shape-}
+```
+public boolean isContain(Shape shape)
+```
+
+
+この shape が別の shape を含んでいるかどうかを示します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| shape | [Shape](../../com.aspose.diagram/shape) |  |
+
+**Returns:**
+boolean
+### isGlued(Shape shape) {#isGlued-com.aspose.diagram.Shape-}
+```
+public boolean isGlued(Shape shape)
+```
+
+
+この 2 つの shape が接着されているかどうかを示します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| shape | [Shape](../../com.aspose.diagram/shape) | シェイプ |
+
+**Returns:**
+boolean
+### isInGroup() {#isInGroup--}
+```
+public boolean isInGroup()
+```
+
+
+この shape が group shape に含まれているかどうかを示します。
+
+**Returns:**
+boolean
+### isIntersect(Shape shape) {#isIntersect-com.aspose.diagram.Shape-}
+```
+public boolean isIntersect(Shape shape)
+```
+
+
+このシェイプが別のシェイプと交差しているかどうかを示します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| shape | [Shape](../../com.aspose.diagram/shape) |  |
+
+**Returns:**
+boolean
+### isTextEmpty() {#isTextEmpty--}
+```
+public boolean isTextEmpty()
+```
+
+
+シェイプにテキストがあり、テキストが空かどうかを示します。
+
+**Returns:**
+boolean
+### move(double dX, double dY) {#move-double-double-}
+```
+public void move(double dX, double dY)
+```
+
+
+シェイプを現在位置から dX および dY インチだけ移動させます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| dX | double | X オフセット double。 |
+| dY | double | Y オフセット double。 |
+
+### moveTo(double newPinX, double newPinY) {#moveTo-double-double-}
+```
+public void moveTo(double newPinX, double newPinY)
+```
+
+
+シェイプをページ上の新しい絶対位置に移動させます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| newPinX | double | 親の原点に対するシェイプのピン（回転中心）の新しい X 座標です。double。 |
+| newPinY | double | 親の原点に対するシェイプのピン（回転中心）の新しい Y 座標です。double。 |
+
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### refreshData() {#refreshData--}
+```
+public void refreshData()
+```
+
+
+シェイプのテキストやその他を変更した際に、xform、接続、ジオメトリを含むシェイプの位置を更新します。シェイプのテキストなどのデータを取得し、シェイプの位置を計算します。このメソッドはシェイプのデータを更新するためだけに使用されます。
+
+### replaceText(String text, String replaceText) {#replaceText-java.lang.String-java.lang.String-}
+```
+public void replaceText(String text, String replaceText)
+```
+
+
+シェイプのテキスト文字列を置き換えます。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| テキスト | java.lang.String |  |
+| replaceText | java.lang.String |  |
+
+### sendBackward() {#sendBackward--}
+```
+public void sendBackward()
+```
+
+
+シェイプを Z オーダーで 1 つ後ろに移動させます。
+
+### sendToBack() {#sendToBack--}
+```
+public void sendToBack()
+```
+
+
+シェイプを Z オーダーの最背面に移動させます。
+
+### setAngle(double angle) {#setAngle-double-}
+```
+public void setAngle(double angle)
+```
+
+
+シェイプの新しい角度を設定します。角度の単位はラジアンです。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 角度 | double | 単位がラジアンで、度ではない新しい角度です。double。 |
+
+### setClippingPath(String value) {#setClippingPath-java.lang.String-}
+```
+public void setClippingPath(String value)
+```
+
+
+このプロパティの説明については、[getClippingPath()](../../com.aspose.diagram/shape\#getClippingPath--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setConnectorsType(int type) {#setConnectorsType-int-}
+```
+public void setConnectorsType(int type)
+```
+
+
+コネクタのタイプを設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| タイプ | int |  |
+
+### setData1(String value) {#setData1-java.lang.String-}
+```
+public void setData1(String value)
+```
+
+
+このプロパティの説明については、[getData1()](../../com.aspose.diagram/shape\#getData1--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setData2(String value) {#setData2-java.lang.String-}
+```
+public void setData2(String value)
+```
+
+
+このプロパティの説明については、[getData2()](../../com.aspose.diagram/shape\#getData2--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setData3(String value) {#setData3-java.lang.String-}
+```
+public void setData3(String value)
+```
+
+
+このプロパティの説明については、[getData3()](../../com.aspose.diagram/shape\#getData3--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+このプロパティの説明については、[getDel()](../../com.aspose.diagram/shape\#getDel--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setDiagram(Diagram value) {#setDiagram-com.aspose.diagram.Diagram-}
+```
+public void setDiagram(Diagram value)
+```
+
+
+このプロパティの説明については、[getDiagram()](../../com.aspose.diagram/shape\#getDiagram--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [Diagram](../../com.aspose.diagram/diagram) |  |
+
+### setEvent(Event value) {#setEvent-com.aspose.diagram.Event-}
+```
+public void setEvent(Event value)
+```
+
+
+このプロパティの説明については、[getEvent()](../../com.aspose.diagram/shape\#getEvent--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [Event](../../com.aspose.diagram/event) |  |
+
+### setFillStyle(StyleSheet value) {#setFillStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setFillStyle(StyleSheet value)
+```
+
+
+このプロパティの説明については、[getFillStyle()](../../com.aspose.diagram/shape\#getFillStyle--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setHeight(double height) {#setHeight-double-}
+```
+public void setHeight(double height)
+```
+
+
+シェイプの新しい高さを設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| height | double | New heightdouble. |
+
+### setID(long value) {#setID-long-}
+```
+public void setID(long value)
+```
+
+
+このプロパティの説明については、[getID()](../../com.aspose.diagram/shape\#getID--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | long |  |
+
+### setLineStyle(StyleSheet value) {#setLineStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setLineStyle(StyleSheet value)
+```
+
+
+このプロパティの説明については、[getLineStyle()](../../com.aspose.diagram/shape\#getLineStyle--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setMaster(Master value) {#setMaster-com.aspose.diagram.Master-}
+```
+public void setMaster(Master value)
+```
+
+
+このプロパティの説明については、[getMaster()](../../com.aspose.diagram/shape\#getMaster--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [Master](../../com.aspose.diagram/master) |  |
+
+### setMasterShape(Shape value) {#setMasterShape-com.aspose.diagram.Shape-}
+```
+public void setMasterShape(Shape value)
+```
+
+
+このプロパティの説明については、[getMasterShape()](../../com.aspose.diagram/shape\#getMasterShape--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [Shape](../../com.aspose.diagram/shape) |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+このプロパティの説明については、[getName()](../../com.aspose.diagram/shape\#getName--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+このプロパティの説明については、[getNameU()](../../com.aspose.diagram/shape\#getNameU--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setPage(Page value) {#setPage-com.aspose.diagram.Page-}
+```
+public void setPage(Page value)
+```
+
+
+このプロパティの説明については、[getPage()](../../com.aspose.diagram/shape\\#getPage--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [Page](../../com.aspose.diagram/page) |  |
+
+### setParentShape(Shape value) {#setParentShape-com.aspose.diagram.Shape-}
+```
+public void setParentShape(Shape value)
+```
+
+
+このプロパティの説明については、[getParentShape()](../../com.aspose.diagram/shape\\#getParentShape--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [Shape](../../com.aspose.diagram/shape) |  |
+
+### setPresetTheme(int value) {#setPresetTheme-int-}
+```
+public void setPresetTheme(int value)
+```
+
+
+このシェイプにプリセットテーマを適用する
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setPresetThemeQuickStyle(int value) {#setPresetThemeQuickStyle-int-}
+```
+public void setPresetThemeQuickStyle(int value)
+```
+
+
+このシェイプにプリセットテーマバリアントのクイックスタイルを適用する
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setPresetThemeStyleMatrics(int styleIndex, int colorIndex) {#setPresetThemeStyleMatrics-int-int-}
+```
+public void setPresetThemeStyleMatrics(int styleIndex, int colorIndex)
+```
+
+
+このシェイプにプリセットテーマバリアントのクイックスタイルを適用する。シェイプスタイルのドロップダウンリストにあるテーマスタイルオプションのように
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| styleIndex | int | the row of style matrics |
+| colorIndex | int | the column of style matrics |
+
+### setPresetThemeVariant(int value) {#setPresetThemeVariant-int-}
+```
+public void setPresetThemeVariant(int value)
+```
+
+
+このシェイプにプリセットテーマバリアントを適用する
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setProps(PropCollection value) {#setProps-com.aspose.diagram.PropCollection-}
+```
+public void setProps(PropCollection value)
+```
+
+
+このプロパティの説明については、[getProps()](../../com.aspose.diagram/shape\\#getProps--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [PropCollection](../../com.aspose.diagram/propcollection) |  |
+
+### setText(Text value) {#setText-com.aspose.diagram.Text-}
+```
+public void setText(Text value)
+```
+
+
+このプロパティの説明については、[getText()](../../com.aspose.diagram/shape\\#getText--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [Text](../../com.aspose.diagram/text) |  |
+
+### setTextStyle(StyleSheet value) {#setTextStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setTextStyle(StyleSheet value)
+```
+
+
+このプロパティの説明については、[getTextStyle()](../../com.aspose.diagram/shape\\#getTextStyle--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setTwoD(boolean value) {#setTwoD-boolean-}
+```
+public void setTwoD(boolean value)
+```
+
+
+このプロパティの説明については、[getTwoD()](../../com.aspose.diagram/shape\\#getTwoD--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setType(int value) {#setType-int-}
+```
+public void setType(int value)
+```
+
+
+このプロパティの説明については、[getType()](../../com.aspose.diagram/shape\\#getType--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setUniqueID(UUID value) {#setUniqueID-java.util.UUID-}
+```
+public void setUniqueID(UUID value)
+```
+
+
+このプロパティの説明については、[getUniqueID()](../../com.aspose.diagram/shape\\#getUniqueID--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.util.UUID |  |
+
+### setWidth(double width) {#setWidth-double-}
+```
+public void setWidth(double width)
+```
+
+
+シェイプの新しい幅を設定します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| width | double | New widthdouble. |
+
+### setXForm(XForm value) {#setXForm-com.aspose.diagram.XForm-}
+```
+public void setXForm(XForm value)
+```
+
+
+このプロパティの説明については、[getXForm()](../../com.aspose.diagram/shape\\#getXForm--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [XForm](../../com.aspose.diagram/xform) |  |
+
+### setXForm1D(XForm1D value) {#setXForm1D-com.aspose.diagram.XForm1D-}
+```
+public void setXForm1D(XForm1D value)
+```
+
+
+このプロパティの説明については、[getXForm1D()](../../com.aspose.diagram/shape\\#getXForm1D--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [XForm1D](../../com.aspose.diagram/xform1d) |  |
+
+### toHTML(InputStream stream, HTMLSaveOptions options) {#toHTML-java.io.InputStream-com.aspose.diagram.HTMLSaveOptions-}
+```
+public void toHTML(InputStream stream, HTMLSaveOptions options)
+```
+
+
+シェイプのHTMLを作成し、指定された形式でストリームに保存します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ストリーム | java.io.InputStream | The output stream. |
+| options | [HTMLSaveOptions](../../com.aspose.diagram/htmlsaveoptions) | Addtional html creation options |
+
+### toHTML(OutputStream stream, HTMLSaveOptions options) {#toHTML-java.io.OutputStream-com.aspose.diagram.HTMLSaveOptions-}
+```
+public void toHTML(OutputStream stream, HTMLSaveOptions options)
+```
+
+
+シェイプのHTMLを作成し、指定された形式でストリームに保存します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ストリーム | java.io.OutputStream | The output stream. |
+| options | [HTMLSaveOptions](../../com.aspose.diagram/htmlsaveoptions) | Addtional html creation options |
+
+### toHTML(String fileName, HTMLSaveOptions options) {#toHTML-java.lang.String-com.aspose.diagram.HTMLSaveOptions-}
+```
+public void toHTML(String fileName, HTMLSaveOptions options)
+```
+
+
+HTMLを作成し、ファイルに保存します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| fileName | java.lang.String |  |
+| options | [HTMLSaveOptions](../../com.aspose.diagram/htmlsaveoptions) | html save options |
+
+### toImage(InputStream stream, ImageSaveOptions options) {#toImage-java.io.InputStream-com.aspose.diagram.ImageSaveOptions-}
+```
+public void toImage(InputStream stream, ImageSaveOptions options)
+```
+
+
+シェイプの画像を作成し、指定された形式でストリームに保存します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ストリーム | java.io.InputStream | The output stream. |
+| options | [ImageSaveOptions](../../com.aspose.diagram/imagesaveoptions) | Additional image creation options |
+
+### toImage(OutputStream stream, ImageSaveOptions options) {#toImage-java.io.OutputStream-com.aspose.diagram.ImageSaveOptions-}
+```
+public void toImage(OutputStream stream, ImageSaveOptions options)
+```
+
+
+シェイプの画像を作成し、指定された形式でストリームに保存します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ストリーム | java.io.OutputStream | The output stream. |
+| options | [ImageSaveOptions](../../com.aspose.diagram/imagesaveoptions) | Additional image creation options |
+
+### toImage(String imageFile, ImageSaveOptions options) {#toImage-java.lang.String-com.aspose.diagram.ImageSaveOptions-}
+```
+public void toImage(String imageFile, ImageSaveOptions options)
+```
+
+
+Creates the shape image and saves it to a file. The extension of the file name determines the format of the image.
+
+The format of the image is specified by using the extension of the file name. For example, if you specify "myfile.png", then the image will be saved in the PNG format. The following file extensions are recognized: .bmp, .gif, .png, .jpg, .jpeg, .tiff, .tif, .emf.
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| imageFile | java.lang.String | The image file name with full path. |
+| options | [ImageSaveOptions](../../com.aspose.diagram/imagesaveoptions) | Additional image creation options |
+
+### toPdf(InputStream stream) {#toPdf-java.io.InputStream-}
+```
+public void toPdf(InputStream stream)
+```
+
+
+シェイプのPDFを作成し、ストリームに保存します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ストリーム | java.io.InputStream | The output stream. |
+
+### toPdf(OutputStream stream) {#toPdf-java.io.OutputStream-}
+```
+public void toPdf(OutputStream stream)
+```
+
+
+シェイプのPDFを作成し、ストリームに保存します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ストリーム | java.io.OutputStream | The output stream. |
+
+### toPdf(String fileName) {#toPdf-java.lang.String-}
+```
+public void toPdf(String fileName)
+```
+
+
+シェイプをPDFファイルに保存します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| fileName | java.lang.String | the pdf file name with full path |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### toSvg(String imageFile, SVGSaveOptions options) {#toSvg-java.lang.String-com.aspose.diagram.SVGSaveOptions-}
+```
+public void toSvg(String imageFile, SVGSaveOptions options)
+```
+
+
+シェイプをSVGファイルに保存します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| imageFile | java.lang.String |  |
+| options | [SVGSaveOptions](../../com.aspose.diagram/svgsaveoptions) |  |
+
+### ungroup() {#ungroup--}
+```
+public void ungroup()
+```
+
+
+シェイプのグループ解除
+
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/shapecollection/_index.md
+++ b/japanese/java/com.aspose.diagram/shapecollection/_index.md
@@ -1,0 +1,326 @@
+---
+title: ShapeCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: シェイプのコレクション。
+type: docs
+weight: 356
+url: /ja/java/com.aspose.diagram/shapecollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ShapeCollection extends Collection
+```
+
+シェイプのコレクション。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(Shape item)](#add-com.aspose.diagram.Shape-) | コレクションにシェイプを追加します。 |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [getShape(String name)](#getShape-java.lang.String-) | 指定された名前の要素を取得します。 |
+| [getShape(long ID)](#getShape-long-) | 指定された ID の要素を取得します。 |
+| [getShapeIncludingChild(int id)](#getShapeIncludingChild-int-) | 指定された ID の子シェイプを含む要素を取得します。 |
+| [getShapeIncludingChild(String name)](#getShapeIncludingChild-java.lang.String-) | 指定された名前の子シェイプを含む要素を取得します。 |
+| [group(Shape[] groupItems)](#group-com.aspose.diagram.Shape---) | シェイプをグループ化します。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Shape item)](#remove-com.aspose.diagram.Shape-) | Remove the shape from the collection. |
+| [removeDependsOn(Shape item)](#removeDependsOn-com.aspose.diagram.Shape-) | Remove the shapes including DEPENDSON shapes from the collection. |
+| [toString()](#toString--) |  |
+| [unGroup(Shape groupShape)](#unGroup-com.aspose.diagram.Shape-) | UnGroup the shape. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Shape item) {#add-com.aspose.diagram.Shape-}
+```
+public int add(Shape item)
+```
+
+
+コレクションにシェイプを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [Shape](../../com.aspose.diagram/shape) |  |
+
+**Returns:**
+int - ID
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Shape get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### getShape(String name) {#getShape-java.lang.String-}
+```
+public Shape getShape(String name)
+```
+
+
+指定された名前の要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String |  |
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape) - 
+### getShape(long ID) {#getShape-long-}
+```
+public Shape getShape(long ID)
+```
+
+
+指定された ID の要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ID | long |  |
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape) - 
+### getShapeIncludingChild(int id) {#getShapeIncludingChild-int-}
+```
+public Shape getShapeIncludingChild(int id)
+```
+
+
+指定された ID の子シェイプを含む要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| id | int |  |
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape) - 
+### getShapeIncludingChild(String name) {#getShapeIncludingChild-java.lang.String-}
+```
+public Shape getShapeIncludingChild(String name)
+```
+
+
+指定された名前の子シェイプを含む要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String |  |
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape) - 
+### group(Shape[] groupItems) {#group-com.aspose.diagram.Shape---}
+```
+public Shape group(Shape[] groupItems)
+```
+
+
+Group the shapes. The shape in the groupItems should not be grouped. The shape must be in this Shapes collection.
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| groupItems | [Shape\[\]](../../com.aspose.diagram/shape) | the group items. |
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape) - Return the group shape.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Shape item) {#remove-com.aspose.diagram.Shape-}
+```
+public void remove(Shape item)
+```
+
+
+Remove the shape from the collection.
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [Shape](../../com.aspose.diagram/shape) | Shape |
+
+### removeDependsOn(Shape item) {#removeDependsOn-com.aspose.diagram.Shape-}
+```
+public void removeDependsOn(Shape item)
+```
+
+
+Remove the shapes including DEPENDSON shapes from the collection.
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [Shape](../../com.aspose.diagram/shape) | Shape |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### unGroup(Shape groupShape) {#unGroup-com.aspose.diagram.Shape-}
+```
+public void unGroup(Shape groupShape)
+```
+
+
+UnGroup the shape.
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| groupShape | [Shape](../../com.aspose.diagram/shape) | the group shape. |
+
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/shapefixedcode/_index.md
+++ b/japanese/java/com.aspose.diagram/shapefixedcode/_index.md
@@ -1,0 +1,179 @@
+---
+title: ShapeFixedCode
+second_title: Aspose.Diagram for Java API リファレンス
+description: 配置可能なシェイプの配置動作を指定します。
+type: docs
+weight: 357
+url: /ja/java/com.aspose.diagram/shapefixedcode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ShapeFixedCode
+```
+
+配置可能なシェイプの配置動作を指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [ShapeFixedCode(int value)](#ShapeFixedCode-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | 配置可能なシェイプの配置動作を指定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/shapefixedcode\#getValue--)をご覧ください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ShapeFixedCode(int value) {#ShapeFixedCode-int-}
+```
+public ShapeFixedCode(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+配置可能なシェイプの配置動作を指定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/shapefixedcode\#getValue--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/shapefixedcodevalue/_index.md
+++ b/japanese/java/com.aspose.diagram/shapefixedcodevalue/_index.md
@@ -1,0 +1,192 @@
+---
+title: ShapeFixedCodeValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: 配置可能なシェイプの配置動作を指定します。
+type: docs
+weight: 358
+url: /ja/java/com.aspose.diagram/shapefixedcodevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ShapeFixedCodeValue
+```
+
+配置可能なシェイプの配置動作を指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [ALLOW_ROUTING_TO_SIDES_WITH_CONNECTION_POINTS](#ALLOW-ROUTING-TO-SIDES-WITH-CONNECTION-POINTS) | 接続ポイントがある側へのルーティングのみを許可します。 |
+| [IGNORE_CONNECTION_POINT](#IGNORE-CONNECTION-POINT) | ルーティング先の接続ポイント位置を無視します。 |
+| [NO_GLUE_TO_PERIMETER](#NO-GLUE-TO-PERIMETER) | このシェイプの周囲に貼り付けないでください。 |
+| [NO_MOVE_ALLOW_SHAPES_PLACED](#NO-MOVE-ALLOW-SHAPES-PLACED) | このシェイプは移動しませんが、他の配置可能なシェイプをその上に配置できるようにします。 |
+| [NO_MOVE_AND_NO_ALLOW_SHAPES_PLACED](#NO-MOVE-AND-NO-ALLOW-SHAPES-PLACED) | このシェイプは移動せず、他の配置可能なシェイプをその上に配置できないようにします。 |
+| [NO_MOVE_USING_LAY_OUT_SHAPES](#NO-MOVE-USING-LAY-OUT-SHAPES) | Microsoft Visio の「レイアウト シェイプ」コマンドを使用する際、このシェイプを移動しないでください。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALLOW_ROUTING_TO_SIDES_WITH_CONNECTION_POINTS {#ALLOW-ROUTING-TO-SIDES-WITH-CONNECTION-POINTS}
+```
+public static final int ALLOW_ROUTING_TO_SIDES_WITH_CONNECTION_POINTS
+```
+
+
+接続ポイントがある側へのルーティングのみを許可します。
+
+### IGNORE_CONNECTION_POINT {#IGNORE-CONNECTION-POINT}
+```
+public static final int IGNORE_CONNECTION_POINT
+```
+
+
+ルーティング先の接続ポイント位置を無視します。
+
+### NO_GLUE_TO_PERIMETER {#NO-GLUE-TO-PERIMETER}
+```
+public static final int NO_GLUE_TO_PERIMETER
+```
+
+
+このシェイプの周囲に貼り付けないでください。代わりにシェイプの配置ボックスに貼り付けます。
+
+### NO_MOVE_ALLOW_SHAPES_PLACED {#NO-MOVE-ALLOW-SHAPES-PLACED}
+```
+public static final int NO_MOVE_ALLOW_SHAPES_PLACED
+```
+
+
+このシェイプは移動しませんが、他の配置可能なシェイプをその上に配置できるようにします。
+
+### NO_MOVE_AND_NO_ALLOW_SHAPES_PLACED {#NO-MOVE-AND-NO-ALLOW-SHAPES-PLACED}
+```
+public static final int NO_MOVE_AND_NO_ALLOW_SHAPES_PLACED
+```
+
+
+このシェイプは移動せず、他の配置可能なシェイプをその上に配置できないようにします。
+
+### NO_MOVE_USING_LAY_OUT_SHAPES {#NO-MOVE-USING-LAY-OUT-SHAPES}
+```
+public static final int NO_MOVE_USING_LAY_OUT_SHAPES
+```
+
+
+Microsoft Visio の「レイアウト シェイプ」コマンドを使用する際、このシェイプを移動しないでください。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/shapeplaceflip/_index.md
+++ b/japanese/java/com.aspose.diagram/shapeplaceflip/_index.md
@@ -1,0 +1,179 @@
+---
+title: ShapePlaceFlip
+second_title: Aspose.Diagram for Java API リファレンス
+description: ユーザーが「Lay Out Shapes Shapes」メニューを選択したときに、配置可能なシェイプがページ上でどのように反転または回転するかを指定します。
+type: docs
+weight: 359
+url: /ja/java/com.aspose.diagram/shapeplaceflip/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ShapePlaceFlip
+```
+
+ユーザーが「Lay Out Shapes」（シェイプ メニュー）を選択したときに、配置可能なシェイプがページ上で反転または回転する方法を指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [ShapePlaceFlip(int value)](#ShapePlaceFlip-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | ユーザーが「Lay Out Shapes」（シェイプ メニュー）を選択したときに、配置可能なシェイプがページ上で反転または回転する方法を指定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/shapeplaceflip\#getValue--) をご覧ください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ShapePlaceFlip(int value) {#ShapePlaceFlip-int-}
+```
+public ShapePlaceFlip(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+ユーザーが「Lay Out Shapes」（シェイプ メニュー）を選択したときに、配置可能なシェイプがページ上で反転または回転する方法を指定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/shapeplaceflip\#getValue--) をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/shapeplaceflipvalue/_index.md
+++ b/japanese/java/com.aspose.diagram/shapeplaceflipvalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: ShapePlaceFlipValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: ユーザーが「Lay Out Shapes Shapes」メニューを選択したときに、配置可能なシェイプがページ上でどのように反転または回転するかを指定します。
+type: docs
+weight: 360
+url: /ja/java/com.aspose.diagram/shapeplaceflipvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ShapePlaceFlipValue
+```
+
+ユーザーが「Lay Out Shapes」（シェイプ メニュー）を選択したときに、配置可能なシェイプがページ上で反転または回転する方法を指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [FLIP_90_DEGREE_INCREMENT_BETWEEN_0_AND_270](#FLIP-90-DEGREE-INCREMENT-BETWEEN-0-AND-270) | 0 から 270 の範囲で、90 度刻みで反転します。 |
+| [FLIP_HORIZONTAL](#FLIP-HORIZONTAL) | 水平に反転します。 |
+| [FLIP_VERTICAL](#FLIP-VERTICAL) | 垂直に反転します。 |
+| [NO_FLIP](#NO-FLIP) | 反転しません。 |
+| [UNDEFINED](#UNDEFINED) | 未定義 |
+| [USE_PAGE_DEFAULT](#USE-PAGE-DEFAULT) | ページのデフォルトを使用します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FLIP_90_DEGREE_INCREMENT_BETWEEN_0_AND_270 {#FLIP-90-DEGREE-INCREMENT-BETWEEN-0-AND-270}
+```
+public static final int FLIP_90_DEGREE_INCREMENT_BETWEEN_0_AND_270
+```
+
+
+0 から 270 の範囲で、90 度刻みで反転します。
+
+### FLIP_HORIZONTAL {#FLIP-HORIZONTAL}
+```
+public static final int FLIP_HORIZONTAL
+```
+
+
+水平に反転します。
+
+### FLIP_VERTICAL {#FLIP-VERTICAL}
+```
+public static final int FLIP_VERTICAL
+```
+
+
+垂直に反転します。
+
+### NO_FLIP {#NO-FLIP}
+```
+public static final int NO_FLIP
+```
+
+
+反転しません。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+未定義
+
+### USE_PAGE_DEFAULT {#USE-PAGE-DEFAULT}
+```
+public static final int USE_PAGE_DEFAULT
+```
+
+
+ページのデフォルトを使用します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/shapeplacestyle/_index.md
+++ b/japanese/java/com.aspose.diagram/shapeplacestyle/_index.md
@@ -1,0 +1,179 @@
+---
+title: ShapePlaceStyle
+second_title: Aspose.Diagram for Java API リファレンス
+description: 子要素の配置スタイルを決定します。
+type: docs
+weight: 361
+url: /ja/java/com.aspose.diagram/shapeplacestyle/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ShapePlaceStyle
+```
+
+子要素の配置スタイルを決定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [ShapePlaceStyle(int value)](#ShapePlaceStyle-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | コネクタの外観を決定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/shapeplacestyle\#getValue--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ShapePlaceStyle(int value) {#ShapePlaceStyle-int-}
+```
+public ShapePlaceStyle(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+コネクタの外観を決定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/shapeplacestyle\#getValue--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/shapeplacestylevalue/_index.md
+++ b/japanese/java/com.aspose.diagram/shapeplacestylevalue/_index.md
@@ -1,0 +1,390 @@
+---
+title: ShapePlaceStyleValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: 子要素の配置スタイルを決定します。
+type: docs
+weight: 362
+url: /ja/java/com.aspose.diagram/shapeplacestylevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ShapePlaceStyleValue
+```
+
+子要素の配置スタイルを決定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [PLACE_BOTTOM_TO_TOP](#PLACE-BOTTOM-TO-TOP) | 下から上へ配置します。 |
+| [PLACE_CIRCULAR](#PLACE-CIRCULAR) | 円形に配置します。 |
+| [PLACE_COMPACT_DOWN_LEFT](#PLACE-COMPACT-DOWN-LEFT) | 左下にコンパクトに配置します。 |
+| [PLACE_COMPACT_DOWN_RIGHT](#PLACE-COMPACT-DOWN-RIGHT) | 右下にコンパクトに配置します。 |
+| [PLACE_COMPACT_LEFT_DOWN](#PLACE-COMPACT-LEFT-DOWN) | 左下にコンパクトに配置します。 |
+| [PLACE_COMPACT_LEFT_UP](#PLACE-COMPACT-LEFT-UP) | 左上にコンパクトに配置します。 |
+| [PLACE_COMPACT_RIGHT_DOWN](#PLACE-COMPACT-RIGHT-DOWN) | 右下にコンパクトに配置します。 |
+| [PLACE_COMPACT_RIGHT_UP](#PLACE-COMPACT-RIGHT-UP) | 右上にコンパクトに配置します。 |
+| [PLACE_COMPACT_UP_LEFT](#PLACE-COMPACT-UP-LEFT) | 上左にコンパクトに配置します。 |
+| [PLACE_COMPACT_UP_RIGHT](#PLACE-COMPACT-UP-RIGHT) | 上右にコンパクトに配置します。 |
+| [PLACE_DEFAULT](#PLACE-DEFAULT) | デフォルトで配置します。 |
+| [PLACE_HIERARCHY_BOTTOM_TO_CENTER](#PLACE-HIERARCHY-BOTTOM-TO-CENTER) | 階層を下から中央に配置します。 |
+| [PLACE_HIERARCHY_BOTTOM_TO_LEFT](#PLACE-HIERARCHY-BOTTOM-TO-LEFT) | 階層を下から左へ配置します。 |
+| [PLACE_HIERARCHY_BOTTOM_TO_RIGHT](#PLACE-HIERARCHY-BOTTOM-TO-RIGHT) | 階層を下から右へ配置します。 |
+| [PLACE_HIERARCHY_LEFT_TO_RIGHT_BOTTOM](#PLACE-HIERARCHY-LEFT-TO-RIGHT-BOTTOM) | 階層を左から右へ下に配置します。 |
+| [PLACE_HIERARCHY_LEFT_TO_RIGHT_MIDDLE](#PLACE-HIERARCHY-LEFT-TO-RIGHT-MIDDLE) | 階層を左から右へ中央に配置します。 |
+| [PLACE_HIERARCHY_LEFT_TO_RIGHT_TOP](#PLACE-HIERARCHY-LEFT-TO-RIGHT-TOP) | 階層を左から右へ上に配置します。 |
+| [PLACE_HIERARCHY_RIGHT_TO_LEFT_BOTTOM](#PLACE-HIERARCHY-RIGHT-TO-LEFT-BOTTOM) | 階層を右から左へ下に配置します。 |
+| [PLACE_HIERARCHY_RIGHT_TO_LEFT_MIDDLE](#PLACE-HIERARCHY-RIGHT-TO-LEFT-MIDDLE) | 階層を右から左へ上に配置します。 |
+| [PLACE_HIERARCHY_RIGHT_TO_LEFT_TOP](#PLACE-HIERARCHY-RIGHT-TO-LEFT-TOP) | 階層を右から左へ上に配置します。 |
+| [PLACE_HIERARCHY_TOP_TO_BOTTOM_CENTER](#PLACE-HIERARCHY-TOP-TO-BOTTOM-CENTER) | 階層を上から下へ中央に配置します。 |
+| [PLACE_HIERARCHY_TOP_TO_BOTTOM_LEFT](#PLACE-HIERARCHY-TOP-TO-BOTTOM-LEFT) | 階層を上から下へ左に配置します。 |
+| [PLACE_HIERARCHY_TOP_TO_BOTTOM_RIGHT](#PLACE-HIERARCHY-TOP-TO-BOTTOM-RIGHT) | 階層を上から下へ右に配置します。 |
+| [PLACE_PARENT_DEFAULT](#PLACE-PARENT-DEFAULT) | 親をデフォルトに配置します。 |
+| [PLACE_RADIAL](#PLACE-RADIAL) | 放射状に配置します。 |
+| [PLACE_RIGHT_TO_LEFT](#PLACE-RIGHT-TO-LEFT) | 右から左へ配置します。 |
+| [PLACE_TOP_TO_BOTTOM](#PLACE-TOP-TO-BOTTOM) | 上から下へ配置します。 |
+| [PLACE_TO_RIGHT](#PLACE-TO-RIGHT) | 右へ配置します。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PLACE_BOTTOM_TO_TOP {#PLACE-BOTTOM-TO-TOP}
+```
+public static final int PLACE_BOTTOM_TO_TOP
+```
+
+
+下から上へ配置します。
+
+### PLACE_CIRCULAR {#PLACE-CIRCULAR}
+```
+public static final int PLACE_CIRCULAR
+```
+
+
+円形に配置します。
+
+### PLACE_COMPACT_DOWN_LEFT {#PLACE-COMPACT-DOWN-LEFT}
+```
+public static final int PLACE_COMPACT_DOWN_LEFT
+```
+
+
+左下にコンパクトに配置します。
+
+### PLACE_COMPACT_DOWN_RIGHT {#PLACE-COMPACT-DOWN-RIGHT}
+```
+public static final int PLACE_COMPACT_DOWN_RIGHT
+```
+
+
+右下にコンパクトに配置します。
+
+### PLACE_COMPACT_LEFT_DOWN {#PLACE-COMPACT-LEFT-DOWN}
+```
+public static final int PLACE_COMPACT_LEFT_DOWN
+```
+
+
+左下にコンパクトに配置します。
+
+### PLACE_COMPACT_LEFT_UP {#PLACE-COMPACT-LEFT-UP}
+```
+public static final int PLACE_COMPACT_LEFT_UP
+```
+
+
+左上にコンパクトに配置します。
+
+### PLACE_COMPACT_RIGHT_DOWN {#PLACE-COMPACT-RIGHT-DOWN}
+```
+public static final int PLACE_COMPACT_RIGHT_DOWN
+```
+
+
+右下にコンパクトに配置します。
+
+### PLACE_COMPACT_RIGHT_UP {#PLACE-COMPACT-RIGHT-UP}
+```
+public static final int PLACE_COMPACT_RIGHT_UP
+```
+
+
+右上にコンパクトに配置します。
+
+### PLACE_COMPACT_UP_LEFT {#PLACE-COMPACT-UP-LEFT}
+```
+public static final int PLACE_COMPACT_UP_LEFT
+```
+
+
+上左にコンパクトに配置します。
+
+### PLACE_COMPACT_UP_RIGHT {#PLACE-COMPACT-UP-RIGHT}
+```
+public static final int PLACE_COMPACT_UP_RIGHT
+```
+
+
+上右にコンパクトに配置します。
+
+### PLACE_DEFAULT {#PLACE-DEFAULT}
+```
+public static final int PLACE_DEFAULT
+```
+
+
+デフォルトで配置します。
+
+### PLACE_HIERARCHY_BOTTOM_TO_CENTER {#PLACE-HIERARCHY-BOTTOM-TO-CENTER}
+```
+public static final int PLACE_HIERARCHY_BOTTOM_TO_CENTER
+```
+
+
+階層を下から中央に配置します。
+
+### PLACE_HIERARCHY_BOTTOM_TO_LEFT {#PLACE-HIERARCHY-BOTTOM-TO-LEFT}
+```
+public static final int PLACE_HIERARCHY_BOTTOM_TO_LEFT
+```
+
+
+階層を下から左へ配置します。
+
+### PLACE_HIERARCHY_BOTTOM_TO_RIGHT {#PLACE-HIERARCHY-BOTTOM-TO-RIGHT}
+```
+public static final int PLACE_HIERARCHY_BOTTOM_TO_RIGHT
+```
+
+
+階層を下から右へ配置します。
+
+### PLACE_HIERARCHY_LEFT_TO_RIGHT_BOTTOM {#PLACE-HIERARCHY-LEFT-TO-RIGHT-BOTTOM}
+```
+public static final int PLACE_HIERARCHY_LEFT_TO_RIGHT_BOTTOM
+```
+
+
+階層を左から右へ下に配置します。
+
+### PLACE_HIERARCHY_LEFT_TO_RIGHT_MIDDLE {#PLACE-HIERARCHY-LEFT-TO-RIGHT-MIDDLE}
+```
+public static final int PLACE_HIERARCHY_LEFT_TO_RIGHT_MIDDLE
+```
+
+
+階層を左から右へ中央に配置します。
+
+### PLACE_HIERARCHY_LEFT_TO_RIGHT_TOP {#PLACE-HIERARCHY-LEFT-TO-RIGHT-TOP}
+```
+public static final int PLACE_HIERARCHY_LEFT_TO_RIGHT_TOP
+```
+
+
+階層を左から右へ上に配置します。
+
+### PLACE_HIERARCHY_RIGHT_TO_LEFT_BOTTOM {#PLACE-HIERARCHY-RIGHT-TO-LEFT-BOTTOM}
+```
+public static final int PLACE_HIERARCHY_RIGHT_TO_LEFT_BOTTOM
+```
+
+
+階層を右から左へ下に配置します。
+
+### PLACE_HIERARCHY_RIGHT_TO_LEFT_MIDDLE {#PLACE-HIERARCHY-RIGHT-TO-LEFT-MIDDLE}
+```
+public static final int PLACE_HIERARCHY_RIGHT_TO_LEFT_MIDDLE
+```
+
+
+階層を右から左へ上に配置します。
+
+### PLACE_HIERARCHY_RIGHT_TO_LEFT_TOP {#PLACE-HIERARCHY-RIGHT-TO-LEFT-TOP}
+```
+public static final int PLACE_HIERARCHY_RIGHT_TO_LEFT_TOP
+```
+
+
+階層を右から左へ上に配置します。
+
+### PLACE_HIERARCHY_TOP_TO_BOTTOM_CENTER {#PLACE-HIERARCHY-TOP-TO-BOTTOM-CENTER}
+```
+public static final int PLACE_HIERARCHY_TOP_TO_BOTTOM_CENTER
+```
+
+
+階層を上から下へ中央に配置します。
+
+### PLACE_HIERARCHY_TOP_TO_BOTTOM_LEFT {#PLACE-HIERARCHY-TOP-TO-BOTTOM-LEFT}
+```
+public static final int PLACE_HIERARCHY_TOP_TO_BOTTOM_LEFT
+```
+
+
+階層を上から下へ左に配置します。
+
+### PLACE_HIERARCHY_TOP_TO_BOTTOM_RIGHT {#PLACE-HIERARCHY-TOP-TO-BOTTOM-RIGHT}
+```
+public static final int PLACE_HIERARCHY_TOP_TO_BOTTOM_RIGHT
+```
+
+
+階層を上から下へ右に配置します。
+
+### PLACE_PARENT_DEFAULT {#PLACE-PARENT-DEFAULT}
+```
+public static final int PLACE_PARENT_DEFAULT
+```
+
+
+親をデフォルトに配置します。
+
+### PLACE_RADIAL {#PLACE-RADIAL}
+```
+public static final int PLACE_RADIAL
+```
+
+
+放射状に配置します。
+
+### PLACE_RIGHT_TO_LEFT {#PLACE-RIGHT-TO-LEFT}
+```
+public static final int PLACE_RIGHT_TO_LEFT
+```
+
+
+右から左へ配置します。
+
+### PLACE_TOP_TO_BOTTOM {#PLACE-TOP-TO-BOTTOM}
+```
+public static final int PLACE_TOP_TO_BOTTOM
+```
+
+
+上から下へ配置します。
+
+### PLACE_TO_RIGHT {#PLACE-TO-RIGHT}
+```
+public static final int PLACE_TO_RIGHT
+```
+
+
+右へ配置します。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/shapeplowcode/_index.md
+++ b/japanese/java/com.aspose.diagram/shapeplowcode/_index.md
@@ -1,0 +1,179 @@
+---
+title: ShapePlowCode
+second_title: Aspose.Diagram for Java API リファレンス
+description: 描画ページ上で別の配置可能なシェイプを対象シェイプの近くにドラッグしたときに、対象シェイプが離れるかどうかを指定します。
+type: docs
+weight: 363
+url: /ja/java/com.aspose.diagram/shapeplowcode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ShapePlowCode
+```
+
+描画ページ上で別の配置可能なシェイプを対象シェイプの近くにドラッグしたときに、対象シェイプが離れるかどうかを指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [ShapePlowCode(int value)](#ShapePlowCode-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | 描画ページ上で別の配置可能なシェイプを対象シェイプの近くにドラッグしたときに、対象シェイプが離れるかどうかを指定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/shapeplowcode\#getValue--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ShapePlowCode(int value) {#ShapePlowCode-int-}
+```
+public ShapePlowCode(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+描画ページ上で別の配置可能なシェイプを対象シェイプの近くにドラッグしたときに、対象シェイプが離れるかどうかを指定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/shapeplowcode\#getValue--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/shapeplowcodevalue/_index.md
+++ b/japanese/java/com.aspose.diagram/shapeplowcodevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: ShapePlowCodeValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: 描画ページ上で別の配置可能なシェイプを対象シェイプの近くにドラッグしたときに、対象シェイプが離れるかどうかを指定します。
+type: docs
+weight: 364
+url: /ja/java/com.aspose.diagram/shapeplowcodevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ShapePlowCodeValue
+```
+
+描画ページ上で別の配置可能なシェイプを対象シェイプの近くにドラッグしたときに、対象シェイプが離れるかどうかを指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [MOVE_SHAPE](#MOVE-SHAPE) | シェイプを移動します。 |
+| [NOMOVE_SHAPE](#NOMOVE-SHAPE) | シェイプを移動しません。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+| [USE_PAGE_DEFAULT](#USE-PAGE-DEFAULT) | ページのデフォルトを使用します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### MOVE_SHAPE {#MOVE-SHAPE}
+```
+public static final int MOVE_SHAPE
+```
+
+
+シェイプを移動します。
+
+### NOMOVE_SHAPE {#NOMOVE-SHAPE}
+```
+public static final int NOMOVE_SHAPE
+```
+
+
+シェイプを移動しません。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### USE_PAGE_DEFAULT {#USE-PAGE-DEFAULT}
+```
+public static final int USE_PAGE_DEFAULT
+```
+
+
+ページのデフォルトを使用します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/shaperoutestyle/_index.md
+++ b/japanese/java/com.aspose.diagram/shaperoutestyle/_index.md
@@ -1,0 +1,179 @@
+---
+title: ShapeRouteStyle
+second_title: Aspose.Diagram for Java API リファレンス
+description: 描画ページ上のコネクタのルーティング スタイルと方向を指定します。
+type: docs
+weight: 365
+url: /ja/java/com.aspose.diagram/shaperoutestyle/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ShapeRouteStyle
+```
+
+描画ページ上のコネクタのルーティング スタイルと方向を指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [ShapeRouteStyle(int value)](#ShapeRouteStyle-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | 描画ページ上のコネクタのルーティング スタイルと方向を指定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | For the description of this property, please see [getValue()](../../com.aspose.diagram/shaperoutestyle\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ShapeRouteStyle(int value) {#ShapeRouteStyle-int-}
+```
+public ShapeRouteStyle(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+描画ページ上のコネクタのルーティング スタイルと方向を指定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+For the description of this property, please see [getValue()](../../com.aspose.diagram/shaperoutestyle\#getValue--)
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/shaperoutestylevalue/_index.md
+++ b/japanese/java/com.aspose.diagram/shaperoutestylevalue/_index.md
@@ -1,0 +1,345 @@
+---
+title: ShapeRouteStyleValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: 描画ページ上のコネクタのルーティング スタイルと方向を指定します。
+type: docs
+weight: 366
+url: /ja/java/com.aspose.diagram/shaperoutestylevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ShapeRouteStyleValue
+```
+
+描画ページ上のコネクタのルーティング スタイルと方向を指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [CENTER_TO_CENTER](#CENTER-TO-CENTER) | Center to center. |
+| [FLOWCHART_BOTTOM_TO_TOP](#FLOWCHART-BOTTOM-TO-TOP) | Flowchart. |
+| [FLOWCHART_LEFT_TO_RIGHT](#FLOWCHART-LEFT-TO-RIGHT) | Flowchart. |
+| [FLOWCHART_RIGHT_TO_LEFT](#FLOWCHART-RIGHT-TO-LEFT) | Flowchart. |
+| [FLOWCHART_TOP_TO_BOTTOM](#FLOWCHART-TOP-TO-BOTTOM) | Flowchart. |
+| [NETWORK](#NETWORK) | Network |
+| [ORGANIZATION_CHART_BOTTOM_TO_TOP](#ORGANIZATION-CHART-BOTTOM-TO-TOP) | Organization chart. |
+| [ORGANIZATION_CHART_LEFT_TO_RIGHT](#ORGANIZATION-CHART-LEFT-TO-RIGHT) | Organization chart. |
+| [ORGANIZATION_CHART_RIGHT_TO_LEFT](#ORGANIZATION-CHART-RIGHT-TO-LEFT) | Organization chart. |
+| [ORGANIZATION_CHART_TOP_TO_BOTTOM](#ORGANIZATION-CHART-TOP-TO-BOTTOM) | Organization chart. |
+| [PAGE_DEFAULT](#PAGE-DEFAULT) | Page default. |
+| [RIGHT_ANGLE](#RIGHT-ANGLE) | Right angle. |
+| [SIMPLE_BOTTOM_TO_TOP](#SIMPLE-BOTTOM-TO-TOP) | Simple. |
+| [SIMPLE_HORIZONTAL_VERTICAL](#SIMPLE-HORIZONTAL-VERTICAL) | Simple horizontal-vertical. |
+| [SIMPLE_LEFT_TO_RIGHT](#SIMPLE-LEFT-TO-RIGHT) | Simple. |
+| [SIMPLE_RIGHT_TO_LEFT](#SIMPLE-RIGHT-TO-LEFT) | Simple. |
+| [SIMPLE_TOP_TO_BOTTOM](#SIMPLE-TOP-TO-BOTTOM) | Simple. |
+| [SIMPLE_VERTICAL_HORIZONTAL](#SIMPLE-VERTICAL-HORIZONTAL) | Simple vertical-horizontal. |
+| [STRAIGHT](#STRAIGHT) | Straight. |
+| [TREE_BOTTOM_TO_TOP](#TREE-BOTTOM-TO-TOP) | Tree. |
+| [TREE_LEFT_TO_RIGHT](#TREE-LEFT-TO-RIGHT) | Tree. |
+| [TREE_RIGHT_TO_LEFT](#TREE-RIGHT-TO-LEFT) | Tree. |
+| [TREE_TOP_TO_BOTTOM](#TREE-TOP-TO-BOTTOM) | Tree. |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CENTER_TO_CENTER {#CENTER-TO-CENTER}
+```
+public static final int CENTER_TO_CENTER
+```
+
+
+Center to center.
+
+### FLOWCHART_BOTTOM_TO_TOP {#FLOWCHART-BOTTOM-TO-TOP}
+```
+public static final int FLOWCHART_BOTTOM_TO_TOP
+```
+
+
+Flowchart. Bottom to top.
+
+### FLOWCHART_LEFT_TO_RIGHT {#FLOWCHART-LEFT-TO-RIGHT}
+```
+public static final int FLOWCHART_LEFT_TO_RIGHT
+```
+
+
+Flowchart. Left to right.
+
+### FLOWCHART_RIGHT_TO_LEFT {#FLOWCHART-RIGHT-TO-LEFT}
+```
+public static final int FLOWCHART_RIGHT_TO_LEFT
+```
+
+
+Flowchart. Right to left.
+
+### FLOWCHART_TOP_TO_BOTTOM {#FLOWCHART-TOP-TO-BOTTOM}
+```
+public static final int FLOWCHART_TOP_TO_BOTTOM
+```
+
+
+Flowchart. Top to bottom.
+
+### NETWORK {#NETWORK}
+```
+public static final int NETWORK
+```
+
+
+Network
+
+### ORGANIZATION_CHART_BOTTOM_TO_TOP {#ORGANIZATION-CHART-BOTTOM-TO-TOP}
+```
+public static final int ORGANIZATION_CHART_BOTTOM_TO_TOP
+```
+
+
+Organization chart. Bottom to top.
+
+### ORGANIZATION_CHART_LEFT_TO_RIGHT {#ORGANIZATION-CHART-LEFT-TO-RIGHT}
+```
+public static final int ORGANIZATION_CHART_LEFT_TO_RIGHT
+```
+
+
+Organization chart. Left to right.
+
+### ORGANIZATION_CHART_RIGHT_TO_LEFT {#ORGANIZATION-CHART-RIGHT-TO-LEFT}
+```
+public static final int ORGANIZATION_CHART_RIGHT_TO_LEFT
+```
+
+
+Organization chart. Right to left.
+
+### ORGANIZATION_CHART_TOP_TO_BOTTOM {#ORGANIZATION-CHART-TOP-TO-BOTTOM}
+```
+public static final int ORGANIZATION_CHART_TOP_TO_BOTTOM
+```
+
+
+Organization chart. Direction Top to bottom.
+
+### PAGE_DEFAULT {#PAGE-DEFAULT}
+```
+public static final int PAGE_DEFAULT
+```
+
+
+Page default.
+
+### RIGHT_ANGLE {#RIGHT-ANGLE}
+```
+public static final int RIGHT_ANGLE
+```
+
+
+Right angle.
+
+### SIMPLE_BOTTOM_TO_TOP {#SIMPLE-BOTTOM-TO-TOP}
+```
+public static final int SIMPLE_BOTTOM_TO_TOP
+```
+
+
+Simple. Bottom to top.
+
+### SIMPLE_HORIZONTAL_VERTICAL {#SIMPLE-HORIZONTAL-VERTICAL}
+```
+public static final int SIMPLE_HORIZONTAL_VERTICAL
+```
+
+
+Simple horizontal-vertical.
+
+### SIMPLE_LEFT_TO_RIGHT {#SIMPLE-LEFT-TO-RIGHT}
+```
+public static final int SIMPLE_LEFT_TO_RIGHT
+```
+
+
+シンプル。左から右へ。
+
+### SIMPLE_RIGHT_TO_LEFT {#SIMPLE-RIGHT-TO-LEFT}
+```
+public static final int SIMPLE_RIGHT_TO_LEFT
+```
+
+
+シンプル。右から左へ。
+
+### SIMPLE_TOP_TO_BOTTOM {#SIMPLE-TOP-TO-BOTTOM}
+```
+public static final int SIMPLE_TOP_TO_BOTTOM
+```
+
+
+シンプル。上から下へ。
+
+### SIMPLE_VERTICAL_HORIZONTAL {#SIMPLE-VERTICAL-HORIZONTAL}
+```
+public static final int SIMPLE_VERTICAL_HORIZONTAL
+```
+
+
+Simple vertical-horizontal.
+
+### STRAIGHT {#STRAIGHT}
+```
+public static final int STRAIGHT
+```
+
+
+Straight.
+
+### TREE_BOTTOM_TO_TOP {#TREE-BOTTOM-TO-TOP}
+```
+public static final int TREE_BOTTOM_TO_TOP
+```
+
+
+ツリー。下から上へ。
+
+### TREE_LEFT_TO_RIGHT {#TREE-LEFT-TO-RIGHT}
+```
+public static final int TREE_LEFT_TO_RIGHT
+```
+
+
+ツリー。左から右へ
+
+### TREE_RIGHT_TO_LEFT {#TREE-RIGHT-TO-LEFT}
+```
+public static final int TREE_RIGHT_TO_LEFT
+```
+
+
+ツリー。右から左へ。
+
+### TREE_TOP_TO_BOTTOM {#TREE-TOP-TO-BOTTOM}
+```
+public static final int TREE_TOP_TO_BOTTOM
+```
+
+
+ツリー。上から下へ。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/shapeshdwshow/_index.md
+++ b/japanese/java/com.aspose.diagram/shapeshdwshow/_index.md
@@ -1,0 +1,179 @@
+---
+title: ShapeShdwShow
+second_title: Aspose.Diagram for Java API リファレンス
+description: シェイプの影のタイプを指定します。
+type: docs
+weight: 367
+url: /ja/java/com.aspose.diagram/shapeshdwshow/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ShapeShdwShow
+```
+
+シェイプの影のタイプを指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [ShapeShdwShow(int value)](#ShapeShdwShow-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | シェイプの影のタイプを指定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/shapeshdwshow\#getValue--)をご覧ください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ShapeShdwShow(int value) {#ShapeShdwShow-int-}
+```
+public ShapeShdwShow(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+シェイプの影のタイプを指定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/shapeshdwshow\#getValue--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/shapeshdwshowvalue/_index.md
+++ b/japanese/java/com.aspose.diagram/shapeshdwshowvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: ShapeShdwShowValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: シェイプの影のタイプを指定します。
+type: docs
+weight: 368
+url: /ja/java/com.aspose.diagram/shapeshdwshowvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ShapeShdwShowValue
+```
+
+シェイプの影のタイプを指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [ALWAYS_SHOW](#ALWAYS-SHOW) | 影効果セットが常に表示されるように指定します。 |
+| [HAS_GEOM_SHOW](#HAS-GEOM-SHOW) | 影効果セットは、シェイプに Geometry Section\_Type がある場合にのみ表示されるように指定します。 |
+| [TOP_LEVEL_SHOW](#TOP-LEVEL-SHOW) | 影効果セットは、シェイプに Geometry Section\_Type があり、かつシェイプがトップレベルのシェイプである場合にのみ表示されるように指定します。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALWAYS_SHOW {#ALWAYS-SHOW}
+```
+public static final int ALWAYS_SHOW
+```
+
+
+影効果セットが常に表示されるように指定します。
+
+### HAS_GEOM_SHOW {#HAS-GEOM-SHOW}
+```
+public static final int HAS_GEOM_SHOW
+```
+
+
+影効果セットは、シェイプに Geometry Section\_Type がある場合にのみ表示されるように指定します。
+
+### TOP_LEVEL_SHOW {#TOP-LEVEL-SHOW}
+```
+public static final int TOP_LEVEL_SHOW
+```
+
+
+影効果セットは、シェイプに Geometry Section\_Type があり、かつシェイプがトップレベルのシェイプである場合にのみ表示されるように指定します。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/shapeshdwtype/_index.md
+++ b/japanese/java/com.aspose.diagram/shapeshdwtype/_index.md
@@ -1,0 +1,179 @@
+---
+title: ShapeShdwType
+second_title: Aspose.Diagram for Java API リファレンス
+description: シェイプの影のタイプを指定します。
+type: docs
+weight: 369
+url: /ja/java/com.aspose.diagram/shapeshdwtype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ShapeShdwType
+```
+
+シェイプの影のタイプを指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [ShapeShdwType(int value)](#ShapeShdwType-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | シェイプの影のタイプを指定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/shapeshdwtype\#getValue--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ShapeShdwType(int value) {#ShapeShdwType-int-}
+```
+public ShapeShdwType(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+シェイプの影のタイプを指定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/shapeshdwtype\#getValue--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/shapeshdwtypevalue/_index.md
+++ b/japanese/java/com.aspose.diagram/shapeshdwtypevalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: ShapeShdwTypeValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: シェイプの影のタイプを指定します。
+type: docs
+weight: 370
+url: /ja/java/com.aspose.diagram/shapeshdwtypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ShapeShdwTypeValue
+```
+
+シェイプの影のタイプを指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [INNER](#INNER) | Inner |
+| [OBLIQUE](#OBLIQUE) | Oblique. |
+| [SIMPLE](#SIMPLE) | Simple. |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+| [USE_PAGE](#USE-PAGE) | Use page default (the default). |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### INNER {#INNER}
+```
+public static final int INNER
+```
+
+
+Inner
+
+### OBLIQUE {#OBLIQUE}
+```
+public static final int OBLIQUE
+```
+
+
+Oblique.
+
+### SIMPLE {#SIMPLE}
+```
+public static final int SIMPLE
+```
+
+
+Simple.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### USE_PAGE {#USE-PAGE}
+```
+public static final int USE_PAGE
+```
+
+
+Use page default (the default).
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/shdwtype/_index.md
+++ b/japanese/java/com.aspose.diagram/shdwtype/_index.md
@@ -1,0 +1,179 @@
+---
+title: ShdwType
+second_title: Aspose.Diagram for Java API リファレンス
+description: ページのデフォルトの影タイプを示します。
+type: docs
+weight: 371
+url: /ja/java/com.aspose.diagram/shdwtype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ShdwType
+```
+
+ページのデフォルトの影タイプを示します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [ShdwType(int value)](#ShdwType-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | ページのデフォルトの影タイプを示します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/shdwtype\#getValue--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ShdwType(int value) {#ShdwType-int-}
+```
+public ShdwType(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+ページのデフォルトの影タイプを示します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/shdwtype\#getValue--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/shdwtypevalue/_index.md
+++ b/japanese/java/com.aspose.diagram/shdwtypevalue/_index.md
@@ -1,0 +1,156 @@
+---
+title: ShdwTypeValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: ページのデフォルトの影タイプを示します。
+type: docs
+weight: 372
+url: /ja/java/com.aspose.diagram/shdwtypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ShdwTypeValue
+```
+
+ページのデフォルトの影タイプを示します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [OBLIQUE](#OBLIQUE) | Oblique. |
+| [SIMPLE](#SIMPLE) | Simple. |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### OBLIQUE {#OBLIQUE}
+```
+public static final int OBLIQUE
+```
+
+
+Oblique.
+
+### SIMPLE {#SIMPLE}
+```
+public static final int SIMPLE
+```
+
+
+Simple.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/showdropbuttontype/_index.md
+++ b/japanese/java/com.aspose.diagram/showdropbuttontype/_index.md
@@ -1,0 +1,156 @@
+---
+title: ShowDropButtonType
+second_title: Aspose.Diagram for Java API リファレンス
+description: ドロップ ボタンを表示するタイミングを指定します
+type: docs
+weight: 373
+url: /ja/java/com.aspose.diagram/showdropbuttontype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ShowDropButtonType
+```
+
+ドロップ ボタンを表示するタイミングを指定します
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [ALWAYS](#ALWAYS) | 常にドロップボタンを表示する。 |
+| [FOCUS](#FOCUS) | コントロールがフォーカスされているときにドロップボタンを表示します。 |
+| [NEVER](#NEVER) | ドロップボタンを表示しません。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALWAYS {#ALWAYS}
+```
+public static final int ALWAYS
+```
+
+
+常にドロップボタンを表示する。
+
+### FOCUS {#FOCUS}
+```
+public static final int FOCUS
+```
+
+
+コントロールがフォーカスされているときにドロップボタンを表示します。
+
+### NEVER {#NEVER}
+```
+public static final int NEVER
+```
+
+
+ドロップボタンを表示しません。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/smarttagdef/_index.md
+++ b/japanese/java/com.aspose.diagram/smarttagdef/_index.md
@@ -1,0 +1,337 @@
+---
+title: SmartTagDef
+second_title: Aspose.Diagram for Java API リファレンス
+description: シェイプまたはページに定義された各スマート タグの情報を含む要素を含みます。
+type: docs
+weight: 374
+url: /ja/java/com.aspose.diagram/smarttagdef/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class SmartTagDef
+```
+
+シェイプまたはページに定義された各スマート タグの情報を含む要素を含みます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [SmartTagDef()](#SmartTagDef--) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getButtonFace()](#getButtonFace--) | スマートタグボタンに表示されるボタンフェイス画像のIDが含まれています。 |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getDescription()](#getDescription--) | Description 要素は、ユーザーがタグ上でマウスを停止したときにツールチップとして表示される、スマートタグを説明する文字列を含みます。 |
+| [getDisabled()](#getDisabled--) | Disabled 要素は、スマートタグが描画ウィンドウに表示されるかどうかを決定します。 |
+| [getDisplayMode()](#getDisplayMode--) | DisplayMode 要素は、ユーザーがタグ上でマウスを止めたとき、シェイプが選択されたとき、または常にスマート タグを表示するかどうかを決定します。 |
+| [getID()](#getID--) | 要素の親要素内における一意の ID。 |
+| [getName()](#getName--) | 要素の名前。 |
+| [getNameU()](#getNameU--) | 要素のユニバーサル名。 |
+| [getTagName()](#getTagName--) | スマートタグの名前が含まれており、これがキーとしてスマートタグとそのアクションを関連付けます。 |
+| [getX()](#getX--) | スマートタグボタンが配置される形状のローカル座標系における x 座標位置。 |
+| [getXJustify()](#getXJustify--) | X および Y 要素で定義された点に対するスマートタグボタンの x オフセットです。 |
+| [getY()](#getY--) | スマートタグボタンが配置される形状のローカル座標系における y 座標位置。 |
+| [getYJustify()](#getYJustify--) | X および Y 要素で定義された点に対するスマートタグボタンの y オフセットを指定します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | このプロパティの説明については、[getDel()](../../com.aspose.diagram/smarttagdef\#getDel--) を参照してください。 |
+| [setID(int value)](#setID-int-) | このプロパティの説明については、[getID()](../../com.aspose.diagram/smarttagdef\#getID--) を参照してください。 |
+| [setName(String value)](#setName-java.lang.String-) | このプロパティの説明については、[getName()](../../com.aspose.diagram/smarttagdef\#getName--) を参照してください。 |
+| [setNameU(String value)](#setNameU-java.lang.String-) | このプロパティの説明については、[getNameU()](../../com.aspose.diagram/smarttagdef\#getNameU--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SmartTagDef() {#SmartTagDef--}
+```
+public SmartTagDef()
+```
+
+
+コンストラクタ。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getButtonFace() {#getButtonFace--}
+```
+public Str2Value getButtonFace()
+```
+
+
+スマートタグボタンに表示されるボタンフェイス画像のIDが含まれています。
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getDescription() {#getDescription--}
+```
+public Str2Value getDescription()
+```
+
+
+Description 要素は、ユーザーがタグ上でマウスを停止したときにツールチップとして表示される、スマートタグを説明する文字列を含みます。
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getDisabled() {#getDisabled--}
+```
+public BoolValue getDisabled()
+```
+
+
+Disabled 要素は、スマートタグが描画ウィンドウに表示されるかどうかを決定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getDisplayMode() {#getDisplayMode--}
+```
+public DisplayModeSmartTagDef getDisplayMode()
+```
+
+
+DisplayMode 要素は、ユーザーがタグ上でマウスを止めたとき、シェイプが選択されたとき、または常にスマート タグを表示するかどうかを決定します。
+
+**Returns:**
+[DisplayModeSmartTagDef](../../com.aspose.diagram/displaymodesmarttagdef)
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+要素の親要素内における一意の ID。
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素の名前。
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+要素のユニバーサル名。
+
+**Returns:**
+java.lang.String
+### getTagName() {#getTagName--}
+```
+public Str2Value getTagName()
+```
+
+
+スマートタグの名前が含まれており、これがキーとしてスマートタグとそのアクションを関連付けます。
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+スマートタグボタンが配置される形状のローカル座標系における x 座標位置。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getXJustify() {#getXJustify--}
+```
+public XJustify getXJustify()
+```
+
+
+X および Y 要素で定義された点に対するスマートタグボタンの x オフセットです。
+
+**Returns:**
+[XJustify](../../com.aspose.diagram/xjustify)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+スマートタグボタンが配置される形状のローカル座標系における y 座標位置。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getYJustify() {#getYJustify--}
+```
+public YJustify getYJustify()
+```
+
+
+X および Y 要素で定義された点に対するスマートタグボタンの y オフセットを指定します。
+
+**Returns:**
+[YJustify](../../com.aspose.diagram/yjustify)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+このプロパティの説明については、[getDel()](../../com.aspose.diagram/smarttagdef\#getDel--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+このプロパティの説明については、[getID()](../../com.aspose.diagram/smarttagdef\#getID--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+このプロパティの説明については、[getName()](../../com.aspose.diagram/smarttagdef\#getName--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+このプロパティの説明については、[getNameU()](../../com.aspose.diagram/smarttagdef\#getNameU--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/smarttagdefcollection/_index.md
+++ b/japanese/java/com.aspose.diagram/smarttagdefcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: SmartTagDefCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: SmartTagDef コレクション。
+type: docs
+weight: 375
+url: /ja/java/com.aspose.diagram/smarttagdefcollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class SmartTagDefCollection extends Collection
+```
+
+SmartTagDef コレクション。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(SmartTagDef item)](#add-com.aspose.diagram.SmartTagDef-) | コレクションに SmartTagDef オブジェクトを追加します。 |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(SmartTagDef item)](#remove-com.aspose.diagram.SmartTagDef-) | コレクションから SmartTagDef オブジェクトを削除します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(SmartTagDef item) {#add-com.aspose.diagram.SmartTagDef-}
+```
+public int add(SmartTagDef item)
+```
+
+
+コレクションに SmartTagDef オブジェクトを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [SmartTagDef](../../com.aspose.diagram/smarttagdef) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public SmartTagDef get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[SmartTagDef](../../com.aspose.diagram/smarttagdef) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(SmartTagDef item) {#remove-com.aspose.diagram.SmartTagDef-}
+```
+public void remove(SmartTagDef item)
+```
+
+
+コレクションから SmartTagDef オブジェクトを削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [SmartTagDef](../../com.aspose.diagram/smarttagdef) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/smoothingmode/_index.md
+++ b/japanese/java/com.aspose.diagram/smoothingmode/_index.md
@@ -1,0 +1,183 @@
+---
+title: SmoothingMode
+second_title: Aspose.Diagram for Java API リファレンス
+description: 線や曲線、塗りつぶし領域のエッジに対してスムージング（アンチエイリアス）が適用されるかどうかを指定します。
+type: docs
+weight: 376
+url: /ja/java/com.aspose.diagram/smoothingmode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class SmoothingMode
+```
+
+線や曲線、塗りつぶし領域のエッジに平滑化（アンチエイリアス）が適用されるかどうかを指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [ANTI_ALIAS](#ANTI-ALIAS) | アンチエイリアスレンダリングを指定します。 |
+| [DEFAULT](#DEFAULT) | アンチエイリアシングなしを指定します。 |
+| [HIGH_QUALITY](#HIGH-QUALITY) | アンチエイリアスレンダリングを指定します。 |
+| [HIGH_SPEED](#HIGH-SPEED) | アンチエイリアシングなしを指定します。 |
+| [INVALID](#INVALID) | 無効なモードを指定します。 |
+| [NONE](#NONE) | アンチエイリアシングなしを指定します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ANTI_ALIAS {#ANTI-ALIAS}
+```
+public static final int ANTI_ALIAS
+```
+
+
+アンチエイリアスレンダリングを指定します。
+
+### DEFAULT {#DEFAULT}
+```
+public static final int DEFAULT
+```
+
+
+アンチエイリアシングなしを指定します。
+
+### HIGH_QUALITY {#HIGH-QUALITY}
+```
+public static final int HIGH_QUALITY
+```
+
+
+アンチエイリアスレンダリングを指定します。
+
+### HIGH_SPEED {#HIGH-SPEED}
+```
+public static final int HIGH_SPEED
+```
+
+
+アンチエイリアシングなしを指定します。
+
+### INVALID {#INVALID}
+```
+public static final int INVALID
+```
+
+
+無効なモードを指定します。
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+アンチエイリアシングなしを指定します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/snapextensions/_index.md
+++ b/japanese/java/com.aspose.diagram/snapextensions/_index.md
@@ -1,0 +1,264 @@
+---
+title: SnapExtensions
+second_title: Aspose.Diagram for Java API リファレンス
+description: アクティブ ウィンドウに対して特定のスナップ拡張設定が有効か無効かを指定します。
+type: docs
+weight: 377
+url: /ja/java/com.aspose.diagram/snapextensions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class SnapExtensions
+```
+
+Specifies whether a specific snap extension setting is enabled or disabled for the active window. The value can be a sum of the values.
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [ALIGNMENT_BOX_EXTENSION](#ALIGNMENT-BOX-EXTENSION) | Snap to alignment box extension. |
+| [CENTER_AXES](#CENTER-AXES) | Snap to center axis extension. |
+| [CURVE_EXTENSION](#CURVE-EXTENSION) | Snap to curve extension. |
+| [CURVE_TANGENT](#CURVE-TANGENT) | Snap to curve tangent extension. |
+| [ELLIPSE_CENTER](#ELLIPSE-CENTER) | Snap to ellipse center extension. |
+| [ENDPOINT](#ENDPOINT) | Snap to end point extension. |
+| [ENDPOINT_HORIZONTAL](#ENDPOINT-HORIZONTAL) | Snap to end point horizontal extension. |
+| [ENDPOINT_PERPENDICULAR](#ENDPOINT-PERPENDICULAR) | Snap to end point perpendicular extension. |
+| [ENDPOINT_VERTICAL](#ENDPOINT-VERTICAL) | Snap to end point vertical extension. |
+| [ISOMETRIC_ANGLES](#ISOMETRIC-ANGLES) | Snap to isometric angles extension. |
+| [LINEAR_EXTENSION](#LINEAR-EXTENSION) | Snap to linear extension. |
+| [MIDPOINT](#MIDPOINT) | Snap to mid point extension. |
+| [MIDPOINT_PERPENDICULAR](#MIDPOINT-PERPENDICULAR) | Snap to mid point perpendicular extension. |
+| [NONE](#NONE) | 何もスナップしません。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALIGNMENT_BOX_EXTENSION {#ALIGNMENT-BOX-EXTENSION}
+```
+public static final int ALIGNMENT_BOX_EXTENSION
+```
+
+
+Snap to alignment box extension.
+
+### CENTER_AXES {#CENTER-AXES}
+```
+public static final int CENTER_AXES
+```
+
+
+Snap to center axis extension.
+
+### CURVE_EXTENSION {#CURVE-EXTENSION}
+```
+public static final int CURVE_EXTENSION
+```
+
+
+Snap to curve extension.
+
+### CURVE_TANGENT {#CURVE-TANGENT}
+```
+public static final int CURVE_TANGENT
+```
+
+
+Snap to curve tangent extension.
+
+### ELLIPSE_CENTER {#ELLIPSE-CENTER}
+```
+public static final int ELLIPSE_CENTER
+```
+
+
+Snap to ellipse center extension.
+
+### ENDPOINT {#ENDPOINT}
+```
+public static final int ENDPOINT
+```
+
+
+Snap to end point extension.
+
+### ENDPOINT_HORIZONTAL {#ENDPOINT-HORIZONTAL}
+```
+public static final int ENDPOINT_HORIZONTAL
+```
+
+
+Snap to end point horizontal extension.
+
+### ENDPOINT_PERPENDICULAR {#ENDPOINT-PERPENDICULAR}
+```
+public static final int ENDPOINT_PERPENDICULAR
+```
+
+
+Snap to end point perpendicular extension.
+
+### ENDPOINT_VERTICAL {#ENDPOINT-VERTICAL}
+```
+public static final int ENDPOINT_VERTICAL
+```
+
+
+Snap to end point vertical extension.
+
+### ISOMETRIC_ANGLES {#ISOMETRIC-ANGLES}
+```
+public static final int ISOMETRIC_ANGLES
+```
+
+
+Snap to isometric angles extension.
+
+### LINEAR_EXTENSION {#LINEAR-EXTENSION}
+```
+public static final int LINEAR_EXTENSION
+```
+
+
+Snap to linear extension.
+
+### MIDPOINT {#MIDPOINT}
+```
+public static final int MIDPOINT
+```
+
+
+Snap to mid point extension.
+
+### MIDPOINT_PERPENDICULAR {#MIDPOINT-PERPENDICULAR}
+```
+public static final int MIDPOINT_PERPENDICULAR
+```
+
+
+Snap to mid point perpendicular extension.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+何もスナップしません。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/snapextensionsvalue/_index.md
+++ b/japanese/java/com.aspose.diagram/snapextensionsvalue/_index.md
@@ -1,0 +1,264 @@
+---
+title: SnapExtensionsValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: アクティブ ウィンドウに対して特定のスナップ拡張設定が有効か無効かを指定します。
+type: docs
+weight: 378
+url: /ja/java/com.aspose.diagram/snapextensionsvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class SnapExtensionsValue
+```
+
+アクティブウィンドウに対して、特定のスナップ拡張設定が有効か無効かを指定します。値は以下の表の値の合計になる場合があります。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [SNAP_TO_ALIGNMENT_BOX_EXTENSION](#SNAP-TO-ALIGNMENT-BOX-EXTENSION) | Snap to alignment box extension. |
+| [SNAP_TO_CENTER_AXIS_EXTENSION](#SNAP-TO-CENTER-AXIS-EXTENSION) | Snap to center axis extension. |
+| [SNAP_TO_CURVE_EXTENSION](#SNAP-TO-CURVE-EXTENSION) | Snap to curve extension. |
+| [SNAP_TO_CURVE_TANGENT_EXTENSION](#SNAP-TO-CURVE-TANGENT-EXTENSION) | Snap to curve tangent extension. |
+| [SNAP_TO_ELLIPSE_CENTER_EXTENSION](#SNAP-TO-ELLIPSE-CENTER-EXTENSION) | Snap to ellipse center extension. |
+| [SNAP_TO_END_POINT_EXTENSION](#SNAP-TO-END-POINT-EXTENSION) | Snap to end point extension. |
+| [SNAP_TO_END_POINT_HORIZONTAL_EXTENSION](#SNAP-TO-END-POINT-HORIZONTAL-EXTENSION) | Snap to end point horizontal extension. |
+| [SNAP_TO_END_POINT_PERPENDICULAR_EXTENSION](#SNAP-TO-END-POINT-PERPENDICULAR-EXTENSION) | Snap to end point perpendicular extension. |
+| [SNAP_TO_END_POINT_VERTICAL_EXTENSION](#SNAP-TO-END-POINT-VERTICAL-EXTENSION) | Snap to end point vertical extension. |
+| [SNAP_TO_ISOMETRIC_ANGLES_EXTENSION](#SNAP-TO-ISOMETRIC-ANGLES-EXTENSION) | Snap to isometric angles extension. |
+| [SNAP_TO_LINEAR_EXTENSION](#SNAP-TO-LINEAR-EXTENSION) | Snap to linear extension. |
+| [SNAP_TO_MID_POINT_EXTENSION](#SNAP-TO-MID-POINT-EXTENSION) | Snap to mid point extension. |
+| [SNAP_TO_MID_POINT_PERPENDICULAR_EXTENSION](#SNAP-TO-MID-POINT-PERPENDICULAR-EXTENSION) | Snap to mid point perpendicular extension. |
+| [SNAP_TO_NOTHING](#SNAP-TO-NOTHING) | 何もスナップしません。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SNAP_TO_ALIGNMENT_BOX_EXTENSION {#SNAP-TO-ALIGNMENT-BOX-EXTENSION}
+```
+public static final int SNAP_TO_ALIGNMENT_BOX_EXTENSION
+```
+
+
+Snap to alignment box extension.
+
+### SNAP_TO_CENTER_AXIS_EXTENSION {#SNAP-TO-CENTER-AXIS-EXTENSION}
+```
+public static final int SNAP_TO_CENTER_AXIS_EXTENSION
+```
+
+
+Snap to center axis extension.
+
+### SNAP_TO_CURVE_EXTENSION {#SNAP-TO-CURVE-EXTENSION}
+```
+public static final int SNAP_TO_CURVE_EXTENSION
+```
+
+
+Snap to curve extension.
+
+### SNAP_TO_CURVE_TANGENT_EXTENSION {#SNAP-TO-CURVE-TANGENT-EXTENSION}
+```
+public static final int SNAP_TO_CURVE_TANGENT_EXTENSION
+```
+
+
+Snap to curve tangent extension.
+
+### SNAP_TO_ELLIPSE_CENTER_EXTENSION {#SNAP-TO-ELLIPSE-CENTER-EXTENSION}
+```
+public static final int SNAP_TO_ELLIPSE_CENTER_EXTENSION
+```
+
+
+Snap to ellipse center extension.
+
+### SNAP_TO_END_POINT_EXTENSION {#SNAP-TO-END-POINT-EXTENSION}
+```
+public static final int SNAP_TO_END_POINT_EXTENSION
+```
+
+
+Snap to end point extension.
+
+### SNAP_TO_END_POINT_HORIZONTAL_EXTENSION {#SNAP-TO-END-POINT-HORIZONTAL-EXTENSION}
+```
+public static final int SNAP_TO_END_POINT_HORIZONTAL_EXTENSION
+```
+
+
+Snap to end point horizontal extension.
+
+### SNAP_TO_END_POINT_PERPENDICULAR_EXTENSION {#SNAP-TO-END-POINT-PERPENDICULAR-EXTENSION}
+```
+public static final int SNAP_TO_END_POINT_PERPENDICULAR_EXTENSION
+```
+
+
+Snap to end point perpendicular extension.
+
+### SNAP_TO_END_POINT_VERTICAL_EXTENSION {#SNAP-TO-END-POINT-VERTICAL-EXTENSION}
+```
+public static final int SNAP_TO_END_POINT_VERTICAL_EXTENSION
+```
+
+
+Snap to end point vertical extension.
+
+### SNAP_TO_ISOMETRIC_ANGLES_EXTENSION {#SNAP-TO-ISOMETRIC-ANGLES-EXTENSION}
+```
+public static final int SNAP_TO_ISOMETRIC_ANGLES_EXTENSION
+```
+
+
+Snap to isometric angles extension.
+
+### SNAP_TO_LINEAR_EXTENSION {#SNAP-TO-LINEAR-EXTENSION}
+```
+public static final int SNAP_TO_LINEAR_EXTENSION
+```
+
+
+Snap to linear extension.
+
+### SNAP_TO_MID_POINT_EXTENSION {#SNAP-TO-MID-POINT-EXTENSION}
+```
+public static final int SNAP_TO_MID_POINT_EXTENSION
+```
+
+
+Snap to mid point extension.
+
+### SNAP_TO_MID_POINT_PERPENDICULAR_EXTENSION {#SNAP-TO-MID-POINT-PERPENDICULAR-EXTENSION}
+```
+public static final int SNAP_TO_MID_POINT_PERPENDICULAR_EXTENSION
+```
+
+
+Snap to mid point perpendicular extension.
+
+### SNAP_TO_NOTHING {#SNAP-TO-NOTHING}
+```
+public static final int SNAP_TO_NOTHING
+```
+
+
+何もスナップしません。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/snapsettings/_index.md
+++ b/japanese/java/com.aspose.diagram/snapsettings/_index.md
@@ -1,0 +1,246 @@
+---
+title: SnapSettings
+second_title: Aspose.Diagram for Java API リファレンス
+description: ウィンドウでスナップが有効なときにシェイプがスナップするオブジェクトを指定します。
+type: docs
+weight: 379
+url: /ja/java/com.aspose.diagram/snapsettings/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class SnapSettings
+```
+
+Specifies the objects that shapes snap to when snap is active in the window. The value may be a sum of the values.
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [ALIGNMENT_BOX](#ALIGNMENT-BOX) | 配置ボックスにスナップします。 |
+| [CONNECTION_POINTS](#CONNECTION-POINTS) | 接続ポイントにスナップします。 |
+| [DISABLED](#DISABLED) | スナップが無効です。 |
+| [EXTENSIONS](#EXTENSIONS) | シェイプ拡張オプションにスナップします。 |
+| [GEOMETRY](#GEOMETRY) | シェイプの可視エッジにスナップします。 |
+| [GRID](#GRID) | グリッドにスナップします。 |
+| [GUIDES](#GUIDES) | ガイドにスナップします。 |
+| [HANDLES](#HANDLES) | 選択ハンドルにスナップします。 |
+| [INTERSECTIONS](#INTERSECTIONS) | 交点にスナップします。 |
+| [NONE](#NONE) | 何もスナップしません。 |
+| [RULER_SUBDIVISIONS](#RULER-SUBDIVISIONS) | 定規の細分割にスナップします。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+| [VERTICES](#VERTICES) | 頂点にスナップします。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALIGNMENT_BOX {#ALIGNMENT-BOX}
+```
+public static final int ALIGNMENT_BOX
+```
+
+
+配置ボックスにスナップします。
+
+### CONNECTION_POINTS {#CONNECTION-POINTS}
+```
+public static final int CONNECTION_POINTS
+```
+
+
+接続ポイントにスナップします。
+
+### DISABLED {#DISABLED}
+```
+public static final int DISABLED
+```
+
+
+スナップが無効です。
+
+### EXTENSIONS {#EXTENSIONS}
+```
+public static final int EXTENSIONS
+```
+
+
+シェイプ拡張オプションにスナップします。
+
+### GEOMETRY {#GEOMETRY}
+```
+public static final int GEOMETRY
+```
+
+
+シェイプの可視エッジにスナップします。
+
+### GRID {#GRID}
+```
+public static final int GRID
+```
+
+
+グリッドにスナップします。
+
+### GUIDES {#GUIDES}
+```
+public static final int GUIDES
+```
+
+
+ガイドにスナップします。
+
+### HANDLES {#HANDLES}
+```
+public static final int HANDLES
+```
+
+
+選択ハンドルにスナップします。
+
+### INTERSECTIONS {#INTERSECTIONS}
+```
+public static final int INTERSECTIONS
+```
+
+
+交点にスナップします。
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+何もスナップしません。
+
+### RULER_SUBDIVISIONS {#RULER-SUBDIVISIONS}
+```
+public static final int RULER_SUBDIVISIONS
+```
+
+
+定規の細分割にスナップします。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### VERTICES {#VERTICES}
+```
+public static final int VERTICES
+```
+
+
+頂点にスナップします。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/snapsettingsvalue/_index.md
+++ b/japanese/java/com.aspose.diagram/snapsettingsvalue/_index.md
@@ -1,0 +1,246 @@
+---
+title: SnapSettingsValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: ウィンドウでスナップが有効なときにシェイプがスナップするオブジェクトを指定します
+type: docs
+weight: 380
+url: /ja/java/com.aspose.diagram/snapsettingsvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class SnapSettingsValue
+```
+
+ウィンドウでスナップが有効なときにシェイプがスナップするオブジェクトを指定します
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [SNAP_DISABLED](#SNAP-DISABLED) | スナップが無効です。 |
+| [SNAP_TO_ALIGNMENT_BOX](#SNAP-TO-ALIGNMENT-BOX) | 配置ボックスにスナップします。 |
+| [SNAP_TO_CONNECTION_POINTS](#SNAP-TO-CONNECTION-POINTS) | 接続ポイントにスナップします。 |
+| [SNAP_TO_GRID](#SNAP-TO-GRID) | グリッドにスナップします。 |
+| [SNAP_TO_GUIDES](#SNAP-TO-GUIDES) | ガイドにスナップします。 |
+| [SNAP_TO_INTERSECTIONS](#SNAP-TO-INTERSECTIONS) | 交点にスナップします。 |
+| [SNAP_TO_NOTHING](#SNAP-TO-NOTHING) | 何もスナップしません。 |
+| [SNAP_TO_RULER_SUBDIVISIONS](#SNAP-TO-RULER-SUBDIVISIONS) | 定規の細分割にスナップします。 |
+| [SNAP_TO_SELECTION_HANDLES](#SNAP-TO-SELECTION-HANDLES) | 選択ハンドルにスナップします。 |
+| [SNAP_TO_SHAPE_EXTENSIONS_OPTIONS](#SNAP-TO-SHAPE-EXTENSIONS-OPTIONS) | シェイプ拡張オプションにスナップします。 |
+| [SNAP_TO_THE_VISIBLE_EDGES_OF_SHAPES](#SNAP-TO-THE-VISIBLE-EDGES-OF-SHAPES) | シェイプの可視エッジにスナップします。 |
+| [SNAP_TO_VERTICES](#SNAP-TO-VERTICES) | 頂点にスナップします。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SNAP_DISABLED {#SNAP-DISABLED}
+```
+public static final int SNAP_DISABLED
+```
+
+
+スナップが無効です。
+
+### SNAP_TO_ALIGNMENT_BOX {#SNAP-TO-ALIGNMENT-BOX}
+```
+public static final int SNAP_TO_ALIGNMENT_BOX
+```
+
+
+配置ボックスにスナップします。
+
+### SNAP_TO_CONNECTION_POINTS {#SNAP-TO-CONNECTION-POINTS}
+```
+public static final int SNAP_TO_CONNECTION_POINTS
+```
+
+
+接続ポイントにスナップします。
+
+### SNAP_TO_GRID {#SNAP-TO-GRID}
+```
+public static final int SNAP_TO_GRID
+```
+
+
+グリッドにスナップします。
+
+### SNAP_TO_GUIDES {#SNAP-TO-GUIDES}
+```
+public static final int SNAP_TO_GUIDES
+```
+
+
+ガイドにスナップします。
+
+### SNAP_TO_INTERSECTIONS {#SNAP-TO-INTERSECTIONS}
+```
+public static final int SNAP_TO_INTERSECTIONS
+```
+
+
+交点にスナップします。
+
+### SNAP_TO_NOTHING {#SNAP-TO-NOTHING}
+```
+public static final int SNAP_TO_NOTHING
+```
+
+
+何もスナップしません。
+
+### SNAP_TO_RULER_SUBDIVISIONS {#SNAP-TO-RULER-SUBDIVISIONS}
+```
+public static final int SNAP_TO_RULER_SUBDIVISIONS
+```
+
+
+定規の細分割にスナップします。
+
+### SNAP_TO_SELECTION_HANDLES {#SNAP-TO-SELECTION-HANDLES}
+```
+public static final int SNAP_TO_SELECTION_HANDLES
+```
+
+
+選択ハンドルにスナップします。
+
+### SNAP_TO_SHAPE_EXTENSIONS_OPTIONS {#SNAP-TO-SHAPE-EXTENSIONS-OPTIONS}
+```
+public static final int SNAP_TO_SHAPE_EXTENSIONS_OPTIONS
+```
+
+
+シェイプ拡張オプションにスナップします。
+
+### SNAP_TO_THE_VISIBLE_EDGES_OF_SHAPES {#SNAP-TO-THE-VISIBLE-EDGES-OF-SHAPES}
+```
+public static final int SNAP_TO_THE_VISIBLE_EDGES_OF_SHAPES
+```
+
+
+シェイプの可視エッジにスナップします。
+
+### SNAP_TO_VERTICES {#SNAP-TO-VERTICES}
+```
+public static final int SNAP_TO_VERTICES
+```
+
+
+頂点にスナップします。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/solutionxml/_index.md
+++ b/japanese/java/com.aspose.diagram/solutionxml/_index.md
@@ -1,0 +1,214 @@
+---
+title: SolutionXML
+second_title: Aspose.Diagram for Java API リファレンス
+description: ソリューション固有の、明示的な名前空間でプレフィックスが付けられた、整形式の XML データを含み、ドキュメントに格納されます。
+type: docs
+weight: 381
+url: /ja/java/com.aspose.diagram/solutionxml/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class SolutionXML
+```
+
+明示的な名前空間でプレフィックスが付けられ、ドキュメントに保存される、ソリューション固有の整形式 XML データを含みます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [SolutionXML(String name, String xmlValue)](#SolutionXML-java.lang.String-java.lang.String-) | コンストラクタ。 |
+| [SolutionXML()](#SolutionXML--) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | XML データセットを識別するための一意の名前です。 |
+| [getXmlValue()](#getXmlValue--) | 明示的な名前空間でプレフィックスが付けられ、ドキュメントに保存される、ソリューション固有の整形式 XML データを含みます。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setName(String value)](#setName-java.lang.String-) | このプロパティの説明については、[getName()](../../com.aspose.diagram/solutionxml\#getName--) を参照してください。 |
+| [setXmlValue(String value)](#setXmlValue-java.lang.String-) | このプロパティの説明については、[getXmlValue()](../../com.aspose.diagram/solutionxml\#getXmlValue--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SolutionXML(String name, String xmlValue) {#SolutionXML-java.lang.String-java.lang.String-}
+```
+public SolutionXML(String name, String xmlValue)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String |  |
+| xmlValue | java.lang.String |  |
+
+### SolutionXML() {#SolutionXML--}
+```
+public SolutionXML()
+```
+
+
+コンストラクタ。
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+XML データセットを識別するための一意の名前です。
+
+**Returns:**
+java.lang.String
+### getXmlValue() {#getXmlValue--}
+```
+public String getXmlValue()
+```
+
+
+明示的な名前空間でプレフィックスが付けられ、ドキュメントに保存される、ソリューション固有の整形式 XML データを含みます。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+このプロパティの説明については、[getName()](../../com.aspose.diagram/solutionxml\#getName--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setXmlValue(String value) {#setXmlValue-java.lang.String-}
+```
+public void setXmlValue(String value)
+```
+
+
+このプロパティの説明については、[getXmlValue()](../../com.aspose.diagram/solutionxml\#getXmlValue--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/solutionxmlcollection/_index.md
+++ b/japanese/java/com.aspose.diagram/solutionxmlcollection/_index.md
@@ -1,0 +1,234 @@
+---
+title: SolutionXMLCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: SolutionXML コレクション。
+type: docs
+weight: 382
+url: /ja/java/com.aspose.diagram/solutionxmlcollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class SolutionXMLCollection extends Collection
+```
+
+SolutionXML コレクション。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(SolutionXML solutionXml)](#add-com.aspose.diagram.SolutionXML-) | コレクションに SolutionXML を追加します。 |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [get(String name)](#get-java.lang.String-) | 指定された属性Nameの要素を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(SolutionXML solutionXml)](#remove-com.aspose.diagram.SolutionXML-) | コレクションから SolutionXML を削除します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(SolutionXML solutionXml) {#add-com.aspose.diagram.SolutionXML-}
+```
+public int add(SolutionXML solutionXml)
+```
+
+
+コレクションに SolutionXML を追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| solutionXml | [SolutionXML](../../com.aspose.diagram/solutionxml) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public SolutionXML get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[SolutionXML](../../com.aspose.diagram/solutionxml) - 
+### get(String name) {#get-java.lang.String-}
+```
+public SolutionXML get(String name)
+```
+
+
+指定された属性Nameの要素を取得します。要素が存在しない場合は null を返します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String |  |
+
+**Returns:**
+[SolutionXML](../../com.aspose.diagram/solutionxml) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(SolutionXML solutionXml) {#remove-com.aspose.diagram.SolutionXML-}
+```
+public void remove(SolutionXML solutionXml)
+```
+
+
+コレクションから SolutionXML を削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| solutionXml | [SolutionXML](../../com.aspose.diagram/solutionxml) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/spinbuttonactivexcontrol/_index.md
+++ b/japanese/java/com.aspose.diagram/spinbuttonactivexcontrol/_index.md
@@ -1,0 +1,547 @@
+---
+title: SpinButtonActiveXControl
+second_title: Aspose.Diagram for Java API リファレンス
+description: SpinButton コントロールを表します。
+type: docs
+weight: 383
+url: /ja/java/com.aspose.diagram/spinbuttonactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class SpinButtonActiveXControl extends ActiveXControl
+```
+
+SpinButton コントロールを表します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBackOleColor()](#getBackOleColor--) | 背景の OLE カラー。 |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | コントロールのバイナリ データ。 |
+| [getForeOleColor()](#getForeOleColor--) | 前景の OLE カラー。 |
+| [getHeight()](#getHeight--) | ポイント単位のコントロールの高さ。 |
+| [getIMEMode()](#getIMEMode--) | コントロールがフォーカスを受け取る際の Input Method Editor のデフォルト実行時モード。 |
+| [getMax()](#getMax--) | 許容される最大値。 |
+| [getMin()](#getMin--) | 許容される最小値。 |
+| [getMouseIcon()](#getMouseIcon--) | コントロールのマウスポインタとして表示するカスタムアイコンです。 |
+| [getMousePointer()](#getMousePointer--) | コントロールのマウスポインタとして表示されるアイコンの種類です。 |
+| [getOrientation()](#getOrientation--) | SpinButton または ScrollBar が垂直方向か水平方向かを示します。 |
+| [getPosition()](#getPosition--) | 値。 |
+| [getSmallChange()](#getSmallChange--) | Position プロパティが変化する量 |
+| [getType()](#getType--) | ActiveX コントロールのタイプを取得します。 |
+| [getWidth()](#getWidth--) | ポイント単位のコントロールの幅です。 |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | コントロールが全内容を表示するために自動的にサイズ変更されるかどうかを示します。 |
+| [isEnabled()](#isEnabled--) | コントロールがフォーカスを受け取り、ユーザー生成イベントに応答できるかどうかを示します。 |
+| [isLocked()](#isLocked--) | コントロール内のデータが編集ロックされているかどうかを示します。 |
+| [isTransparent()](#isTransparent--) | コントロールが透明かどうかを示します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | このプロパティの説明については、[isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) を参照してください |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | このプロパティの説明については、[getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) を参照してください |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | このプロパティの説明については、[isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) を参照してください |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | このプロパティの説明については、[getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) を参照してください |
+| [setHeight(double value)](#setHeight-double-) | このプロパティの説明については、[getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) を参照してください |
+| [setIMEMode(int value)](#setIMEMode-int-) | このプロパティの説明については、[getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) を参照してください |
+| [setLocked(boolean value)](#setLocked-boolean-) | このプロパティの説明については、[isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) を参照してください |
+| [setMax(int value)](#setMax-int-) | このプロパティの説明については、[getMax()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getMax--) をご覧ください。 |
+| [setMin(int value)](#setMin-int-) | このプロパティの説明については、[getMin()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getMin--) をご覧ください。 |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | このプロパティの説明については、[getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) を参照してください |
+| [setMousePointer(int value)](#setMousePointer-int-) | このプロパティの説明については、[getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) を参照してください |
+| [setOrientation(int value)](#setOrientation-int-) | このプロパティの説明については、[getOrientation()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getOrientation--) をご覧ください。 |
+| [setPosition(int value)](#setPosition-int-) | このプロパティの説明については、[getPosition()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getPosition--) をご覧ください。 |
+| [setSmallChange(int value)](#setSmallChange-int-) | このプロパティの説明については、[getSmallChange()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getSmallChange--) をご覧ください。 |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | このプロパティの説明については、[isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) を参照してください |
+| [setWidth(double value)](#setWidth-double-) | このプロパティの説明については、[getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) を参照してください |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+背景の OLE カラー。
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+コントロールのバイナリ データ。
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+前景の OLE カラーです。Image コントロールには適用されません。
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+ポイント単位のコントロールの高さ。
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+コントロールがフォーカスを受け取る際の Input Method Editor のデフォルト実行時モード。
+
+**Returns:**
+int
+### getMax() {#getMax--}
+```
+public int getMax()
+```
+
+
+許容される最大値。
+
+**Returns:**
+int
+### getMin() {#getMin--}
+```
+public int getMin()
+```
+
+
+許容される最小値。
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+コントロールのマウスポインタとして表示するカスタムアイコンです。
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+コントロールのマウスポインタとして表示されるアイコンの種類です。
+
+**Returns:**
+int
+### getOrientation() {#getOrientation--}
+```
+public int getOrientation()
+```
+
+
+SpinButton または ScrollBar が垂直方向か水平方向かを示します。
+
+**Returns:**
+int
+### getPosition() {#getPosition--}
+```
+public int getPosition()
+```
+
+
+値。
+
+**Returns:**
+int
+### getSmallChange() {#getSmallChange--}
+```
+public int getSmallChange()
+```
+
+
+Position プロパティが変化する量
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+ActiveX コントロールのタイプを取得します。
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+ポイント単位のコントロールの幅です。
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+コントロールが全内容を表示するために自動的にサイズ変更されるかどうかを示します。
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+コントロールがフォーカスを受け取り、ユーザー生成イベントに応答できるかどうかを示します。
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+コントロール内のデータが編集ロックされているかどうかを示します。
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+コントロールが透明かどうかを示します。
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+このプロパティの説明については、[isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+このプロパティの説明については、[getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+このプロパティの説明については、[isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+このプロパティの説明については、[getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+このプロパティの説明については、[getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+このプロパティの説明については、[getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+このプロパティの説明については、[isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setMax(int value) {#setMax-int-}
+```
+public void setMax(int value)
+```
+
+
+このプロパティの説明については、[getMax()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getMax--) をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setMin(int value) {#setMin-int-}
+```
+public void setMin(int value)
+```
+
+
+このプロパティの説明については、[getMin()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getMin--) をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+このプロパティの説明については、[getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+このプロパティの説明については、[getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setOrientation(int value) {#setOrientation-int-}
+```
+public void setOrientation(int value)
+```
+
+
+このプロパティの説明については、[getOrientation()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getOrientation--) をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setPosition(int value) {#setPosition-int-}
+```
+public void setPosition(int value)
+```
+
+
+このプロパティの説明については、[getPosition()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getPosition--) をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setSmallChange(int value) {#setSmallChange-int-}
+```
+public void setSmallChange(int value)
+```
+
+
+このプロパティの説明については、[getSmallChange()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getSmallChange--) をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+このプロパティの説明については、[isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+このプロパティの説明については、[getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/splineknot/_index.md
+++ b/japanese/java/com.aspose.diagram/splineknot/_index.md
@@ -1,0 +1,274 @@
+---
+title: SplineKnot
+second_title: Aspose.Diagram for Java API リファレンス
+description: Contains x- and y-coordinates for a splines control point and a splines knot represented by the X Y and A elements respectively.
+type: docs
+weight: 384
+url: /ja/java/com.aspose.diagram/splineknot/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class SplineKnot extends Coordinate
+```
+
+スプラインの制御点およびスプラインのノットの x および y 座標を含み、これらはそれぞれ X、Y、A 要素で表されます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [SplineKnot()](#SplineKnot--) | Creates an instance of the [SplineKnot](../../com.aspose.diagram/splineknot) class. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | One of the spline's knots (other than the last one or the first two). |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getIX()](#getIX--) | 親要素内の要素のゼロベースインデックスです。 |
+| [getX()](#getX--) | The x-coordinate of a control point. |
+| [getY()](#getY--) | The y-coordinate of a control point. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | For the description of this property, please see [getA()](../../com.aspose.diagram/splineknot\#getA--) |
+| [setDel(int value)](#setDel-int-) | For the description of this property, please see [getDel()](../../com.aspose.diagram/splineknot\#getDel--) |
+| [setIX(int value)](#setIX-int-) | For the description of this property, please see [getIX()](../../com.aspose.diagram/splineknot\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | For the description of this property, please see [getX()](../../com.aspose.diagram/splineknot\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | For the description of this property, please see [getY()](../../com.aspose.diagram/splineknot\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SplineKnot() {#SplineKnot--}
+```
+public SplineKnot()
+```
+
+
+Creates an instance of the [SplineKnot](../../com.aspose.diagram/splineknot) class.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+One of the spline's knots (other than the last one or the first two).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+親要素内の要素のゼロベースインデックスです。
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+The x-coordinate of a control point.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+The y-coordinate of a control point.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+For the description of this property, please see [getA()](../../com.aspose.diagram/splineknot\#getA--)
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+For the description of this property, please see [getDel()](../../com.aspose.diagram/splineknot\#getDel--)
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+For the description of this property, please see [getIX()](../../com.aspose.diagram/splineknot\#getIX--)
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+For the description of this property, please see [getX()](../../com.aspose.diagram/splineknot\#getX--)
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+For the description of this property, please see [getY()](../../com.aspose.diagram/splineknot\#getY--)
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/splineknotcollection/_index.md
+++ b/japanese/java/com.aspose.diagram/splineknotcollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: SplineKnotCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: SplineKnot コレクション。
+type: docs
+weight: 385
+url: /ja/java/com.aspose.diagram/splineknotcollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class SplineKnotCollection extends Collection
+```
+
+SplineKnot コレクション。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public SplineKnot get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[SplineKnot](../../com.aspose.diagram/splineknot) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/splinestart/_index.md
+++ b/japanese/java/com.aspose.diagram/splinestart/_index.md
@@ -1,0 +1,349 @@
+---
+title: SplineStart
+second_title: Aspose.Diagram for Java API リファレンス
+description: スプラインの第2制御点、その第2ノット、第1ノット、最後のノット、およびスプラインの次数の x および y 座標を含みます。
+type: docs
+weight: 386
+url: /ja/java/com.aspose.diagram/splinestart/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class SplineStart extends Coordinate
+```
+
+スプラインの第2制御点、その第2ノット、第1ノット、最後のノット、およびスプラインの次数の x および y 座標を含みます。この情報はそれぞれ X、Y、A、B、C、D 要素に格納されています。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [SplineStart()](#SplineStart--) | [SplineStart](../../com.aspose.diagram/splinestart) クラスのインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | スプラインの第2ノット。 |
+| [getB()](#getB--) | スプラインの第1ノット。 |
+| [getC()](#getC--) | スプラインの最後のノット。 |
+| [getClass()](#getClass--) |  |
+| [getD()](#getD--) | スプラインの次数（1 から 25 の整数）。 |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getIX()](#getIX--) | 親要素内の要素のゼロベースインデックスです。 |
+| [getX()](#getX--) | スプラインの第2制御点の x 座標。 |
+| [getY()](#getY--) | スプラインの第2制御点の y 座標。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getA()](../../com.aspose.diagram/splinestart\#getA--) を参照してください |
+| [setB(DoubleValue value)](#setB-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getB()](../../com.aspose.diagram/splinestart\#getB--) を参照してください |
+| [setC(DoubleValue value)](#setC-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getC()](../../com.aspose.diagram/splinestart\#getC--) を参照してください |
+| [setD(IntValue value)](#setD-com.aspose.diagram.IntValue-) | このプロパティの説明については、[getD()](../../com.aspose.diagram/splinestart\#getD--) を参照してください |
+| [setDel(int value)](#setDel-int-) | このプロパティの説明については、[getDel()](../../com.aspose.diagram/splinestart\#getDel--) を参照してください |
+| [setIX(int value)](#setIX-int-) | このプロパティの説明については、[getIX()](../../com.aspose.diagram/splinestart\#getIX--) を参照してください |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getX()](../../com.aspose.diagram/splinestart\#getX--)をご覧ください。 |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getY()](../../com.aspose.diagram/splinestart\#getY--)をご覧ください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SplineStart() {#SplineStart--}
+```
+public SplineStart()
+```
+
+
+[SplineStart](../../com.aspose.diagram/splinestart) クラスのインスタンスを作成します。
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+スプラインの第2ノット。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getB() {#getB--}
+```
+public DoubleValue getB()
+```
+
+
+スプラインの第1ノット。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getC() {#getC--}
+```
+public DoubleValue getC()
+```
+
+
+スプラインの最後のノット。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getD() {#getD--}
+```
+public IntValue getD()
+```
+
+
+スプラインの次数（1 から 25 の整数）。
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+親要素内の要素のゼロベースインデックスです。
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+スプラインの第2制御点の x 座標。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+スプラインの第2制御点の y 座標。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getA()](../../com.aspose.diagram/splinestart\#getA--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setB(DoubleValue value) {#setB-com.aspose.diagram.DoubleValue-}
+```
+public void setB(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getB()](../../com.aspose.diagram/splinestart\#getB--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setC(DoubleValue value) {#setC-com.aspose.diagram.DoubleValue-}
+```
+public void setC(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getC()](../../com.aspose.diagram/splinestart\#getC--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setD(IntValue value) {#setD-com.aspose.diagram.IntValue-}
+```
+public void setD(IntValue value)
+```
+
+
+このプロパティの説明については、[getD()](../../com.aspose.diagram/splinestart\#getD--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+このプロパティの説明については、[getDel()](../../com.aspose.diagram/splinestart\#getDel--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+このプロパティの説明については、[getIX()](../../com.aspose.diagram/splinestart\#getIX--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getX()](../../com.aspose.diagram/splinestart\#getX--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getY()](../../com.aspose.diagram/splinestart\#getY--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/splinestartcollection/_index.md
+++ b/japanese/java/com.aspose.diagram/splinestartcollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: SplineStartCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: SplineStart コレクション。
+type: docs
+weight: 387
+url: /ja/java/com.aspose.diagram/splinestartcollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class SplineStartCollection extends Collection
+```
+
+SplineStart コレクション。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public SplineStart get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[SplineStart](../../com.aspose.diagram/splinestart) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/str2value/_index.md
+++ b/japanese/java/com.aspose.diagram/str2value/_index.md
@@ -1,0 +1,244 @@
+---
+title: Str2Value
+second_title: Aspose.Diagram for Java API リファレンス
+description: 文字列の値。
+type: docs
+weight: 388
+url: /ja/java/com.aspose.diagram/str2value/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.StrValue](../../com.aspose.diagram/strvalue)
+```
+public class Str2Value extends StrValue
+```
+
+文字列の値。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Str2Value(String value)](#Str2Value-java.lang.String-) | コンストラクタ。 |
+| [Str2Value(String value, UnitFormulaErrV ufev)](#Str2Value-java.lang.String-com.aspose.diagram.UnitFormulaErrV-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性。 |
+| [getUfev()](#getUfev--) | 要素の属性。 |
+| [getValue()](#getValue--) | 文字列の値。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | このプロパティの説明については、[getUfe()](../../com.aspose.diagram/strvalue\#getUfe--) を参照してください。 |
+| [setUfev(UnitFormulaErrV value)](#setUfev-com.aspose.diagram.UnitFormulaErrV-) | このプロパティの説明については、[getUfev()](../../com.aspose.diagram/str2value\#getUfev--) を参照してください。 |
+| [setValue(String value)](#setValue-java.lang.String-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/strvalue\#getValue--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Str2Value(String value) {#Str2Value-java.lang.String-}
+```
+public Str2Value(String value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### Str2Value(String value, UnitFormulaErrV ufev) {#Str2Value-java.lang.String-com.aspose.diagram.UnitFormulaErrV-}
+```
+public Str2Value(String value, UnitFormulaErrV ufev)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+| ufev | [UnitFormulaErrV](../../com.aspose.diagram/unitformulaerrv) |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getUfev() {#getUfev--}
+```
+public UnitFormulaErrV getUfev()
+```
+
+
+要素の属性。
+
+**Returns:**
+[UnitFormulaErrV](../../com.aspose.diagram/unitformulaerrv)
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+文字列の値。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+このプロパティの説明については、[getUfe()](../../com.aspose.diagram/strvalue\#getUfe--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setUfev(UnitFormulaErrV value) {#setUfev-com.aspose.diagram.UnitFormulaErrV-}
+```
+public void setUfev(UnitFormulaErrV value)
+```
+
+
+このプロパティの説明については、[getUfev()](../../com.aspose.diagram/str2value\#getUfev--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [UnitFormulaErrV](../../com.aspose.diagram/unitformulaerrv) |  |
+
+### setValue(String value) {#setValue-java.lang.String-}
+```
+public void setValue(String value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/strvalue\#getValue--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/streamprovideroptions/_index.md
+++ b/japanese/java/com.aspose.diagram/streamprovideroptions/_index.md
@@ -1,0 +1,186 @@
+---
+title: StreamProviderOptions
+second_title: Aspose.Diagram for Java API リファレンス
+description: ストリーム オプションを表します。
+type: docs
+weight: 390
+url: /ja/java/com.aspose.diagram/streamprovideroptions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class StreamProviderOptions
+```
+
+ストリーム オプションを表します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [StreamProviderOptions()](#StreamProviderOptions--) |  |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDefaultPath()](#getDefaultPath--) | 参照されたソースのために生成された HTML ファイルに保存されるデフォルトのパス（URL）。 |
+| [getStream()](#getStream--) | 保存されたデータを書き込む出力ストリームを取得/設定します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCustomPath(String value)](#setCustomPath-java.lang.String-) | 参照されたソースのために生成された HTML ファイルに保存されるユーザーカスタムパス（URL）。 |
+| [setStream(OutputStream value)](#setStream-java.io.OutputStream-) | このプロパティの説明については、[getStream()](../../com.aspose.diagram/streamprovideroptions\#getStream--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### StreamProviderOptions() {#StreamProviderOptions--}
+```
+public StreamProviderOptions()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultPath() {#getDefaultPath--}
+```
+public String getDefaultPath()
+```
+
+
+参照されたソースのために生成された HTML ファイルに保存されるデフォルトのパス（URL）。例えば、シートデータが xxx\_files/sheet001.htm に保存される場合、メイン HTML ファイルで使用される URL は "src=\"xxx\_files/sheet001.htm\"" のようになる必要があります。
+
+**Returns:**
+java.lang.String
+### getStream() {#getStream--}
+```
+public OutputStream getStream()
+```
+
+
+保存されたデータを書き込む出力ストリームを取得/設定します。
+
+**Returns:**
+java.io.OutputStream
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCustomPath(String value) {#setCustomPath-java.lang.String-}
+```
+public void setCustomPath(String value)
+```
+
+
+参照されたソースのために生成された HTML ファイルに保存されるユーザーカスタムパス（URL）。ユーザーが定義しない場合は DefaultPath が使用されます。例えば、シートデータがユーザーによって d:/sheet001.htm に保存される場合、メイン HTML ファイルで使用される URL は "d:/sheet001.htm" もしくはメイン HTML ファイルからアクセス可能な他の有効な相対パスである必要があります。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setStream(OutputStream value) {#setStream-java.io.OutputStream-}
+```
+public void setStream(OutputStream value)
+```
+
+
+このプロパティの説明については、[getStream()](../../com.aspose.diagram/streamprovideroptions\#getStream--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.io.OutputStream |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/strvalue/_index.md
+++ b/japanese/java/com.aspose.diagram/strvalue/_index.md
@@ -1,0 +1,234 @@
+---
+title: StrValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: 文字列の値
+type: docs
+weight: 389
+url: /ja/java/com.aspose.diagram/strvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class StrValue
+```
+
+文字列の値
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [StrValue(String value)](#StrValue-java.lang.String-) | コンストラクタ。 |
+| [StrValue(String value, UnitFormulaErr ufe)](#StrValue-java.lang.String-com.aspose.diagram.UnitFormulaErr-) | コンストラクタ。 |
+| [StrValue(String value, int unit)](#StrValue-java.lang.String-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性。 |
+| [getValue()](#getValue--) | 文字列の値。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | このプロパティの説明については、[getUfe()](../../com.aspose.diagram/strvalue\#getUfe--) を参照してください。 |
+| [setValue(String value)](#setValue-java.lang.String-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/strvalue\#getValue--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### StrValue(String value) {#StrValue-java.lang.String-}
+```
+public StrValue(String value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### StrValue(String value, UnitFormulaErr ufe) {#StrValue-java.lang.String-com.aspose.diagram.UnitFormulaErr-}
+```
+public StrValue(String value, UnitFormulaErr ufe)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+| ufe | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### StrValue(String value, int unit) {#StrValue-java.lang.String-int-}
+```
+public StrValue(String value, int unit)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+| 単位 | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+文字列の値。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+このプロパティの説明については、[getUfe()](../../com.aspose.diagram/strvalue\#getUfe--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(String value) {#setValue-java.lang.String-}
+```
+public void setValue(String value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/strvalue\#getValue--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/style/_index.md
+++ b/japanese/java/com.aspose.diagram/style/_index.md
@@ -1,0 +1,204 @@
+---
+title: Style
+second_title: Aspose.Diagram for Java API リファレンス
+description: Specifies the character formatting applied to a range of text in the shapes text block.
+type: docs
+weight: 391
+url: /ja/java/com.aspose.diagram/style/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Style
+```
+
+シェイプのテキスト ブロック内のテキスト範囲に適用される文字書式設定を指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Style(int value)](#Style-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | シェイプのテキスト ブロック内のテキスト範囲に適用される文字書式設定を指定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | For the description of this property, please see [getUfe()](../../com.aspose.diagram/style\#getUfe--) |
+| [setValue(int value)](#setValue-int-) | For the description of this property, please see [getValue()](../../com.aspose.diagram/style\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Style(int value) {#Style-int-}
+```
+public Style(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+シェイプのテキスト ブロック内のテキスト範囲に適用される文字書式設定を指定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+For the description of this property, please see [getUfe()](../../com.aspose.diagram/style\#getUfe--)
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+For the description of this property, please see [getValue()](../../com.aspose.diagram/style\#getValue--)
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/styleprop/_index.md
+++ b/japanese/java/com.aspose.diagram/styleprop/_index.md
@@ -1,0 +1,194 @@
+---
+title: StyleProp
+second_title: Aspose.Diagram for Java API リファレンス
+description: スタイルの動作（テキストラインや塗り属性を含むかどうか）を制御する要素を含みます。
+type: docs
+weight: 392
+url: /ja/java/com.aspose.diagram/styleprop/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class StyleProp
+```
+
+スタイルがテキスト、ライン、塗りつぶし属性を含むかどうかなど、スタイルの動作を制御する要素を含みます。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getEnableFillProps()](#getEnableFillProps--) | スタイルが塗りプロパティを含むかどうかを指定します。 |
+| [getEnableLineProps()](#getEnableLineProps--) | スタイルに線のプロパティが含まれるかどうかを指定します |
+| [getEnableTextProps()](#getEnableTextProps--) | スタイルにテキストのプロパティが含まれるかどうかを指定します。 |
+| [getHideForApply()](#getHideForApply--) | Microsoft Visio ユーザーインターフェイスでスタイルが表示される場所を指定します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | このプロパティの説明については、[getDel()](../../com.aspose.diagram/styleprop\#getDel--) を参照してください |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getEnableFillProps() {#getEnableFillProps--}
+```
+public BoolValue getEnableFillProps()
+```
+
+
+スタイルが塗りプロパティを含むかどうかを指定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getEnableLineProps() {#getEnableLineProps--}
+```
+public BoolValue getEnableLineProps()
+```
+
+
+スタイルに線のプロパティが含まれるかどうかを指定します
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getEnableTextProps() {#getEnableTextProps--}
+```
+public BoolValue getEnableTextProps()
+```
+
+
+スタイルにテキストのプロパティが含まれるかどうかを指定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getHideForApply() {#getHideForApply--}
+```
+public BoolValue getHideForApply()
+```
+
+
+Microsoft Visio ユーザーインターフェイスでスタイルが表示される場所を指定します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+このプロパティの説明については、[getDel()](../../com.aspose.diagram/styleprop\#getDel--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/stylesheet/_index.md
+++ b/japanese/java/com.aspose.diagram/stylesheet/_index.md
@@ -1,0 +1,519 @@
+---
+title: StyleSheet
+second_title: Aspose.Diagram for Java API リファレンス
+description: ドキュメントで定義されたスタイルを表します。
+type: docs
+weight: 393
+url: /ja/java/com.aspose.diagram/stylesheet/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class StyleSheet
+```
+
+ドキュメントで定義されたスタイルを表します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [StyleSheet()](#StyleSheet--) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getChars()](#getChars--) | Char 要素のコレクションを含みます。 |
+| [getClass()](#getClass--) |  |
+| [getConnectionABCDs()](#getConnectionABCDs--) | ConnectionABCD 要素のコレクションを含みます。 |
+| [getConnections()](#getConnections--) | Connection 要素のコレクションを含みます。 |
+| [getEvent()](#getEvent--) | シェイプ イベントを制御する数式を指定する要素を含みます。 |
+| [getFill()](#getFill--) | シェイプとシェイプのドロップシャドウの現在の塗りつぶし書式設定値を含み、パターン、前景色、背景色が含まれます。 |
+| [getFillStyle()](#getFillStyle--) | このスタイルが塗りつぶし書式を継承する StyleSheet 要素。 |
+| [getForeign()](#getForeign--) | Microsoft Visio ドキュメントで使用される別のプログラムからのオブジェクトの幅と高さを指定する要素を含みます。 |
+| [getForeignData()](#getForeignData--) | Windows メタファイル、ビットマップ、または OLE データなどの画像データの MIME (Multipurpose Internet Mail Extensions) エンコード BLOB を含みます。 |
+| [getGroup()](#getGroup--) | グループにシェイプを追加する方法、グループのメンバーを移動する方法、グループを選択する方法を制御する要素を含みます。 |
+| [getHelp()](#getHelp--) | Shape 要素のヘルプファイルトピックと著作権情報を指定する要素を含みます。 |
+| [getID()](#getID--) | 要素の親要素内における一意の ID。 |
+| [getImage()](#getImage--) | ビットマップのガンマ、明るさ、コントラスト、ぼかし、シャープ、ノイズ除去、透明度の値を含みます。 |
+| [getLayout()](#getLayout--) | シェイプの配置とコネクタのルーティング設定を制御する要素を含みます。 |
+| [getLine()](#getLine--) | パターン、太さ、色など、シェイプの線属性を制御する要素を含みます。 |
+| [getLineStyle()](#getLineStyle--) | このスタイルが線書式を継承する StyleSheet 要素。 |
+| [getMisc()](#getMisc--) | Shape 要素のヘルプファイルトピックと著作権情報を指定する要素を含みます。 |
+| [getName()](#getName--) | 要素の名前。 |
+| [getNameU()](#getNameU--) | 要素のユニバーサル名。 |
+| [getPageLayout()](#getPageLayout--) | ページ上のすべての図形やコネクタの間隔、ページ上のすべてのコネクタの間隔、コネクタのルーティングスタイルなど、図形とコネクタのページレイアウト設定を制御する Diagram を含みます。 |
+| [getParas()](#getParas--) | Para 要素のコレクションを含みます。 |
+| [getProtection()](#getProtection--) | ロックはシェイプへの偶発的な変更を防止するのに役立ちますが、他の状況で Microsoft Visio が値をリセットすることは防げません。 |
+| [getRulerGrid()](#getRulerGrid--) | ページの定規とグリッドの設定を指定する要素を含みます。 |
+| [getStyleProp()](#getStyleProp--) | スタイルがテキスト、ライン、塗りつぶし属性を含むかどうかなど、スタイルの動作を制御する要素を含みます。 |
+| [getTabsCollection()](#getTabsCollection--) | Tab 要素のコレクションを含みます。 |
+| [getTextBlock()](#getTextBlock--) | シェイプのテキスト ブロック内のテキストの配置、余白、デフォルトのタブ位置を指定する要素を含みます。 |
+| [getTextStyle()](#getTextStyle--) | このスタイルがテキスト書式を継承する StyleSheet 要素。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setFillStyle(StyleSheet value)](#setFillStyle-com.aspose.diagram.StyleSheet-) | このプロパティの説明については、[getFillStyle()](../../com.aspose.diagram/stylesheet\#getFillStyle--) を参照してください。 |
+| [setID(int value)](#setID-int-) | このプロパティの説明については、[getID()](../../com.aspose.diagram/stylesheet\#getID--) を参照してください。 |
+| [setLineStyle(StyleSheet value)](#setLineStyle-com.aspose.diagram.StyleSheet-) | このプロパティの説明については、[getLineStyle()](../../com.aspose.diagram/stylesheet\#getLineStyle--) を参照してください。 |
+| [setName(String value)](#setName-java.lang.String-) | このプロパティの説明については、[getName()](../../com.aspose.diagram/stylesheet\#getName--) を参照してください。 |
+| [setNameU(String value)](#setNameU-java.lang.String-) | このプロパティの説明については、[getNameU()](../../com.aspose.diagram/stylesheet\#getNameU--) を参照してください。 |
+| [setTextStyle(StyleSheet value)](#setTextStyle-com.aspose.diagram.StyleSheet-) | このプロパティの説明については、[getTextStyle()](../../com.aspose.diagram/stylesheet\#getTextStyle--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### StyleSheet() {#StyleSheet--}
+```
+public StyleSheet()
+```
+
+
+コンストラクタ。
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getChars() {#getChars--}
+```
+public CharCollection getChars()
+```
+
+
+Char 要素のコレクションを含みます。
+
+**Returns:**
+[CharCollection](../../com.aspose.diagram/charcollection)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConnectionABCDs() {#getConnectionABCDs--}
+```
+public ConnectionABCDCollection getConnectionABCDs()
+```
+
+
+ConnectionABCD 要素のコレクションを含みます。
+
+**Returns:**
+[ConnectionABCDCollection](../../com.aspose.diagram/connectionabcdcollection)
+### getConnections() {#getConnections--}
+```
+public ConnectionCollection getConnections()
+```
+
+
+Connection 要素のコレクションを含みます。
+
+**Returns:**
+[ConnectionCollection](../../com.aspose.diagram/connectioncollection)
+### getEvent() {#getEvent--}
+```
+public Event getEvent()
+```
+
+
+シェイプ イベントを制御する数式を指定する要素を含みます。
+
+**Returns:**
+[Event](../../com.aspose.diagram/event)
+### getFill() {#getFill--}
+```
+public Fill getFill()
+```
+
+
+シェイプとシェイプのドロップシャドウの現在の塗りつぶし書式設定値を含み、パターン、前景色、背景色が含まれます。
+
+**Returns:**
+[Fill](../../com.aspose.diagram/fill)
+### getFillStyle() {#getFillStyle--}
+```
+public StyleSheet getFillStyle()
+```
+
+
+このスタイルが塗りつぶし書式を継承する StyleSheet 要素。
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getForeign() {#getForeign--}
+```
+public Foreign getForeign()
+```
+
+
+Microsoft Visio ドキュメントで使用される他のプログラムからのオブジェクトの幅と高さを指定する要素を含みます。また、オブジェクトの画像が境界内でオフセットされる距離を指定する要素も含みます。
+
+**Returns:**
+[Foreign](../../com.aspose.diagram/foreign)
+### getForeignData() {#getForeignData--}
+```
+public ForeignData getForeignData()
+```
+
+
+Windows メタファイル、ビットマップ、または OLE データなどの画像データの MIME (Multipurpose Internet Mail Extensions) エンコード BLOB を含みます。
+
+**Returns:**
+[ForeignData](../../com.aspose.diagram/foreigndata)
+### getGroup() {#getGroup--}
+```
+public Group getGroup()
+```
+
+
+グループにシェイプを追加する方法、グループのメンバーを移動する方法、グループを選択する方法を制御する要素を含みます。
+
+**Returns:**
+[Group](../../com.aspose.diagram/group)
+### getHelp() {#getHelp--}
+```
+public Help getHelp()
+```
+
+
+Shape 要素のヘルプファイルトピックと著作権情報を指定する要素を含みます。
+
+**Returns:**
+[Help](../../com.aspose.diagram/help)
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+要素の親要素内における一意の ID。
+
+**Returns:**
+int
+### getImage() {#getImage--}
+```
+public Image getImage()
+```
+
+
+ビットマップのガンマ、明るさ、コントラスト、ぼかし、シャープ、ノイズ除去、透明度の値を含みます。
+
+**Returns:**
+[Image](../../com.aspose.diagram/image)
+### getLayout() {#getLayout--}
+```
+public Layout getLayout()
+```
+
+
+シェイプの配置とコネクタのルーティング設定を制御する要素を含みます。
+
+**Returns:**
+[Layout](../../com.aspose.diagram/layout)
+### getLine() {#getLine--}
+```
+public Line getLine()
+```
+
+
+シェイプの線属性（パターン、太さ、色など）を制御する要素が含まれます。これらの要素は、線端が書式設定されているか（例: 矢じり）、線端書式のサイズ、線に適用される丸みの円の半径、そして線のキャップスタイル（丸形または四角形）を決定します。
+
+**Returns:**
+[Line](../../com.aspose.diagram/line)
+### getLineStyle() {#getLineStyle--}
+```
+public StyleSheet getLineStyle()
+```
+
+
+このスタイルが線書式を継承する StyleSheet 要素。
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getMisc() {#getMisc--}
+```
+public Misc getMisc()
+```
+
+
+Shape 要素のヘルプファイルトピックと著作権情報を指定する要素を含みます。
+
+**Returns:**
+[Misc](../../com.aspose.diagram/misc)
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素の名前。
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+要素のユニバーサル名。
+
+**Returns:**
+java.lang.String
+### getPageLayout() {#getPageLayout--}
+```
+public PageLayout getPageLayout()
+```
+
+
+ページ上のすべての図形やコネクタの間隔、ページ上のすべてのコネクタの間隔、コネクタのルーティングスタイルなど、図形とコネクタのページレイアウト設定を制御する Diagram を含みます。
+
+**Returns:**
+[PageLayout](../../com.aspose.diagram/pagelayout)
+### getParas() {#getParas--}
+```
+public ParaCollection getParas()
+```
+
+
+Para 要素のコレクションを含みます。
+
+**Returns:**
+[ParaCollection](../../com.aspose.diagram/paracollection)
+### getProtection() {#getProtection--}
+```
+public Protection getProtection()
+```
+
+
+ロック機能はシェイプへの偶発的な変更を防止するのに役立ちますが、他の状況で Microsoft Visio が値をリセットすることは防げません。また、ShapeSheet ウィンドウで行われた変更からも保護されません。
+
+**Returns:**
+[Protection](../../com.aspose.diagram/protection)
+### getRulerGrid() {#getRulerGrid--}
+```
+public RulerGrid getRulerGrid()
+```
+
+
+ページの定規とグリッドの設定を指定する要素を含みます。
+
+**Returns:**
+[RulerGrid](../../com.aspose.diagram/rulergrid)
+### getStyleProp() {#getStyleProp--}
+```
+public StyleProp getStyleProp()
+```
+
+
+スタイルがテキスト、ライン、塗りつぶし属性を含むかどうかなど、スタイルの動作を制御する要素を含みます。
+
+**Returns:**
+[StyleProp](../../com.aspose.diagram/styleprop)
+### getTabsCollection() {#getTabsCollection--}
+```
+public TabsCollection getTabsCollection()
+```
+
+
+Tab 要素のコレクションを含みます。
+
+**Returns:**
+[TabsCollection](../../com.aspose.diagram/tabscollection)
+### getTextBlock() {#getTextBlock--}
+```
+public TextBlock getTextBlock()
+```
+
+
+シェイプのテキスト ブロック内のテキストの配置、余白、デフォルトのタブ位置を指定する要素を含みます。
+
+**Returns:**
+[TextBlock](../../com.aspose.diagram/textblock)
+### getTextStyle() {#getTextStyle--}
+```
+public StyleSheet getTextStyle()
+```
+
+
+このスタイルがテキスト書式を継承する StyleSheet 要素。
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setFillStyle(StyleSheet value) {#setFillStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setFillStyle(StyleSheet value)
+```
+
+
+このプロパティの説明については、[getFillStyle()](../../com.aspose.diagram/stylesheet\#getFillStyle--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+このプロパティの説明については、[getID()](../../com.aspose.diagram/stylesheet\#getID--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setLineStyle(StyleSheet value) {#setLineStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setLineStyle(StyleSheet value)
+```
+
+
+このプロパティの説明については、[getLineStyle()](../../com.aspose.diagram/stylesheet\#getLineStyle--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+このプロパティの説明については、[getName()](../../com.aspose.diagram/stylesheet\#getName--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+このプロパティの説明については、[getNameU()](../../com.aspose.diagram/stylesheet\#getNameU--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setTextStyle(StyleSheet value) {#setTextStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setTextStyle(StyleSheet value)
+```
+
+
+このプロパティの説明については、[getTextStyle()](../../com.aspose.diagram/stylesheet\#getTextStyle--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/stylesheetcollection/_index.md
+++ b/japanese/java/com.aspose.diagram/stylesheetcollection/_index.md
@@ -1,0 +1,234 @@
+---
+title: StyleSheetCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: StyleSheets のコレクション。
+type: docs
+weight: 394
+url: /ja/java/com.aspose.diagram/stylesheetcollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class StyleSheetCollection extends Collection
+```
+
+StyleSheets のコレクション。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(StyleSheet item)](#add-com.aspose.diagram.StyleSheet-) | コレクションに StyleSheet を追加します。 |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [getStyleSheet(int ID)](#getStyleSheet-int-) | 指定された ID の要素を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(StyleSheet item)](#remove-com.aspose.diagram.StyleSheet-) | コレクションから StyleSheet を削除します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(StyleSheet item) {#add-com.aspose.diagram.StyleSheet-}
+```
+public int add(StyleSheet item)
+```
+
+
+コレクションに StyleSheet を追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public StyleSheet get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### getStyleSheet(int ID) {#getStyleSheet-int-}
+```
+public StyleSheet getStyleSheet(int ID)
+```
+
+
+指定された ID の要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ID | int |  |
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet) - 
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(StyleSheet item) {#remove-com.aspose.diagram.StyleSheet-}
+```
+public void remove(StyleSheet item)
+```
+
+
+コレクションから StyleSheet を削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/stylevalue/_index.md
+++ b/japanese/java/com.aspose.diagram/stylevalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: StyleValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: Specifies the character formatting applied to a range of text in the shapes text block.
+type: docs
+weight: 395
+url: /ja/java/com.aspose.diagram/stylevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class StyleValue
+```
+
+シェイプのテキスト ブロック内のテキスト範囲に適用される文字書式設定を指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [BOLD](#BOLD) | Bold. |
+| [ITALIC](#ITALIC) | Italic. |
+| [SMALL_CAPS](#SMALL-CAPS) | Small caps. |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+| [UNDERLINE](#UNDERLINE) | Underline. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOLD {#BOLD}
+```
+public static final int BOLD
+```
+
+
+Bold.
+
+### ITALIC {#ITALIC}
+```
+public static final int ITALIC
+```
+
+
+Italic.
+
+### SMALL_CAPS {#SMALL-CAPS}
+```
+public static final int SMALL_CAPS
+```
+
+
+Small caps.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### UNDERLINE {#UNDERLINE}
+```
+public static final int UNDERLINE
+```
+
+
+Underline.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/svgsaveoptions/_index.md
+++ b/japanese/java/com.aspose.diagram/svgsaveoptions/_index.md
@@ -1,0 +1,604 @@
+---
+title: SVGSaveOptions
+second_title: Aspose.Diagram for Java API リファレンス
+description: 図ページを SVG にレンダリングする際に追加オプションを指定できます。
+type: docs
+weight: 347
+url: /ja/java/com.aspose.diagram/svgsaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.SaveOptions](../../com.aspose.diagram/saveoptions), [com.aspose.diagram.RenderingSaveOptions](../../com.aspose.diagram/renderingsaveoptions)
+```
+public class SVGSaveOptions extends RenderingSaveOptions
+```
+
+図ページを SVG にレンダリングする際に追加オプションを指定できます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [SVGSaveOptions()](#SVGSaveOptions--) | このクラスの新しいインスタンスを初期化します。このインスタンスは Aspose.Diagram.SaveFileFormat 形式でドキュメントを保存するために使用できます。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | 指定された保存形式に適したクラスの保存オプションオブジェクトを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCustomImagePath()](#getCustomImagePath--) | 生成された SVG ファイルに保存される画像用のユーザーカスタムパス（URL）。 |
+| [getDefaultFont()](#getDefaultFont--) | 図内の文字が Unicode で、正しいフォント値が設定されていない、またはフォントがローカルにインストールされていない場合、pdf、画像、または XPS でブロックとして表示されることがあります。 |
+| [getEmfRenderSetting()](#getEmfRenderSetting--) | Emf メタファイルのレンダリング設定です。 |
+| [getEnlargePage()](#getEnlargePage--) | ページを拡大するかどうかを指定します。 |
+| [getExportElementAsRectTag()](#getExportElementAsRectTag--) | 矩形要素を rect タグとしてエクスポートするかどうかを定義します。 |
+| [getExportGuideShapes()](#getExportGuideShapes--) | ガイドシェイプをエクスポートするかどうかを定義します。 |
+| [getExportHiddenPage()](#getExportHiddenPage--) | 非表示ページをエクスポートするかどうかを定義します。 |
+| [getPageIndex()](#getPageIndex--) | レンダリングするページの 0 ベースインデックスです。 |
+| [getPageSize()](#getPageSize--) | 生成された画像のページサイズ。 |
+| [getQuality()](#getQuality--) | ページを JPEG 形式で保存する際にのみ適用される、生成された画像の品質を決定する値です。 |
+| [getSVGFitToViewPort()](#getSVGFitToViewPort--) | このプロパティが true の場合、生成された SVG はビューポートに合わせてサイズが調整されます。 |
+| [getSaveFormat()](#getSaveFormat--) | この保存オプションオブジェクトが使用される場合、ドキュメントが保存される形式を指定します。 |
+| [getShapes()](#getShapes--) | レンダリングするシェイプ。 |
+| [getWarningCallback()](#getWarningCallback--) | 警告コールバック。 |
+| [hashCode()](#hashCode--) |  |
+| [isExportComments()](#isExportComments--) | コメントをエクスポートするかどうかを定義します。 |
+| [isExportScaleInMatrix()](#isExportScaleInMatrix--) | スケールを行列としてエクスポートするかどうかを定義します。 |
+| [isSavingCustomLinePattern()](#isSavingCustomLinePattern--) | カスタムラインパターンを保存するかどうかを定義します。 |
+| [isSavingImageSeparately()](#isSavingImageSeparately--) | 画像を別々に保存するかどうかを定義します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCustomImagePath(String value)](#setCustomImagePath-java.lang.String-) | このプロパティの説明については、[getCustomImagePath()](../../com.aspose.diagram/svgsaveoptions\#getCustomImagePath--) を参照してください |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | このプロパティの説明については、[getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--) を参照してください。 |
+| [setEmfRenderSetting(int value)](#setEmfRenderSetting-int-) | このプロパティの説明については、[getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--) を参照してください。 |
+| [setEnlargePage(boolean value)](#setEnlargePage-boolean-) | このプロパティの説明については、[getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--) を参照してください。 |
+| [setExportComments(boolean value)](#setExportComments-boolean-) | このプロパティの説明については、[isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--) を参照してください。 |
+| [setExportElementAsRectTag(boolean value)](#setExportElementAsRectTag-boolean-) | このプロパティの説明については、[getExportElementAsRectTag()](../../com.aspose.diagram/svgsaveoptions\#getExportElementAsRectTag--) を参照してください |
+| [setExportGuideShapes(boolean value)](#setExportGuideShapes-boolean-) | このプロパティの説明については、[getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--) を参照してください。 |
+| [setExportHiddenPage(boolean value)](#setExportHiddenPage-boolean-) | このプロパティの説明については、[getExportHiddenPage()](../../com.aspose.diagram/svgsaveoptions\#getExportHiddenPage--) を参照してください |
+| [setExportScaleInMatrix(boolean value)](#setExportScaleInMatrix-boolean-) | このプロパティの説明については、[isExportScaleInMatrix()](../../com.aspose.diagram/svgsaveoptions\#isExportScaleInMatrix--) を参照してください |
+| [setPageIndex(int value)](#setPageIndex-int-) | このプロパティの説明については、[getPageIndex()](../../com.aspose.diagram/svgsaveoptions\#getPageIndex--) を参照してください |
+| [setPageSize(PageSize value)](#setPageSize-com.aspose.diagram.PageSize-) | このプロパティの説明については、[getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--) を参照してください。 |
+| [setQuality(int value)](#setQuality-int-) | このプロパティの説明については、[getQuality()](../../com.aspose.diagram/svgsaveoptions\#getQuality--) を参照してください |
+| [setSVGFitToViewPort(boolean value)](#setSVGFitToViewPort-boolean-) | このプロパティの説明については、[getSVGFitToViewPort()](../../com.aspose.diagram/svgsaveoptions\#getSVGFitToViewPort--) を参照してください。 |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | このプロパティの説明については、[getSaveFormat()](../../com.aspose.diagram/saveoptions\#getSaveFormat--) を参照してください。 |
+| [setSavingCustomLinePattern(boolean value)](#setSavingCustomLinePattern-boolean-) | このプロパティの説明については、[isSavingCustomLinePattern()](../../com.aspose.diagram/svgsaveoptions\#isSavingCustomLinePattern--) を参照してください。 |
+| [setSavingImageSeparately(boolean value)](#setSavingImageSeparately-boolean-) | このプロパティの説明については、[isSavingImageSeparately()](../../com.aspose.diagram/svgsaveoptions\#isSavingImageSeparately--) を参照してください。 |
+| [setShapes(ShapeCollection value)](#setShapes-com.aspose.diagram.ShapeCollection-) | このプロパティの説明については、[getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--) を参照してください。 |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SVGSaveOptions() {#SVGSaveOptions--}
+```
+public SVGSaveOptions()
+```
+
+
+このクラスの新しいインスタンスを初期化します。このインスタンスは Aspose.Diagram.SaveFileFormat 形式でドキュメントを保存するために使用できます。
+
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+指定された保存形式に適したクラスの保存オプションオブジェクトを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| saveFormat | int | 保存オプションオブジェクトを作成するための Aspose.Diagram.SaveFileFormat です。 |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCustomImagePath() {#getCustomImagePath--}
+```
+public String getCustomImagePath()
+```
+
+
+画像の生成された SVG ファイルに保存されるユーザーカスタムパス（URL）。ユーザーが定義しない場合、現在のディレクトリが使用されます。
+
+**Returns:**
+java.lang.String
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+ダイアグラム内の文字が Unicode で、正しいフォントが設定されていない、またはフォントがローカルにインストールされていない場合、PDF、画像、または XPS で文字がブロックとして表示されることがあります。MingLiu や MS Gothic などの DefaultFont を設定して、これらの文字を表示してください。
+
+**Returns:**
+java.lang.String
+### getEmfRenderSetting() {#getEmfRenderSetting--}
+```
+public int getEmfRenderSetting()
+```
+
+
+Emf メタファイルのレンダリング設定です。\"EMF+ Dual\" と識別される EMF メタファイルは、EMF+ レコードと EMF レコードの両方を含むことができます。画像のレンダリングには、どちらのレコードタイプも使用でき、EMF+ レコードのみ、または EMF レコードのみを使用することもできます。EmfPlusPrefer が設定されている場合は EMF+ レコードが解析され、設定されていない場合は EMF レコードのみが解析されます。デフォルト値は EmfOnly です。
+
+**Returns:**
+int
+### getEnlargePage() {#getEnlargePage--}
+```
+public boolean getEnlargePage()
+```
+
+
+ページを拡大するかどうかを指定します。true の場合はページを拡大し、false の場合は拡大しません。デフォルト値は true です。
+
+**Returns:**
+boolean
+### getExportElementAsRectTag() {#getExportElementAsRectTag--}
+```
+public boolean getExportElementAsRectTag()
+```
+
+
+矩形要素を rect タグとしてエクスポートするかどうかを定義します。デフォルト値は false です。
+
+**Returns:**
+boolean
+### getExportGuideShapes() {#getExportGuideShapes--}
+```
+public boolean getExportGuideShapes()
+```
+
+
+ガイドシェイプをエクスポートするかどうかを定義します。デフォルト値は true です。
+
+**Returns:**
+boolean
+### getExportHiddenPage() {#getExportHiddenPage--}
+```
+public boolean getExportHiddenPage()
+```
+
+
+非表示ページをエクスポートするかどうかを定義します。デフォルト値は true です。
+
+**Returns:**
+boolean
+### getPageIndex() {#getPageIndex--}
+```
+public int getPageIndex()
+```
+
+
+レンダリングするページの 0 ベースインデックス。デフォルトは 0 です。
+
+**Returns:**
+int
+### getPageSize() {#getPageSize--}
+```
+public PageSize getPageSize()
+```
+
+
+生成された画像のページサイズです。 [PageSize](../../com.aspose.diagram/pagesize) または null にできます。デフォルト値は null です。PageSize が null の場合、生成された画像のページサイズはソース図から取得されます。
+
+**Returns:**
+[PageSize](../../com.aspose.diagram/pagesize)
+### getQuality() {#getQuality--}
+```
+public int getQuality()
+```
+
+
+生成された画像の品質を決定する値で、ページを JPEG 形式で保存する場合にのみ適用されます。デフォルト値は 100 です。JPEG で保存する場合にのみ効果があります。値は 0 から 100 の間でなければなりません。デフォルト値は 100 です。
+
+**Returns:**
+int
+### getSVGFitToViewPort() {#getSVGFitToViewPort--}
+```
+public boolean getSVGFitToViewPort()
+```
+
+
+このプロパティが true の場合、生成された SVG はビューポートに合わせてサイズが調整されます。
+
+**Returns:**
+boolean
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+この保存オプションオブジェクトが使用される場合、ドキュメントが保存される形式を指定します。
+
+**Returns:**
+int
+### getShapes() {#getShapes--}
+```
+public ShapeCollection getShapes()
+```
+
+
+レンダリングするシェイプです。デフォルトのカウントは 0 です。
+
+**Returns:**
+[ShapeCollection](../../com.aspose.diagram/shapecollection)
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+警告コールバック。
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExportComments() {#isExportComments--}
+```
+public boolean isExportComments()
+```
+
+
+コメントをエクスポートするかどうかを定義します。デフォルト値は false です。
+
+**Returns:**
+boolean
+### isExportScaleInMatrix() {#isExportScaleInMatrix--}
+```
+public boolean isExportScaleInMatrix()
+```
+
+
+スケールを行列としてエクスポートするかどうかを定義します。デフォルト値は true です。
+
+**Returns:**
+boolean
+### isSavingCustomLinePattern() {#isSavingCustomLinePattern--}
+```
+public boolean isSavingCustomLinePattern()
+```
+
+
+カスタムラインパターンを保存するかどうかを定義します。
+
+**Returns:**
+boolean
+### isSavingImageSeparately() {#isSavingImageSeparately--}
+```
+public boolean isSavingImageSeparately()
+```
+
+
+画像を別々に保存するかどうかを定義します。
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCustomImagePath(String value) {#setCustomImagePath-java.lang.String-}
+```
+public void setCustomImagePath(String value)
+```
+
+
+このプロパティの説明については、[getCustomImagePath()](../../com.aspose.diagram/svgsaveoptions\#getCustomImagePath--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+このプロパティの説明については、[getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setEmfRenderSetting(int value) {#setEmfRenderSetting-int-}
+```
+public void setEmfRenderSetting(int value)
+```
+
+
+このプロパティの説明については、[getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setEnlargePage(boolean value) {#setEnlargePage-boolean-}
+```
+public void setEnlargePage(boolean value)
+```
+
+
+このプロパティの説明については、[getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setExportComments(boolean value) {#setExportComments-boolean-}
+```
+public void setExportComments(boolean value)
+```
+
+
+このプロパティの説明については、[isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setExportElementAsRectTag(boolean value) {#setExportElementAsRectTag-boolean-}
+```
+public void setExportElementAsRectTag(boolean value)
+```
+
+
+このプロパティの説明については、[getExportElementAsRectTag()](../../com.aspose.diagram/svgsaveoptions\#getExportElementAsRectTag--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setExportGuideShapes(boolean value) {#setExportGuideShapes-boolean-}
+```
+public void setExportGuideShapes(boolean value)
+```
+
+
+このプロパティの説明については、[getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setExportHiddenPage(boolean value) {#setExportHiddenPage-boolean-}
+```
+public void setExportHiddenPage(boolean value)
+```
+
+
+このプロパティの説明については、[getExportHiddenPage()](../../com.aspose.diagram/svgsaveoptions\#getExportHiddenPage--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setExportScaleInMatrix(boolean value) {#setExportScaleInMatrix-boolean-}
+```
+public void setExportScaleInMatrix(boolean value)
+```
+
+
+このプロパティの説明については、[isExportScaleInMatrix()](../../com.aspose.diagram/svgsaveoptions\#isExportScaleInMatrix--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setPageIndex(int value) {#setPageIndex-int-}
+```
+public void setPageIndex(int value)
+```
+
+
+このプロパティの説明については、[getPageIndex()](../../com.aspose.diagram/svgsaveoptions\#getPageIndex--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setPageSize(PageSize value) {#setPageSize-com.aspose.diagram.PageSize-}
+```
+public void setPageSize(PageSize value)
+```
+
+
+このプロパティの説明については、[getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [PageSize](../../com.aspose.diagram/pagesize) |  |
+
+### setQuality(int value) {#setQuality-int-}
+```
+public void setQuality(int value)
+```
+
+
+このプロパティの説明については、[getQuality()](../../com.aspose.diagram/svgsaveoptions\#getQuality--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setSVGFitToViewPort(boolean value) {#setSVGFitToViewPort-boolean-}
+```
+public void setSVGFitToViewPort(boolean value)
+```
+
+
+このプロパティの説明については、[getSVGFitToViewPort()](../../com.aspose.diagram/svgsaveoptions\#getSVGFitToViewPort--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+このプロパティの説明については、[getSaveFormat()](../../com.aspose.diagram/saveoptions\#getSaveFormat--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setSavingCustomLinePattern(boolean value) {#setSavingCustomLinePattern-boolean-}
+```
+public void setSavingCustomLinePattern(boolean value)
+```
+
+
+このプロパティの説明については、[isSavingCustomLinePattern()](../../com.aspose.diagram/svgsaveoptions\#isSavingCustomLinePattern--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setSavingImageSeparately(boolean value) {#setSavingImageSeparately-boolean-}
+```
+public void setSavingImageSeparately(boolean value)
+```
+
+
+このプロパティの説明については、[isSavingImageSeparately()](../../com.aspose.diagram/svgsaveoptions\#isSavingImageSeparately--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setShapes(ShapeCollection value) {#setShapes-com.aspose.diagram.ShapeCollection-}
+```
+public void setShapes(ShapeCollection value)
+```
+
+
+このプロパティの説明については、[getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [ShapeCollection](../../com.aspose.diagram/shapecollection) |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/tab/_index.md
+++ b/japanese/java/com.aspose.diagram/tab/_index.md
@@ -1,0 +1,261 @@
+---
+title: Tab
+second_title: Aspose.Diagram for Java API リファレンス
+description: Tab 要素のコレクションを含みます。
+type: docs
+weight: 396
+url: /ja/java/com.aspose.diagram/tab/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Tab
+```
+
+Tab 要素のコレクションを含みます。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAlignment()](#getAlignment--) | タブの配置を指定します。 |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getIX()](#getIX--) | 親要素内の要素のゼロベースインデックスです。 |
+| [getLeader()](#getLeader--) | リーダーを指定しました。 |
+| [getPosition()](#getPosition--) | タブストップの位置を指定します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAlignment(Alignment value)](#setAlignment-com.aspose.diagram.Alignment-) | このプロパティの説明については、[getAlignment()](../../com.aspose.diagram/tab\#getAlignment--) をご覧ください。 |
+| [setDel(int value)](#setDel-int-) | このプロパティの説明については、[getDel()](../../com.aspose.diagram/tab\#getDel--) をご覧ください。 |
+| [setIX(int value)](#setIX-int-) | このプロパティの説明については、[getIX()](../../com.aspose.diagram/tab\#getIX--) をご覧ください。 |
+| [setLeader(StrValue value)](#setLeader-com.aspose.diagram.StrValue-) | このプロパティの説明については、[getLeader()](../../com.aspose.diagram/tab\#getLeader--) をご覧ください。 |
+| [setPosition(DoubleValue value)](#setPosition-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getPosition()](../../com.aspose.diagram/tab\#getPosition--) をご覧ください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAlignment() {#getAlignment--}
+```
+public Alignment getAlignment()
+```
+
+
+タブの配置を指定します。
+
+**Returns:**
+[Alignment](../../com.aspose.diagram/alignment)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+親要素内の要素のゼロベースインデックスです。
+
+**Returns:**
+int
+### getLeader() {#getLeader--}
+```
+public StrValue getLeader()
+```
+
+
+リーダーを指定しました。
+
+**Returns:**
+[StrValue](../../com.aspose.diagram/strvalue)
+### getPosition() {#getPosition--}
+```
+public DoubleValue getPosition()
+```
+
+
+タブストップの位置を指定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAlignment(Alignment value) {#setAlignment-com.aspose.diagram.Alignment-}
+```
+public void setAlignment(Alignment value)
+```
+
+
+このプロパティの説明については、[getAlignment()](../../com.aspose.diagram/tab\#getAlignment--) をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [Alignment](../../com.aspose.diagram/alignment) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+このプロパティの説明については、[getDel()](../../com.aspose.diagram/tab\#getDel--) をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+このプロパティの説明については、[getIX()](../../com.aspose.diagram/tab\#getIX--) をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setLeader(StrValue value) {#setLeader-com.aspose.diagram.StrValue-}
+```
+public void setLeader(StrValue value)
+```
+
+
+このプロパティの説明については、[getLeader()](../../com.aspose.diagram/tab\#getLeader--) をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [StrValue](../../com.aspose.diagram/strvalue) |  |
+
+### setPosition(DoubleValue value) {#setPosition-com.aspose.diagram.DoubleValue-}
+```
+public void setPosition(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getPosition()](../../com.aspose.diagram/tab\#getPosition--) をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/tabcollection/_index.md
+++ b/japanese/java/com.aspose.diagram/tabcollection/_index.md
@@ -1,0 +1,268 @@
+---
+title: TabCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: Tab 要素のコレクションを含みます
+type: docs
+weight: 397
+url: /ja/java/com.aspose.diagram/tabcollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class TabCollection extends Collection
+```
+
+Tab 要素のコレクションを含みます
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(Tab item)](#add-com.aspose.diagram.Tab-) | コレクションに Tab オブジェクトを追加します。 |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getIX()](#getIX--) | 親要素内の要素のゼロベースインデックスです。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Tab item)](#remove-com.aspose.diagram.Tab-) | コレクションから Tab オブジェクトを削除します。 |
+| [setDel(int value)](#setDel-int-) | このプロパティの説明については、[getDel()](../../com.aspose.diagram/tabcollection\#getDel--) を参照してください。 |
+| [setIX(int value)](#setIX-int-) | このプロパティの説明については、[getIX()](../../com.aspose.diagram/tabcollection\#getIX--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Tab item) {#add-com.aspose.diagram.Tab-}
+```
+public int add(Tab item)
+```
+
+
+コレクションに Tab オブジェクトを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [Tab](../../com.aspose.diagram/tab) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Tab get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[Tab](../../com.aspose.diagram/tab) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+親要素内の要素のゼロベースインデックスです。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Tab item) {#remove-com.aspose.diagram.Tab-}
+```
+public void remove(Tab item)
+```
+
+
+コレクションから Tab オブジェクトを削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [Tab](../../com.aspose.diagram/tab) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+このプロパティの説明については、[getDel()](../../com.aspose.diagram/tabcollection\#getDel--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+このプロパティの説明については、[getIX()](../../com.aspose.diagram/tabcollection\#getIX--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/tabscollection/_index.md
+++ b/japanese/java/com.aspose.diagram/tabscollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: TabsCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: TabCollection 要素のコレクションを含みます
+type: docs
+weight: 398
+url: /ja/java/com.aspose.diagram/tabscollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class TabsCollection extends Collection
+```
+
+TabCollection 要素のコレクションを含みます
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(TabCollection item)](#add-com.aspose.diagram.TabCollection-) | コレクションに Tab オブジェクトを追加します。 |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(TabCollection item)](#remove-com.aspose.diagram.TabCollection-) | コレクションから Tab オブジェクトを削除します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(TabCollection item) {#add-com.aspose.diagram.TabCollection-}
+```
+public int add(TabCollection item)
+```
+
+
+コレクションに Tab オブジェクトを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [TabCollection](../../com.aspose.diagram/tabcollection) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public TabCollection get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[TabCollection](../../com.aspose.diagram/tabcollection) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(TabCollection item) {#remove-com.aspose.diagram.TabCollection-}
+```
+public void remove(TabCollection item)
+```
+
+
+コレクションから Tab オブジェクトを削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [TabCollection](../../com.aspose.diagram/tabcollection) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/text/_index.md
+++ b/japanese/java/com.aspose.diagram/text/_index.md
@@ -1,0 +1,160 @@
+---
+title: テキスト
+second_title: Aspose.Diagram for Java API リファレンス
+description: シェイプのテキストを含みます。
+type: docs
+weight: 399
+url: /ja/java/com.aspose.diagram/text/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Text
+```
+
+シェイプのテキストを含みます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Text()](#Text--) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getValue()](#getValue--) | シェイプのテキストを含む FormatTxt コレクション。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Text() {#Text--}
+```
+public Text()
+```
+
+
+コンストラクタ。
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getValue() {#getValue--}
+```
+public FormatTxtCollection getValue()
+```
+
+
+シェイプのテキストを含む FormatTxt コレクション。
+
+**Returns:**
+[FormatTxtCollection](../../com.aspose.diagram/formattxtcollection)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/textblock/_index.md
+++ b/japanese/java/com.aspose.diagram/textblock/_index.md
@@ -1,0 +1,386 @@
+---
+title: TextBlock
+second_title: Aspose.Diagram for Java API リファレンス
+description: シェイプのテキストブロック内のテキストの配置余白とデフォルトタブ位置を指定する要素を含みます。
+type: docs
+weight: 400
+url: /ja/java/com.aspose.diagram/textblock/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class TextBlock
+```
+
+シェイプのテキスト ブロック内のテキストの配置、余白、デフォルトのタブ位置を指定する要素を含みます。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBottomMargin()](#getBottomMargin--) | テキストブロックの下端と含まれる最後のテキスト行との距離を決定します。 |
+| [getClass()](#getClass--) |  |
+| [getDefaultTabStop()](#getDefaultTabStop--) | テキストブロック内のデフォルトタブストップの間隔を指定します。 |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getLeftMargin()](#getLeftMargin--) | テキストブロックの左端と含まれるテキストとの距離を指定します。 |
+| [getRightMargin()](#getRightMargin--) | テキストブロックの右端と含まれるテキストとの距離を指定します。 |
+| [getTextBkgnd()](#getTextBkgnd--) | シェイプのテキスト背景色を指定します。 |
+| [getTextBkgndTrans()](#getTextBkgndTrans--) | シェイプのテキストブロックの背景色の透明度レベルを、0（完全に不透明）から1（完全に透明）まで指定します。 |
+| [getTextDirection()](#getTextDirection--) | テキスト ブロック内の文字の方向を指定します。 |
+| [getTopMargin()](#getTopMargin--) | テキストブロックの上端と含まれる最初のテキスト行との距離を指定します。 |
+| [getVerticalAlign()](#getVerticalAlign--) | テキストブロック内のテキストの垂直配置を指定します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setBottomMargin(DoubleValue value)](#setBottomMargin-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getBottomMargin()](../../com.aspose.diagram/textblock\#getBottomMargin--) を参照してください。 |
+| [setDefaultTabStop(DoubleValue value)](#setDefaultTabStop-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getDefaultTabStop()](../../com.aspose.diagram/textblock\#getDefaultTabStop--) を参照してください。 |
+| [setDel(int value)](#setDel-int-) | このプロパティの説明については、[getDel()](../../com.aspose.diagram/textblock\#getDel--) を参照してください。 |
+| [setLeftMargin(DoubleValue value)](#setLeftMargin-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getLeftMargin()](../../com.aspose.diagram/textblock\#getLeftMargin--) を参照してください。 |
+| [setRightMargin(DoubleValue value)](#setRightMargin-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getRightMargin()](../../com.aspose.diagram/textblock\#getRightMargin--) を参照してください。 |
+| [setTextBkgnd(ColorValue value)](#setTextBkgnd-com.aspose.diagram.ColorValue-) | このプロパティの説明については、[getTextBkgnd()](../../com.aspose.diagram/textblock\#getTextBkgnd--) を参照してください。 |
+| [setTextBkgndTrans(DoubleValue value)](#setTextBkgndTrans-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getTextBkgndTrans()](../../com.aspose.diagram/textblock\#getTextBkgndTrans--) を参照してください。 |
+| [setTextDirection(TextDirection value)](#setTextDirection-com.aspose.diagram.TextDirection-) | このプロパティの説明については、[getTextDirection()](../../com.aspose.diagram/textblock\#getTextDirection--) を参照してください。 |
+| [setTopMargin(DoubleValue value)](#setTopMargin-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getTopMargin()](../../com.aspose.diagram/textblock\#getTopMargin--) を参照してください。 |
+| [setVerticalAlign(VerticalAlign value)](#setVerticalAlign-com.aspose.diagram.VerticalAlign-) | このプロパティの説明については、[getVerticalAlign()](../../com.aspose.diagram/textblock\#getVerticalAlign--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBottomMargin() {#getBottomMargin--}
+```
+public DoubleValue getBottomMargin()
+```
+
+
+テキストブロックの下端と含まれる最後のテキスト行との間の距離を決定します。デフォルトは 4 pt です。この値は図のスケールに依存しません。図が拡大縮小されても、下余白は同じままです。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultTabStop() {#getDefaultTabStop--}
+```
+public DoubleValue getDefaultTabStop()
+```
+
+
+テキストブロック内のデフォルトタブストップの間隔を指定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getLeftMargin() {#getLeftMargin--}
+```
+public DoubleValue getLeftMargin()
+```
+
+
+テキストブロックの左端と含まれるテキストとの間の距離を指定します。この値は図のスケールに依存しません。図が拡大縮小されても、左余白は同じままです。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getRightMargin() {#getRightMargin--}
+```
+public DoubleValue getRightMargin()
+```
+
+
+テキストブロックの右端と含まれるテキストとの間の距離を指定します。この値は図のスケールに依存しません。図が拡大縮小されても、右余白は同じままです。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTextBkgnd() {#getTextBkgnd--}
+```
+public ColorValue getTextBkgnd()
+```
+
+
+シェイプのテキスト背景色を指定します。
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getTextBkgndTrans() {#getTextBkgndTrans--}
+```
+public DoubleValue getTextBkgndTrans()
+```
+
+
+シェイプのテキストブロックの背景色の透明度レベルを、0（完全に不透明）から1（完全に透明）まで指定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTextDirection() {#getTextDirection--}
+```
+public TextDirection getTextDirection()
+```
+
+
+テキスト ブロック内の文字の方向を指定します。
+
+**Returns:**
+[TextDirection](../../com.aspose.diagram/textdirection)
+### getTopMargin() {#getTopMargin--}
+```
+public DoubleValue getTopMargin()
+```
+
+
+テキストブロックの上端と含まれる最初のテキスト行との距離を指定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getVerticalAlign() {#getVerticalAlign--}
+```
+public VerticalAlign getVerticalAlign()
+```
+
+
+テキストブロック内のテキストの垂直配置を指定します。
+
+**Returns:**
+[VerticalAlign](../../com.aspose.diagram/verticalalign)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setBottomMargin(DoubleValue value) {#setBottomMargin-com.aspose.diagram.DoubleValue-}
+```
+public void setBottomMargin(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getBottomMargin()](../../com.aspose.diagram/textblock\#getBottomMargin--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDefaultTabStop(DoubleValue value) {#setDefaultTabStop-com.aspose.diagram.DoubleValue-}
+```
+public void setDefaultTabStop(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getDefaultTabStop()](../../com.aspose.diagram/textblock\#getDefaultTabStop--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+このプロパティの説明については、[getDel()](../../com.aspose.diagram/textblock\#getDel--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setLeftMargin(DoubleValue value) {#setLeftMargin-com.aspose.diagram.DoubleValue-}
+```
+public void setLeftMargin(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getLeftMargin()](../../com.aspose.diagram/textblock\#getLeftMargin--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setRightMargin(DoubleValue value) {#setRightMargin-com.aspose.diagram.DoubleValue-}
+```
+public void setRightMargin(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getRightMargin()](../../com.aspose.diagram/textblock\#getRightMargin--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTextBkgnd(ColorValue value) {#setTextBkgnd-com.aspose.diagram.ColorValue-}
+```
+public void setTextBkgnd(ColorValue value)
+```
+
+
+このプロパティの説明については、[getTextBkgnd()](../../com.aspose.diagram/textblock\#getTextBkgnd--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setTextBkgndTrans(DoubleValue value) {#setTextBkgndTrans-com.aspose.diagram.DoubleValue-}
+```
+public void setTextBkgndTrans(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getTextBkgndTrans()](../../com.aspose.diagram/textblock\#getTextBkgndTrans--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTextDirection(TextDirection value) {#setTextDirection-com.aspose.diagram.TextDirection-}
+```
+public void setTextDirection(TextDirection value)
+```
+
+
+このプロパティの説明については、[getTextDirection()](../../com.aspose.diagram/textblock\#getTextDirection--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [TextDirection](../../com.aspose.diagram/textdirection) |  |
+
+### setTopMargin(DoubleValue value) {#setTopMargin-com.aspose.diagram.DoubleValue-}
+```
+public void setTopMargin(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getTopMargin()](../../com.aspose.diagram/textblock\#getTopMargin--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setVerticalAlign(VerticalAlign value) {#setVerticalAlign-com.aspose.diagram.VerticalAlign-}
+```
+public void setVerticalAlign(VerticalAlign value)
+```
+
+
+このプロパティの説明については、[getVerticalAlign()](../../com.aspose.diagram/textblock\#getVerticalAlign--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [VerticalAlign](../../com.aspose.diagram/verticalalign) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/textboxactivexcontrol/_index.md
+++ b/japanese/java/com.aspose.diagram/textboxactivexcontrol/_index.md
@@ -1,0 +1,922 @@
+---
+title: TextBoxActiveXControl
+second_title: Aspose.Diagram for Java API リファレンス
+description: テキスト ボックス ActiveX コントロールを表します。
+type: docs
+weight: 401
+url: /ja/java/com.aspose.diagram/textboxactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class TextBoxActiveXControl extends ActiveXControl
+```
+
+テキスト ボックス ActiveX コントロールを表します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBackOleColor()](#getBackOleColor--) | 背景の OLE カラー。 |
+| [getBorderOleColor()](#getBorderOleColor--) | 背景の OLE カラー。 |
+| [getBorderStyle()](#getBorderStyle--) | コントロールで使用される境界線の種類。 |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | コントロールのバイナリ データ。 |
+| [getDropButtonStyle()](#getDropButtonStyle--) | ドロップボタンに表示されるシンボルを指定します。 |
+| [getEnterFieldBehavior()](#getEnterFieldBehavior--) | コントロールに入るときの選択動作を指定します。 |
+| [getEnterKeyBehavior()](#getEnterKeyBehavior--) | ENTER キーの動作を指定します。 |
+| [getForeOleColor()](#getForeOleColor--) | 前景の OLE カラー。 |
+| [getHeight()](#getHeight--) | ポイント単位のコントロールの高さ。 |
+| [getHideSelection()](#getHideSelection--) | コントロールがフォーカスを持っていないときに、コントロール内の選択されたテキストがハイライト表示されるかどうかを示します。 |
+| [getIMEMode()](#getIMEMode--) | コントロールがフォーカスを受け取る際の Input Method Editor のデフォルト実行時モード。 |
+| [getIntegralHeight()](#getIntegralHeight--) | コントロールが部分的な行を表示せず、完全な行のみを表示するかどうかを示します。 |
+| [getMaxLength()](#getMaxLength--) | 最大文字数 |
+| [getMouseIcon()](#getMouseIcon--) | コントロールのマウスポインタとして表示するカスタムアイコンです。 |
+| [getMousePointer()](#getMousePointer--) | コントロールのマウスポインタとして表示されるアイコンの種類です。 |
+| [getPasswordChar()](#getPasswordChar--) | 入力された文字の代わりに表示される文字。 |
+| [getScrollBars()](#getScrollBars--) | コントロールに垂直スクロールバー、水平スクロールバー、両方、またはどちらもないかを示します。 |
+| [getShowDropButtonTypeWhen()](#getShowDropButtonTypeWhen--) | ドロップボタンに表示されるシンボルを指定します。 |
+| [getSpecialEffect()](#getSpecialEffect--) | コントロールの特殊効果です。 |
+| [getTabKeyBehavior()](#getTabKeyBehavior--) | コントロールのテキストでタブ文字が許可されているかどうかを示します。 |
+| [getText()](#getText--) | コントロールのテキスト。 |
+| [getType()](#getType--) | ActiveX コントロールのタイプを取得します。 |
+| [getWidth()](#getWidth--) | ポイント単位のコントロールの幅です。 |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | コントロールが全内容を表示するために自動的にサイズ変更されるかどうかを示します。 |
+| [isAutoTab()](#isAutoTab--) | ユーザーが最大文字数を入力したときに、フォーカスが自動的に次のコントロールへ移動するかどうかを示します。 |
+| [isAutoWordSelected()](#isAutoWordSelected--) | 選択範囲を拡張する際に使用される基本単位を指定します。 |
+| [isDragBehaviorEnabled()](#isDragBehaviorEnabled--) | コントロールでドラッグ アンド ドロップが有効かどうかを示します。 |
+| [isEditable()](#isEditable--) | ユーザーがコントロールに入力できるかどうかを示します。 |
+| [isEnabled()](#isEnabled--) | コントロールがフォーカスを受け取り、ユーザー生成イベントに応答できるかどうかを示します。 |
+| [isLocked()](#isLocked--) | コントロール内のデータが編集ロックされているかどうかを示します。 |
+| [isMultiLine()](#isMultiLine--) | コントロールが複数行のテキストを表示できるかどうかを示します。 |
+| [isTransparent()](#isTransparent--) | コントロールが透明かどうかを示します。 |
+| [isWordWrapped()](#isWordWrapped--) | コントロールの内容が行末で自動的に折り返されるかどうかを示します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | このプロパティの説明については、[isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) を参照してください |
+| [setAutoTab(boolean value)](#setAutoTab-boolean-) | このプロパティの説明については、[isAutoTab()](../../com.aspose.diagram/textboxactivexcontrol\#isAutoTab--) を参照してください。 |
+| [setAutoWordSelected(boolean value)](#setAutoWordSelected-boolean-) | このプロパティの説明については、[isAutoWordSelected()](../../com.aspose.diagram/textboxactivexcontrol\#isAutoWordSelected--) を参照してください。 |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | このプロパティの説明については、[getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) を参照してください |
+| [setBorderOleColor(int value)](#setBorderOleColor-int-) | このプロパティの説明については、[getBorderOleColor()](../../com.aspose.diagram/textboxactivexcontrol\#getBorderOleColor--) を参照してください。 |
+| [setBorderStyle(int value)](#setBorderStyle-int-) | このプロパティの説明については、[getBorderStyle()](../../com.aspose.diagram/textboxactivexcontrol\#getBorderStyle--) を参照してください。 |
+| [setDragBehaviorEnabled(boolean value)](#setDragBehaviorEnabled-boolean-) | このプロパティの説明については、[isDragBehaviorEnabled()](../../com.aspose.diagram/textboxactivexcontrol\#isDragBehaviorEnabled--) を参照してください。 |
+| [setDropButtonStyle(int value)](#setDropButtonStyle-int-) | このプロパティの説明については、[getDropButtonStyle()](../../com.aspose.diagram/textboxactivexcontrol\#getDropButtonStyle--) を参照してください。 |
+| [setEditable(boolean value)](#setEditable-boolean-) | このプロパティの説明については、[isEditable()](../../com.aspose.diagram/textboxactivexcontrol\#isEditable--) を参照してください。 |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | このプロパティの説明については、[isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) を参照してください |
+| [setEnterFieldBehavior(boolean value)](#setEnterFieldBehavior-boolean-) | このプロパティの説明については、[getEnterFieldBehavior()](../../com.aspose.diagram/textboxactivexcontrol\#getEnterFieldBehavior--) を参照してください。 |
+| [setEnterKeyBehavior(boolean value)](#setEnterKeyBehavior-boolean-) | このプロパティの説明については、[getEnterKeyBehavior()](../../com.aspose.diagram/textboxactivexcontrol\#getEnterKeyBehavior--) を参照してください。 |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | このプロパティの説明については、[getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) を参照してください |
+| [setHeight(double value)](#setHeight-double-) | このプロパティの説明については、[getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) を参照してください |
+| [setHideSelection(boolean value)](#setHideSelection-boolean-) | このプロパティの説明については、[getHideSelection()](../../com.aspose.diagram/textboxactivexcontrol\#getHideSelection--) を参照してください。 |
+| [setIMEMode(int value)](#setIMEMode-int-) | このプロパティの説明については、[getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) を参照してください |
+| [setIntegralHeight(boolean value)](#setIntegralHeight-boolean-) | このプロパティの説明については、[getIntegralHeight()](../../com.aspose.diagram/textboxactivexcontrol\#getIntegralHeight--) を参照してください。 |
+| [setLocked(boolean value)](#setLocked-boolean-) | このプロパティの説明については、[isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) を参照してください |
+| [setMaxLength(int value)](#setMaxLength-int-) | このプロパティの説明については、[getMaxLength()](../../com.aspose.diagram/textboxactivexcontrol\#getMaxLength--) を参照してください。 |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | このプロパティの説明については、[getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) を参照してください |
+| [setMousePointer(int value)](#setMousePointer-int-) | このプロパティの説明については、[getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) を参照してください |
+| [setMultiLine(boolean value)](#setMultiLine-boolean-) | このプロパティの説明については、[isMultiLine()](../../com.aspose.diagram/textboxactivexcontrol\#isMultiLine--) を参照してください。 |
+| [setPasswordChar(char value)](#setPasswordChar-char-) | このプロパティの説明については、[getPasswordChar()](../../com.aspose.diagram/textboxactivexcontrol\#getPasswordChar--) を参照してください。 |
+| [setScrollBars(int value)](#setScrollBars-int-) | このプロパティの説明については、[getScrollBars()](../../com.aspose.diagram/textboxactivexcontrol\#getScrollBars--) を参照してください。 |
+| [setShowDropButtonTypeWhen(int value)](#setShowDropButtonTypeWhen-int-) | このプロパティの説明については、[getShowDropButtonTypeWhen()](../../com.aspose.diagram/textboxactivexcontrol\#getShowDropButtonTypeWhen--) を参照してください。 |
+| [setSpecialEffect(int value)](#setSpecialEffect-int-) | このプロパティの説明については、[getSpecialEffect()](../../com.aspose.diagram/textboxactivexcontrol\#getSpecialEffect--) を参照してください。 |
+| [setTabKeyBehavior(boolean value)](#setTabKeyBehavior-boolean-) | このプロパティの説明については、[getTabKeyBehavior()](../../com.aspose.diagram/textboxactivexcontrol\#getTabKeyBehavior--) を参照してください。 |
+| [setText(String value)](#setText-java.lang.String-) | このプロパティの説明については、[getText()](../../com.aspose.diagram/textboxactivexcontrol\#getText--) を参照してください。 |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | このプロパティの説明については、[isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) を参照してください |
+| [setWidth(double value)](#setWidth-double-) | このプロパティの説明については、[getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) を参照してください |
+| [setWordWrapped(boolean value)](#setWordWrapped-boolean-) | このプロパティの説明については、[isWordWrapped()](../../com.aspose.diagram/textboxactivexcontrol\#isWordWrapped--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+背景の OLE カラー。
+
+**Returns:**
+int
+### getBorderOleColor() {#getBorderOleColor--}
+```
+public int getBorderOleColor()
+```
+
+
+背景の OLE カラー。
+
+**Returns:**
+int
+### getBorderStyle() {#getBorderStyle--}
+```
+public int getBorderStyle()
+```
+
+
+コントロールで使用される境界線の種類。
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+コントロールのバイナリ データ。
+
+**Returns:**
+byte[]
+### getDropButtonStyle() {#getDropButtonStyle--}
+```
+public int getDropButtonStyle()
+```
+
+
+ドロップボタンに表示されるシンボルを指定します。
+
+**Returns:**
+int
+### getEnterFieldBehavior() {#getEnterFieldBehavior--}
+```
+public boolean getEnterFieldBehavior()
+```
+
+
+コントロールに入るときの選択動作を指定します。True の場合、選択は前回コントロールがアクティブだったときから変更されません。False の場合、コントロールに入るときにテキスト全体が選択されます。
+
+**Returns:**
+boolean
+### getEnterKeyBehavior() {#getEnterKeyBehavior--}
+```
+public boolean getEnterKeyBehavior()
+```
+
+
+ENTER キーの動作を指定します。True の場合、ENTER を押すと新しい行が作成されます。False の場合、ENTER を押すとタブ順の次のオブジェクトにフォーカスが移動します。
+
+**Returns:**
+boolean
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+前景の OLE カラーです。Image コントロールには適用されません。
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+ポイント単位のコントロールの高さ。
+
+**Returns:**
+double
+### getHideSelection() {#getHideSelection--}
+```
+public boolean getHideSelection()
+```
+
+
+コントロールがフォーカスを持っていないときに、コントロール内の選択されたテキストがハイライト表示されるかどうかを示します。
+
+**Returns:**
+boolean
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+コントロールがフォーカスを受け取る際の Input Method Editor のデフォルト実行時モード。
+
+**Returns:**
+int
+### getIntegralHeight() {#getIntegralHeight--}
+```
+public boolean getIntegralHeight()
+```
+
+
+コントロールが部分的な行を表示せず、完全な行のみを表示するかどうかを示します。
+
+**Returns:**
+boolean
+### getMaxLength() {#getMaxLength--}
+```
+public int getMaxLength()
+```
+
+
+最大文字数
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+コントロールのマウスポインタとして表示するカスタムアイコンです。
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+コントロールのマウスポインタとして表示されるアイコンの種類です。
+
+**Returns:**
+int
+### getPasswordChar() {#getPasswordChar--}
+```
+public char getPasswordChar()
+```
+
+
+入力された文字の代わりに表示される文字。
+
+**Returns:**
+char
+### getScrollBars() {#getScrollBars--}
+```
+public int getScrollBars()
+```
+
+
+コントロールに垂直スクロールバー、水平スクロールバー、両方、またはどちらもないかを示します。
+
+**Returns:**
+int
+### getShowDropButtonTypeWhen() {#getShowDropButtonTypeWhen--}
+```
+public int getShowDropButtonTypeWhen()
+```
+
+
+ドロップボタンに表示されるシンボルを指定します。
+
+**Returns:**
+int
+### getSpecialEffect() {#getSpecialEffect--}
+```
+public int getSpecialEffect()
+```
+
+
+コントロールの特殊効果です。
+
+**Returns:**
+int
+### getTabKeyBehavior() {#getTabKeyBehavior--}
+```
+public boolean getTabKeyBehavior()
+```
+
+
+コントロールのテキストでタブ文字が許可されているかどうかを示します。
+
+**Returns:**
+boolean
+### getText() {#getText--}
+```
+public String getText()
+```
+
+
+コントロールのテキスト。
+
+**Returns:**
+java.lang.String
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+ActiveX コントロールのタイプを取得します。
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+ポイント単位のコントロールの幅です。
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+コントロールが全内容を表示するために自動的にサイズ変更されるかどうかを示します。
+
+**Returns:**
+boolean
+### isAutoTab() {#isAutoTab--}
+```
+public boolean isAutoTab()
+```
+
+
+ユーザーが最大文字数を入力したときに、フォーカスが自動的に次のコントロールへ移動するかどうかを示します。
+
+**Returns:**
+boolean
+### isAutoWordSelected() {#isAutoWordSelected--}
+```
+public boolean isAutoWordSelected()
+```
+
+
+選択を拡張する際に使用される基本単位を指定します。True の場合、基本単位は単一文字です。false の場合、基本単位は単語全体です。
+
+**Returns:**
+boolean
+### isDragBehaviorEnabled() {#isDragBehaviorEnabled--}
+```
+public boolean isDragBehaviorEnabled()
+```
+
+
+コントロールでドラッグ アンド ドロップが有効かどうかを示します。
+
+**Returns:**
+boolean
+### isEditable() {#isEditable--}
+```
+public boolean isEditable()
+```
+
+
+ユーザーがコントロールに入力できるかどうかを示します。
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+コントロールがフォーカスを受け取り、ユーザー生成イベントに応答できるかどうかを示します。
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+コントロール内のデータが編集ロックされているかどうかを示します。
+
+**Returns:**
+boolean
+### isMultiLine() {#isMultiLine--}
+```
+public boolean isMultiLine()
+```
+
+
+コントロールが複数行のテキストを表示できるかどうかを示します。
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+コントロールが透明かどうかを示します。
+
+**Returns:**
+boolean
+### isWordWrapped() {#isWordWrapped--}
+```
+public boolean isWordWrapped()
+```
+
+
+コントロールの内容が行末で自動的に折り返されるかどうかを示します。
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+このプロパティの説明については、[isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setAutoTab(boolean value) {#setAutoTab-boolean-}
+```
+public void setAutoTab(boolean value)
+```
+
+
+このプロパティの説明については、[isAutoTab()](../../com.aspose.diagram/textboxactivexcontrol\#isAutoTab--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setAutoWordSelected(boolean value) {#setAutoWordSelected-boolean-}
+```
+public void setAutoWordSelected(boolean value)
+```
+
+
+このプロパティの説明については、[isAutoWordSelected()](../../com.aspose.diagram/textboxactivexcontrol\#isAutoWordSelected--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+このプロパティの説明については、[getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setBorderOleColor(int value) {#setBorderOleColor-int-}
+```
+public void setBorderOleColor(int value)
+```
+
+
+このプロパティの説明については、[getBorderOleColor()](../../com.aspose.diagram/textboxactivexcontrol\#getBorderOleColor--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setBorderStyle(int value) {#setBorderStyle-int-}
+```
+public void setBorderStyle(int value)
+```
+
+
+このプロパティの説明については、[getBorderStyle()](../../com.aspose.diagram/textboxactivexcontrol\#getBorderStyle--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setDragBehaviorEnabled(boolean value) {#setDragBehaviorEnabled-boolean-}
+```
+public void setDragBehaviorEnabled(boolean value)
+```
+
+
+このプロパティの説明については、[isDragBehaviorEnabled()](../../com.aspose.diagram/textboxactivexcontrol\#isDragBehaviorEnabled--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setDropButtonStyle(int value) {#setDropButtonStyle-int-}
+```
+public void setDropButtonStyle(int value)
+```
+
+
+このプロパティの説明については、[getDropButtonStyle()](../../com.aspose.diagram/textboxactivexcontrol\#getDropButtonStyle--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setEditable(boolean value) {#setEditable-boolean-}
+```
+public void setEditable(boolean value)
+```
+
+
+このプロパティの説明については、[isEditable()](../../com.aspose.diagram/textboxactivexcontrol\#isEditable--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+このプロパティの説明については、[isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setEnterFieldBehavior(boolean value) {#setEnterFieldBehavior-boolean-}
+```
+public void setEnterFieldBehavior(boolean value)
+```
+
+
+このプロパティの説明については、[getEnterFieldBehavior()](../../com.aspose.diagram/textboxactivexcontrol\#getEnterFieldBehavior--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setEnterKeyBehavior(boolean value) {#setEnterKeyBehavior-boolean-}
+```
+public void setEnterKeyBehavior(boolean value)
+```
+
+
+このプロパティの説明については、[getEnterKeyBehavior()](../../com.aspose.diagram/textboxactivexcontrol\#getEnterKeyBehavior--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+このプロパティの説明については、[getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+このプロパティの説明については、[getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double |  |
+
+### setHideSelection(boolean value) {#setHideSelection-boolean-}
+```
+public void setHideSelection(boolean value)
+```
+
+
+このプロパティの説明については、[getHideSelection()](../../com.aspose.diagram/textboxactivexcontrol\#getHideSelection--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+このプロパティの説明については、[getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setIntegralHeight(boolean value) {#setIntegralHeight-boolean-}
+```
+public void setIntegralHeight(boolean value)
+```
+
+
+このプロパティの説明については、[getIntegralHeight()](../../com.aspose.diagram/textboxactivexcontrol\#getIntegralHeight--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+このプロパティの説明については、[isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setMaxLength(int value) {#setMaxLength-int-}
+```
+public void setMaxLength(int value)
+```
+
+
+このプロパティの説明については、[getMaxLength()](../../com.aspose.diagram/textboxactivexcontrol\#getMaxLength--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+このプロパティの説明については、[getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+このプロパティの説明については、[getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setMultiLine(boolean value) {#setMultiLine-boolean-}
+```
+public void setMultiLine(boolean value)
+```
+
+
+このプロパティの説明については、[isMultiLine()](../../com.aspose.diagram/textboxactivexcontrol\#isMultiLine--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setPasswordChar(char value) {#setPasswordChar-char-}
+```
+public void setPasswordChar(char value)
+```
+
+
+このプロパティの説明については、[getPasswordChar()](../../com.aspose.diagram/textboxactivexcontrol\#getPasswordChar--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | char |  |
+
+### setScrollBars(int value) {#setScrollBars-int-}
+```
+public void setScrollBars(int value)
+```
+
+
+このプロパティの説明については、[getScrollBars()](../../com.aspose.diagram/textboxactivexcontrol\#getScrollBars--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setShowDropButtonTypeWhen(int value) {#setShowDropButtonTypeWhen-int-}
+```
+public void setShowDropButtonTypeWhen(int value)
+```
+
+
+このプロパティの説明については、[getShowDropButtonTypeWhen()](../../com.aspose.diagram/textboxactivexcontrol\#getShowDropButtonTypeWhen--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setSpecialEffect(int value) {#setSpecialEffect-int-}
+```
+public void setSpecialEffect(int value)
+```
+
+
+このプロパティの説明については、[getSpecialEffect()](../../com.aspose.diagram/textboxactivexcontrol\#getSpecialEffect--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setTabKeyBehavior(boolean value) {#setTabKeyBehavior-boolean-}
+```
+public void setTabKeyBehavior(boolean value)
+```
+
+
+このプロパティの説明については、[getTabKeyBehavior()](../../com.aspose.diagram/textboxactivexcontrol\#getTabKeyBehavior--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setText(String value) {#setText-java.lang.String-}
+```
+public void setText(String value)
+```
+
+
+このプロパティの説明については、[getText()](../../com.aspose.diagram/textboxactivexcontrol\#getText--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+このプロパティの説明については、[isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+このプロパティの説明については、[getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double |  |
+
+### setWordWrapped(boolean value) {#setWordWrapped-boolean-}
+```
+public void setWordWrapped(boolean value)
+```
+
+
+このプロパティの説明については、[isWordWrapped()](../../com.aspose.diagram/textboxactivexcontrol\#isWordWrapped--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/textcollection/_index.md
+++ b/japanese/java/com.aspose.diagram/textcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: TextCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: シェイプのテキストを含みます。
+type: docs
+weight: 402
+url: /ja/java/com.aspose.diagram/textcollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class TextCollection extends Collection
+```
+
+Contains the text of a shape. Each item is text with character, paragraph and tabs properties.
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(Text item)](#add-com.aspose.diagram.Text-) | Add the Text object in the collection. |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Text item)](#remove-com.aspose.diagram.Text-) | Remove the Text object from the collection. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Text item) {#add-com.aspose.diagram.Text-}
+```
+public int add(Text item)
+```
+
+
+Add the Text object in the collection.
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [Text](../../com.aspose.diagram/text) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Text get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[Text](../../com.aspose.diagram/text) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Text item) {#remove-com.aspose.diagram.Text-}
+```
+public void remove(Text item)
+```
+
+
+Remove the Text object from the collection.
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [Text](../../com.aspose.diagram/text) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/textdirection/_index.md
+++ b/japanese/java/com.aspose.diagram/textdirection/_index.md
@@ -1,0 +1,204 @@
+---
+title: TextDirection
+second_title: Aspose.Diagram for Java API リファレンス
+description: テキスト ブロック内の文字の方向を指定します。
+type: docs
+weight: 403
+url: /ja/java/com.aspose.diagram/textdirection/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class TextDirection
+```
+
+テキスト ブロック内の文字の方向を指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [TextDirection(int value)](#TextDirection-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | テキスト ブロック内の文字の方向を指定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | このプロパティの説明については、[getUfe()](../../com.aspose.diagram/textdirection\#getUfe--) を参照してください。 |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/textdirection\#getValue--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### TextDirection(int value) {#TextDirection-int-}
+```
+public TextDirection(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+テキスト ブロック内の文字の方向を指定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+このプロパティの説明については、[getUfe()](../../com.aspose.diagram/textdirection\#getUfe--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/textdirection\#getValue--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/textdirectionvalue/_index.md
+++ b/japanese/java/com.aspose.diagram/textdirectionvalue/_index.md
@@ -1,0 +1,156 @@
+---
+title: TextDirectionValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: テキスト ブロック内の文字の方向を指定します。
+type: docs
+weight: 404
+url: /ja/java/com.aspose.diagram/textdirectionvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class TextDirectionValue
+```
+
+テキスト ブロック内の文字の方向を指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [HORIZONTAL](#HORIZONTAL) | 水平。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+| [VERTICAL](#VERTICAL) | 垂直。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### HORIZONTAL {#HORIZONTAL}
+```
+public static final int HORIZONTAL
+```
+
+
+水平。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### VERTICAL {#VERTICAL}
+```
+public static final int VERTICAL
+```
+
+
+垂直。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/textxform/_index.md
+++ b/japanese/java/com.aspose.diagram/textxform/_index.md
@@ -1,0 +1,336 @@
+---
+title: TextXForm
+second_title: Aspose.Diagram for Java API リファレンス
+description: シェイプのテキストブロックに関する位置情報を指定する要素を含みます。
+type: docs
+weight: 405
+url: /ja/java/com.aspose.diagram/textxform/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class TextXForm
+```
+
+シェイプのテキスト ブロックに関する位置情報を指定する要素を含みます。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getTxtAngle()](#getTxtAngle--) | シェイプの x 軸に対するテキストブロックの現在の回転角度を指定します。 |
+| [getTxtHeight()](#getTxtHeight--) | テキストブロックの高さを指定します。 |
+| [getTxtLocPinX()](#getTxtLocPinX--) | テキストブロックの回転中心の x 座標を、テキストブロックの原点に対して指定します。 |
+| [getTxtLocPinY()](#getTxtLocPinY--) | テキストブロックの回転中心の y 座標を、テキストブロックの原点に対して指定します。 |
+| [getTxtPinX()](#getTxtPinX--) | シェイプの原点に対して、テキストブロックの回転中心の x 座標を指定します。 |
+| [getTxtPinY()](#getTxtPinY--) | シェイプの原点に対して、テキストブロックの回転中心の y 座標を指定します。 |
+| [getTxtWidth()](#getTxtWidth--) | テキストブロックの幅を指定します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | このプロパティの説明については、[getDel()](../../com.aspose.diagram/textxform\#getDel--)をご覧ください。 |
+| [setTxtAngle(DoubleValue value)](#setTxtAngle-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getTxtAngle()](../../com.aspose.diagram/textxform\#getTxtAngle--)をご覧ください。 |
+| [setTxtHeight(DoubleValue value)](#setTxtHeight-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getTxtHeight()](../../com.aspose.diagram/textxform\#getTxtHeight--)をご覧ください。 |
+| [setTxtLocPinX(DoubleValue value)](#setTxtLocPinX-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getTxtLocPinX()](../../com.aspose.diagram/textxform\#getTxtLocPinX--)をご覧ください。 |
+| [setTxtLocPinY(DoubleValue value)](#setTxtLocPinY-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getTxtLocPinY()](../../com.aspose.diagram/textxform\#getTxtLocPinY--)をご覧ください。 |
+| [setTxtPinX(DoubleValue value)](#setTxtPinX-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getTxtPinX()](../../com.aspose.diagram/textxform\#getTxtPinX--)をご覧ください。 |
+| [setTxtPinY(DoubleValue value)](#setTxtPinY-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getTxtPinY()](../../com.aspose.diagram/textxform\#getTxtPinY--)をご覧ください。 |
+| [setTxtWidth(DoubleValue value)](#setTxtWidth-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getTxtWidth()](../../com.aspose.diagram/textxform\#getTxtWidth--)をご覧ください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getTxtAngle() {#getTxtAngle--}
+```
+public DoubleValue getTxtAngle()
+```
+
+
+シェイプの x 軸に対するテキストブロックの現在の回転角度を指定します。デフォルトは 0 度です。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTxtHeight() {#getTxtHeight--}
+```
+public DoubleValue getTxtHeight()
+```
+
+
+テキストブロックの高さを指定します。デフォルトの数式は、シェイプの高さになる F="Height\*1" です。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTxtLocPinX() {#getTxtLocPinX--}
+```
+public DoubleValue getTxtLocPinX()
+```
+
+
+テキストブロックの回転中心の x 座標を、テキストブロックの原点に対して指定します。デフォルトの数式は、テキストブロックの水平中心になる F="TxtWidth\*0.5" です。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTxtLocPinY() {#getTxtLocPinY--}
+```
+public DoubleValue getTxtLocPinY()
+```
+
+
+テキストブロックの回転中心の y 座標を、テキストブロックの原点に対して指定します。デフォルトの数式は、テキストブロックの垂直中心になる F="TxtHeight\*0.5" です。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTxtPinX() {#getTxtPinX--}
+```
+public DoubleValue getTxtPinX()
+```
+
+
+シェイプの原点に対して、テキストブロックの回転中心の x 座標を指定します。デフォルトの数式は、シェイプの水平中心になる F="Width\*0.5" です。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTxtPinY() {#getTxtPinY--}
+```
+public DoubleValue getTxtPinY()
+```
+
+
+シェイプの原点に対して、テキストブロックの回転中心の y 座標を指定します。デフォルトの数式は、シェイプの垂直中心になる F="Height\*0.5" です。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTxtWidth() {#getTxtWidth--}
+```
+public DoubleValue getTxtWidth()
+```
+
+
+テキストブロックの幅を指定します。デフォルトの数式は、シェイプの幅になる F="Width\*1" です。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+このプロパティの説明については、[getDel()](../../com.aspose.diagram/textxform\#getDel--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setTxtAngle(DoubleValue value) {#setTxtAngle-com.aspose.diagram.DoubleValue-}
+```
+public void setTxtAngle(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getTxtAngle()](../../com.aspose.diagram/textxform\#getTxtAngle--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTxtHeight(DoubleValue value) {#setTxtHeight-com.aspose.diagram.DoubleValue-}
+```
+public void setTxtHeight(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getTxtHeight()](../../com.aspose.diagram/textxform\#getTxtHeight--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTxtLocPinX(DoubleValue value) {#setTxtLocPinX-com.aspose.diagram.DoubleValue-}
+```
+public void setTxtLocPinX(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getTxtLocPinX()](../../com.aspose.diagram/textxform\#getTxtLocPinX--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTxtLocPinY(DoubleValue value) {#setTxtLocPinY-com.aspose.diagram.DoubleValue-}
+```
+public void setTxtLocPinY(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getTxtLocPinY()](../../com.aspose.diagram/textxform\#getTxtLocPinY--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTxtPinX(DoubleValue value) {#setTxtPinX-com.aspose.diagram.DoubleValue-}
+```
+public void setTxtPinX(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getTxtPinX()](../../com.aspose.diagram/textxform\#getTxtPinX--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTxtPinY(DoubleValue value) {#setTxtPinY-com.aspose.diagram.DoubleValue-}
+```
+public void setTxtPinY(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getTxtPinY()](../../com.aspose.diagram/textxform\#getTxtPinY--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTxtWidth(DoubleValue value) {#setTxtWidth-com.aspose.diagram.DoubleValue-}
+```
+public void setTxtWidth(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getTxtWidth()](../../com.aspose.diagram/textxform\#getTxtWidth--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/threedformat/_index.md
+++ b/japanese/java/com.aspose.diagram/threedformat/_index.md
@@ -1,0 +1,625 @@
+---
+title: ThreeDFormat
+second_title: Aspose.Diagram for Java API リファレンス
+description: シェイプの三次元書式設定を表します。
+type: docs
+weight: 406
+url: /ja/java/com.aspose.diagram/threedformat/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ThreeDFormat
+```
+
+シェイプの三次元書式設定を表します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object obj)](#equals-java.lang.Object-) |  |
+| [getBevelBottomHeight()](#getBevelBottomHeight--) | 3D 形状の底部ベベルの高さを指定します。 |
+| [getBevelBottomType()](#getBevelBottomType--) | 3D 形状の底部ベベルのプリセットベベルタイプを指定します |
+| [getBevelBottomWidth()](#getBevelBottomWidth--) | 3D 形状の底部ベベルの幅を指定します。 |
+| [getBevelContourColor()](#getBevelContourColor--) | 3D 形状の輪郭の色を指定します |
+| [getBevelContourSize()](#getBevelContourSize--) | 3D 形状の輪郭の太さを指定します |
+| [getBevelDepthColor()](#getBevelDepthColor--) | 3D 形状の押し出し色を指定します |
+| [getBevelDepthSize()](#getBevelDepthSize--) | 3D 形状の押し出し深さを指定します |
+| [getBevelLightingAngle()](#getBevelLightingAngle--) | 3D 形状の照明方向を指定します。 |
+| [getBevelLightingType()](#getBevelLightingType--) | 3D 形状の照明のプリセットタイプを指定します |
+| [getBevelMaterialType()](#getBevelMaterialType--) | 3D 形状の表面外観のプリセットを指定します |
+| [getBevelTopHeight()](#getBevelTopHeight--) | 3D 形状の上部ベベルの高さを指定します |
+| [getBevelTopType()](#getBevelTopType--) | 3D 形状の上部ベベルのプリセットベベルタイプを指定します |
+| [getBevelTopWidth()](#getBevelTopWidth--) | 3D 形状の上部ベベルの幅を指定します。 |
+| [getClass()](#getClass--) |  |
+| [getDistanceFromGround()](#getDistanceFromGround--) | 3D 回転プロパティを持つシェイプの距離を指定します |
+| [getKeepTextFlat()](#getKeepTextFlat--) | 3D 回転プロパティがシェイプのテキストに適用されるかどうかを指定します |
+| [getPerspective()](#getPerspective--) | 3D 回転プロパティを持つシェイプの視野角を指定します |
+| [getRotationType()](#getRotationType--) | シェイプの効果プロパティの投影タイプを指定します。 |
+| [getRotationXAngle()](#getRotationXAngle--) | シェイプを y 軸周りに反時計回りに回転させる角度を指定します。 |
+| [getRotationYAngle()](#getRotationYAngle--) | シェイプを x 軸周りに反時計回りに回転させる角度を指定します |
+| [getRotationZAngle()](#getRotationZAngle--) | シェイプを z 軸周りに反時計回りに回転させる角度を指定します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setBevelBottomHeight(DoubleValue value)](#setBevelBottomHeight-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getBevelBottomHeight()](../../com.aspose.diagram/threedformat\#getBevelBottomHeight--) を参照してください |
+| [setBevelBottomType(BevelType value)](#setBevelBottomType-com.aspose.diagram.BevelType-) | このプロパティの説明については、[getBevelBottomType()](../../com.aspose.diagram/threedformat\#getBevelBottomType--) を参照してください |
+| [setBevelBottomWidth(DoubleValue value)](#setBevelBottomWidth-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getBevelBottomWidth()](../../com.aspose.diagram/threedformat\#getBevelBottomWidth--) を参照してください |
+| [setBevelContourColor(ColorValue value)](#setBevelContourColor-com.aspose.diagram.ColorValue-) | このプロパティの説明については、[getBevelContourColor()](../../com.aspose.diagram/threedformat\#getBevelContourColor--) を参照してください |
+| [setBevelContourSize(DoubleValue value)](#setBevelContourSize-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getBevelContourSize()](../../com.aspose.diagram/threedformat\#getBevelContourSize--) を参照してください |
+| [setBevelDepthColor(ColorValue value)](#setBevelDepthColor-com.aspose.diagram.ColorValue-) | このプロパティの説明については、[getBevelDepthColor()](../../com.aspose.diagram/threedformat\#getBevelDepthColor--) を参照してください。 |
+| [setBevelDepthSize(DoubleValue value)](#setBevelDepthSize-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getBevelDepthSize()](../../com.aspose.diagram/threedformat\#getBevelDepthSize--) を参照してください。 |
+| [setBevelLightingAngle(DoubleValue value)](#setBevelLightingAngle-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getBevelLightingAngle()](../../com.aspose.diagram/threedformat\#getBevelLightingAngle--) を参照してください。 |
+| [setBevelLightingType(BevelLightingType value)](#setBevelLightingType-com.aspose.diagram.BevelLightingType-) | このプロパティの説明については、[getBevelLightingType()](../../com.aspose.diagram/threedformat\#getBevelLightingType--) を参照してください。 |
+| [setBevelMaterialType(BevelMaterialType value)](#setBevelMaterialType-com.aspose.diagram.BevelMaterialType-) | このプロパティの説明については、[getBevelMaterialType()](../../com.aspose.diagram/threedformat\#getBevelMaterialType--) を参照してください。 |
+| [setBevelTopHeight(DoubleValue value)](#setBevelTopHeight-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getBevelTopHeight()](../../com.aspose.diagram/threedformat\#getBevelTopHeight--) を参照してください。 |
+| [setBevelTopType(BevelType value)](#setBevelTopType-com.aspose.diagram.BevelType-) | このプロパティの説明については、[getBevelTopType()](../../com.aspose.diagram/threedformat\#getBevelTopType--) を参照してください。 |
+| [setBevelTopWidth(DoubleValue value)](#setBevelTopWidth-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getBevelTopWidth()](../../com.aspose.diagram/threedformat\#getBevelTopWidth--) を参照してください。 |
+| [setDistanceFromGround(DoubleValue value)](#setDistanceFromGround-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getDistanceFromGround()](../../com.aspose.diagram/threedformat\#getDistanceFromGround--) を参照してください。 |
+| [setKeepTextFlat(BoolValue value)](#setKeepTextFlat-com.aspose.diagram.BoolValue-) | このプロパティの説明については、[getKeepTextFlat()](../../com.aspose.diagram/threedformat\#getKeepTextFlat--) を参照してください。 |
+| [setPerspective(DoubleValue value)](#setPerspective-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getPerspective()](../../com.aspose.diagram/threedformat\#getPerspective--) を参照してください。 |
+| [setRotationType(RotationType value)](#setRotationType-com.aspose.diagram.RotationType-) | このプロパティの説明については、[getRotationType()](../../com.aspose.diagram/threedformat\#getRotationType--) を参照してください。 |
+| [setRotationXAngle(DoubleValue value)](#setRotationXAngle-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getRotationXAngle()](../../com.aspose.diagram/threedformat\#getRotationXAngle--) を参照してください。 |
+| [setRotationYAngle(DoubleValue value)](#setRotationYAngle-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getRotationYAngle()](../../com.aspose.diagram/threedformat\#getRotationYAngle--) を参照してください。 |
+| [setRotationZAngle(DoubleValue value)](#setRotationZAngle-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getRotationZAngle()](../../com.aspose.diagram/threedformat\#getRotationZAngle--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| obj | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getBevelBottomHeight() {#getBevelBottomHeight--}
+```
+public DoubleValue getBevelBottomHeight()
+```
+
+
+3D 形状の底部ベベルの高さを指定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBevelBottomType() {#getBevelBottomType--}
+```
+public BevelType getBevelBottomType()
+```
+
+
+3D 形状の底部ベベルのプリセットベベルタイプを指定します
+
+**Returns:**
+[BevelType](../../com.aspose.diagram/beveltype)
+### getBevelBottomWidth() {#getBevelBottomWidth--}
+```
+public DoubleValue getBevelBottomWidth()
+```
+
+
+3D 形状の底部ベベルの幅を指定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBevelContourColor() {#getBevelContourColor--}
+```
+public ColorValue getBevelContourColor()
+```
+
+
+3D 形状の輪郭の色を指定します
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getBevelContourSize() {#getBevelContourSize--}
+```
+public DoubleValue getBevelContourSize()
+```
+
+
+3D 形状の輪郭の太さを指定します
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBevelDepthColor() {#getBevelDepthColor--}
+```
+public ColorValue getBevelDepthColor()
+```
+
+
+3D 形状の押し出し色を指定します
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getBevelDepthSize() {#getBevelDepthSize--}
+```
+public DoubleValue getBevelDepthSize()
+```
+
+
+3D 形状の押し出し深さを指定します
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBevelLightingAngle() {#getBevelLightingAngle--}
+```
+public DoubleValue getBevelLightingAngle()
+```
+
+
+3D 形状の照明方向を指定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBevelLightingType() {#getBevelLightingType--}
+```
+public BevelLightingType getBevelLightingType()
+```
+
+
+3D 形状の照明のプリセットタイプを指定します
+
+**Returns:**
+[BevelLightingType](../../com.aspose.diagram/bevellightingtype)
+### getBevelMaterialType() {#getBevelMaterialType--}
+```
+public BevelMaterialType getBevelMaterialType()
+```
+
+
+3D 形状の表面外観のプリセットを指定します
+
+**Returns:**
+[BevelMaterialType](../../com.aspose.diagram/bevelmaterialtype)
+### getBevelTopHeight() {#getBevelTopHeight--}
+```
+public DoubleValue getBevelTopHeight()
+```
+
+
+3D 形状の上部ベベルの高さを指定します
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBevelTopType() {#getBevelTopType--}
+```
+public BevelType getBevelTopType()
+```
+
+
+3D 形状の上部ベベルのプリセットベベルタイプを指定します
+
+**Returns:**
+[BevelType](../../com.aspose.diagram/beveltype)
+### getBevelTopWidth() {#getBevelTopWidth--}
+```
+public DoubleValue getBevelTopWidth()
+```
+
+
+3D 形状の上部ベベルの幅を指定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDistanceFromGround() {#getDistanceFromGround--}
+```
+public DoubleValue getDistanceFromGround()
+```
+
+
+3D 回転プロパティを持つシェイプの距離を指定します
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getKeepTextFlat() {#getKeepTextFlat--}
+```
+public BoolValue getKeepTextFlat()
+```
+
+
+3D 回転プロパティがシェイプのテキストに適用されるかどうかを指定します
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getPerspective() {#getPerspective--}
+```
+public DoubleValue getPerspective()
+```
+
+
+3D 回転プロパティを持つシェイプの視野角を指定します
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getRotationType() {#getRotationType--}
+```
+public RotationType getRotationType()
+```
+
+
+シェイプの効果プロパティの投影タイプを指定します。
+
+**Returns:**
+[RotationType](../../com.aspose.diagram/rotationtype)
+### getRotationXAngle() {#getRotationXAngle--}
+```
+public DoubleValue getRotationXAngle()
+```
+
+
+シェイプを y 軸周りに反時計回りに回転させる角度を指定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getRotationYAngle() {#getRotationYAngle--}
+```
+public DoubleValue getRotationYAngle()
+```
+
+
+シェイプを x 軸周りに反時計回りに回転させる角度を指定します
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getRotationZAngle() {#getRotationZAngle--}
+```
+public DoubleValue getRotationZAngle()
+```
+
+
+シェイプを z 軸周りに反時計回りに回転させる角度を指定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setBevelBottomHeight(DoubleValue value) {#setBevelBottomHeight-com.aspose.diagram.DoubleValue-}
+```
+public void setBevelBottomHeight(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getBevelBottomHeight()](../../com.aspose.diagram/threedformat\#getBevelBottomHeight--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setBevelBottomType(BevelType value) {#setBevelBottomType-com.aspose.diagram.BevelType-}
+```
+public void setBevelBottomType(BevelType value)
+```
+
+
+このプロパティの説明については、[getBevelBottomType()](../../com.aspose.diagram/threedformat\#getBevelBottomType--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [BevelType](../../com.aspose.diagram/beveltype) |  |
+
+### setBevelBottomWidth(DoubleValue value) {#setBevelBottomWidth-com.aspose.diagram.DoubleValue-}
+```
+public void setBevelBottomWidth(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getBevelBottomWidth()](../../com.aspose.diagram/threedformat\#getBevelBottomWidth--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setBevelContourColor(ColorValue value) {#setBevelContourColor-com.aspose.diagram.ColorValue-}
+```
+public void setBevelContourColor(ColorValue value)
+```
+
+
+このプロパティの説明については、[getBevelContourColor()](../../com.aspose.diagram/threedformat\#getBevelContourColor--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setBevelContourSize(DoubleValue value) {#setBevelContourSize-com.aspose.diagram.DoubleValue-}
+```
+public void setBevelContourSize(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getBevelContourSize()](../../com.aspose.diagram/threedformat\#getBevelContourSize--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setBevelDepthColor(ColorValue value) {#setBevelDepthColor-com.aspose.diagram.ColorValue-}
+```
+public void setBevelDepthColor(ColorValue value)
+```
+
+
+このプロパティの説明については、[getBevelDepthColor()](../../com.aspose.diagram/threedformat\#getBevelDepthColor--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setBevelDepthSize(DoubleValue value) {#setBevelDepthSize-com.aspose.diagram.DoubleValue-}
+```
+public void setBevelDepthSize(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getBevelDepthSize()](../../com.aspose.diagram/threedformat\#getBevelDepthSize--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setBevelLightingAngle(DoubleValue value) {#setBevelLightingAngle-com.aspose.diagram.DoubleValue-}
+```
+public void setBevelLightingAngle(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getBevelLightingAngle()](../../com.aspose.diagram/threedformat\#getBevelLightingAngle--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setBevelLightingType(BevelLightingType value) {#setBevelLightingType-com.aspose.diagram.BevelLightingType-}
+```
+public void setBevelLightingType(BevelLightingType value)
+```
+
+
+このプロパティの説明については、[getBevelLightingType()](../../com.aspose.diagram/threedformat\#getBevelLightingType--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [BevelLightingType](../../com.aspose.diagram/bevellightingtype) |  |
+
+### setBevelMaterialType(BevelMaterialType value) {#setBevelMaterialType-com.aspose.diagram.BevelMaterialType-}
+```
+public void setBevelMaterialType(BevelMaterialType value)
+```
+
+
+このプロパティの説明については、[getBevelMaterialType()](../../com.aspose.diagram/threedformat\#getBevelMaterialType--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [BevelMaterialType](../../com.aspose.diagram/bevelmaterialtype) |  |
+
+### setBevelTopHeight(DoubleValue value) {#setBevelTopHeight-com.aspose.diagram.DoubleValue-}
+```
+public void setBevelTopHeight(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getBevelTopHeight()](../../com.aspose.diagram/threedformat\#getBevelTopHeight--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setBevelTopType(BevelType value) {#setBevelTopType-com.aspose.diagram.BevelType-}
+```
+public void setBevelTopType(BevelType value)
+```
+
+
+このプロパティの説明については、[getBevelTopType()](../../com.aspose.diagram/threedformat\#getBevelTopType--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [BevelType](../../com.aspose.diagram/beveltype) |  |
+
+### setBevelTopWidth(DoubleValue value) {#setBevelTopWidth-com.aspose.diagram.DoubleValue-}
+```
+public void setBevelTopWidth(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getBevelTopWidth()](../../com.aspose.diagram/threedformat\#getBevelTopWidth--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDistanceFromGround(DoubleValue value) {#setDistanceFromGround-com.aspose.diagram.DoubleValue-}
+```
+public void setDistanceFromGround(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getDistanceFromGround()](../../com.aspose.diagram/threedformat\#getDistanceFromGround--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setKeepTextFlat(BoolValue value) {#setKeepTextFlat-com.aspose.diagram.BoolValue-}
+```
+public void setKeepTextFlat(BoolValue value)
+```
+
+
+このプロパティの説明については、[getKeepTextFlat()](../../com.aspose.diagram/threedformat\#getKeepTextFlat--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setPerspective(DoubleValue value) {#setPerspective-com.aspose.diagram.DoubleValue-}
+```
+public void setPerspective(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getPerspective()](../../com.aspose.diagram/threedformat\#getPerspective--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setRotationType(RotationType value) {#setRotationType-com.aspose.diagram.RotationType-}
+```
+public void setRotationType(RotationType value)
+```
+
+
+このプロパティの説明については、[getRotationType()](../../com.aspose.diagram/threedformat\#getRotationType--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [RotationType](../../com.aspose.diagram/rotationtype) |  |
+
+### setRotationXAngle(DoubleValue value) {#setRotationXAngle-com.aspose.diagram.DoubleValue-}
+```
+public void setRotationXAngle(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getRotationXAngle()](../../com.aspose.diagram/threedformat\#getRotationXAngle--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setRotationYAngle(DoubleValue value) {#setRotationYAngle-com.aspose.diagram.DoubleValue-}
+```
+public void setRotationYAngle(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getRotationYAngle()](../../com.aspose.diagram/threedformat\#getRotationYAngle--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setRotationZAngle(DoubleValue value) {#setRotationZAngle-com.aspose.diagram.DoubleValue-}
+```
+public void setRotationZAngle(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getRotationZAngle()](../../com.aspose.diagram/threedformat\#getRotationZAngle--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/tiffcompression/_index.md
+++ b/japanese/java/com.aspose.diagram/tiffcompression/_index.md
@@ -1,0 +1,174 @@
+---
+title: TiffCompression
+second_title: Aspose.Diagram for Java API リファレンス
+description: ページを TIFF 形式で保存する際に適用する圧縮タイプを指定します。
+type: docs
+weight: 407
+url: /ja/java/com.aspose.diagram/tiffcompression/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class TiffCompression
+```
+
+ページを TIFF 形式で保存する際に適用する圧縮タイプを指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [CCITT_3](#CCITT-3) | CCITT3 圧縮方式を指定します。 |
+| [CCITT_4](#CCITT-4) | CCITT4 圧縮方式を指定します。 |
+| [LZW](#LZW) | LZW 圧縮方式を指定します。 |
+| [NONE](#NONE) | 圧縮なしを指定します。 |
+| [RLE](#RLE) | RLE 圧縮方式を指定します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CCITT_3 {#CCITT-3}
+```
+public static final int CCITT_3
+```
+
+
+CCITT3 圧縮方式を指定します。
+
+### CCITT_4 {#CCITT-4}
+```
+public static final int CCITT_4
+```
+
+
+CCITT4 圧縮方式を指定します。
+
+### LZW {#LZW}
+```
+public static final int LZW
+```
+
+
+LZW 圧縮方式を指定します。
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+圧縮なしを指定します。
+
+### RLE {#RLE}
+```
+public static final int RLE
+```
+
+
+RLE 圧縮方式を指定します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/timelinehelper/_index.md
+++ b/japanese/java/com.aspose.diagram/timelinehelper/_index.md
@@ -1,0 +1,512 @@
+---
+title: TimeLineHelper
+second_title: Aspose.Diagram for Java API リファレンス
+description: タイムライン シェイプのプロパティを設定するための TimeLineHelper。
+type: docs
+weight: 408
+url: /ja/java/com.aspose.diagram/timelinehelper/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class TimeLineHelper
+```
+
+タイムライン シェイプのプロパティを設定するための TimeLineHelper。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [TimeLineHelper(Shape shape)](#TimeLineHelper-com.aspose.diagram.Shape-) | TimeLineHelper. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDoubleStringFromDateTime(DateTime dateTime)](#getDoubleStringFromDateTime-com.aspose.diagram.DateTime-) | 日付時刻を double 値に変換します。 |
+| [getTimePeriodFinish()](#getTimePeriodFinish--) | タイムラインシェイプの終了の時間期間 |
+| [getTimePeriodStart()](#getTimePeriodStart--) | タイムラインシェイプの開始の時間期間 |
+| [getTimeScale()](#getTimeScale--) | タイムラインシェイプのスケール |
+| [getWeekEnd(DateTime startDate, int weekStart)](#getWeekEnd-com.aspose.diagram.DateTime-int-) | getweekstart |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [refreshTimeLine()](#refreshTimeLine--) | タイムラインシェイプの更新時間 |
+| [setArrowHead(int value)](#setArrowHead-int-) | タイムラインシェイプの ArrowHead |
+| [setAutoUpdate(boolean value)](#setAutoUpdate-boolean-) | タイムライン上でマーカー（マイルストーン、間隔）が移動される際にデータを更新するかどうか |
+| [setBeginWeek(int value)](#setBeginWeek-int-) | タイムラインシェイプの開始週 |
+|  | [setDateFormatForBE(int value)](#setDateFormatForBE-int-) | タイムラインシェイプの開始と終了の DateFormat /// |
+
+| ----------------------- | ------------------------------- |
+| **Value**\u9286\u20ac | **Format String**\u9286\u20ac |
+| 0                       | dddd, yyyy-M-d                  |
+| 1                       | yyyy-MM-dd                      |
+| 2                       | yy-MMM-d                        |
+| 3                       | yyyy/M/d                        |
+| 4                       | yy-MMM.                         | |
+|  | [setDateFormatForIntm(int value)](#setDateFormatForIntm-int-) | タイムラインシェイプの Intm の DateFormat /// |
+
+| ----------------------- | ------------------------------- |
+| **Value**\u9286\u20ac | **Format String**\u9286\u20ac |
+| 0                       | dddd, yyyy-M-d                  |
+| 1                       | yyyy-MM-dd                      |
+| 2                       | yy-MMM-d                        |
+| 3                       | yyyy/M/d                        |
+| 4                       | yy-MMM.                         | |
+| [setDateFormatStringForBE(String value)](#setDateFormatStringForBE-java.lang.String-) | タイムラインシェイプの開始と終了の DateFormat 文字列 |
+| [setDateFormatStringForIntm(String value)](#setDateFormatStringForIntm-java.lang.String-) | タイムラインシェイプの Intm の DateFormat 文字列 |
+| [setDisplayBE(boolean value)](#setDisplayBE-boolean-) | タイムライン上に開始日と終了日を表示するかどうか |
+| [setDisplayIntm(boolean value)](#setDisplayIntm-boolean-) | タイムライン上に中間の日付/時刻目盛りを表示するかどうか |
+| [setDisplayIntmDates(boolean value)](#setDisplayIntmDates-boolean-) | 中間の目盛りに中間日付を表示するかどうか |
+| [setFiscalStart(DateTime value)](#setFiscalStart-com.aspose.diagram.DateTime-) | 会計年度の最初の日 |
+| [setTimeLineType(int value)](#setTimeLineType-int-) | タイムラインシェイプの開始週 |
+| [setTimePeriodFinish(DateTime value)](#setTimePeriodFinish-com.aspose.diagram.DateTime-) |  |
+| [setTimePeriodStart(DateTime value)](#setTimePeriodStart-com.aspose.diagram.DateTime-) |  |
+| [setTimeScale(int value)](#setTimeScale-int-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### TimeLineHelper(Shape shape) {#TimeLineHelper-com.aspose.diagram.Shape-}
+```
+public TimeLineHelper(Shape shape)
+```
+
+
+TimeLineHelper.
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| shape | [Shape](../../com.aspose.diagram/shape) |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDoubleStringFromDateTime(DateTime dateTime) {#getDoubleStringFromDateTime-com.aspose.diagram.DateTime-}
+```
+public static String getDoubleStringFromDateTime(DateTime dateTime)
+```
+
+
+日付時刻を double 値に変換します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| dateTime | [DateTime](../../com.aspose.diagram/datetime) | 日時。 |
+
+**Returns:**
+java.lang.String -
+### getTimePeriodFinish() {#getTimePeriodFinish--}
+```
+public DateTime getTimePeriodFinish()
+```
+
+
+タイムラインシェイプの終了の時間期間
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### getTimePeriodStart() {#getTimePeriodStart--}
+```
+public DateTime getTimePeriodStart()
+```
+
+
+タイムラインシェイプの開始の時間期間
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### getTimeScale() {#getTimeScale--}
+```
+public int getTimeScale()
+```
+
+
+タイムラインシェイプのスケール
+
+**Returns:**
+int
+### getWeekEnd(DateTime startDate, int weekStart) {#getWeekEnd-com.aspose.diagram.DateTime-int-}
+```
+public static DateTime getWeekEnd(DateTime startDate, int weekStart)
+```
+
+
+getweekstart
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| startDate | [DateTime](../../com.aspose.diagram/datetime) |  |
+| 週開始 | int | (0日曜日 1月曜日 2 3 4 5 6) |
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - 
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### refreshTimeLine() {#refreshTimeLine--}
+```
+public void refreshTimeLine()
+```
+
+
+タイムラインシェイプの更新時間
+
+### setArrowHead(int value) {#setArrowHead-int-}
+```
+public void setArrowHead(int value)
+```
+
+
+タイムラインシェイプの ArrowHead
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setAutoUpdate(boolean value) {#setAutoUpdate-boolean-}
+```
+public void setAutoUpdate(boolean value)
+```
+
+
+タイムライン上でマーカー（マイルストーン、間隔）が移動される際にデータを更新するかどうか
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setBeginWeek(int value) {#setBeginWeek-int-}
+```
+public void setBeginWeek(int value)
+```
+
+
+タイムラインシェイプの開始週
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setDateFormatForBE(int value) {#setDateFormatForBE-int-}
+```
+public void setDateFormatForBE(int value)
+```
+
+
+タイムラインシェイプの開始と終了の DateFormat ///
+
+| ----------------------- | ------------------------------- |
+| **Value**\u9286\u20ac | **Format String**\u9286\u20ac |
+| 0                       | dddd, yyyy-M-d                  |
+| 1                       | yyyy-MM-dd                      |
+| 2                       | yy-MMM-d                        |
+| 3                       | yyyy/M/d                        |
+| 4                       | yy-MMM.-d                       |
+| 5                       | d MMMM yyyy                     |
+| 6                       | yy-M                            |
+| 7                       | MMM-yy                          |
+| 8                       | MMMM d, yyyy                    |
+| 9                       | MMM d, yyyy                     |
+| 10                      | M-d-yy                          |
+| 11                      | M-d                             |
+| 12                      | d MMMM, yyyy                    |
+| 13                      | d MMM, yyyy                     |
+| 14                      | d-M-yy                          |
+| 15                      | d-M                             |
+| 16                      | yy-M-d                          |
+| 17                      | yyyy-M-d                        |
+| 18                      | M-yy                            |
+| 19                      | M-yyyy                          |
+| 20                      | MMMM yyyy                       |
+| 21                      | MMMM yy                         |
+| 22                      | MMM yyyy                        |
+| 23                      | MMM yy                          |
+| 24                      | yy                              |
+| 25                      | yyyy                            |
+| 26                      | d                               |
+| 27                      | MMMM                            |
+| 28                      | MMM                             |
+| 29                      | M                               |
+| 30                      | MM/dd/yyyy                      |
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setDateFormatForIntm(int value) {#setDateFormatForIntm-int-}
+```
+public void setDateFormatForIntm(int value)
+```
+
+
+タイムラインシェイプの Intm の DateFormat ///
+
+| ----------------------- | ------------------------------- |
+| **Value**\u9286\u20ac | **Format String**\u9286\u20ac |
+| 0                       | dddd, yyyy-M-d                  |
+| 1                       | yyyy-MM-dd                      |
+| 2                       | yy-MMM-d                        |
+| 3                       | yyyy/M/d                        |
+| 4                       | yy-MMM.-d                       |
+| 5                       | d MMMM yyyy                     |
+| 6                       | yy-M                            |
+| 7                       | MMM-yy                          |
+| 8                       | MMMM d, yyyy                    |
+| 9                       | MMM d, yyyy                     |
+| 10                      | M-d-yy                          |
+| 11                      | M-d                             |
+| 12                      | d MMMM, yyyy                    |
+| 13                      | d MMM, yyyy                     |
+| 14                      | d-M-yy                          |
+| 15                      | d-M                             |
+| 16                      | yy-M-d                          |
+| 17                      | yyyy-M-d                        |
+| 18                      | M-yy                            |
+| 19                      | M-yyyy                          |
+| 20                      | MMMM yyyy                       |
+| 21                      | MMMM yy                         |
+| 22                      | MMM yyyy                        |
+| 23                      | MMM yy                          |
+| 24                      | yy                              |
+| 25                      | yyyy                            |
+| 26                      | d                               |
+| 27                      | MMMM                            |
+| 28                      | MMM                             |
+| 29                      | M                               |
+| 30                      | MM/dd/yyyy                      |
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setDateFormatStringForBE(String value) {#setDateFormatStringForBE-java.lang.String-}
+```
+public void setDateFormatStringForBE(String value)
+```
+
+
+タイムラインシェイプの開始と終了の DateFormat 文字列
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setDateFormatStringForIntm(String value) {#setDateFormatStringForIntm-java.lang.String-}
+```
+public void setDateFormatStringForIntm(String value)
+```
+
+
+タイムラインシェイプの Intm の DateFormat 文字列
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setDisplayBE(boolean value) {#setDisplayBE-boolean-}
+```
+public void setDisplayBE(boolean value)
+```
+
+
+タイムライン上に開始日と終了日を表示するかどうか
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setDisplayIntm(boolean value) {#setDisplayIntm-boolean-}
+```
+public void setDisplayIntm(boolean value)
+```
+
+
+タイムライン上に中間の日付/時刻目盛りを表示するかどうか
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setDisplayIntmDates(boolean value) {#setDisplayIntmDates-boolean-}
+```
+public void setDisplayIntmDates(boolean value)
+```
+
+
+中間の目盛りに中間日付を表示するかどうか
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setFiscalStart(DateTime value) {#setFiscalStart-com.aspose.diagram.DateTime-}
+```
+public void setFiscalStart(DateTime value)
+```
+
+
+会計年度の最初の日
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setTimeLineType(int value) {#setTimeLineType-int-}
+```
+public void setTimeLineType(int value)
+```
+
+
+タイムラインシェイプの開始週
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setTimePeriodFinish(DateTime value) {#setTimePeriodFinish-com.aspose.diagram.DateTime-}
+```
+public void setTimePeriodFinish(DateTime value)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setTimePeriodStart(DateTime value) {#setTimePeriodStart-com.aspose.diagram.DateTime-}
+```
+public void setTimePeriodStart(DateTime value)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setTimeScale(int value) {#setTimeScale-int-}
+```
+public void setTimeScale(int value)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/togglebuttonactivexcontrol/_index.md
+++ b/japanese/java/com.aspose.diagram/togglebuttonactivexcontrol/_index.md
@@ -1,0 +1,604 @@
+---
+title: ToggleButtonActiveXControl
+second_title: Aspose.Diagram for Java API リファレンス
+description: ToggleButton ActiveX コントロールを表します。
+type: docs
+weight: 410
+url: /ja/java/com.aspose.diagram/togglebuttonactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class ToggleButtonActiveXControl extends ActiveXControl
+```
+
+ToggleButton ActiveX コントロールを表します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAccelerator()](#getAccelerator--) | コントロールのアクセラレータキーです。 |
+| [getBackOleColor()](#getBackOleColor--) | 背景の OLE カラー。 |
+| [getCaption()](#getCaption--) | コントロール上に表示される説明テキストです。 |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | コントロールのバイナリ データ。 |
+| [getForeOleColor()](#getForeOleColor--) | 前景の OLE カラー。 |
+| [getHeight()](#getHeight--) | ポイント単位のコントロールの高さ。 |
+| [getIMEMode()](#getIMEMode--) | コントロールがフォーカスを受け取る際の Input Method Editor のデフォルト実行時モード。 |
+| [getMouseIcon()](#getMouseIcon--) | コントロールのマウスポインタとして表示するカスタムアイコンです。 |
+| [getMousePointer()](#getMousePointer--) | コントロールのマウスポインタとして表示されるアイコンの種類です。 |
+| [getPicture()](#getPicture--) | 画像のデータです。 |
+| [getPicturePosition()](#getPicturePosition--) | コントロールのキャプションに対する画像の位置。 |
+| [getSpecialEffect()](#getSpecialEffect--) | コントロールの特殊効果です。 |
+| [getType()](#getType--) | ActiveX コントロールのタイプを取得します。 |
+| [getValue()](#getValue--) | コントロールがチェックされているかどうかを示します。 |
+| [getWidth()](#getWidth--) | ポイント単位のコントロールの幅です。 |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | コントロールが全内容を表示するために自動的にサイズ変更されるかどうかを示します。 |
+| [isEnabled()](#isEnabled--) | コントロールがフォーカスを受け取り、ユーザー生成イベントに応答できるかどうかを示します。 |
+| [isLocked()](#isLocked--) | コントロール内のデータが編集ロックされているかどうかを示します。 |
+| [isTransparent()](#isTransparent--) | コントロールが透明かどうかを示します。 |
+| [isTripleState()](#isTripleState--) | 指定されたコントロールが Null 値をどのように表示するかを示します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAccelerator(char value)](#setAccelerator-char-) | このプロパティの説明については、[getAccelerator()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getAccelerator--) を参照してください。 |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | このプロパティの説明については、[isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) を参照してください |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | このプロパティの説明については、[getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) を参照してください |
+| [setCaption(String value)](#setCaption-java.lang.String-) | このプロパティの説明については、[getCaption()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getCaption--) を参照してください。 |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | このプロパティの説明については、[isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) を参照してください |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | このプロパティの説明については、[getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) を参照してください |
+| [setHeight(double value)](#setHeight-double-) | このプロパティの説明については、[getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) を参照してください |
+| [setIMEMode(int value)](#setIMEMode-int-) | このプロパティの説明については、[getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) を参照してください |
+| [setLocked(boolean value)](#setLocked-boolean-) | このプロパティの説明については、[isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) を参照してください |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | このプロパティの説明については、[getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) を参照してください |
+| [setMousePointer(int value)](#setMousePointer-int-) | このプロパティの説明については、[getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) を参照してください |
+| [setPicture(byte[] value)](#setPicture-byte---) | このプロパティの説明については、[getPicture()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getPicture--) を参照してください。 |
+| [setPicturePosition(int value)](#setPicturePosition-int-) | このプロパティの説明については、[getPicturePosition()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getPicturePosition--) を参照してください。 |
+| [setSpecialEffect(int value)](#setSpecialEffect-int-) | このプロパティの説明については、[getSpecialEffect()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getSpecialEffect--) を参照してください。 |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | このプロパティの説明については、[isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) を参照してください |
+| [setTripleState(boolean value)](#setTripleState-boolean-) | このプロパティの説明については、[isTripleState()](../../com.aspose.diagram/togglebuttonactivexcontrol\#isTripleState--) を参照してください。 |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getValue--) を参照してください。 |
+| [setWidth(double value)](#setWidth-double-) | このプロパティの説明については、[getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) を参照してください |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAccelerator() {#getAccelerator--}
+```
+public char getAccelerator()
+```
+
+
+コントロールのアクセラレータキーです。
+
+**Returns:**
+char
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+背景の OLE カラー。
+
+**Returns:**
+int
+### getCaption() {#getCaption--}
+```
+public String getCaption()
+```
+
+
+コントロール上に表示される説明テキストです。
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+コントロールのバイナリ データ。
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+前景の OLE カラーです。Image コントロールには適用されません。
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+ポイント単位のコントロールの高さ。
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+コントロールがフォーカスを受け取る際の Input Method Editor のデフォルト実行時モード。
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+コントロールのマウスポインタとして表示するカスタムアイコンです。
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+コントロールのマウスポインタとして表示されるアイコンの種類です。
+
+**Returns:**
+int
+### getPicture() {#getPicture--}
+```
+public byte[] getPicture()
+```
+
+
+画像のデータです。
+
+**Returns:**
+byte[]
+### getPicturePosition() {#getPicturePosition--}
+```
+public int getPicturePosition()
+```
+
+
+コントロールのキャプションに対する画像の位置。
+
+**Returns:**
+int
+### getSpecialEffect() {#getSpecialEffect--}
+```
+public int getSpecialEffect()
+```
+
+
+コントロールの特殊効果です。
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+ActiveX コントロールのタイプを取得します。
+
+**Returns:**
+int
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+コントロールがチェックされているかどうかを示します。
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+ポイント単位のコントロールの幅です。
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+コントロールが全内容を表示するために自動的にサイズ変更されるかどうかを示します。
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+コントロールがフォーカスを受け取り、ユーザー生成イベントに応答できるかどうかを示します。
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+コントロール内のデータが編集ロックされているかどうかを示します。
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+コントロールが透明かどうかを示します。
+
+**Returns:**
+boolean
+### isTripleState() {#isTripleState--}
+```
+public boolean isTripleState()
+```
+
+
+指定されたコントロールが Null 値をどのように表示するかを示します。
+
+| ------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| 設定 | 説明 |
+| True    | コントロールは Yes、No、Null の状態を循環します。Value プロパティが Null に設定されている場合、コントロールは暗く（グレー表示）なります。 |
+| False   | (Default) コントロールは Yes と No の状態を循環します。Null 値は No 値として表示されます。 |
+
+|
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAccelerator(char value) {#setAccelerator-char-}
+```
+public void setAccelerator(char value)
+```
+
+
+このプロパティの説明については、[getAccelerator()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getAccelerator--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | char |  |
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+このプロパティの説明については、[isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+このプロパティの説明については、[getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setCaption(String value) {#setCaption-java.lang.String-}
+```
+public void setCaption(String value)
+```
+
+
+このプロパティの説明については、[getCaption()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getCaption--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+このプロパティの説明については、[isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+このプロパティの説明については、[getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+このプロパティの説明については、[getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+このプロパティの説明については、[getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+このプロパティの説明については、[isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+このプロパティの説明については、[getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+このプロパティの説明については、[getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setPicture(byte[] value) {#setPicture-byte---}
+```
+public void setPicture(byte[] value)
+```
+
+
+このプロパティの説明については、[getPicture()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getPicture--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | byte[] |  |
+
+### setPicturePosition(int value) {#setPicturePosition-int-}
+```
+public void setPicturePosition(int value)
+```
+
+
+このプロパティの説明については、[getPicturePosition()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getPicturePosition--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setSpecialEffect(int value) {#setSpecialEffect-int-}
+```
+public void setSpecialEffect(int value)
+```
+
+
+このプロパティの説明については、[getSpecialEffect()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getSpecialEffect--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+このプロパティの説明については、[isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setTripleState(boolean value) {#setTripleState-boolean-}
+```
+public void setTripleState(boolean value)
+```
+
+
+このプロパティの説明については、[isTripleState()](../../com.aspose.diagram/togglebuttonactivexcontrol\#isTripleState--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getValue--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+このプロパティの説明については、[getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/topartvalue/_index.md
+++ b/japanese/java/com.aspose.diagram/topartvalue/_index.md
@@ -1,0 +1,201 @@
+---
+title: ToPartValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: 接続が行われるシェイプの部分。
+type: docs
+weight: 409
+url: /ja/java/com.aspose.diagram/topartvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ToPartValue
+```
+
+接続が行われるシェイプの部分。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [CONNECTION_POINT](#CONNECTION-POINT) | 接続点。 |
+| [GUIDE_INTERSECTION](#GUIDE-INTERSECTION) | ガイド交点。 |
+| [GUIDE_X](#GUIDE-X) | GuideX。 |
+| [GUIDE_Y](#GUIDE-Y) | GuideY。 |
+| [NONE](#NONE) | None. |
+| [TO_ANGLE](#TO-ANGLE) | 角度へ。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+| [WHOLE_SHAPE](#WHOLE-SHAPE) | 全体シェイプ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CONNECTION_POINT {#CONNECTION-POINT}
+```
+public static final int CONNECTION_POINT
+```
+
+
+接続点。
+
+### GUIDE_INTERSECTION {#GUIDE-INTERSECTION}
+```
+public static final int GUIDE_INTERSECTION
+```
+
+
+ガイド交点。
+
+### GUIDE_X {#GUIDE-X}
+```
+public static final int GUIDE_X
+```
+
+
+GuideX。
+
+### GUIDE_Y {#GUIDE-Y}
+```
+public static final int GUIDE_Y
+```
+
+
+GuideY。
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+None.
+
+### TO_ANGLE {#TO-ANGLE}
+```
+public static final int TO_ANGLE
+```
+
+
+角度へ。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### WHOLE_SHAPE {#WHOLE-SHAPE}
+```
+public static final int WHOLE_SHAPE
+```
+
+
+全体シェイプ。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/tp/_index.md
+++ b/japanese/java/com.aspose.diagram/tp/_index.md
@@ -1,0 +1,154 @@
+---
+title: Tp
+second_title: Aspose.Diagram for Java API リファレンス
+description: タブ プロパティ ランの開始位置を指定します。
+type: docs
+weight: 411
+url: /ja/java/com.aspose.diagram/tp/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.FormatTxt](../../com.aspose.diagram/formattxt)
+```
+public class Tp extends FormatTxt
+```
+
+タブプロパティのランの開始を指定します。ランはテキストの末尾まで、または次のまで定義されます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Tp(int IX)](#Tp-int-) | コンストラクタ |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getValue()](#getValue--) | 値 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Tp(int IX) {#Tp-int-}
+```
+public Tp(int IX)
+```
+
+
+コンストラクタ
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| IX | int | 親要素内の要素のゼロベースインデックスです。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+値
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/txt/_index.md
+++ b/japanese/java/com.aspose.diagram/txt/_index.md
@@ -1,0 +1,179 @@
+---
+title: Txt
+second_title: Aspose.Diagram for Java API リファレンス
+description: シェイプのテキスト
+type: docs
+weight: 412
+url: /ja/java/com.aspose.diagram/txt/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.FormatTxt](../../com.aspose.diagram/formattxt)
+```
+public class Txt extends FormatTxt
+```
+
+シェイプのテキスト
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Txt(String value)](#Txt-java.lang.String-) | コンストラクタ |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getText()](#getText--) | シェイプのテキストを含みます。 |
+| [getValue()](#getValue--) | 値 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setText(String value)](#setText-java.lang.String-) | このプロパティの説明については、[getText()](../../com.aspose.diagram/txt\#getText--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Txt(String value) {#Txt-java.lang.String-}
+```
+public Txt(String value)
+```
+
+
+コンストラクタ
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String | シェイプのテキスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getText() {#getText--}
+```
+public String getText()
+```
+
+
+シェイプのテキストを含みます。
+
+**Returns:**
+java.lang.String
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+値
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setText(String value) {#setText-java.lang.String-}
+```
+public void setText(String value)
+```
+
+
+このプロパティの説明については、[getText()](../../com.aspose.diagram/txt\#getText--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/typeconnection/_index.md
+++ b/japanese/java/com.aspose.diagram/typeconnection/_index.md
@@ -1,0 +1,190 @@
+---
+title: TypeConnection
+second_title: Aspose.Diagram for Java API リファレンス
+description: 含まれる要素に基づいてさまざまなタイプを指定します。
+type: docs
+weight: 413
+url: /ja/java/com.aspose.diagram/typeconnection/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class TypeConnection
+```
+
+含まれる要素に基づいてさまざまなタイプを指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [TypeConnection(int value)](#TypeConnection-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | 含まれる要素に基づいてさまざまなタイプを指定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/typeconnection\#getValue--)をご覧ください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### TypeConnection(int value) {#TypeConnection-int-}
+```
+public TypeConnection(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+含まれる要素に基づいてさまざまなタイプを指定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/typeconnection\#getValue--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/typeconnectionvalue/_index.md
+++ b/japanese/java/com.aspose.diagram/typeconnectionvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: TypeConnectionValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: 含まれる要素に基づいてさまざまなタイプを指定します。
+type: docs
+weight: 414
+url: /ja/java/com.aspose.diagram/typeconnectionvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class TypeConnectionValue
+```
+
+含まれる要素に基づいてさまざまなタイプを指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [INWARD](#INWARD) | Inward. |
+| [INWARD_OUTWARD](#INWARD-OUTWARD) | Inward and outward. |
+| [OUTWARD](#OUTWARD) | Outward. |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### INWARD {#INWARD}
+```
+public static final int INWARD
+```
+
+
+Inward.
+
+### INWARD_OUTWARD {#INWARD-OUTWARD}
+```
+public static final int INWARD_OUTWARD
+```
+
+
+Inward and outward.
+
+### OUTWARD {#OUTWARD}
+```
+public static final int OUTWARD
+```
+
+
+Outward.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/typefield/_index.md
+++ b/japanese/java/com.aspose.diagram/typefield/_index.md
@@ -1,0 +1,190 @@
+---
+title: TypeField
+second_title: Aspose.Diagram for Java API リファレンス
+description: Type はテキスト フィールドの値のデータ型を指定します。
+type: docs
+weight: 415
+url: /ja/java/com.aspose.diagram/typefield/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class TypeField
+```
+
+Type はテキスト フィールドの値のデータ型を指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [TypeField(int value)](#TypeField-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | Type はテキスト フィールドの値のデータ型を指定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/typefield\#getValue--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### TypeField(int value) {#TypeField-int-}
+```
+public TypeField(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Type はテキスト フィールドの値のデータ型を指定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/typefield\#getValue--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/typefieldvalue/_index.md
+++ b/japanese/java/com.aspose.diagram/typefieldvalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: TypeFieldValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: Type はテキスト フィールドの値のデータ型を指定します。
+type: docs
+weight: 416
+url: /ja/java/com.aspose.diagram/typefieldvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class TypeFieldValue
+```
+
+Type はテキスト フィールドの値のデータ型を指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [CURRENCY](#CURRENCY) | Currency value. |
+| [DATE_TIME](#DATE-TIME) | Date or time value. |
+| [DURATION](#DURATION) | Duration value. |
+| [NUMBER](#NUMBER) | Number. |
+| [STRING](#STRING) | 文字列。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CURRENCY {#CURRENCY}
+```
+public static final int CURRENCY
+```
+
+
+通貨の値です。システムの現在の地域設定を使用します。
+
+### DATE_TIME {#DATE-TIME}
+```
+public static final int DATE_TIME
+```
+
+
+Date or time value. 日、月、年、または秒、分、時間、あるいは日付と時刻を組み合わせた値を表示します。
+
+### DURATION {#DURATION}
+```
+public static final int DURATION
+```
+
+
+Duration value. 経過時間を表示します。
+
+### NUMBER {#NUMBER}
+```
+public static final int NUMBER
+```
+
+
+Number. 日付、時刻、期間、通貨の値に加えて、スカラー、寸法、角度を含みます。
+
+### STRING {#STRING}
+```
+public static final int STRING
+```
+
+
+文字列。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/typeprop/_index.md
+++ b/japanese/java/com.aspose.diagram/typeprop/_index.md
@@ -1,0 +1,193 @@
+---
+title: TypeProp
+second_title: Aspose.Diagram for Java API リファレンス
+description: Type はカスタム プロパティの値のデータ型を指定します。
+type: docs
+weight: 417
+url: /ja/java/com.aspose.diagram/typeprop/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class TypeProp
+```
+
+Type はカスタム プロパティの値のデータ型を指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [TypeProp(int value)](#TypeProp-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | Type はカスタム プロパティの値のデータ型を指定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | このプロパティの説明については、[getUfe()](../../com.aspose.diagram/typeprop\#getUfe--) を参照してください。 |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/typeprop\#getValue--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### TypeProp(int value) {#TypeProp-int-}
+```
+public TypeProp(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Type はカスタム プロパティの値のデータ型を指定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+このプロパティの説明については、[getUfe()](../../com.aspose.diagram/typeprop\#getUfe--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/typeprop\#getValue--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/typepropvalue/_index.md
+++ b/japanese/java/com.aspose.diagram/typepropvalue/_index.md
@@ -1,0 +1,210 @@
+---
+title: TypePropValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: Type はカスタム プロパティの値のデータ型を指定します。
+type: docs
+weight: 418
+url: /ja/java/com.aspose.diagram/typepropvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class TypePropValue
+```
+
+Type はカスタム プロパティの値のデータ型を指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [BOOLEAN](#BOOLEAN) | ブール値。 |
+| [CURRENCY](#CURRENCY) | Currency value. |
+| [DATE_TIME](#DATE-TIME) | Date or time value. |
+| [DURATION](#DURATION) | Duration value. |
+| [FIXED_LIST](#FIXED-LIST) | Fixed list. |
+| [NUMBER](#NUMBER) | Number. |
+| [STRING](#STRING) | 文字列。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+| [VARIABLE_LIST](#VARIABLE-LIST) | 変数リスト。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOOLEAN {#BOOLEAN}
+```
+public static final int BOOLEAN
+```
+
+
+Boolean. ユーザーが Visio アプリケーションのカスタム プロパティ ダイアログ ボックスでドロップダウン リスト ボックスから選択できる項目として FALSE と TRUE を表示します。
+
+### CURRENCY {#CURRENCY}
+```
+public static final int CURRENCY
+```
+
+
+Currency value. システムの現在の地域設定を使用します。
+
+### DATE_TIME {#DATE-TIME}
+```
+public static final int DATE_TIME
+```
+
+
+Date or time value. 日、月、年、または秒、分、時間、あるいは日付と時刻を組み合わせた値を表示します。
+
+### DURATION {#DURATION}
+```
+public static final int DURATION
+```
+
+
+Duration value. 経過時間を表示します。
+
+### FIXED_LIST {#FIXED-LIST}
+```
+public static final int FIXED_LIST
+```
+
+
+Fixed list. カスタム プロパティ ダイアログ ボックスのドロップダウン コンボ ボックスにリスト項目を表示します。
+
+### NUMBER {#NUMBER}
+```
+public static final int NUMBER
+```
+
+
+Number. 日付、時刻、期間、通貨の値に加えて、スカラー、寸法、角度を含みます。
+
+### STRING {#STRING}
+```
+public static final int STRING
+```
+
+
+String. これはデフォルトです。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### VARIABLE_LIST {#VARIABLE-LIST}
+```
+public static final int VARIABLE_LIST
+```
+
+
+Variable list. Visio のカスタム プロパティ ダイアログ ボックスのドロップダウン コンボ ボックスにリスト項目を表示します。ユーザーはリスト項目を選択するか、新しい項目を入力して Format 要素の現在のリストに追加できます。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/typevalue/_index.md
+++ b/japanese/java/com.aspose.diagram/typevalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: TypeValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: オプション列挙。
+type: docs
+weight: 419
+url: /ja/java/com.aspose.diagram/typevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class TypeValue
+```
+
+オプションの列挙体。シェイプのタイプです。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [FOREIGN](#FOREIGN) | 外部。 |
+| [GROUP](#GROUP) | グループ。 |
+| [GUIDE](#GUIDE) | ガイド。 |
+| [SHAPE](#SHAPE) | シェイプ。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FOREIGN {#FOREIGN}
+```
+public static final int FOREIGN
+```
+
+
+外部。
+
+### GROUP {#GROUP}
+```
+public static final int GROUP
+```
+
+
+グループ。
+
+### GUIDE {#GUIDE}
+```
+public static final int GUIDE
+```
+
+
+ガイド。
+
+### SHAPE {#SHAPE}
+```
+public static final int SHAPE
+```
+
+
+シェイプ。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/uivisibility/_index.md
+++ b/japanese/java/com.aspose.diagram/uivisibility/_index.md
@@ -1,0 +1,179 @@
+---
+title: UIVisibility
+second_title: Aspose.Diagram for Java API リファレンス
+description: タブの配置を指定します。
+type: docs
+weight: 420
+url: /ja/java/com.aspose.diagram/uivisibility/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class UIVisibility
+```
+
+タブの配置を指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [UIVisibility(int value)](#UIVisibility-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | uivisibility を指定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/uivisibility\#getValue--) を参照してください |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### UIVisibility(int value) {#UIVisibility-int-}
+```
+public UIVisibility(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+uivisibility を指定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/uivisibility\#getValue--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/uivisibilityvalue/_index.md
+++ b/japanese/java/com.aspose.diagram/uivisibilityvalue/_index.md
@@ -1,0 +1,156 @@
+---
+title: UIVisibilityValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: タブの配置を指定します。
+type: docs
+weight: 421
+url: /ja/java/com.aspose.diagram/uivisibilityvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class UIVisibilityValue
+```
+
+タブの配置を指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [HIDDEN](#HIDDEN) | Hidden. |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+| [VISIBLE](#VISIBLE) | Visible . |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### HIDDEN {#HIDDEN}
+```
+public static final int HIDDEN
+```
+
+
+Hidden.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### VISIBLE {#VISIBLE}
+```
+public static final int VISIBLE
+```
+
+
+Visible .
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/unitformulaerr/_index.md
+++ b/japanese/java/com.aspose.diagram/unitformulaerr/_index.md
@@ -1,0 +1,240 @@
+---
+title: UnitFormulaErr
+second_title: Aspose.Diagram for Java API リファレンス
+description: 要素の属性を指定します。
+type: docs
+weight: 422
+url: /ja/java/com.aspose.diagram/unitformulaerr/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class UnitFormulaErr
+```
+
+要素の属性を指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [UnitFormulaErr(int unit, String f, String err)](#UnitFormulaErr-int-java.lang.String-java.lang.String-) | コンストラクタ。 |
+| [UnitFormulaErr()](#UnitFormulaErr--) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getErr()](#getErr--) | 式の評価結果がエラーになることを示します。 |
+| [getF()](#getF--) | 要素の式を表します。 |
+| [getUnit()](#getUnit--) | 測定単位。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setErr(String value)](#setErr-java.lang.String-) | このプロパティの説明については、[getErr()](../../com.aspose.diagram/unitformulaerr\#getErr--) を参照してください。 |
+| [setF(String value)](#setF-java.lang.String-) | このプロパティの説明については、[getF()](../../com.aspose.diagram/unitformulaerr\#getF--) を参照してください。 |
+| [setUnit(int value)](#setUnit-int-) | このプロパティの説明については、[getUnit()](../../com.aspose.diagram/unitformulaerr\#getUnit--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### UnitFormulaErr(int unit, String f, String err) {#UnitFormulaErr-int-java.lang.String-java.lang.String-}
+```
+public UnitFormulaErr(int unit, String f, String err)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 単位 | int |  |
+| f | java.lang.String |  |
+| err | java.lang.String |  |
+
+### UnitFormulaErr() {#UnitFormulaErr--}
+```
+public UnitFormulaErr()
+```
+
+
+コンストラクタ。
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getErr() {#getErr--}
+```
+public String getErr()
+```
+
+
+式の評価結果がエラーになることを示します。
+
+**Returns:**
+java.lang.String
+### getF() {#getF--}
+```
+public String getF()
+```
+
+
+要素の式を表します。
+
+**Returns:**
+java.lang.String
+### getUnit() {#getUnit--}
+```
+public int getUnit()
+```
+
+
+測定単位。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setErr(String value) {#setErr-java.lang.String-}
+```
+public void setErr(String value)
+```
+
+
+このプロパティの説明については、[getErr()](../../com.aspose.diagram/unitformulaerr\#getErr--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setF(String value) {#setF-java.lang.String-}
+```
+public void setF(String value)
+```
+
+
+このプロパティの説明については、[getF()](../../com.aspose.diagram/unitformulaerr\#getF--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setUnit(int value) {#setUnit-int-}
+```
+public void setUnit(int value)
+```
+
+
+このプロパティの説明については、[getUnit()](../../com.aspose.diagram/unitformulaerr\#getUnit--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/unitformulaerrv/_index.md
+++ b/japanese/java/com.aspose.diagram/unitformulaerrv/_index.md
@@ -1,0 +1,257 @@
+---
+title: UnitFormulaErrV
+second_title: Aspose.Diagram for Java API リファレンス
+description: 要素の指定された属性。
+type: docs
+weight: 423
+url: /ja/java/com.aspose.diagram/unitformulaerrv/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+```
+public class UnitFormulaErrV extends UnitFormulaErr
+```
+
+要素の指定された属性。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [UnitFormulaErrV(int unit, String f, String err, String v)](#UnitFormulaErrV-int-java.lang.String-java.lang.String-java.lang.String-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getErr()](#getErr--) | 式の評価結果がエラーになることを示します。 |
+| [getF()](#getF--) | 要素の式を表します。 |
+| [getUnit()](#getUnit--) | 測定単位。 |
+| [getV()](#getV--) | 文字列セル値の null 文字列条件を表します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setErr(String value)](#setErr-java.lang.String-) | このプロパティの説明については、[getErr()](../../com.aspose.diagram/unitformulaerr\#getErr--) を参照してください。 |
+| [setF(String value)](#setF-java.lang.String-) | このプロパティの説明については、[getF()](../../com.aspose.diagram/unitformulaerr\#getF--) を参照してください。 |
+| [setUnit(int value)](#setUnit-int-) | このプロパティの説明については、[getUnit()](../../com.aspose.diagram/unitformulaerr\#getUnit--) を参照してください。 |
+| [setV(String value)](#setV-java.lang.String-) | このプロパティの説明については、[getV()](../../com.aspose.diagram/unitformulaerrv\#getV--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### UnitFormulaErrV(int unit, String f, String err, String v) {#UnitFormulaErrV-int-java.lang.String-java.lang.String-java.lang.String-}
+```
+public UnitFormulaErrV(int unit, String f, String err, String v)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 単位 | int |  |
+| f | java.lang.String |  |
+| err | java.lang.String |  |
+| v | java.lang.String |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getErr() {#getErr--}
+```
+public String getErr()
+```
+
+
+式の評価結果がエラーになることを示します。
+
+**Returns:**
+java.lang.String
+### getF() {#getF--}
+```
+public String getF()
+```
+
+
+要素の式を表します。
+
+**Returns:**
+java.lang.String
+### getUnit() {#getUnit--}
+```
+public int getUnit()
+```
+
+
+測定単位。
+
+**Returns:**
+int
+### getV() {#getV--}
+```
+public String getV()
+```
+
+
+文字列セル値の null 文字列条件を表します。場合によっては、空文字列セルが null であることと、null 文字列セル値を区別することが有用です。この属性は、これらの空の値の形態を区別するために使用されます。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setErr(String value) {#setErr-java.lang.String-}
+```
+public void setErr(String value)
+```
+
+
+このプロパティの説明については、[getErr()](../../com.aspose.diagram/unitformulaerr\#getErr--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setF(String value) {#setF-java.lang.String-}
+```
+public void setF(String value)
+```
+
+
+このプロパティの説明については、[getF()](../../com.aspose.diagram/unitformulaerr\#getF--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setUnit(int value) {#setUnit-int-}
+```
+public void setUnit(int value)
+```
+
+
+このプロパティの説明については、[getUnit()](../../com.aspose.diagram/unitformulaerr\#getUnit--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setV(String value) {#setV-java.lang.String-}
+```
+public void setV(String value)
+```
+
+
+このプロパティの説明については、[getV()](../../com.aspose.diagram/unitformulaerrv\#getV--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/unknowncontrol/_index.md
+++ b/japanese/java/com.aspose.diagram/unknowncontrol/_index.md
@@ -1,0 +1,449 @@
+---
+title: UnknownControl
+second_title: Aspose.Diagram for Java API リファレンス
+description: 不明なコントロール。
+type: docs
+weight: 424
+url: /ja/java/com.aspose.diagram/unknowncontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class UnknownControl extends ActiveXControl
+```
+
+不明なコントロール。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBackOleColor()](#getBackOleColor--) | 背景の OLE カラー。 |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | コントロールのバイナリ データ。 |
+| [getForeOleColor()](#getForeOleColor--) | 前景の OLE カラー。 |
+| [getHeight()](#getHeight--) | ポイント単位のコントロールの高さ。 |
+| [getIMEMode()](#getIMEMode--) | コントロールがフォーカスを受け取る際の Input Method Editor のデフォルト実行時モード。 |
+| [getMouseIcon()](#getMouseIcon--) | コントロールのマウスポインタとして表示するカスタムアイコンです。 |
+| [getMousePointer()](#getMousePointer--) | コントロールのマウスポインタとして表示されるアイコンの種類です。 |
+| [getPersistenceType()](#getPersistenceType--) | ActiveX コントロールを永続化するための永続化方法を取得します。 |
+| [getRelationshipData(String relId)](#getRelationshipData-java.lang.String-) | リレーションシップ データを取得します。 |
+| [getType()](#getType--) | ActiveX コントロールのタイプを取得します。 |
+| [getWidth()](#getWidth--) | ポイント単位のコントロールの幅です。 |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | コントロールが全内容を表示するために自動的にサイズ変更されるかどうかを示します。 |
+| [isEnabled()](#isEnabled--) | コントロールがフォーカスを受け取り、ユーザー生成イベントに応答できるかどうかを示します。 |
+| [isLocked()](#isLocked--) | コントロール内のデータが編集ロックされているかどうかを示します。 |
+| [isTransparent()](#isTransparent--) | コントロールが透明かどうかを示します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | このプロパティの説明については、[isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) を参照してください |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | このプロパティの説明については、[getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) を参照してください |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | このプロパティの説明については、[isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) を参照してください |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | このプロパティの説明については、[getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) を参照してください |
+| [setHeight(double value)](#setHeight-double-) | このプロパティの説明については、[getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) を参照してください |
+| [setIMEMode(int value)](#setIMEMode-int-) | このプロパティの説明については、[getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) を参照してください |
+| [setLocked(boolean value)](#setLocked-boolean-) | このプロパティの説明については、[isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) を参照してください |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | このプロパティの説明については、[getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) を参照してください |
+| [setMousePointer(int value)](#setMousePointer-int-) | このプロパティの説明については、[getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) を参照してください |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | このプロパティの説明については、[isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) を参照してください |
+| [setWidth(double value)](#setWidth-double-) | このプロパティの説明については、[getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) を参照してください |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+背景の OLE カラー。
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+コントロールのバイナリ データ。
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+前景の OLE カラーです。Image コントロールには適用されません。
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+ポイント単位のコントロールの高さ。
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+コントロールがフォーカスを受け取る際の Input Method Editor のデフォルト実行時モード。
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+コントロールのマウスポインタとして表示するカスタムアイコンです。
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+コントロールのマウスポインタとして表示されるアイコンの種類です。
+
+**Returns:**
+int
+### getPersistenceType() {#getPersistenceType--}
+```
+public int getPersistenceType()
+```
+
+
+ActiveX コントロールを永続化するための永続化方法を取得します。
+
+**Returns:**
+int
+### getRelationshipData(String relId) {#getRelationshipData-java.lang.String-}
+```
+public byte[] getRelationshipData(String relId)
+```
+
+
+リレーションシップ データを取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| relId | java.lang.String | リレーションシップ IDです。 |
+
+**Returns:**
+byte[] - リレーションシップ データを返します。
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+ActiveX コントロールのタイプを取得します。
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+ポイント単位のコントロールの幅です。
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+コントロールが全内容を表示するために自動的にサイズ変更されるかどうかを示します。
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+コントロールがフォーカスを受け取り、ユーザー生成イベントに応答できるかどうかを示します。
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+コントロール内のデータが編集ロックされているかどうかを示します。
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+コントロールが透明かどうかを示します。
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+このプロパティの説明については、[isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+このプロパティの説明については、[getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+このプロパティの説明については、[isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+このプロパティの説明については、[getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+このプロパティの説明については、[getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+このプロパティの説明については、[getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+このプロパティの説明については、[isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+このプロパティの説明については、[getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+このプロパティの説明については、[getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+このプロパティの説明については、[isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+このプロパティの説明については、[getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/user/_index.md
+++ b/japanese/java/com.aspose.diagram/user/_index.md
@@ -1,0 +1,299 @@
+---
+title: User
+second_title: Aspose.Diagram for Java API リファレンス
+description: 他の要素やアドオンツールから参照されるユーザー固有の要素で数式を入力する作業領域を含みます。
+type: docs
+weight: 425
+url: /ja/java/com.aspose.diagram/user/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class User
+```
+
+他の要素やアドオンツールから参照されるユーザー固有の要素で数式を入力する作業領域を含みます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [User()](#User--) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getID()](#getID--) | 要素の親要素内における一意の ID。 |
+| [getName()](#getName--) | 要素の名前。 |
+| [getNameU()](#getNameU--) | 要素のユニバーサル名。 |
+| [getPrompt()](#getPrompt--) | ユーザー定義要素の説明的なプロンプトまたはコメントを指定します。 |
+| [getValue()](#getValue--) | 明示的な名前空間でプレフィックスが付けられ、ドキュメントに保存される、ソリューション固有の整形式 XML データを含みます。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | このプロパティの説明については、[getDel()](../../com.aspose.diagram/user\#getDel--) を参照してください。 |
+| [setID(int value)](#setID-int-) | このプロパティの説明については、[getID()](../../com.aspose.diagram/user\#getID--) を参照してください。 |
+| [setName(String value)](#setName-java.lang.String-) | このプロパティの説明については、[getName()](../../com.aspose.diagram/user\#getName--) を参照してください。 |
+| [setNameU(String value)](#setNameU-java.lang.String-) | このプロパティの説明については、[getNameU()](../../com.aspose.diagram/user\#getNameU--) を参照してください。 |
+| [setPrompt(Str2Value value)](#setPrompt-com.aspose.diagram.Str2Value-) | このプロパティの説明については、[getPrompt()](../../com.aspose.diagram/user\#getPrompt--) を参照してください。 |
+| [setValue(Value value)](#setValue-com.aspose.diagram.Value-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/user\#getValue--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### User() {#User--}
+```
+public User()
+```
+
+
+コンストラクタ。
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+要素の親要素内における一意の ID。
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素の名前。
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+要素のユニバーサル名。
+
+**Returns:**
+java.lang.String
+### getPrompt() {#getPrompt--}
+```
+public Str2Value getPrompt()
+```
+
+
+ユーザー定義要素の説明的なプロンプトまたはコメントを指定します。
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getValue() {#getValue--}
+```
+public Value getValue()
+```
+
+
+明示的な名前空間でプレフィックスが付けられ、ドキュメントに保存される、ソリューション固有の整形式 XML データを含みます。
+
+**Returns:**
+[Value](../../com.aspose.diagram/value)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+このプロパティの説明については、[getDel()](../../com.aspose.diagram/user\#getDel--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+このプロパティの説明については、[getID()](../../com.aspose.diagram/user\#getID--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+このプロパティの説明については、[getName()](../../com.aspose.diagram/user\#getName--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+このプロパティの説明については、[getNameU()](../../com.aspose.diagram/user\#getNameU--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setPrompt(Str2Value value) {#setPrompt-com.aspose.diagram.Str2Value-}
+```
+public void setPrompt(Str2Value value)
+```
+
+
+このプロパティの説明については、[getPrompt()](../../com.aspose.diagram/user\#getPrompt--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [Str2Value](../../com.aspose.diagram/str2value) |  |
+
+### setValue(Value value) {#setValue-com.aspose.diagram.Value-}
+```
+public void setValue(Value value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/user\#getValue--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [Value](../../com.aspose.diagram/value) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/usercollection/_index.md
+++ b/japanese/java/com.aspose.diagram/usercollection/_index.md
@@ -1,0 +1,250 @@
+---
+title: UserCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: ユーザーコレクション。
+type: docs
+weight: 426
+url: /ja/java/com.aspose.diagram/usercollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class UserCollection extends Collection
+```
+
+ユーザーコレクション。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(User item)](#add-com.aspose.diagram.User-) | コレクションに User オブジェクトを追加します。 |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [getUser(int ID)](#getUser-int-) | 指定された ID の要素を取得します。 |
+| [getUser(String name)](#getUser-java.lang.String-) | 指定された ID の要素を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(User item)](#remove-com.aspose.diagram.User-) | コレクションから User オブジェクトを削除します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(User item) {#add-com.aspose.diagram.User-}
+```
+public int add(User item)
+```
+
+
+コレクションに User オブジェクトを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [User](../../com.aspose.diagram/user) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public User get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[User](../../com.aspose.diagram/user) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### getUser(int ID) {#getUser-int-}
+```
+public User getUser(int ID)
+```
+
+
+指定された ID の要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| ID | int |  |
+
+**Returns:**
+[User](../../com.aspose.diagram/user) - 
+### getUser(String name) {#getUser-java.lang.String-}
+```
+public User getUser(String name)
+```
+
+
+指定された ID の要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String |  |
+
+**Returns:**
+[User](../../com.aspose.diagram/user) - 
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(User item) {#remove-com.aspose.diagram.User-}
+```
+public void remove(User item)
+```
+
+
+コレクションから User オブジェクトを削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| item | [User](../../com.aspose.diagram/user) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/validation/_index.md
+++ b/japanese/java/com.aspose.diagram/validation/_index.md
@@ -1,0 +1,158 @@
+---
+title: 検証
+second_title: Aspose.Diagram for Java API リファレンス
+description: ドキュメントの図表検証に関する情報を格納します。
+type: docs
+weight: 427
+url: /ja/java/com.aspose.diagram/validation/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Validation
+```
+
+ドキュメントの図表検証に関する情報を格納します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getIssues()](#getIssues--) | ドキュメントのすべての Issue 要素を含みます。 |
+| [getRuleSets()](#getRuleSets--) | ドキュメント内の各検証ルールセットに対して RuleSet 要素を含みます。 |
+| [getValidationProperties()](#getValidationProperties--) | ドキュメントの検証に関連するプロパティをカプセル化します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getIssues() {#getIssues--}
+```
+public IssueCollection getIssues()
+```
+
+
+ドキュメントのすべての Issue 要素を含みます。
+
+**Returns:**
+[IssueCollection](../../com.aspose.diagram/issuecollection)
+### getRuleSets() {#getRuleSets--}
+```
+public RuleSetCollection getRuleSets()
+```
+
+
+ドキュメント内の各検証ルールセットに対して RuleSet 要素を含みます。
+
+**Returns:**
+[RuleSetCollection](../../com.aspose.diagram/rulesetcollection)
+### getValidationProperties() {#getValidationProperties--}
+```
+public ValidationProperties getValidationProperties()
+```
+
+
+ドキュメントの検証に関連するプロパティをカプセル化します。
+
+**Returns:**
+[ValidationProperties](../../com.aspose.diagram/validationproperties)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/validationproperties/_index.md
+++ b/japanese/java/com.aspose.diagram/validationproperties/_index.md
@@ -1,0 +1,194 @@
+---
+title: ValidationProperties
+second_title: Aspose.Diagram for Java API リファレンス
+description: ドキュメントの検証に関連するプロパティをカプセル化します。
+type: docs
+weight: 428
+url: /ja/java/com.aspose.diagram/validationproperties/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ValidationProperties
+```
+
+ドキュメントの検証に関連するプロパティをカプセル化します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [ValidationProperties(DateTime lastValidated, int showIgnored)](#ValidationProperties-com.aspose.diagram.DateTime-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getLastValidated()](#getLastValidated--) | ドキュメントが最後に検証された日時 |
+| [getShowIgnored()](#getShowIgnored--) | Issues ウィンドウに無視された検証問題を表示するかどうか。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setLastValidated(DateTime value)](#setLastValidated-com.aspose.diagram.DateTime-) | このプロパティの説明については、[getLastValidated()](../../com.aspose.diagram/validationproperties\#getLastValidated--) を参照してください。 |
+| [setShowIgnored(int value)](#setShowIgnored-int-) | このプロパティの説明については、[getShowIgnored()](../../com.aspose.diagram/validationproperties\#getShowIgnored--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ValidationProperties(DateTime lastValidated, int showIgnored) {#ValidationProperties-com.aspose.diagram.DateTime-int-}
+```
+public ValidationProperties(DateTime lastValidated, int showIgnored)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| lastValidated | [DateTime](../../com.aspose.diagram/datetime) |  |
+| showIgnored | int |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLastValidated() {#getLastValidated--}
+```
+public DateTime getLastValidated()
+```
+
+
+ドキュメントが最後に検証された日時
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### getShowIgnored() {#getShowIgnored--}
+```
+public int getShowIgnored()
+```
+
+
+Issues ウィンドウに無視された検証問題を表示するかどうか。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setLastValidated(DateTime value) {#setLastValidated-com.aspose.diagram.DateTime-}
+```
+public void setLastValidated(DateTime value)
+```
+
+
+このプロパティの説明については、[getLastValidated()](../../com.aspose.diagram/validationproperties\#getLastValidated--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setShowIgnored(int value) {#setShowIgnored-int-}
+```
+public void setShowIgnored(int value)
+```
+
+
+このプロパティの説明については、[getShowIgnored()](../../com.aspose.diagram/validationproperties\#getShowIgnored--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/value/_index.md
+++ b/japanese/java/com.aspose.diagram/value/_index.md
@@ -1,0 +1,211 @@
+---
+title: 値
+second_title: Aspose.Diagram for Java API リファレンス
+description: 値。
+type: docs
+weight: 429
+url: /ja/java/com.aspose.diagram/value/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Value
+```
+
+値。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object obj)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getSolutionXML()](#getSolutionXML--) | 明示的な名前空間でプレフィックスが付けられ、ドキュメントに保存される、ソリューション固有の整形式 XML データを含みます。 |
+| [getUfev()](#getUfev--) | 要素の指定された属性。 |
+| [getVal()](#getVal--) | テキスト値 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setSolutionXML(SolutionXML value)](#setSolutionXML-com.aspose.diagram.SolutionXML-) | このプロパティの説明については、[getSolutionXML()](../../com.aspose.diagram/value\#getSolutionXML--) を参照してください。 |
+| [setUfev(UnitFormulaErrV value)](#setUfev-com.aspose.diagram.UnitFormulaErrV-) | このプロパティの説明については、[getUfev()](../../com.aspose.diagram/value\#getUfev--) を参照してください。 |
+| [setVal(String value)](#setVal-java.lang.String-) | このプロパティの説明については、[getVal()](../../com.aspose.diagram/value\#getVal--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| obj | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getSolutionXML() {#getSolutionXML--}
+```
+public SolutionXML getSolutionXML()
+```
+
+
+明示的な名前空間でプレフィックスが付けられ、ドキュメントに保存される、ソリューション固有の整形式 XML データを含みます。
+
+**Returns:**
+[SolutionXML](../../com.aspose.diagram/solutionxml)
+### getUfev() {#getUfev--}
+```
+public UnitFormulaErrV getUfev()
+```
+
+
+要素の指定された属性。
+
+**Returns:**
+[UnitFormulaErrV](../../com.aspose.diagram/unitformulaerrv)
+### getVal() {#getVal--}
+```
+public String getVal()
+```
+
+
+テキスト値
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setSolutionXML(SolutionXML value) {#setSolutionXML-com.aspose.diagram.SolutionXML-}
+```
+public void setSolutionXML(SolutionXML value)
+```
+
+
+このプロパティの説明については、[getSolutionXML()](../../com.aspose.diagram/value\#getSolutionXML--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [SolutionXML](../../com.aspose.diagram/solutionxml) |  |
+
+### setUfev(UnitFormulaErrV value) {#setUfev-com.aspose.diagram.UnitFormulaErrV-}
+```
+public void setUfev(UnitFormulaErrV value)
+```
+
+
+このプロパティの説明については、[getUfev()](../../com.aspose.diagram/value\#getUfev--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [UnitFormulaErrV](../../com.aspose.diagram/unitformulaerrv) |  |
+
+### setVal(String value) {#setVal-java.lang.String-}
+```
+public void setVal(String value)
+```
+
+
+このプロパティの説明については、[getVal()](../../com.aspose.diagram/value\#getVal--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/vbamodule/_index.md
+++ b/japanese/java/com.aspose.diagram/vbamodule/_index.md
@@ -1,0 +1,186 @@
+---
+title: VbaModule
+second_title: Aspose.Diagram for Java API リファレンス
+description: VBA プロジェクトに含まれるモジュールを表します。
+type: docs
+weight: 430
+url: /ja/java/com.aspose.diagram/vbamodule/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class VbaModule
+```
+
+VBA プロジェクトに含まれるモジュールを表します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCodes()](#getCodes--) | モジュールのコードです。 |
+| [getName()](#getName--) | モジュールの名前です。 |
+| [getType()](#getType--) | Gets the type of module. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCodes(String value)](#setCodes-java.lang.String-) | For the description of this property, please see [getCodes()](../../com.aspose.diagram/vbamodule\#getCodes--) |
+| [setName(String value)](#setName-java.lang.String-) | For the description of this property, please see [getName()](../../com.aspose.diagram/vbamodule\#getName--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCodes() {#getCodes--}
+```
+public String getCodes()
+```
+
+
+モジュールのコードです。
+
+**Returns:**
+java.lang.String
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+モジュールの名前です。
+
+**Returns:**
+java.lang.String
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Gets the type of module.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCodes(String value) {#setCodes-java.lang.String-}
+```
+public void setCodes(String value)
+```
+
+
+For the description of this property, please see [getCodes()](../../com.aspose.diagram/vbamodule\#getCodes--)
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+For the description of this property, please see [getName()](../../com.aspose.diagram/vbamodule\#getName--)
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/vbamodulecollection/_index.md
+++ b/japanese/java/com.aspose.diagram/vbamodulecollection/_index.md
@@ -1,0 +1,311 @@
+---
+title: VbaModuleCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: Represents the list of
+type: docs
+weight: 431
+url: /ja/java/com.aspose.diagram/vbamodulecollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.CollectionBase](../../com.aspose.diagram/collectionbase)
+```
+public class VbaModuleCollection extends CollectionBase
+```
+
+Represents the list of [VbaModule](../../com.aspose.diagram/vbamodule)
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(Page page)](#add-com.aspose.diagram.Page-) | Adds module for a page. |
+| [add(int type, String name)](#add-int-java.lang.String-) | Adds module. |
+| [add(Object o)](#add-java.lang.Object-) | Adds an item to the CollectionBase instance. |
+| [clear()](#clear--) | Removes all objects from the CollectionBase instance. |
+| [contains(Object o)](#contains-java.lang.Object-) | Return whether instance contains this object |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Gets [VbaModule](../../com.aspose.diagram/vbamodule) in the list by the index. |
+| [get(String name)](#get-java.lang.String-) | 名前でリスト内の [VbaModule](../../com.aspose.diagram/vbamodule) を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gets the number of elements contained in the CollectionBase instance. |
+| [hashCode()](#hashCode--) |  |
+| [indexOf(Object o)](#indexOf-java.lang.Object-) | Determines the index of a specific item in the CollectionBase instance. |
+| [iterator()](#iterator--) | Returns an enumerator that iterates through the CollectionBase instance. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Page page)](#remove-com.aspose.diagram.Page-) | ページ用のモジュールを削除します。 |
+| [remove(String name)](#remove-java.lang.String-) | 名前でモジュールを削除します |
+| [removeAt(int index)](#removeAt-int-) | Removes the item at the specified index. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Page page) {#add-com.aspose.diagram.Page-}
+```
+public int add(Page page)
+```
+
+
+Adds module for a page.
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| page | [Page](../../com.aspose.diagram/page) | ページ |
+
+**Returns:**
+int -
+### add(int type, String name) {#add-int-java.lang.String-}
+```
+public int add(int type, String name)
+```
+
+
+Adds module.
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| タイプ | int | モジュールのタイプ。 |
+| 名前 | java.lang.String | モジュールの名前。 |
+
+**Returns:**
+int -
+### add(Object o) {#add-java.lang.Object-}
+```
+public int add(Object o)
+```
+
+
+Adds an item to the CollectionBase instance.
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| o | java.lang.Object | The Object to add to the CollectionBase instance. |
+
+**Returns:**
+int - The position into which the new element was inserted.
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Removes all objects from the CollectionBase instance.
+
+### contains(Object o) {#contains-java.lang.Object-}
+```
+public boolean contains(Object o)
+```
+
+
+Return whether instance contains this object
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| o | java.lang.Object | テストオブジェクト |
+
+**Returns:**
+boolean - インスタンスがこのオブジェクトを含むかどうか
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public VbaModule get(int index)
+```
+
+
+Gets [VbaModule](../../com.aspose.diagram/vbamodule) in the list by the index.
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | The index. |
+
+**Returns:**
+[VbaModule](../../com.aspose.diagram/vbamodule) - 
+### get(String name) {#get-java.lang.String-}
+```
+public VbaModule get(String name)
+```
+
+
+名前でリスト内の [VbaModule](../../com.aspose.diagram/vbamodule) を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String | モジュールの名前。 |
+
+**Returns:**
+[VbaModule](../../com.aspose.diagram/vbamodule) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gets the number of elements contained in the CollectionBase instance.
+
+**Returns:**
+int - CollectionBase インスタンスに含まれる要素数です。
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### indexOf(Object o) {#indexOf-java.lang.Object-}
+```
+public int indexOf(Object o)
+```
+
+
+Determines the index of a specific item in the CollectionBase instance.
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| o | java.lang.Object | Determines the index of a specific item in the CollectionBase instance. |
+
+**Returns:**
+int - リスト内に値が見つかった場合のインデックス。見つからない場合は -1 です。
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Returns an enumerator that iterates through the CollectionBase instance.
+
+**Returns:**
+java.util.Iterator - CollectionBase インスタンス用のイテレータです。
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Page page) {#remove-com.aspose.diagram.Page-}
+```
+public void remove(Page page)
+```
+
+
+ページ用のモジュールを削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| page | [Page](../../com.aspose.diagram/page) | ページ |
+
+### remove(String name) {#remove-java.lang.String-}
+```
+public void remove(String name)
+```
+
+
+名前でモジュールを削除します
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String |  |
+
+### removeAt(int index) {#removeAt-int-}
+```
+public void removeAt(int index)
+```
+
+
+Removes the item at the specified index.
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 削除する項目のゼロベースインデックスです。 |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/vbamoduletype/_index.md
+++ b/japanese/java/com.aspose.diagram/vbamoduletype/_index.md
@@ -1,0 +1,165 @@
+---
+title: VbaModuleType
+second_title: Aspose.Diagram for Java API リファレンス
+description: VBA モジュールのタイプを表します。
+type: docs
+weight: 432
+url: /ja/java/com.aspose.diagram/vbamoduletype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class VbaModuleType
+```
+
+VBA モジュールのタイプを表します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [CLASS](#CLASS) | クラスモジュールを表します。 |
+| [DESIGNER](#DESIGNER) | デザイナーモジュールを表します。 |
+| [DOCUMENT](#DOCUMENT) | ドキュメントモジュールを表します。 |
+| [PROCEDURAL](#PROCEDURAL) | 手続きモジュールを表します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CLASS {#CLASS}
+```
+public static final int CLASS
+```
+
+
+クラスモジュールを表します。
+
+### DESIGNER {#DESIGNER}
+```
+public static final int DESIGNER
+```
+
+
+デザイナーモジュールを表します。
+
+### DOCUMENT {#DOCUMENT}
+```
+public static final int DOCUMENT
+```
+
+
+ドキュメントモジュールを表します。
+
+### PROCEDURAL {#PROCEDURAL}
+```
+public static final int PROCEDURAL
+```
+
+
+手続きモジュールを表します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/vbaproject/_index.md
+++ b/japanese/java/com.aspose.diagram/vbaproject/_index.md
@@ -1,0 +1,183 @@
+---
+title: VbaProject
+second_title: Aspose.Diagram for Java API リファレンス
+description: VBA プロジェクトを表します。
+type: docs
+weight: 433
+url: /ja/java/com.aspose.diagram/vbaproject/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class VbaProject
+```
+
+VBA プロジェクトを表します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getModules()](#getModules--) | すべての[VbaModule](../../com.aspose.diagram/vbamodule)オブジェクトを取得します。 |
+| [getName()](#getName--) | VBAプロジェクトの名前。 |
+| [getReferences()](#getReferences--) | VBAプロジェクトのすべての参照を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isSigned()](#isSigned--) | VBAcodeが署名されているかどうかを示します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setName(String value)](#setName-java.lang.String-) | このプロパティの説明については、[getName()](../../com.aspose.diagram/vbaproject\#getName--)をご覧ください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getModules() {#getModules--}
+```
+public VbaModuleCollection getModules()
+```
+
+
+すべての[VbaModule](../../com.aspose.diagram/vbamodule)オブジェクトを取得します。
+
+**Returns:**
+[VbaModuleCollection](../../com.aspose.diagram/vbamodulecollection)
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+VBAプロジェクトの名前。
+
+**Returns:**
+java.lang.String
+### getReferences() {#getReferences--}
+```
+public VbaProjectReferenceCollection getReferences()
+```
+
+
+VBAプロジェクトのすべての参照を取得します。
+
+**Returns:**
+[VbaProjectReferenceCollection](../../com.aspose.diagram/vbaprojectreferencecollection)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isSigned() {#isSigned--}
+```
+public boolean isSigned()
+```
+
+
+VBAcodeが署名されているかどうかを示します。
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+このプロパティの説明については、[getName()](../../com.aspose.diagram/vbaproject\#getName--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/vbaprojectreference/_index.md
+++ b/japanese/java/com.aspose.diagram/vbaprojectreference/_index.md
@@ -1,0 +1,261 @@
+---
+title: VbaProjectReference
+second_title: Aspose.Diagram for Java API リファレンス
+description: VBA プロジェクトの参照を表します。
+type: docs
+weight: 434
+url: /ja/java/com.aspose.diagram/vbaprojectreference/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class VbaProjectReference
+```
+
+VBA プロジェクトの参照を表します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getExtendedLibid()](#getExtendedLibid--) | 参照の拡張 Libid。 |
+| [getLibid()](#getLibid--) | 参照の Libid。 |
+| [getName()](#getName--) | 参照の名前。 |
+| [getRelativeLibid()](#getRelativeLibid--) | 参照された VBA プロジェクト\u9225\u6a9a 識別子（相対パス付き）。 |
+| [getTwiddledlibid()](#getTwiddledlibid--) | 参照のツイドルされた Libid。 |
+| [getType()](#getType--) | この参照の型を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setExtendedLibid(String value)](#setExtendedLibid-java.lang.String-) | このプロパティの説明については、[getExtendedLibid()](../../com.aspose.diagram/vbaprojectreference\#getExtendedLibid--) を参照してください。 |
+| [setLibid(String value)](#setLibid-java.lang.String-) | このプロパティの説明については、[getLibid()](../../com.aspose.diagram/vbaprojectreference\#getLibid--) を参照してください。 |
+| [setName(String value)](#setName-java.lang.String-) | このプロパティの説明については、[getName()](../../com.aspose.diagram/vbaprojectreference\#getName--) を参照してください。 |
+| [setRelativeLibid(String value)](#setRelativeLibid-java.lang.String-) | このプロパティの説明については、[getRelativeLibid()](../../com.aspose.diagram/vbaprojectreference\#getRelativeLibid--) を参照してください。 |
+| [setTwiddledlibid(String value)](#setTwiddledlibid-java.lang.String-) | このプロパティの説明については、[getTwiddledlibid()](../../com.aspose.diagram/vbaprojectreference\#getTwiddledlibid--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getExtendedLibid() {#getExtendedLibid--}
+```
+public String getExtendedLibid()
+```
+
+
+参照の拡張 Libid。コントロール参照にのみ使用されます。
+
+**Returns:**
+java.lang.String
+### getLibid() {#getLibid--}
+```
+public String getLibid()
+```
+
+
+参照の Libid。
+
+**Returns:**
+java.lang.String
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+参照の名前。
+
+**Returns:**
+java.lang.String
+### getRelativeLibid() {#getRelativeLibid--}
+```
+public String getRelativeLibid()
+```
+
+
+参照された VBA プロジェクト\u9225\u6a9a 識別子（相対パス付き）。プロジェクト参照にのみ使用されます。
+
+**Returns:**
+java.lang.String
+### getTwiddledlibid() {#getTwiddledlibid--}
+```
+public String getTwiddledlibid()
+```
+
+
+参照のツイドルされた Libid。コントロール参照にのみ使用されます。
+
+**Returns:**
+java.lang.String
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+この参照の型を取得します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setExtendedLibid(String value) {#setExtendedLibid-java.lang.String-}
+```
+public void setExtendedLibid(String value)
+```
+
+
+このプロパティの説明については、[getExtendedLibid()](../../com.aspose.diagram/vbaprojectreference\#getExtendedLibid--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setLibid(String value) {#setLibid-java.lang.String-}
+```
+public void setLibid(String value)
+```
+
+
+このプロパティの説明については、[getLibid()](../../com.aspose.diagram/vbaprojectreference\#getLibid--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+このプロパティの説明については、[getName()](../../com.aspose.diagram/vbaprojectreference\#getName--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setRelativeLibid(String value) {#setRelativeLibid-java.lang.String-}
+```
+public void setRelativeLibid(String value)
+```
+
+
+このプロパティの説明については、[getRelativeLibid()](../../com.aspose.diagram/vbaprojectreference\#getRelativeLibid--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setTwiddledlibid(String value) {#setTwiddledlibid-java.lang.String-}
+```
+public void setTwiddledlibid(String value)
+```
+
+
+このプロパティの説明については、[getTwiddledlibid()](../../com.aspose.diagram/vbaprojectreference\#getTwiddledlibid--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/vbaprojectreferencecollection/_index.md
+++ b/japanese/java/com.aspose.diagram/vbaprojectreferencecollection/_index.md
@@ -1,0 +1,288 @@
+---
+title: VbaProjectReferenceCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: VBA プロジェクトのすべての参照を表します。
+type: docs
+weight: 435
+url: /ja/java/com.aspose.diagram/vbaprojectreferencecollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.CollectionBase](../../com.aspose.diagram/collectionbase)
+```
+public class VbaProjectReferenceCollection extends CollectionBase
+```
+
+VBA プロジェクトのすべての参照を表します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(Object o)](#add-java.lang.Object-) | Adds an item to the CollectionBase instance. |
+| [addControlRefrernce(String name, String libid, String twiddledlibid, String extendedLibid)](#addControlRefrernce-java.lang.String-java.lang.String-java.lang.String-java.lang.String-) | Add a reference to a twiddled type library and its extended type library. |
+| [addProjectRefrernce(String name, String absoluteLibid, String relativeLibid)](#addProjectRefrernce-java.lang.String-java.lang.String-java.lang.String-) | Add a reference to an external VBA project. |
+| [addRegisteredReference(String name, String libid)](#addRegisteredReference-java.lang.String-java.lang.String-) | Add a reference to an Automation type library. |
+| [clear()](#clear--) | Removes all objects from the CollectionBase instance. |
+| [contains(Object o)](#contains-java.lang.Object-) | Return whether instance contains this object |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int i)](#get-int-) | Get the reference in the list by the index. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Gets the number of elements contained in the CollectionBase instance. |
+| [hashCode()](#hashCode--) |  |
+| [indexOf(Object o)](#indexOf-java.lang.Object-) | Determines the index of a specific item in the CollectionBase instance. |
+| [iterator()](#iterator--) | Returns an enumerator that iterates through the CollectionBase instance. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [removeAt(int index)](#removeAt-int-) | Removes the item at the specified index. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Object o) {#add-java.lang.Object-}
+```
+public int add(Object o)
+```
+
+
+Adds an item to the CollectionBase instance.
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| o | java.lang.Object | The Object to add to the CollectionBase instance. |
+
+**Returns:**
+int - The position into which the new element was inserted.
+### addControlRefrernce(String name, String libid, String twiddledlibid, String extendedLibid) {#addControlRefrernce-java.lang.String-java.lang.String-java.lang.String-java.lang.String-}
+```
+public int addControlRefrernce(String name, String libid, String twiddledlibid, String extendedLibid)
+```
+
+
+Add a reference to a twiddled type library and its extended type library.
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String | The name of reference. |
+| libid | java.lang.String | The identifier of an Automation type library. |
+| twiddledlibid | java.lang.String | The identifier of a twiddled type library |
+| extendedLibid | java.lang.String | The identifier of an extended type library |
+
+**Returns:**
+int -
+### addProjectRefrernce(String name, String absoluteLibid, String relativeLibid) {#addProjectRefrernce-java.lang.String-java.lang.String-java.lang.String-}
+```
+public int addProjectRefrernce(String name, String absoluteLibid, String relativeLibid)
+```
+
+
+Add a reference to an external VBA project.
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String | The name of reference. |
+| absoluteLibid | java.lang.String | The referenced VBA project\\u9225\\u6a9a identifier with an absolute path. |
+| relativeLibid | java.lang.String | The referenced VBA project\\u9225\\u6a9a identifier with an relative path. |
+
+**Returns:**
+int -
+### addRegisteredReference(String name, String libid) {#addRegisteredReference-java.lang.String-java.lang.String-}
+```
+public int addRegisteredReference(String name, String libid)
+```
+
+
+Add a reference to an Automation type library.
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String | The name of reference. |
+| libid | java.lang.String | The identifier of an Automation type library. |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Removes all objects from the CollectionBase instance.
+
+### contains(Object o) {#contains-java.lang.Object-}
+```
+public boolean contains(Object o)
+```
+
+
+Return whether instance contains this object
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| o | java.lang.Object | テストオブジェクト |
+
+**Returns:**
+boolean - インスタンスがこのオブジェクトを含むかどうか
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int i) {#get-int-}
+```
+public VbaProjectReference get(int i)
+```
+
+
+Get the reference in the list by the index.
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| i | int | The index. |
+
+**Returns:**
+[VbaProjectReference](../../com.aspose.diagram/vbaprojectreference) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Gets the number of elements contained in the CollectionBase instance.
+
+**Returns:**
+int - CollectionBase インスタンスに含まれる要素数です。
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### indexOf(Object o) {#indexOf-java.lang.Object-}
+```
+public int indexOf(Object o)
+```
+
+
+Determines the index of a specific item in the CollectionBase instance.
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| o | java.lang.Object | Determines the index of a specific item in the CollectionBase instance. |
+
+**Returns:**
+int - リスト内に値が見つかった場合のインデックス。見つからない場合は -1 です。
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Returns an enumerator that iterates through the CollectionBase instance.
+
+**Returns:**
+java.util.Iterator - CollectionBase インスタンス用のイテレータです。
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### removeAt(int index) {#removeAt-int-}
+```
+public void removeAt(int index)
+```
+
+
+Removes the item at the specified index.
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 削除する項目のゼロベースインデックスです。 |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/vbaprojectreferencetype/_index.md
+++ b/japanese/java/com.aspose.diagram/vbaprojectreferencetype/_index.md
@@ -1,0 +1,156 @@
+---
+title: VbaProjectReferenceType
+second_title: Aspose.Diagram for Java API リファレンス
+description: VBA プロジェクト参照のタイプを表します。
+type: docs
+weight: 436
+url: /ja/java/com.aspose.diagram/vbaprojectreferencetype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class VbaProjectReferenceType
+```
+
+VBA プロジェクト参照のタイプを表します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [CONTROL](#CONTROL) | ツイドルされた型ライブラリとその拡張型ライブラリへの参照を指定します。 |
+| [PROJECT](#PROJECT) | 外部 VBA プロジェクトへの参照を指定します。 |
+| [REGISTERED](#REGISTERED) | Automation 型ライブラリへの参照を指定します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CONTROL {#CONTROL}
+```
+public static final int CONTROL
+```
+
+
+ツイドルされた型ライブラリとその拡張型ライブラリへの参照を指定します。
+
+### PROJECT {#PROJECT}
+```
+public static final int PROJECT
+```
+
+
+外部 VBA プロジェクトへの参照を指定します。
+
+### REGISTERED {#REGISTERED}
+```
+public static final int REGISTERED
+```
+
+
+Automation 型ライブラリへの参照を指定します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/verticalalign/_index.md
+++ b/japanese/java/com.aspose.diagram/verticalalign/_index.md
@@ -1,0 +1,204 @@
+---
+title: VerticalAlign
+second_title: Aspose.Diagram for Java API リファレンス
+description: テキストブロック内のテキストの垂直配置を指定します。
+type: docs
+weight: 437
+url: /ja/java/com.aspose.diagram/verticalalign/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class VerticalAlign
+```
+
+テキストブロック内のテキストの垂直配置を指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [VerticalAlign(int value)](#VerticalAlign-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | テキストブロック内のテキストの垂直配置を指定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | このプロパティの説明については、[getUfe()](../../com.aspose.diagram/verticalalign\#getUfe--) を参照してください。 |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/verticalalign\#getValue--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### VerticalAlign(int value) {#VerticalAlign-int-}
+```
+public VerticalAlign(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+テキストブロック内のテキストの垂直配置を指定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+このプロパティの説明については、[getUfe()](../../com.aspose.diagram/verticalalign\#getUfe--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/verticalalign\#getValue--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/verticalalignvalue/_index.md
+++ b/japanese/java/com.aspose.diagram/verticalalignvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: VerticalAlignValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: テキストブロック内のテキストの垂直配置を指定します。
+type: docs
+weight: 438
+url: /ja/java/com.aspose.diagram/verticalalignvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class VerticalAlignValue
+```
+
+テキストブロック内のテキストの垂直配置を指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [BOTTOM](#BOTTOM) | 下。 |
+| [MIDDLE](#MIDDLE) | 中央。 |
+| [TOP](#TOP) | 上。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOTTOM {#BOTTOM}
+```
+public static final int BOTTOM
+```
+
+
+下。
+
+### MIDDLE {#MIDDLE}
+```
+public static final int MIDDLE
+```
+
+
+中央。
+
+### TOP {#TOP}
+```
+public static final int TOP
+```
+
+
+上。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/visruletargetsvalue/_index.md
+++ b/japanese/java/com.aspose.diagram/visruletargetsvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: VisRuleTargetsValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: ValidationRule.TargetType プロパティに渡され、返される検証ルールの対象を定義する内容を指定します。
+type: docs
+weight: 439
+url: /ja/java/com.aspose.diagram/visruletargetsvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class VisRuleTargetsValue
+```
+
+検証ルールの対象を定義する内容を指定します。ValidationRule.TargetType プロパティに渡され、返されます。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+| [VIS_RULE_TARGET_DOCUMENT](#VIS-RULE-TARGET-DOCUMENT) | このルールはドキュメント内のシェイプに適用されます。 |
+| [VIS_RULE_TARGET_PAGE](#VIS-RULE-TARGET-PAGE) | このルールはドキュメント内のページに適用されます。 |
+| [VIS_RULE_TARGET_SHAPE](#VIS-RULE-TARGET-SHAPE) | このルールはドキュメント自体に適用されます。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### VIS_RULE_TARGET_DOCUMENT {#VIS-RULE-TARGET-DOCUMENT}
+```
+public static final int VIS_RULE_TARGET_DOCUMENT
+```
+
+
+このルールはドキュメント内のシェイプに適用されます。
+
+### VIS_RULE_TARGET_PAGE {#VIS-RULE-TARGET-PAGE}
+```
+public static final int VIS_RULE_TARGET_PAGE
+```
+
+
+このルールはドキュメント内のページに適用されます。
+
+### VIS_RULE_TARGET_SHAPE {#VIS-RULE-TARGET-SHAPE}
+```
+public static final int VIS_RULE_TARGET_SHAPE
+```
+
+
+このルールはドキュメント自体に適用されます。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/walkpreference/_index.md
+++ b/japanese/java/com.aspose.diagram/walkpreference/_index.md
@@ -1,0 +1,179 @@
+---
+title: WalkPreference
+second_title: Aspose.Diagram for Java API リファレンス
+description: 形状が曖昧な位置に移動した際、動的接着を使用して接着された形状上の水平または垂直の接続点に 1-D 形状の端点が移動するかどうかを指定します。
+type: docs
+weight: 440
+url: /ja/java/com.aspose.diagram/walkpreference/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class WalkPreference
+```
+
+形状が曖昧な位置に移動したとき、動的接着を使用して、1 次元形状の端点が接着された形状上の水平または垂直の接続点に移動するかどうかを指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [WalkPreference(int value)](#WalkPreference-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | 形状が曖昧な位置に移動したとき、動的接着を使用して、1 次元形状の端点が接着された形状上の水平または垂直の接続点に移動するかどうかを指定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | For the description of this property, please see [getValue()](../../com.aspose.diagram/walkpreference\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### WalkPreference(int value) {#WalkPreference-int-}
+```
+public WalkPreference(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+形状が曖昧な位置に移動したとき、動的接着を使用して、1 次元形状の端点が接着された形状上の水平または垂直の接続点に移動するかどうかを指定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+For the description of this property, please see [getValue()](../../com.aspose.diagram/walkpreference\#getValue--)
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/walkpreferencevalue/_index.md
+++ b/japanese/java/com.aspose.diagram/walkpreferencevalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: WalkPreferenceValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: 形状が曖昧な位置に移動した際、動的接着を使用して接着された形状上の水平または垂直の接続点に 1-D 形状の端点が移動するかどうかを指定します。
+type: docs
+weight: 441
+url: /ja/java/com.aspose.diagram/walkpreferencevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class WalkPreferenceValue
+```
+
+形状が曖昧な位置に移動したとき、動的接着を使用して、1 次元形状の端点が接着された形状上の水平または垂直の接続点に移動するかどうかを指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [SIDE_TO_SIDE_CONNECTIONS](#SIDE-TO-SIDE-CONNECTIONS) | デフォルトです。 |
+| [SIDE_TO_TOP_OR_SIDE_TO_BOTTOM_CONNECTIONS](#SIDE-TO-TOP-OR-SIDE-TO-BOTTOM-CONNECTIONS) | 1 次元シェイプの開始点が水平接続点に移動し、終了点が垂直接続点に移動します（側面から上部または下部への接続）。 |
+| [TOP_TO_BOTTOM_CONNECTIONS](#TOP-TO-BOTTOM-CONNECTIONS) | 1 次元シェイプの両端点が垂直接続点に移動します（上部から下部への接続）。 |
+| [TOP_TO_SIDE_OR_BOTTOM_TO_SIDE_CONNECTIONS](#TOP-TO-SIDE-OR-BOTTOM-TO-SIDE-CONNECTIONS) | 1 次元シェイプの開始点が垂直接続点に移動し、終了点が水平接続点に移動します（上部から側面または下部から側面への接続）。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SIDE_TO_SIDE_CONNECTIONS {#SIDE-TO-SIDE-CONNECTIONS}
+```
+public static final int SIDE_TO_SIDE_CONNECTIONS
+```
+
+
+デフォルトです。1 次元シェイプの両端点が水平接続点に移動します（側面から側面への接続）。
+
+### SIDE_TO_TOP_OR_SIDE_TO_BOTTOM_CONNECTIONS {#SIDE-TO-TOP-OR-SIDE-TO-BOTTOM-CONNECTIONS}
+```
+public static final int SIDE_TO_TOP_OR_SIDE_TO_BOTTOM_CONNECTIONS
+```
+
+
+1 次元シェイプの開始点が水平接続点に移動し、終了点が垂直接続点に移動します（側面から上部または下部への接続）。
+
+### TOP_TO_BOTTOM_CONNECTIONS {#TOP-TO-BOTTOM-CONNECTIONS}
+```
+public static final int TOP_TO_BOTTOM_CONNECTIONS
+```
+
+
+1 次元シェイプの両端点が垂直接続点に移動します（上部から下部への接続）。
+
+### TOP_TO_SIDE_OR_BOTTOM_TO_SIDE_CONNECTIONS {#TOP-TO-SIDE-OR-BOTTOM-TO-SIDE-CONNECTIONS}
+```
+public static final int TOP_TO_SIDE_OR_BOTTOM_TO_SIDE_CONNECTIONS
+```
+
+
+1 次元シェイプの開始点が垂直接続点に移動し、終了点が水平接続点に移動します（上部から側面または下部から側面への接続）。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/warninginfo/_index.md
+++ b/japanese/java/com.aspose.diagram/warninginfo/_index.md
@@ -1,0 +1,166 @@
+---
+title: WarningInfo
+second_title: Aspose.Diagram for Java API リファレンス
+description: 警告情報
+type: docs
+weight: 442
+url: /ja/java/com.aspose.diagram/warninginfo/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class WarningInfo
+```
+
+警告情報
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [WarningInfo(int warningType, String description)](#WarningInfo-int-java.lang.String-) | Create warning info. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDescription()](#getDescription--) | Get description of warning info. |
+| [getWarningType()](#getWarningType--) | Get warning type. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### WarningInfo(int warningType, String description) {#WarningInfo-int-java.lang.String-}
+```
+public WarningInfo(int warningType, String description)
+```
+
+
+Create warning info.
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| warningType | int | warning type |
+| description | java.lang.String | warning description |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDescription() {#getDescription--}
+```
+public String getDescription()
+```
+
+
+Get description of warning info.
+
+**Returns:**
+java.lang.String
+### getWarningType() {#getWarningType--}
+```
+public int getWarningType()
+```
+
+
+Get warning type.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/warningtype/_index.md
+++ b/japanese/java/com.aspose.diagram/warningtype/_index.md
@@ -1,0 +1,138 @@
+---
+title: WarningType
+second_title: Aspose.Diagram for Java API リファレンス
+description: WarningType
+type: docs
+weight: 443
+url: /ja/java/com.aspose.diagram/warningtype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class WarningType
+```
+
+WarningType
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [FONT_SUBSTITUTION](#FONT-SUBSTITUTION) | フォントが見つからなかった場合のフォント置換警告タイプで、この警告タイプを取得できます。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FONT_SUBSTITUTION {#FONT-SUBSTITUTION}
+```
+public static final int FONT_SUBSTITUTION
+```
+
+
+フォントが見つからなかった場合のフォント置換警告タイプで、この警告タイプを取得できます。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/window/_index.md
+++ b/japanese/java/com.aspose.diagram/window/_index.md
@@ -1,0 +1,899 @@
+---
+title: Window
+second_title: Aspose.Diagram for Java API リファレンス
+description: Microsoft Visio インスタンス内の開いているウィンドウを表します。
+type: docs
+weight: 444
+url: /ja/java/com.aspose.diagram/window/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Window
+```
+
+Microsoft Visio インスタンス内の開いているウィンドウを表します。この要素には、DatadiagramML ファイルが Visio によって最初に開かれたときに、アプリケーション ワークスペース内でユーザー インターフェイス ウィンドウを正確に再作成するために必要な情報が含まれています。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Window()](#Window--) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getContainer()](#getContainer--) | コンテナの ID: ページ、シート、またはマスター。 |
+| [getContainerType()](#getContainerType--) | 次のいずれかの値を取ります: Document、Page、または Master。 |
+| [getDocument()](#getDocument--) | このウィンドウに表示されているドキュメントのファイル パス。 |
+| [getDynamicGridEnabled()](#getDynamicGridEnabled--) | ドキュメントまたはウィンドウに対して動的グリッド機能が有効かどうかを指定します。 |
+| [getGlueSettings()](#getGlueSettings--) | ドキュメントで接着が有効な場合に、シェイプが接着するオブジェクトを指定します。 |
+| [getID()](#getID--) | 要素の親要素内における一意の ID。 |
+| [getMaster()](#getMaster--) | このウィンドウがマスターを表示している場合のマスター ID。 |
+| [getPage()](#getPage--) | このウィンドウがページを表示している場合のページ ID。 |
+| [getParentWindow()](#getParentWindow--) | このステンシル ウィンドウが含まれるウィンドウの ID。 |
+| [getReadOnly()](#getReadOnly--) | このステンシルがドキュメント ステンシルでない場合の読み取り専用フラグ。 |
+| [getSheet()](#getSheet--) | コンテナ内のシートの ID。 |
+| [getShowConnectionPoints()](#getShowConnectionPoints--) | ウィンドウに接続ポイントを表示するかどうかを指定します。 |
+| [getShowGrid()](#getShowGrid--) | 図面ウィンドウにグリッドを表示するかどうかを指定します。 |
+| [getShowGuides()](#getShowGuides--) | 図面ウィンドウにガイドを表示するかどうかを指定します。 |
+| [getShowPageBreaks()](#getShowPageBreaks--) | ウィンドウに改ページ記号を表示するかどうかを指定します。 |
+| [getShowRulers()](#getShowRulers--) | 図面ウィンドウに定規を表示するかどうかを指定します。 |
+| [getSnapAngles()](#getSnapAngles--) | SnapAngle 要素のコレクションを含みます。 |
+| [getSnapExtensions()](#getSnapExtensions--) | アクティブ ウィンドウに対して特定のスナップ拡張設定が有効か無効かを指定します。 |
+| [getSnapSettings()](#getSnapSettings--) | ウィンドウでスナップが有効なときにシェイプがスナップするオブジェクトを指定します。 |
+| [getStencilGroup()](#getStencilGroup--) | ウィンドウが所属する結合されたステンシル ウィンドウのグループを指定します。 |
+| [getStencilGroupPos()](#getStencilGroupPos--) | ウィンドウ内のグループ内でステンシルの相対位置を指定する整数を含みます。 |
+| [getTabSplitterPos()](#getTabSplitterPos--) | 図面ウィンドウのページ タブ コントロールの幅を指定します（図面ウィンドウ全体の幅に対する割合として）。 |
+| [getViewCenterX()](#getViewCenterX--) | オプションの double。 |
+| [getViewCenterY()](#getViewCenterY--) | オプションの double。 |
+| [getViewScale()](#getViewScale--) | オプションの double。 |
+| [getWindowHeight()](#getWindowHeight--) | ウィンドウ矩形の高さ。 |
+| [getWindowLeft()](#getWindowLeft--) | ウィンドウ矩形の左座標。 |
+| [getWindowState()](#getWindowState--) | この属性は以下の値の合計になる場合があります。 |
+| [getWindowTop()](#getWindowTop--) | ウィンドウ矩形の上座標。 |
+| [getWindowType()](#getWindowType--) | 列挙値で、次のいずれかになる可能性があります: Drawing、Sheet、Stencil、または Icon。WindowType='Stencil' の Window 要素は、親の図面ウィンドウ (WindowType='Drawing') の後、他の図面ウィンドウ要素の前に出現しなければなりません。 |
+| [getWindowWidth()](#getWindowWidth--) | ウィンドウ矩形の幅。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setContainer(int value)](#setContainer-int-) | このプロパティの説明については、[getContainer()](../../com.aspose.diagram/window\\#getContainer--) を参照してください。 |
+| [setContainerType(int value)](#setContainerType-int-) | このプロパティの説明については、[getContainerType()](../../com.aspose.diagram/window\\#getContainerType--) を参照してください。 |
+| [setDocument(String value)](#setDocument-java.lang.String-) | このプロパティの説明については、[getDocument()](../../com.aspose.diagram/window\#getDocument--) を参照してください |
+| [setDynamicGridEnabled(int value)](#setDynamicGridEnabled-int-) | このプロパティの説明については、[getDynamicGridEnabled()](../../com.aspose.diagram/window\#getDynamicGridEnabled--) を参照してください |
+| [setGlueSettings(int value)](#setGlueSettings-int-) | このプロパティの説明については、[getGlueSettings()](../../com.aspose.diagram/window\#getGlueSettings--) を参照してください |
+| [setID(int value)](#setID-int-) | このプロパティの説明については、[getID()](../../com.aspose.diagram/window\#getID--) を参照してください |
+| [setMaster(Master value)](#setMaster-com.aspose.diagram.Master-) | このプロパティの説明については、[getMaster()](../../com.aspose.diagram/window\#getMaster--) を参照してください |
+| [setPage(Page value)](#setPage-com.aspose.diagram.Page-) | このプロパティの説明については、[getPage()](../../com.aspose.diagram/window\#getPage--) を参照してください |
+| [setParentWindow(int value)](#setParentWindow-int-) | このプロパティの説明については、[getParentWindow()](../../com.aspose.diagram/window\#getParentWindow--) を参照してください |
+| [setReadOnly(int value)](#setReadOnly-int-) | このプロパティの説明については、[getReadOnly()](../../com.aspose.diagram/window\#getReadOnly--) を参照してください |
+| [setSheet(int value)](#setSheet-int-) | このプロパティの説明については、[getSheet()](../../com.aspose.diagram/window\#getSheet--) を参照してください |
+| [setShowConnectionPoints(int value)](#setShowConnectionPoints-int-) | このプロパティの説明については、[getShowConnectionPoints()](../../com.aspose.diagram/window\#getShowConnectionPoints--) を参照してください |
+| [setShowGrid(int value)](#setShowGrid-int-) | このプロパティの説明については、[getShowGrid()](../../com.aspose.diagram/window\#getShowGrid--) を参照してください |
+| [setShowGuides(int value)](#setShowGuides-int-) | このプロパティの説明については、[getShowGuides()](../../com.aspose.diagram/window\#getShowGuides--) を参照してください |
+| [setShowPageBreaks(int value)](#setShowPageBreaks-int-) | このプロパティの説明については、[getShowPageBreaks()](../../com.aspose.diagram/window\#getShowPageBreaks--) を参照してください |
+| [setShowRulers(int value)](#setShowRulers-int-) | このプロパティの説明については、[getShowRulers()](../../com.aspose.diagram/window\#getShowRulers--) を参照してください |
+| [setSnapExtensions(int value)](#setSnapExtensions-int-) | このプロパティの説明については、[getSnapExtensions()](../../com.aspose.diagram/window\#getSnapExtensions--) を参照してください |
+| [setSnapSettings(int value)](#setSnapSettings-int-) | このプロパティの説明については、[getSnapSettings()](../../com.aspose.diagram/window\#getSnapSettings--) を参照してください |
+| [setStencilGroup(String value)](#setStencilGroup-java.lang.String-) | このプロパティの説明については、[getStencilGroup()](../../com.aspose.diagram/window\#getStencilGroup--) を参照してください |
+| [setStencilGroupPos(int value)](#setStencilGroupPos-int-) | このプロパティの説明については、[getStencilGroupPos()](../../com.aspose.diagram/window\#getStencilGroupPos--) を参照してください |
+| [setTabSplitterPos(double value)](#setTabSplitterPos-double-) | このプロパティの説明については、[getTabSplitterPos()](../../com.aspose.diagram/window\#getTabSplitterPos--) を参照してください |
+| [setViewCenterX(double value)](#setViewCenterX-double-) | このプロパティの説明については、[getViewCenterX()](../../com.aspose.diagram/window\#getViewCenterX--) を参照してください |
+| [setViewCenterY(double value)](#setViewCenterY-double-) | このプロパティの説明については、[getViewCenterY()](../../com.aspose.diagram/window\#getViewCenterY--) を参照してください |
+| [setViewScale(double value)](#setViewScale-double-) | このプロパティの説明については、[getViewScale()](../../com.aspose.diagram/window\#getViewScale--) を参照してください |
+| [setWindowHeight(long value)](#setWindowHeight-long-) | このプロパティの説明については、[getWindowHeight()](../../com.aspose.diagram/window\#getWindowHeight--) を参照してください |
+| [setWindowLeft(int value)](#setWindowLeft-int-) | このプロパティの説明については、[getWindowLeft()](../../com.aspose.diagram/window\#getWindowLeft--) を参照してください |
+| [setWindowState(int value)](#setWindowState-int-) | このプロパティの説明については、[getWindowState()](../../com.aspose.diagram/window\#getWindowState--) を参照してください |
+| [setWindowTop(int value)](#setWindowTop-int-) | このプロパティの説明については、[getWindowTop()](../../com.aspose.diagram/window\#getWindowTop--)をご覧ください。 |
+| [setWindowType(int value)](#setWindowType-int-) | このプロパティの説明については、[getWindowType()](../../com.aspose.diagram/window\#getWindowType--)をご覧ください。 |
+| [setWindowWidth(long value)](#setWindowWidth-long-) | このプロパティの説明については、[getWindowWidth()](../../com.aspose.diagram/window\#getWindowWidth--)をご覧ください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Window() {#Window--}
+```
+public Window()
+```
+
+
+コンストラクタ。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getContainer() {#getContainer--}
+```
+public int getContainer()
+```
+
+
+コンテナの ID: Page、Sheet、または Master。ContainerType が指定されている場合にのみ関連し、必要です。
+
+**Returns:**
+int
+### getContainerType() {#getContainerType--}
+```
+public int getContainerType()
+```
+
+
+May be one of the following values: Document, Page, or Master. Only relevant when WindowType is specified as Drawing or Sheet.
+
+**Returns:**
+int
+### getDocument() {#getDocument--}
+```
+public String getDocument()
+```
+
+
+このウィンドウに表示されるドキュメントのファイルパス。WindowType が Stencil と指定されているウィンドウに関連する属性です。
+
+**Returns:**
+java.lang.String
+### getDynamicGridEnabled() {#getDynamicGridEnabled--}
+```
+public int getDynamicGridEnabled()
+```
+
+
+ドキュメントまたはウィンドウに対して動的グリッド機能が有効かどうかを指定します。
+
+**Returns:**
+int
+### getGlueSettings() {#getGlueSettings--}
+```
+public int getGlueSettings()
+```
+
+
+ドキュメントで接着が有効な場合に、シェイプが接着するオブジェクトを指定します。
+
+**Returns:**
+int
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+要素の親要素内における一意の ID。
+
+**Returns:**
+int
+### getMaster() {#getMaster--}
+```
+public Master getMaster()
+```
+
+
+このウィンドウがマスターを表示している場合のマスター ID。
+
+**Returns:**
+[Master](../../com.aspose.diagram/master)
+### getPage() {#getPage--}
+```
+public Page getPage()
+```
+
+
+このウィンドウがページを表示している場合のページ ID。WindowType が Drawing、かつ ContainerType が Page と指定されている場合にのみ関連します。
+
+**Returns:**
+[Page](../../com.aspose.diagram/page)
+### getParentWindow() {#getParentWindow--}
+```
+public int getParentWindow()
+```
+
+
+このステンシルウィンドウが含まれるウィンドウの ID。WindowType が Stencil と指定されている場合にのみ関連します。
+
+**Returns:**
+int
+### getReadOnly() {#getReadOnly--}
+```
+public int getReadOnly()
+```
+
+
+このステンシルがドキュメント ステンシルでない場合の読み取り専用フラグ。
+
+**Returns:**
+int
+### getSheet() {#getSheet--}
+```
+public int getSheet()
+```
+
+
+コンテナ内のシートの ID。Container が Sheet と指定されている場合にのみ関連します。
+
+**Returns:**
+int
+### getShowConnectionPoints() {#getShowConnectionPoints--}
+```
+public int getShowConnectionPoints()
+```
+
+
+ウィンドウに接続ポイントを表示するかどうかを指定します。
+
+**Returns:**
+int
+### getShowGrid() {#getShowGrid--}
+```
+public int getShowGrid()
+```
+
+
+図面ウィンドウにグリッドを表示するかどうかを指定します。
+
+**Returns:**
+int
+### getShowGuides() {#getShowGuides--}
+```
+public int getShowGuides()
+```
+
+
+図面ウィンドウにガイドを表示するかどうかを指定します。
+
+**Returns:**
+int
+### getShowPageBreaks() {#getShowPageBreaks--}
+```
+public int getShowPageBreaks()
+```
+
+
+ウィンドウに改ページ記号を表示するかどうかを指定します。
+
+**Returns:**
+int
+### getShowRulers() {#getShowRulers--}
+```
+public int getShowRulers()
+```
+
+
+図面ウィンドウに定規を表示するかどうかを指定します。
+
+**Returns:**
+int
+### getSnapAngles() {#getSnapAngles--}
+```
+public FloatPointNumCollection getSnapAngles()
+```
+
+
+SnapAngle 要素のコレクションを含みます。
+
+**Returns:**
+[FloatPointNumCollection](../../com.aspose.diagram/floatpointnumcollection)
+### getSnapExtensions() {#getSnapExtensions--}
+```
+public int getSnapExtensions()
+```
+
+
+アクティブウィンドウに対して、特定のスナップ拡張設定が有効か無効かを指定します。値は以下の表の値の合計になる場合があります。
+
+**Returns:**
+int
+### getSnapSettings() {#getSnapSettings--}
+```
+public int getSnapSettings()
+```
+
+
+ウィンドウでスナップが有効なときに、シェイプがスナップする対象オブジェクトを指定します。値は以下の表の値の合計になる場合があります。
+
+**Returns:**
+int
+### getStencilGroup() {#getStencilGroup--}
+```
+public String getStencilGroup()
+```
+
+
+ウィンドウが所属する結合されたステンシルウィンドウのグループを指定します。この属性は、Window 要素の WindowType 属性が Stencil に設定され、かつステンシルウィンドウが結合されたステンシルウィンドウのグループの一部である場合にのみ関連します。同じ結合グループに属するすべてのステンシルウィンドウは、同じ StencilGroup 要素値を持ちます。
+
+**Returns:**
+java.lang.String
+### getStencilGroupPos() {#getStencilGroupPos--}
+```
+public int getStencilGroupPos()
+```
+
+
+ウィンドウ内のグループ内でステンシルの相対位置を指定する整数を含みます。
+
+**Returns:**
+int
+### getTabSplitterPos() {#getTabSplitterPos--}
+```
+public double getTabSplitterPos()
+```
+
+
+図面ウィンドウのページ タブ コントロールの幅を指定します（図面ウィンドウ全体の幅に対する割合として）。
+
+**Returns:**
+double
+### getViewCenterX() {#getViewCenterX--}
+```
+public double getViewCenterX()
+```
+
+
+オプションの double。
+
+**Returns:**
+double
+### getViewCenterY() {#getViewCenterY--}
+```
+public double getViewCenterY()
+```
+
+
+オプションの double。
+
+**Returns:**
+double
+### getViewScale() {#getViewScale--}
+```
+public double getViewScale()
+```
+
+
+オプションの double。
+
+**Returns:**
+double
+### getWindowHeight() {#getWindowHeight--}
+```
+public long getWindowHeight()
+```
+
+
+ウィンドウ矩形の高さ。
+
+**Returns:**
+long
+### getWindowLeft() {#getWindowLeft--}
+```
+public int getWindowLeft()
+```
+
+
+ウィンドウ矩形の左座標。
+
+**Returns:**
+int
+### getWindowState() {#getWindowState--}
+```
+public int getWindowState()
+```
+
+
+この属性は以下の値の合計になる場合があります。
+
+**Returns:**
+int
+### getWindowTop() {#getWindowTop--}
+```
+public int getWindowTop()
+```
+
+
+ウィンドウ矩形の上座標。
+
+**Returns:**
+int
+### getWindowType() {#getWindowType--}
+```
+public int getWindowType()
+```
+
+
+列挙値で、次のいずれかになる可能性があります: Drawing、Sheet、Stencil、または Icon。WindowType='Stencil' の Window 要素は、親の図面ウィンドウ (WindowType='Drawing') の後、他の図面ウィンドウ要素の前に出現しなければなりません。
+
+**Returns:**
+int
+### getWindowWidth() {#getWindowWidth--}
+```
+public long getWindowWidth()
+```
+
+
+ウィンドウ矩形の幅。
+
+**Returns:**
+long
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setContainer(int value) {#setContainer-int-}
+```
+public void setContainer(int value)
+```
+
+
+このプロパティの説明については、[getContainer()](../../com.aspose.diagram/window\\#getContainer--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setContainerType(int value) {#setContainerType-int-}
+```
+public void setContainerType(int value)
+```
+
+
+このプロパティの説明については、[getContainerType()](../../com.aspose.diagram/window\\#getContainerType--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setDocument(String value) {#setDocument-java.lang.String-}
+```
+public void setDocument(String value)
+```
+
+
+このプロパティの説明については、[getDocument()](../../com.aspose.diagram/window\#getDocument--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setDynamicGridEnabled(int value) {#setDynamicGridEnabled-int-}
+```
+public void setDynamicGridEnabled(int value)
+```
+
+
+このプロパティの説明については、[getDynamicGridEnabled()](../../com.aspose.diagram/window\#getDynamicGridEnabled--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setGlueSettings(int value) {#setGlueSettings-int-}
+```
+public void setGlueSettings(int value)
+```
+
+
+このプロパティの説明については、[getGlueSettings()](../../com.aspose.diagram/window\#getGlueSettings--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+このプロパティの説明については、[getID()](../../com.aspose.diagram/window\#getID--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setMaster(Master value) {#setMaster-com.aspose.diagram.Master-}
+```
+public void setMaster(Master value)
+```
+
+
+このプロパティの説明については、[getMaster()](../../com.aspose.diagram/window\#getMaster--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [Master](../../com.aspose.diagram/master) |  |
+
+### setPage(Page value) {#setPage-com.aspose.diagram.Page-}
+```
+public void setPage(Page value)
+```
+
+
+このプロパティの説明については、[getPage()](../../com.aspose.diagram/window\#getPage--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [Page](../../com.aspose.diagram/page) |  |
+
+### setParentWindow(int value) {#setParentWindow-int-}
+```
+public void setParentWindow(int value)
+```
+
+
+このプロパティの説明については、[getParentWindow()](../../com.aspose.diagram/window\#getParentWindow--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setReadOnly(int value) {#setReadOnly-int-}
+```
+public void setReadOnly(int value)
+```
+
+
+このプロパティの説明については、[getReadOnly()](../../com.aspose.diagram/window\#getReadOnly--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setSheet(int value) {#setSheet-int-}
+```
+public void setSheet(int value)
+```
+
+
+このプロパティの説明については、[getSheet()](../../com.aspose.diagram/window\#getSheet--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setShowConnectionPoints(int value) {#setShowConnectionPoints-int-}
+```
+public void setShowConnectionPoints(int value)
+```
+
+
+このプロパティの説明については、[getShowConnectionPoints()](../../com.aspose.diagram/window\#getShowConnectionPoints--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setShowGrid(int value) {#setShowGrid-int-}
+```
+public void setShowGrid(int value)
+```
+
+
+このプロパティの説明については、[getShowGrid()](../../com.aspose.diagram/window\#getShowGrid--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setShowGuides(int value) {#setShowGuides-int-}
+```
+public void setShowGuides(int value)
+```
+
+
+このプロパティの説明については、[getShowGuides()](../../com.aspose.diagram/window\#getShowGuides--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setShowPageBreaks(int value) {#setShowPageBreaks-int-}
+```
+public void setShowPageBreaks(int value)
+```
+
+
+このプロパティの説明については、[getShowPageBreaks()](../../com.aspose.diagram/window\#getShowPageBreaks--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setShowRulers(int value) {#setShowRulers-int-}
+```
+public void setShowRulers(int value)
+```
+
+
+このプロパティの説明については、[getShowRulers()](../../com.aspose.diagram/window\#getShowRulers--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setSnapExtensions(int value) {#setSnapExtensions-int-}
+```
+public void setSnapExtensions(int value)
+```
+
+
+このプロパティの説明については、[getSnapExtensions()](../../com.aspose.diagram/window\#getSnapExtensions--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setSnapSettings(int value) {#setSnapSettings-int-}
+```
+public void setSnapSettings(int value)
+```
+
+
+このプロパティの説明については、[getSnapSettings()](../../com.aspose.diagram/window\#getSnapSettings--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setStencilGroup(String value) {#setStencilGroup-java.lang.String-}
+```
+public void setStencilGroup(String value)
+```
+
+
+このプロパティの説明については、[getStencilGroup()](../../com.aspose.diagram/window\#getStencilGroup--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setStencilGroupPos(int value) {#setStencilGroupPos-int-}
+```
+public void setStencilGroupPos(int value)
+```
+
+
+このプロパティの説明については、[getStencilGroupPos()](../../com.aspose.diagram/window\#getStencilGroupPos--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setTabSplitterPos(double value) {#setTabSplitterPos-double-}
+```
+public void setTabSplitterPos(double value)
+```
+
+
+このプロパティの説明については、[getTabSplitterPos()](../../com.aspose.diagram/window\#getTabSplitterPos--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double |  |
+
+### setViewCenterX(double value) {#setViewCenterX-double-}
+```
+public void setViewCenterX(double value)
+```
+
+
+このプロパティの説明については、[getViewCenterX()](../../com.aspose.diagram/window\#getViewCenterX--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double |  |
+
+### setViewCenterY(double value) {#setViewCenterY-double-}
+```
+public void setViewCenterY(double value)
+```
+
+
+このプロパティの説明については、[getViewCenterY()](../../com.aspose.diagram/window\#getViewCenterY--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double |  |
+
+### setViewScale(double value) {#setViewScale-double-}
+```
+public void setViewScale(double value)
+```
+
+
+このプロパティの説明については、[getViewScale()](../../com.aspose.diagram/window\#getViewScale--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | double |  |
+
+### setWindowHeight(long value) {#setWindowHeight-long-}
+```
+public void setWindowHeight(long value)
+```
+
+
+このプロパティの説明については、[getWindowHeight()](../../com.aspose.diagram/window\#getWindowHeight--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | long |  |
+
+### setWindowLeft(int value) {#setWindowLeft-int-}
+```
+public void setWindowLeft(int value)
+```
+
+
+このプロパティの説明については、[getWindowLeft()](../../com.aspose.diagram/window\#getWindowLeft--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setWindowState(int value) {#setWindowState-int-}
+```
+public void setWindowState(int value)
+```
+
+
+このプロパティの説明については、[getWindowState()](../../com.aspose.diagram/window\#getWindowState--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setWindowTop(int value) {#setWindowTop-int-}
+```
+public void setWindowTop(int value)
+```
+
+
+このプロパティの説明については、[getWindowTop()](../../com.aspose.diagram/window\#getWindowTop--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setWindowType(int value) {#setWindowType-int-}
+```
+public void setWindowType(int value)
+```
+
+
+このプロパティの説明については、[getWindowType()](../../com.aspose.diagram/window\#getWindowType--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setWindowWidth(long value) {#setWindowWidth-long-}
+```
+public void setWindowWidth(long value)
+```
+
+
+このプロパティの説明については、[getWindowWidth()](../../com.aspose.diagram/window\#getWindowWidth--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | long |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/windowcollection/_index.md
+++ b/japanese/java/com.aspose.diagram/windowcollection/_index.md
@@ -1,0 +1,268 @@
+---
+title: WindowCollection
+second_title: Aspose.Diagram for Java API リファレンス
+description: ウィンドウコレクション。
+type: docs
+weight: 445
+url: /ja/java/com.aspose.diagram/windowcollection/
+---
+
+**Inheritance:**
+java.lang.Object、[com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class WindowCollection extends Collection
+```
+
+ウィンドウコレクション。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(Window window)](#add-com.aspose.diagram.Window-) | コレクションにウィンドウを追加します。 |
+| [clear()](#clear--) | コレクションからすべての要素を削除します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 指定されたインデックスの要素を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getClientHeight()](#getClientHeight--) | オプションの int。 |
+| [getClientWidth()](#getClientWidth--) | オプションの int。 |
+| [getCount()](#getCount--) | コレクションに実際に含まれる要素数を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | コレクションに項目が存在するかどうかを確認します。 |
+| [iterator()](#iterator--) | ジェネリックではないコレクションに対するシンプルな反復をサポートします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Window window)](#remove-com.aspose.diagram.Window-) | コレクションからウィンドウを削除します。 |
+| [setClientHeight(int value)](#setClientHeight-int-) | このプロパティの説明については、[getClientHeight()](../../com.aspose.diagram/windowcollection\#getClientHeight--) を参照してください。 |
+| [setClientWidth(int value)](#setClientWidth-int-) | このプロパティの説明については、[getClientWidth()](../../com.aspose.diagram/windowcollection\#getClientWidth--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Window window) {#add-com.aspose.diagram.Window-}
+```
+public int add(Window window)
+```
+
+
+コレクションにウィンドウを追加します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| window | [Window](../../com.aspose.diagram/window) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+コレクションからすべての要素を削除します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Window get(int index)
+```
+
+
+指定されたインデックスの要素を取得します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int |  |
+
+**Returns:**
+[Window](../../com.aspose.diagram/window) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getClientHeight() {#getClientHeight--}
+```
+public int getClientHeight()
+```
+
+
+オプションの int。
+
+**Returns:**
+int
+### getClientWidth() {#getClientWidth--}
+```
+public int getClientWidth()
+```
+
+
+オプションの int。
+
+**Returns:**
+int
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+コレクションに実際に含まれる要素数を取得します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+コレクションに項目が存在するかどうかを確認します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素のインデックス。 |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+ジェネリックではないコレクションに対するシンプルな反復をサポートします。
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Window window) {#remove-com.aspose.diagram.Window-}
+```
+public void remove(Window window)
+```
+
+
+コレクションからウィンドウを削除します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| window | [Window](../../com.aspose.diagram/window) |  |
+
+### setClientHeight(int value) {#setClientHeight-int-}
+```
+public void setClientHeight(int value)
+```
+
+
+このプロパティの説明については、[getClientHeight()](../../com.aspose.diagram/windowcollection\#getClientHeight--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setClientWidth(int value) {#setClientWidth-int-}
+```
+public void setClientWidth(int value)
+```
+
+
+このプロパティの説明については、[getClientWidth()](../../com.aspose.diagram/windowcollection\#getClientWidth--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/windowstatevalue/_index.md
+++ b/japanese/java/com.aspose.diagram/windowstatevalue/_index.md
@@ -1,0 +1,264 @@
+---
+title: WindowStateValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: ビットフラグを指定する整数。
+type: docs
+weight: 446
+url: /ja/java/com.aspose.diagram/windowstatevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class WindowStateValue
+```
+
+ビットフラグを指定する整数です。この属性は以下の値の合計になる可能性があります。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [ACTIVE](#ACTIVE) | アクティブ。 |
+| [ANCHOR_BOTTOM](#ANCHOR-BOTTOM) | 下部に固定。 |
+| [ANCHOR_LEFT](#ANCHOR-LEFT) | 左側に固定。 |
+| [ANCHOR_MERGED](#ANCHOR-MERGED) | 結合された位置に固定。 |
+| [ANCHOR_RIGHT](#ANCHOR-RIGHT) | 右側に固定。 |
+| [ANCHOR_TOP](#ANCHOR-TOP) | 上部に固定。 |
+| [DOCKED_BOTTOM](#DOCKED-BOTTOM) | 下部にドッキング。 |
+| [DOCKED_LEFT](#DOCKED-LEFT) | 左部にドッキング。 |
+| [DOCKED_RIGHT](#DOCKED-RIGHT) | 右部にドッキング。 |
+| [DOCKED_TOP](#DOCKED-TOP) | 上部にドッキング。 |
+| [DOUBLEING](#DOUBLEING) | 二重化。 |
+| [MAXIMIZED](#MAXIMIZED) | 最大化。 |
+| [MINIMIZED](#MINIMIZED) | 最小化。 |
+| [RESTORED](#RESTORED) | 復元。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ACTIVE {#ACTIVE}
+```
+public static final int ACTIVE
+```
+
+
+アクティブ。
+
+### ANCHOR_BOTTOM {#ANCHOR-BOTTOM}
+```
+public static final int ANCHOR_BOTTOM
+```
+
+
+下部に固定。
+
+### ANCHOR_LEFT {#ANCHOR-LEFT}
+```
+public static final int ANCHOR_LEFT
+```
+
+
+左側に固定。
+
+### ANCHOR_MERGED {#ANCHOR-MERGED}
+```
+public static final int ANCHOR_MERGED
+```
+
+
+結合された位置に固定。
+
+### ANCHOR_RIGHT {#ANCHOR-RIGHT}
+```
+public static final int ANCHOR_RIGHT
+```
+
+
+右側に固定。
+
+### ANCHOR_TOP {#ANCHOR-TOP}
+```
+public static final int ANCHOR_TOP
+```
+
+
+上部に固定。
+
+### DOCKED_BOTTOM {#DOCKED-BOTTOM}
+```
+public static final int DOCKED_BOTTOM
+```
+
+
+下部にドッキング。
+
+### DOCKED_LEFT {#DOCKED-LEFT}
+```
+public static final int DOCKED_LEFT
+```
+
+
+左部にドッキング。
+
+### DOCKED_RIGHT {#DOCKED-RIGHT}
+```
+public static final int DOCKED_RIGHT
+```
+
+
+右部にドッキング。
+
+### DOCKED_TOP {#DOCKED-TOP}
+```
+public static final int DOCKED_TOP
+```
+
+
+上部にドッキング。
+
+### DOUBLEING {#DOUBLEING}
+```
+public static final int DOUBLEING
+```
+
+
+二重化。
+
+### MAXIMIZED {#MAXIMIZED}
+```
+public static final int MAXIMIZED
+```
+
+
+最大化。
+
+### MINIMIZED {#MINIMIZED}
+```
+public static final int MINIMIZED
+```
+
+
+最小化。
+
+### RESTORED {#RESTORED}
+```
+public static final int RESTORED
+```
+
+
+復元。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/windowtypevalue/_index.md
+++ b/japanese/java/com.aspose.diagram/windowtypevalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: WindowTypeValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: An enumerated value that may be one of the following Drawing Sheet Stencil or Icon.
+type: docs
+weight: 447
+url: /ja/java/com.aspose.diagram/windowtypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class WindowTypeValue
+```
+
+An enumerated value that may be one of the following: Drawing, Sheet, Stencil, or Icon. A Window element of WindowType='Stencil' must appear after its parent drawing window (WindowType='Drawing') and before any other drawing window elements.
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [DRAWING](#DRAWING) | Drawing |
+| [ICON](#ICON) | Icon. |
+| [SHEET](#SHEET) | Sheet |
+| [STENCIL](#STENCIL) | Stencil. |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DRAWING {#DRAWING}
+```
+public static final int DRAWING
+```
+
+
+Drawing
+
+### ICON {#ICON}
+```
+public static final int ICON
+```
+
+
+Icon.
+
+### SHEET {#SHEET}
+```
+public static final int SHEET
+```
+
+
+Sheet
+
+### STENCIL {#STENCIL}
+```
+public static final int STENCIL
+```
+
+
+Stencil.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/xamlsaveoptions/_index.md
+++ b/japanese/java/com.aspose.diagram/xamlsaveoptions/_index.md
@@ -1,0 +1,329 @@
+---
+title: XAMLSaveOptions
+second_title: Aspose.Diagram for Java API リファレンス
+description: ダイアグラムページを XAML にレンダリングする際に、追加オプションを指定できます。
+type: docs
+weight: 448
+url: /ja/java/com.aspose.diagram/xamlsaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.SaveOptions](../../com.aspose.diagram/saveoptions)
+```
+public class XAMLSaveOptions extends SaveOptions
+```
+
+ダイアグラムページを XAML にレンダリングする際に、追加オプションを指定できます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [XAMLSaveOptions()](#XAMLSaveOptions--) | このクラスの新しいインスタンスを初期化します。このインスタンスは Aspose.Diagram.SaveFileFormat 形式でドキュメントを保存するために使用できます。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | 指定された保存形式に適したクラスの保存オプションオブジェクトを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDefaultFont()](#getDefaultFont--) | 図内の文字が Unicode で、正しいフォント値が設定されていない、またはフォントがローカルにインストールされていない場合、pdf、画像、または XPS でブロックとして表示されることがあります。 |
+| [getPageCount()](#getPageCount--) | XAMLでレンダリングするページの数。 |
+| [getPageIndex()](#getPageIndex--) | レンダリングする最初のページの 0 ベースインデックス。 |
+| [getSaveForegroundPagesOnly()](#getSaveForegroundPagesOnly--) | すべてのページを画像として保存するか、前景のみを保存するかを指定します。 |
+| [getSaveFormat()](#getSaveFormat--) | この保存オプションオブジェクトが使用された場合、レンダリングされた図ページが保存される形式を指定します。 |
+| [getStreamProvider()](#getStreamProvider--) | オブジェクトをエクスポートするための IStreamProvider。 |
+| [getWarningCallback()](#getWarningCallback--) | 警告コールバック。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | このプロパティの説明については、[getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--) を参照してください。 |
+| [setPageCount(int value)](#setPageCount-int-) | このプロパティの説明については、[getPageCount()](../../com.aspose.diagram/xamlsaveoptions\#getPageCount--)をご覧ください。 |
+| [setPageIndex(int value)](#setPageIndex-int-) | このプロパティの説明については、[getPageIndex()](../../com.aspose.diagram/xamlsaveoptions\#getPageIndex--)をご覧ください。 |
+| [setSaveForegroundPagesOnly(boolean value)](#setSaveForegroundPagesOnly-boolean-) | このプロパティの説明については、[getSaveForegroundPagesOnly()](../../com.aspose.diagram/xamlsaveoptions\#getSaveForegroundPagesOnly--)をご覧ください。 |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | このプロパティの説明については、[getSaveFormat()](../../com.aspose.diagram/xamlsaveoptions\#getSaveFormat--)をご覧ください。 |
+| [setStreamProvider(IStreamProvider value)](#setStreamProvider-com.aspose.diagram.IStreamProvider-) | このプロパティの説明については、[getStreamProvider()](../../com.aspose.diagram/xamlsaveoptions\#getStreamProvider--)をご覧ください。 |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### XAMLSaveOptions() {#XAMLSaveOptions--}
+```
+public XAMLSaveOptions()
+```
+
+
+このクラスの新しいインスタンスを初期化します。このインスタンスは Aspose.Diagram.SaveFileFormat 形式でドキュメントを保存するために使用できます。
+
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+指定された保存形式に適したクラスの保存オプションオブジェクトを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| saveFormat | int | 保存オプションオブジェクトを作成するための Aspose.Diagram.SaveFileFormat です。 |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+ダイアグラム内の文字が Unicode で、正しいフォントが設定されていない、またはフォントがローカルにインストールされていない場合、PDF、画像、または XPS で文字がブロックとして表示されることがあります。MingLiu や MS Gothic などの DefaultFont を設定して、これらの文字を表示してください。
+
+**Returns:**
+java.lang.String
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+XAMLでレンダリングするページ数です。デフォルトは MaxValue で、これは図のすべてのページがレンダリングされることを意味します。
+
+**Returns:**
+int
+### getPageIndex() {#getPageIndex--}
+```
+public int getPageIndex()
+```
+
+
+レンダリングする最初のページの 0 ベースインデックスです。デフォルトは 0 です。
+
+**Returns:**
+int
+### getSaveForegroundPagesOnly() {#getSaveForegroundPagesOnly--}
+```
+public boolean getSaveForegroundPagesOnly()
+```
+
+
+すべてのページを画像として保存するか、前景のみを保存するかを指定します。true の場合、前景ページのみがレンダリングされます（背景が存在すれば含む）。false の場合、前景ページがレンダリングされた後、空の背景ページが続きます。PageCount が 1 より大きい場合にのみ true を返すことができます。デフォルト値は false です。
+
+**Returns:**
+boolean
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+この保存オプションオブジェクトが使用される場合、レンダリングされた図ページが保存される形式を指定します。Aspose.Diagram.SaveFileFormat のみ使用できます。
+
+**Returns:**
+int
+### getStreamProvider() {#getStreamProvider--}
+```
+public IStreamProvider getStreamProvider()
+```
+
+
+オブジェクトをエクスポートするための IStreamProvider。
+
+**Returns:**
+[IStreamProvider](../../com.aspose.diagram/istreamprovider)
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+警告コールバック。
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+このプロパティの説明については、[getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setPageCount(int value) {#setPageCount-int-}
+```
+public void setPageCount(int value)
+```
+
+
+このプロパティの説明については、[getPageCount()](../../com.aspose.diagram/xamlsaveoptions\#getPageCount--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setPageIndex(int value) {#setPageIndex-int-}
+```
+public void setPageIndex(int value)
+```
+
+
+このプロパティの説明については、[getPageIndex()](../../com.aspose.diagram/xamlsaveoptions\#getPageIndex--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setSaveForegroundPagesOnly(boolean value) {#setSaveForegroundPagesOnly-boolean-}
+```
+public void setSaveForegroundPagesOnly(boolean value)
+```
+
+
+このプロパティの説明については、[getSaveForegroundPagesOnly()](../../com.aspose.diagram/xamlsaveoptions\#getSaveForegroundPagesOnly--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+このプロパティの説明については、[getSaveFormat()](../../com.aspose.diagram/xamlsaveoptions\#getSaveFormat--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setStreamProvider(IStreamProvider value) {#setStreamProvider-com.aspose.diagram.IStreamProvider-}
+```
+public void setStreamProvider(IStreamProvider value)
+```
+
+
+このプロパティの説明については、[getStreamProvider()](../../com.aspose.diagram/xamlsaveoptions\#getStreamProvider--)をご覧ください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [IStreamProvider](../../com.aspose.diagram/istreamprovider) |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/xform/_index.md
+++ b/japanese/java/com.aspose.diagram/xform/_index.md
@@ -1,0 +1,436 @@
+---
+title: XForm
+second_title: Aspose.Diagram for Java API リファレンス
+description: パターンの太さや色など、シェイプの線属性を制御する要素を含みます。
+type: docs
+weight: 449
+url: /ja/java/com.aspose.diagram/xform/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class XForm
+```
+
+シェイプの線属性（パターン、太さ、色など）を制御する要素が含まれます。これらの要素は、線端が書式設定されているか（例: 矢じり）、線端書式のサイズ、線に適用される丸みの円の半径、そして線のキャップスタイル（丸形または四角形）を決定します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAngle()](#getAngle--) | シェイプの親に対する現在の回転角度を表します。 |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getFlipX()](#getFlipX--) | シェイプが水平方向に反転されているかどうかを示します |
+| [getFlipY()](#getFlipY--) | シェイプが垂直方向に反転されているかどうかを示します。 |
+| [getHeight()](#getHeight--) | シェイプの高さを描画単位で指定します。 |
+| [getLocPinX()](#getLocPinX--) | シェイプの原点に対するシェイプのピン（回転中心）の x 座標を指定します。 |
+| [getLocPinY()](#getLocPinY--) | シェイプの原点に対するシェイプのピン（回転中心）の y 座標を指定します。 |
+| [getPinPos()](#getPinPos--) | シェイプのピン位置を指定します |
+| [getPinX()](#getPinX--) | 親の原点に対するシェイプのピン（回転中心）の x 座標を指定します。 |
+| [getPinY()](#getPinY--) | 親の原点に対するシェイプのピン（回転中心）の y 座標を指定します。 |
+| [getResizeMode()](#getResizeMode--) | グループ内に含まれる形状の現在のリサイズ動作設定を指定します。 |
+| [getWidth()](#getWidth--) | 関連するシェイプの幅を描画単位で含みます。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAngle(DoubleValue value)](#setAngle-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getAngle()](../../com.aspose.diagram/xform\#getAngle--) を参照してください |
+| [setDel(int value)](#setDel-int-) | このプロパティの説明については、[getDel()](../../com.aspose.diagram/xform\#getDel--) を参照してください |
+| [setFlipX(BoolValue value)](#setFlipX-com.aspose.diagram.BoolValue-) | このプロパティの説明については、[getFlipX()](../../com.aspose.diagram/xform\#getFlipX--) を参照してください |
+| [setFlipY(BoolValue value)](#setFlipY-com.aspose.diagram.BoolValue-) | このプロパティの説明については、[getFlipY()](../../com.aspose.diagram/xform\#getFlipY--) を参照してください |
+| [setHeight(DoubleValue value)](#setHeight-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getHeight()](../../com.aspose.diagram/xform\#getHeight--) を参照してください |
+| [setLocPinX(DoubleValue value)](#setLocPinX-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getLocPinX()](../../com.aspose.diagram/xform\#getLocPinX--) を参照してください |
+| [setLocPinY(DoubleValue value)](#setLocPinY-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getLocPinY()](../../com.aspose.diagram/xform\#getLocPinY--) を参照してください |
+| [setPinPos(int value)](#setPinPos-int-) | このプロパティの説明については、[getPinPos()](../../com.aspose.diagram/xform\#getPinPos--) を参照してください |
+| [setPinX(DoubleValue value)](#setPinX-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getPinX()](../../com.aspose.diagram/xform\#getPinX--) を参照してください |
+| [setPinY(DoubleValue value)](#setPinY-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getPinY()](../../com.aspose.diagram/xform\#getPinY--) を参照してください |
+| [setResizeMode(ResizeMode value)](#setResizeMode-com.aspose.diagram.ResizeMode-) | このプロパティの説明については、[getResizeMode()](../../com.aspose.diagram/xform\#getResizeMode--) を参照してください |
+| [setWidth(DoubleValue value)](#setWidth-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getWidth()](../../com.aspose.diagram/xform\#getWidth--) を参照してください |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAngle() {#getAngle--}
+```
+public DoubleValue getAngle()
+```
+
+
+シェイプの親に対する現在の回転角度を表します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getFlipX() {#getFlipX--}
+```
+public BoolValue getFlipX()
+```
+
+
+シェイプが水平方向に反転されているかどうかを示します
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getFlipY() {#getFlipY--}
+```
+public BoolValue getFlipY()
+```
+
+
+シェイプが垂直方向に反転されているかどうかを示します。
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getHeight() {#getHeight--}
+```
+public DoubleValue getHeight()
+```
+
+
+シェイプの高さを描画単位で指定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLocPinX() {#getLocPinX--}
+```
+public DoubleValue getLocPinX()
+```
+
+
+シェイプの原点に対するシェイプのピン（回転中心）の x 座標を指定します。LocPinX を決定するデフォルトの式は次のとおりです: F='Width\* 0.5'。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLocPinY() {#getLocPinY--}
+```
+public DoubleValue getLocPinY()
+```
+
+
+シェイプの原点に対するシェイプのピン（回転中心）の y 座標を指定します。LocPinY を決定するデフォルトの式は次のとおりです: F='Height \* 0.5'。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getPinPos() {#getPinPos--}
+```
+public int getPinPos()
+```
+
+
+シェイプのピン位置を指定します
+
+**Returns:**
+int
+### getPinX() {#getPinX--}
+```
+public DoubleValue getPinX()
+```
+
+
+親の原点に対するシェイプのピン（回転中心）の x 座標を指定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getPinY() {#getPinY--}
+```
+public DoubleValue getPinY()
+```
+
+
+親の原点に対するシェイプのピン（回転中心）の y 座標を指定します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getResizeMode() {#getResizeMode--}
+```
+public ResizeMode getResizeMode()
+```
+
+
+グループ内に含まれる形状の現在のリサイズ動作設定を指定します。
+
+**Returns:**
+[ResizeMode](../../com.aspose.diagram/resizemode)
+### getWidth() {#getWidth--}
+```
+public DoubleValue getWidth()
+```
+
+
+関連するシェイプの幅を描画単位で含みます。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAngle(DoubleValue value) {#setAngle-com.aspose.diagram.DoubleValue-}
+```
+public void setAngle(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getAngle()](../../com.aspose.diagram/xform\#getAngle--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+このプロパティの説明については、[getDel()](../../com.aspose.diagram/xform\#getDel--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setFlipX(BoolValue value) {#setFlipX-com.aspose.diagram.BoolValue-}
+```
+public void setFlipX(BoolValue value)
+```
+
+
+このプロパティの説明については、[getFlipX()](../../com.aspose.diagram/xform\#getFlipX--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setFlipY(BoolValue value) {#setFlipY-com.aspose.diagram.BoolValue-}
+```
+public void setFlipY(BoolValue value)
+```
+
+
+このプロパティの説明については、[getFlipY()](../../com.aspose.diagram/xform\#getFlipY--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setHeight(DoubleValue value) {#setHeight-com.aspose.diagram.DoubleValue-}
+```
+public void setHeight(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getHeight()](../../com.aspose.diagram/xform\#getHeight--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setLocPinX(DoubleValue value) {#setLocPinX-com.aspose.diagram.DoubleValue-}
+```
+public void setLocPinX(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getLocPinX()](../../com.aspose.diagram/xform\#getLocPinX--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setLocPinY(DoubleValue value) {#setLocPinY-com.aspose.diagram.DoubleValue-}
+```
+public void setLocPinY(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getLocPinY()](../../com.aspose.diagram/xform\#getLocPinY--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setPinPos(int value) {#setPinPos-int-}
+```
+public void setPinPos(int value)
+```
+
+
+このプロパティの説明については、[getPinPos()](../../com.aspose.diagram/xform\#getPinPos--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setPinX(DoubleValue value) {#setPinX-com.aspose.diagram.DoubleValue-}
+```
+public void setPinX(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getPinX()](../../com.aspose.diagram/xform\#getPinX--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setPinY(DoubleValue value) {#setPinY-com.aspose.diagram.DoubleValue-}
+```
+public void setPinY(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getPinY()](../../com.aspose.diagram/xform\#getPinY--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setResizeMode(ResizeMode value) {#setResizeMode-com.aspose.diagram.ResizeMode-}
+```
+public void setResizeMode(ResizeMode value)
+```
+
+
+このプロパティの説明については、[getResizeMode()](../../com.aspose.diagram/xform\#getResizeMode--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [ResizeMode](../../com.aspose.diagram/resizemode) |  |
+
+### setWidth(DoubleValue value) {#setWidth-com.aspose.diagram.DoubleValue-}
+```
+public void setWidth(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getWidth()](../../com.aspose.diagram/xform\#getWidth--) を参照してください
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/xform1d/_index.md
+++ b/japanese/java/com.aspose.diagram/xform1d/_index.md
@@ -1,0 +1,261 @@
+---
+title: XForm1D
+second_title: Aspose.Diagram for Java API リファレンス
+description: 1 次元シェイプの開始点と終了点の x 座標と y 座標を含みます。
+type: docs
+weight: 450
+url: /ja/java/com.aspose.diagram/xform1d/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class XForm1D
+```
+
+1 次元シェイプの開始点と終了点の x および y 座標が含まれます。この要素は 1 次元シェイプにのみ表示されます。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このインスタンスのディープコピーを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBeginX()](#getBeginX--) | 親の原点に対する 1 次元シェイプの開始点の x 座標を表します。 |
+| [getBeginY()](#getBeginY--) | 親の原点に対する 1 次元シェイプの開始点の y 座標を表します。 |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 要素がローカルで削除されたかどうかを示すフラグです。 |
+| [getEndX()](#getEndX--) | 親の原点に対する 1 次元シェイプの終了点の x 座標を表します。 |
+| [getEndY()](#getEndY--) | 親の原点に対する1次元形状の終点の y 座標を表します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setBeginX(DoubleValue value)](#setBeginX-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getBeginX()](../../com.aspose.diagram/xform1d\#getBeginX--) を参照してください。 |
+| [setBeginY(DoubleValue value)](#setBeginY-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getBeginY()](../../com.aspose.diagram/xform1d\#getBeginY--) を参照してください。 |
+| [setDel(int value)](#setDel-int-) | このプロパティの説明については、[getDel()](../../com.aspose.diagram/xform1d\#getDel--) を参照してください。 |
+| [setEndX(DoubleValue value)](#setEndX-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getEndX()](../../com.aspose.diagram/xform1d\#getEndX--) を参照してください。 |
+| [setEndY(DoubleValue value)](#setEndY-com.aspose.diagram.DoubleValue-) | このプロパティの説明については、[getEndY()](../../com.aspose.diagram/xform1d\#getEndY--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+このインスタンスのディープコピーを作成します。
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBeginX() {#getBeginX--}
+```
+public DoubleValue getBeginX()
+```
+
+
+親の原点に対する 1 次元シェイプの開始点の x 座標を表します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBeginY() {#getBeginY--}
+```
+public DoubleValue getBeginY()
+```
+
+
+親の原点に対する 1 次元シェイプの開始点の y 座標を表します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+A flag indicating whether the element has been deleted locally. A value of 1 indicates that the element was deleted locally.
+
+**Returns:**
+int
+### getEndX() {#getEndX--}
+```
+public DoubleValue getEndX()
+```
+
+
+親の原点に対する 1 次元シェイプの終了点の x 座標を表します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getEndY() {#getEndY--}
+```
+public DoubleValue getEndY()
+```
+
+
+親の原点に対する1次元形状の終点の y 座標を表します。
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setBeginX(DoubleValue value) {#setBeginX-com.aspose.diagram.DoubleValue-}
+```
+public void setBeginX(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getBeginX()](../../com.aspose.diagram/xform1d\#getBeginX--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setBeginY(DoubleValue value) {#setBeginY-com.aspose.diagram.DoubleValue-}
+```
+public void setBeginY(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getBeginY()](../../com.aspose.diagram/xform1d\#getBeginY--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+このプロパティの説明については、[getDel()](../../com.aspose.diagram/xform1d\#getDel--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setEndX(DoubleValue value) {#setEndX-com.aspose.diagram.DoubleValue-}
+```
+public void setEndX(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getEndX()](../../com.aspose.diagram/xform1d\#getEndX--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setEndY(DoubleValue value) {#setEndY-com.aspose.diagram.DoubleValue-}
+```
+public void setEndY(DoubleValue value)
+```
+
+
+このプロパティの説明については、[getEndY()](../../com.aspose.diagram/xform1d\#getEndY--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/xjustify/_index.md
+++ b/japanese/java/com.aspose.diagram/xjustify/_index.md
@@ -1,0 +1,179 @@
+---
+title: XJustify
+second_title: Aspose.Diagram for Java API リファレンス
+description: X および Y 要素で定義された点に対するスマートタグボタンの x オフセットです。
+type: docs
+weight: 451
+url: /ja/java/com.aspose.diagram/xjustify/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class XJustify
+```
+
+X および Y 要素で定義された点に対するスマートタグボタンの x オフセットです。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [XJustify(int value)](#XJustify-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | X および Y 要素で定義された点に対するスマートタグボタンの x オフセットです。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/xjustify\#getValue--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### XJustify(int value) {#XJustify-int-}
+```
+public XJustify(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+X および Y 要素で定義された点に対するスマートタグボタンの x オフセットです。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/xjustify\#getValue--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/xjustifyvalue/_index.md
+++ b/japanese/java/com.aspose.diagram/xjustifyvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: XJustifyValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: X および Y 要素で定義された点に対するスマートタグボタンの x オフセットです。
+type: docs
+weight: 452
+url: /ja/java/com.aspose.diagram/xjustifyvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class XJustifyValue
+```
+
+X および Y 要素で定義された点に対するスマートタグボタンの x オフセットです。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [CENTERED](#CENTERED) | Centered. |
+| [LEFT_JUSTIFIED](#LEFT-JUSTIFIED) | Left justified (the default). |
+| [RIGHT_JUSTIFIED](#RIGHT-JUSTIFIED) | Right justified. |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CENTERED {#CENTERED}
+```
+public static final int CENTERED
+```
+
+
+Centered.
+
+### LEFT_JUSTIFIED {#LEFT-JUSTIFIED}
+```
+public static final int LEFT_JUSTIFIED
+```
+
+
+Left justified (the default).
+
+### RIGHT_JUSTIFIED {#RIGHT-JUSTIFIED}
+```
+public static final int RIGHT_JUSTIFIED
+```
+
+
+Right justified.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/xpssaveoptions/_index.md
+++ b/japanese/java/com.aspose.diagram/xpssaveoptions/_index.md
@@ -1,0 +1,329 @@
+---
+title: XPSSaveOptions
+second_title: Aspose.Diagram for Java API リファレンス
+description: ダイアグラムページを XPS にレンダリングする際に、追加オプションを指定できます。
+type: docs
+weight: 453
+url: /ja/java/com.aspose.diagram/xpssaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.SaveOptions](../../com.aspose.diagram/saveoptions)
+```
+public class XPSSaveOptions extends SaveOptions
+```
+
+ダイアグラムページを XPS にレンダリングする際に、追加オプションを指定できます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [XPSSaveOptions()](#XPSSaveOptions--) | このクラスの新しいインスタンスを初期化します。このインスタンスは Aspose.Diagram.SaveFileFormat 形式でドキュメントを保存するために使用できます。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | 指定された保存形式に適したクラスの保存オプションオブジェクトを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDefaultFont()](#getDefaultFont--) | 図内の文字が Unicode で、正しいフォント値が設定されていない、またはフォントがローカルにインストールされていない場合、pdf、画像、または XPS でブロックとして表示されることがあります。 |
+| [getExportHiddenPage()](#getExportHiddenPage--) | 非表示ページをエクスポートするかどうかを定義します。 |
+| [getPageCount()](#getPageCount--) | XPS でレンダリングするページ数。 |
+| [getPageIndex()](#getPageIndex--) | レンダリングする最初のページの 0 ベースインデックス。 |
+| [getSaveForegroundPagesOnly()](#getSaveForegroundPagesOnly--) | すべてのページを画像として保存するか、前景のみを保存するかを指定します。 |
+| [getSaveFormat()](#getSaveFormat--) | この保存オプションオブジェクトが使用された場合、レンダリングされた図ページが保存される形式を指定します。 |
+| [getWarningCallback()](#getWarningCallback--) | 警告コールバック。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | このプロパティの説明については、[getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--) を参照してください。 |
+| [setExportHiddenPage(boolean value)](#setExportHiddenPage-boolean-) | このプロパティの説明については、[getExportHiddenPage()](../../com.aspose.diagram/xpssaveoptions\#getExportHiddenPage--) を参照してください。 |
+| [setPageCount(int value)](#setPageCount-int-) | このプロパティの説明については、[getPageCount()](../../com.aspose.diagram/xpssaveoptions\#getPageCount--) を参照してください。 |
+| [setPageIndex(int value)](#setPageIndex-int-) | このプロパティの説明については、[getPageIndex()](../../com.aspose.diagram/xpssaveoptions\#getPageIndex--) を参照してください。 |
+| [setSaveForegroundPagesOnly(boolean value)](#setSaveForegroundPagesOnly-boolean-) | このプロパティの説明については、[getSaveForegroundPagesOnly()](../../com.aspose.diagram/xpssaveoptions\#getSaveForegroundPagesOnly--) を参照してください。 |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | このプロパティの説明については、[getSaveFormat()](../../com.aspose.diagram/xpssaveoptions\#getSaveFormat--) を参照してください。 |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### XPSSaveOptions() {#XPSSaveOptions--}
+```
+public XPSSaveOptions()
+```
+
+
+このクラスの新しいインスタンスを初期化します。このインスタンスは Aspose.Diagram.SaveFileFormat 形式でドキュメントを保存するために使用できます。
+
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+指定された保存形式に適したクラスの保存オプションオブジェクトを作成します。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| saveFormat | int | 保存オプションオブジェクトを作成するための Aspose.Diagram.SaveFileFormat です。 |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+ダイアグラム内の文字が Unicode で、正しいフォントが設定されていない、またはフォントがローカルにインストールされていない場合、PDF、画像、または XPS で文字がブロックとして表示されることがあります。MingLiu や MS Gothic などの DefaultFont を設定して、これらの文字を表示してください。
+
+**Returns:**
+java.lang.String
+### getExportHiddenPage() {#getExportHiddenPage--}
+```
+public boolean getExportHiddenPage()
+```
+
+
+非表示ページをエクスポートするかどうかを定義します。デフォルト値は true です。
+
+**Returns:**
+boolean
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+XPS でレンダリングするページ数。デフォルトは MaxValue で、これはダイアグラムのすべてのページがレンダリングされることを意味します。
+
+**Returns:**
+int
+### getPageIndex() {#getPageIndex--}
+```
+public int getPageIndex()
+```
+
+
+レンダリングする最初のページの 0 ベースインデックスです。デフォルトは 0 です。
+
+**Returns:**
+int
+### getSaveForegroundPagesOnly() {#getSaveForegroundPagesOnly--}
+```
+public boolean getSaveForegroundPagesOnly()
+```
+
+
+すべてのページを画像として保存するか、前景のみを保存するかを指定します。true の場合、前景ページのみがレンダリングされます（背景が存在すれば含む）。false の場合、前景ページがレンダリングされた後、空の背景ページが続きます。PageCount が 1 より大きい場合にのみ true を返すことができます。デフォルト値は false です。
+
+**Returns:**
+boolean
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+この保存オプションオブジェクトが使用される場合、レンダリングされた図ページが保存される形式を指定します。Aspose.Diagram.SaveFileFormat のみ使用できます。
+
+**Returns:**
+int
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+警告コールバック。
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+このプロパティの説明については、[getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.String |  |
+
+### setExportHiddenPage(boolean value) {#setExportHiddenPage-boolean-}
+```
+public void setExportHiddenPage(boolean value)
+```
+
+
+このプロパティの説明については、[getExportHiddenPage()](../../com.aspose.diagram/xpssaveoptions\#getExportHiddenPage--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setPageCount(int value) {#setPageCount-int-}
+```
+public void setPageCount(int value)
+```
+
+
+このプロパティの説明については、[getPageCount()](../../com.aspose.diagram/xpssaveoptions\#getPageCount--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setPageIndex(int value) {#setPageIndex-int-}
+```
+public void setPageIndex(int value)
+```
+
+
+このプロパティの説明については、[getPageIndex()](../../com.aspose.diagram/xpssaveoptions\#getPageIndex--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setSaveForegroundPagesOnly(boolean value) {#setSaveForegroundPagesOnly-boolean-}
+```
+public void setSaveForegroundPagesOnly(boolean value)
+```
+
+
+このプロパティの説明については、[getSaveForegroundPagesOnly()](../../com.aspose.diagram/xpssaveoptions\#getSaveForegroundPagesOnly--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | boolean |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+このプロパティの説明については、[getSaveFormat()](../../com.aspose.diagram/xpssaveoptions\#getSaveFormat--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/yjustify/_index.md
+++ b/japanese/java/com.aspose.diagram/yjustify/_index.md
@@ -1,0 +1,179 @@
+---
+title: YJustify
+second_title: Aspose.Diagram for Java API リファレンス
+description: X および Y 要素で定義された点に対するスマートタグボタンの y オフセットを指定します。
+type: docs
+weight: 454
+url: /ja/java/com.aspose.diagram/yjustify/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class YJustify
+```
+
+X および Y 要素で定義された点に対するスマートタグボタンの y オフセットを指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [YJustify(int value)](#YJustify-int-) | コンストラクタ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | オブジェクトは等しいですか。 |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 要素の属性を指定します。 |
+| [getValue()](#getValue--) | X および Y 要素で定義された点に対するスマートタグボタンの y オフセットを指定します。 |
+| [hashCode()](#hashCode--) | 特定の型に対するハッシュ関数として機能します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | このプロパティの説明については、[getValue()](../../com.aspose.diagram/yjustify\#getValue--) を参照してください。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### YJustify(int value) {#YJustify-int-}
+```
+public YJustify(int value)
+```
+
+
+コンストラクタ。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+オブジェクトは等しいですか。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+要素の属性を指定します。
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+X および Y 要素で定義された点に対するスマートタグボタンの y オフセットを指定します。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+特定の型に対するハッシュ関数として機能します。
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+このプロパティの説明については、[getValue()](../../com.aspose.diagram/yjustify\#getValue--) を参照してください。
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| 値 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.diagram/yjustifyvalue/_index.md
+++ b/japanese/java/com.aspose.diagram/yjustifyvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: YJustifyValue
+second_title: Aspose.Diagram for Java API リファレンス
+description: X および Y 要素で定義された点に対するスマートタグボタンの y オフセットを指定します。
+type: docs
+weight: 455
+url: /ja/java/com.aspose.diagram/yjustifyvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class YJustifyValue
+```
+
+X および Y 要素で定義された点に対するスマートタグボタンの y オフセットを指定します。
+## Fields
+
+| Field | 説明 |
+| --- | --- |
+| [BOTTOM_JUSTIFIED](#BOTTOM-JUSTIFIED) | 下揃え。 |
+| [CENTERED](#CENTERED) | Centered. |
+| [TOP_JUSTIFIED](#TOP-JUSTIFIED) | 上揃え（デフォルト）。 |
+| [UNDEFINED](#UNDEFINED) | Undefined. |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOTTOM_JUSTIFIED {#BOTTOM-JUSTIFIED}
+```
+public static final int BOTTOM_JUSTIFIED
+```
+
+
+下揃え。
+
+### CENTERED {#CENTERED}
+```
+public static final int CENTERED
+```
+
+
+Centered.
+
+### TOP_JUSTIFIED {#TOP-JUSTIFIED}
+```
+public static final int TOP_JUSTIFIED
+```
+
+
+上揃え（デフォルト）。
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Undefined.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメーター | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+


### PR DESCRIPTION
Automated translation of the JAVA API Reference to **Japanese** (`ja`) generated by RDA.

- Pages translated: 451/451
- Errors: 0
- Source: `english/java`
- Output: `japanese/java`

🤖 Generated by RDA